### PR TITLE
 `c-expr-dsl`: parse macros as function-like only if there is no whitespace after the name

### DIFF
--- a/c-expr-dsl/src/C/Expr/Parse/Expr.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Expr.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE OverloadedRecordDot #-}
+
 module C.Expr.Parse.Expr (parseMacro, parseMacroType) where
 
 import Control.Monad
@@ -42,9 +44,14 @@ import Clang.LowLevel.Core
 -- value expressions.
 parseMacro :: ClangCStandard -> Parser Macro
 parseMacro cStd = do
-    (macroLoc, macroName) <- parseLocName
-    let functionLike :: Parser Macro
+    (macroLocRange, macroName) <- parseLocName
+    let
+        macroLoc :: MultiLoc
+        macroLoc = macroLocRange.rangeStart
+
+        functionLike :: Parser Macro
         functionLike = do
+          noWhitespace macroLocRange
           paramNames <- formalParams
           Vec.reifyList (reverse paramNames) $ \macroParams -> do
             macroExpr <- bodyExpr macroParams
@@ -73,6 +80,28 @@ lookupParam _ VNil    = Nothing
 lookupParam n (m ::: vec)
   | n == m    = Just IZ
   | otherwise = IS <$> lookupParam n vec
+
+-- | Check that there is no whitespace between the previous token and the current
+-- token
+--
+-- Function-like macros are only function-like if there is /no/ whitespace
+-- between the macro name and the opening parenthesis of the parameter list.
+--
+-- We used to not check whitespace, which was the source of a bug. See issue
+-- #1903: <https://github.com/well-typed/hs-bindgen/issues/1903>
+noWhitespace ::
+     -- | Source range for the previous token
+     Range MultiLoc
+  -> Parser ()
+noWhitespace prevRange = lookAhead $ do
+    tok <- anyToken
+    let prev    = prevRange.rangeEnd.multiLocExpansion
+        current = tok.tokenExtent.rangeStart.multiLocExpansion
+        p       = prev.singleLocPath   == current.singleLocPath &&
+                  prev.singleLocLine   == current.singleLocLine &&
+                  prev.singleLocColumn == current.singleLocColumn
+    unless p $
+      parserFail "unexpected whitespace"
 
 {-------------------------------------------------------------------------------
   Types

--- a/c-expr-dsl/src/C/Expr/Parse/Name.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Name.hs
@@ -34,12 +34,12 @@ parseName = token $ \t -> do
 -- 16), @bool@ is classified as a keyword rather than an identifier. We accept
 -- keywords here so that macros such as @#define bool int@ can be parsed. Even
 -- in C23 the meaning of @bool@ can be overwritten (the macro takes precedence).
-parseLocName :: Parser (MultiLoc, Name)
+parseLocName :: Parser (Range MultiLoc, Name)
 parseLocName = token $ \t -> do
     let spelling = getTokenSpelling (tokenSpelling t)
     let ki = fromSimpleEnum (tokenKind t)
     guard $ ki == Right CXToken_Identifier || ki == Right CXToken_Keyword
     return (
-        rangeStart $ tokenExtent t
+        tokenExtent t
       , Name spelling
       )

--- a/c-expr-dsl/test/fixtures/macros.C17.golden
+++ b/c-expr-dsl/test/fixtures/macros.C17.golden
@@ -69,9 +69,9 @@ FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaA
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)
-CAST_SINGLE_NOKW: Right Term (Var NoXVar "x" [])
+CAST_SINGLE_NOKW: Left <parse error>
 CAST_SINGLE_KW: Left <parse error>
-BAD_CAST: Left <parse error>
+CAST_MULTI_KW: Left <parse error>
 BAD_KEYWORD_AS_PARAM: Left <parse error>
 TYPE_FUN_WITH_PARAM: Right Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt))))
 BAD_TERNARY: Left <parse error>

--- a/c-expr-dsl/test/fixtures/macros.C23.golden
+++ b/c-expr-dsl/test/fixtures/macros.C23.golden
@@ -69,9 +69,9 @@ FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaA
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)
-CAST_SINGLE_NOKW: Right Term (Var NoXVar "x" [])
+CAST_SINGLE_NOKW: Left <parse error>
 CAST_SINGLE_KW: Left <parse error>
-BAD_CAST: Left <parse error>
+CAST_MULTI_KW: Left <parse error>
 BAD_KEYWORD_AS_PARAM: Left <parse error>
 TYPE_FUN_WITH_PARAM: Right Term (Literal (TypeLit (TypeInt Nothing (Just SizeInt))))
 BAD_TERNARY: Left <parse error>

