### PR TITLE
`c-expr-dsl`: use `tasty-golden` instead of a custom test runner

### DIFF
--- a/c-expr-dsl/c-expr-dsl.cabal
+++ b/c-expr-dsl/c-expr-dsl.cabal
@@ -1,14 +1,14 @@
-cabal-version:      3.0
-name:               c-expr-dsl
-version:            0.1.0.0
-license:            BSD-3-Clause
-license-file:       LICENSE
-author:             Well-Typed LLP
-maintainer:         info@well-typed.com
-category:           System
-build-type:         Simple
-extra-doc-files:    CHANGELOG.md
-synopsis:           DSL for the language support by c-expr-runtime
+cabal-version:   3.0
+name:            c-expr-dsl
+version:         0.1.0.0
+license:         BSD-3-Clause
+license-file:    LICENSE
+author:          Well-Typed LLP
+maintainer:      info@well-typed.com
+category:        System
+build-type:      Simple
+extra-doc-files: CHANGELOG.md
+synopsis:        DSL for the language support by c-expr-runtime
 tested-with:
   GHC ==9.2.8
    || ==9.4.8
@@ -18,7 +18,8 @@ tested-with:
    || ==9.12.2
    || ==9.14.1
 
-extra-source-files: test/fixtures/**.golden
+data-files:      test/fixtures/**.golden
+data-dir:        test/fixtures
 
 common lang
   build-depends:      base >=4.16 && <4.23
@@ -90,11 +91,12 @@ library
     , vec                  >=0.5     && <0.6
 
 test-suite test-c-expr-dsl
-  import:         lang
-  type:           exitcode-stdio-1.0
-  main-is:        Main.hs
-  hs-source-dirs: test
+  import:          lang
+  type:            exitcode-stdio-1.0
+  main-is:         Main.hs
+  hs-source-dirs:  test
   other-modules:
+    Paths_c_expr_dsl
     Test.CExpr.Parse
     Test.CExpr.Parse.Golden
     Test.CExpr.Parse.Infra
@@ -104,6 +106,8 @@ test-suite test-c-expr-dsl
     Test.CExpr.Typecheck.Classify
     Test.CExpr.Typecheck.Infra
 
+  autogen-modules: Paths_c_expr_dsl
+
   -- internal dependencies
   build-depends:
     , c-expr-dsl
@@ -112,14 +116,14 @@ test-suite test-c-expr-dsl
 
   -- external dependencies
   build-depends:
-    , bytestring   >=0.10  && <0.13
-    , containers   >=0.6   && <0.9
-    , debruijn     >=0.3.1 && <0.4
-    , directory    >=1.3   && <1.4
-    , filepath     >=1.4   && <1.6
-    , fin          >=0.3.2 && <0.4
-    , parsec       >=3.1   && <3.2
-    , tasty        >=1.4   && <1.6
-    , tasty-hunit  >=0.10  && <0.11
-    , text         >=1.2   && <2.2
-    , vec          >=0.5   && <0.6
+    , bytestring    >=0.10  && <0.13
+    , containers    >=0.6   && <0.9
+    , debruijn      >=0.3.1 && <0.4
+    , filepath      >=1.4   && <1.6
+    , fin           >=0.3.2 && <0.4
+    , parsec        >=3.1   && <3.2
+    , tasty         >=1.4   && <1.6
+    , tasty-golden  >=2.3   && <2.4
+    , tasty-hunit   >=0.10  && <0.11
+    , text          >=1.2   && <2.2
+    , vec           >=0.5   && <0.6

--- a/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
+++ b/c-expr-dsl/test/Test/CExpr/Parse/Golden.hs
@@ -4,18 +4,17 @@
 -- @test/fixtures/macros.h@, feed the token streams to 'parseMacro', and
 -- compare the results against the golden file @test/fixtures/macros.golden@.
 --
--- To regenerate the golden file, delete it and re-run the test suite.
+-- Golden file can be regenerated using the @--accept@ CLI option.
 module Test.CExpr.Parse.Golden (tests) where
 
-import Control.Monad (filterM, unless)
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Text (Text)
 import Data.Text qualified as Text
-import System.Directory (doesDirectoryExist, doesFileExist)
 import System.FilePath ((</>))
+import System.IO.Unsafe (unsafePerformIO)
 import Test.Tasty (TestName, TestTree, testGroup)
-import Test.Tasty.HUnit (assertFailure, testCase)
+import Test.Tasty.Golden (goldenVsString)
 
 import C.Expr.Parse
 import C.Expr.Syntax
@@ -29,6 +28,8 @@ import Clang.HighLevel.Types
 import Clang.LowLevel.Core
 import Clang.Paths
 import Clang.Version
+
+import Paths_c_expr_dsl (getDataDir)
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -57,28 +58,14 @@ tests = testGroup "Parse.Golden" $ [goldenWith CExprC17] ++ mbC23
 goldenWith :: TestCStandard -> TestTree
 goldenWith testCStd =
     goldenDynamic ("macros-" <> show cStd)
-        (findFixturesDir >>= \dir ->
-          pure $ dir </> "macros." <> show cStd <> ".golden")
-        (findFixturesDir >>= \dir ->
-          parseMacrosFixture testCStd (dir </> "macros.h"))
+      (datadir </> "macros." <> show cStd <> ".golden")
+      (parseMacrosFixture testCStd (datadir </> "macros.h"))
   where
     cStd = testCStandardToCStandard testCStd
 
--- | Find the fixtures directory, trying locations relative to the repo root
--- (when the test is run by @cabal test@ from the project root) and relative to
--- the package directory (when the test binary is run directly).
-findFixturesDir :: IO FilePath
-findFixturesDir = do
-    let candidates = [
-            "c-expr-dsl" </> "test" </> "fixtures"  -- from repo root
-          , "test" </> "fixtures"                    -- from package root
-          ]
-    found <- filterM doesDirectoryExist candidates
-    case found of
-      (d : _) -> return d
-      []      -> ioError $ userError $ unlines $
-                   "Cannot find fixtures directory; tried:" :
-                   map ("  " ++) candidates
+{-# NOINLINE datadir #-}
+datadir :: FilePath
+datadir = unsafePerformIO getDataDir
 
 -- | Minimal golden test using an 'IO' action to resolve the golden file path.
 --
@@ -88,27 +75,10 @@ findFixturesDir = do
 -- about how to regenerate the file.
 goldenDynamic ::
      TestName
-  -> IO FilePath        -- ^ path to the golden file (resolved at runtime)
+  -> FilePath           -- ^ path to the golden file
   -> IO LBS.ByteString  -- ^ action producing the actual output
   -> TestTree
-goldenDynamic name getGoldenPath getActual =
-    testCase name $ do
-        goldenPath <- getGoldenPath
-        actual     <- getActual
-        exists     <- doesFileExist goldenPath
-        if exists
-          then do
-            expected <- LBS.readFile goldenPath
-            unless (actual == expected) $
-              assertFailure $ unlines [
-                  "Output differs from golden file " ++ goldenPath ++ "."
-                , "Delete the golden file and re-run to regenerate it."
-                ]
-          else do
-            LBS.writeFile goldenPath actual
-            assertFailure $
-              "Golden file did not exist; created " ++ goldenPath ++
-              ".\nRe-run the test suite to verify."
+goldenDynamic name goldenPath getActual = goldenVsString name goldenPath getActual
 
 {-------------------------------------------------------------------------------
   Run the parser on all macros in the fixture file


### PR DESCRIPTION
Branches off from #1990