--- a/c-expr-dsl/test/fixtures/macros.h
+++ b/c-expr-dsl/test/fixtures/macros.h
@@ -172,24 +172,14 @@
 // Erroneous macros or macros with bodies the parser cannot handle
 // ---------------------------------------------------------------------------
 
-// TODO: <https://github.com/well-typed/hs-bindgen/issues/1903>
+// A macro is only function-like if there is no whitespace between the macro
+// name and the opening parenthesis of the parameter list.
 //
-// A space after the macro name makes the macro object-like (not function-like)!
-// We do not detect this in `c-expr-dsl` yet (we only get tokens after the macro
-// name).
-//
-// Beware, also casts look like functions. For example, these are C cast
-// expressions, but the parser actually treats them as function-like macros:
-//
-// 'X' is not a keyword; '(X)' is parsed as a formal parameter list ["X"], and
-// 'value' as the function body.
+// Beware: casts look like function-like macros, but they are parsed as
+// object-like macros because there is whitespace after the macro name.
 #define CAST_SINGLE_NOKW (X) x
-// 'int' is a keyword which must not be a formal parameter, inducing a parse
-// error.
 #define CAST_SINGLE_KW (int)x
-// '(unsigned int)' cannot be parsed as a formal parameter list (two tokens, not
-// one identifier).
-#define BAD_CAST (unsigned int)x
+#define CAST_MULTI_KW (unsigned int)x
 
 // This is genuine erroneous function; keywords must not be parameter names.
 #define BAD_KEYWORD_AS_PARAM(int) x

--- a/hs-bindgen/test-artefacts/fixtures/macros/object_like_as_function_like/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/object_like_as_function_like/Example.hs
@@ -3,7 +3,6 @@
 
 module Example
     ( Example.f
-    , Example.g
     )
   where
 
@@ -17,12 +16,3 @@ import qualified C.Expr.HostPlatform
 -}
 f :: forall a0 b1. C.Expr.HostPlatform.Add a0 b1 => a0 -> b1 -> C.Expr.HostPlatform.AddRes a0 b1
 f = \x0 -> \y1 -> (C.Expr.HostPlatform.+) x0 y1
-
-{-| __C declaration:__ @macro G@
-
-    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
-
-    __exported by:__ @macros\/object_like_as_function_like.h@
--}
-g :: forall a0 b1. C.Expr.HostPlatform.Add a0 b1 => a0 -> b1 -> C.Expr.HostPlatform.AddRes a0 b1
-g = \x0 -> \y1 -> (C.Expr.HostPlatform.+) x0 y1

--- a/hs-bindgen/test-artefacts/fixtures/macros/object_like_as_function_like/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/object_like_as_function_like/th.txt
@@ -20,20 +20,6 @@ f :: forall a_0 b_1 . Add a_0 b_1 => a_0 -> b_1 -> AddRes a_0 b_1
     __exported by:__ @macros\/object_like_as_function_like.h@
 -}
 f = \x_0 -> \y_1 -> (+) x_0 y_1
-{-| __C declaration:__ @macro G@
-
-    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
-
-    __exported by:__ @macros\/object_like_as_function_like.h@
--}
-g :: forall a_0 b_1 . Add a_0 b_1 => a_0 -> b_1 -> AddRes a_0 b_1
-{-| __C declaration:__ @macro G@
-
-    __defined at:__ @macros\/object_like_as_function_like.h 11:9@
-
-    __exported by:__ @macros\/object_like_as_function_like.h@
--}
-g = \x_0 -> \y_1 -> (+) x_0 y_1
 -- __unique:__ @test_macrosobject_like_as_function_Example_get_a@
 foreign import ccall unsafe "hs_bindgen_06ace787c069879f" hs_bindgen_06ace787c069879f_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/headers/golden/macros/object_like_as_function_like.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/object_like_as_function_like.h
@@ -1,9 +1,9 @@
 // F is a function-like macro definition while G is an object-like macro
 // definition. The difference is in the whitespace between the identifier and
-// the opening parenthesis. hs-bindgen treats F and G both as function-like
-// macro definitions, which is wrong.
-//
-// TODO <https://github.com/well-typed/hs-bindgen/issues/1903>
+// the opening parenthesis. hs-bindgen used to treat F and G both as
+// function-like macro definitions, which was wrong. Now only F is considered
+// function-like. See issue #1903:
+// <https://github.com/well-typed/hs-bindgen/issues/1903>
 //
 // <https://en.cppreference.com/w/cpp/preprocessor/replace.html>
 


### PR DESCRIPTION
Resolves #1903

Function-like macros are only function-like if there is *no* whitespace between the macro name and the opening parenthesis of the parameter list. We were sometimes parsing object-like macros as function-like macros because we were not considering this. This is now fixed.