### PR TITLE
`c-expr-dsl`: support multi-line macro definitions

### DIFF
--- a/c-expr-dsl/src/C/Expr/Parse/Infra.hs
+++ b/c-expr-dsl/src/C/Expr/Parse/Infra.hs
@@ -103,21 +103,44 @@ tokenOfKind kind f = token $ \t ->
       then f $ getTokenSpelling (tokenSpelling t)
       else Nothing
 
-exact :: CXTokenKind -> Text -> Parser ()
-exact kind expected = tokenOfKind kind (\actual -> guard $ expected == actual)
+tokenOfKind' :: CXTokenKind -> (Text -> Bool) -> Parser ()
+tokenOfKind' kind cmp = tokenOfKind kind (\actual -> guard $ cmp actual)
 
 {-------------------------------------------------------------------------------
   Punctuation
 -------------------------------------------------------------------------------}
 
 punctuation :: Text -> Parser ()
-punctuation = exact CXToken_Punctuation
+punctuation expected = tokenOfKind' CXToken_Punctuation $
+    \actual -> Text.unpack expected == removeMultilines (Text.unpack actual)
 
 parens :: Parser a -> Parser a
 parens p = punctuation "(" *> p <* punctuation ")"
 
 comma :: Parser ()
 comma = punctuation ","
+
+
+-- | Remove multiline characters from the string
+--
+-- Multiline characters are a pair of characters of the form "\\\n". These
+-- characters are sometimes included in (punctuation) tokens. In other cases
+-- @libclang@ handles multiline characters for us and does not report them. We
+-- should remove multiline characters before comparing against a target string.
+-- For example, we want @punctuation "("@ to match with a token that has
+-- spelling "\\\n(".
+--
+-- >>> removeMultilines "a\\\ngbe\\\n"
+-- "agbe"
+--
+removeMultilines :: String -> String
+removeMultilines = \case
+    []     -> []
+    (c:cs) -> go c cs
+  where
+    go prev []        = [prev]
+    go '\\' ('\n':cs) = removeMultilines cs
+    go prev (c   :cs) = prev : go c cs
 
 {-------------------------------------------------------------------------------
   Parse individual tokens

--- a/c-expr-dsl/test/fixtures/macros.C17.golden
+++ b/c-expr-dsl/test/fixtures/macros.C17.golden
@@ -67,7 +67,7 @@ FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) :
 FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
 FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
 FUNC_SINGLELINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
-FUNC_MULTILINE: Left <parse error>
+FUNC_MULTILINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)

--- a/c-expr-dsl/test/fixtures/macros.C17.golden
+++ b/c-expr-dsl/test/fixtures/macros.C17.golden
@@ -66,6 +66,8 @@ FUNC_IDENTITY: Right Term (LocalParam 0)
 FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
 FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
 FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
+FUNC_SINGLELINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
+FUNC_MULTILINE: Left <parse error>
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)

--- a/c-expr-dsl/test/fixtures/macros.C23.golden
+++ b/c-expr-dsl/test/fixtures/macros.C23.golden
@@ -67,7 +67,7 @@ FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) :
 FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
 FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
 FUNC_SINGLELINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
-FUNC_MULTILINE: Left <parse error>
+FUNC_MULTILINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)

--- a/c-expr-dsl/test/fixtures/macros.C23.golden
+++ b/c-expr-dsl/test/fixtures/macros.C23.golden
@@ -66,6 +66,8 @@ FUNC_IDENTITY: Right Term (LocalParam 0)
 FUNC_ADD: Right VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
 FUNC_NEG: Right VaApp NoXApp MUnaryMinus (Term (LocalParam 0) ::: VNil)
 FUNC_MULTIPLE_LOCAL_PARAMS: Right VaApp NoXApp MAdd (Term (LocalParam 3) ::: VaApp NoXApp MSub (Term (LocalParam 2) ::: VaApp NoXApp MAdd (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil) ::: VNil) ::: VNil)
+FUNC_SINGLELINE: Right VaApp NoXApp MMult (Term (LocalParam 1) ::: Term (LocalParam 0) ::: VNil)
+FUNC_MULTILINE: Left <parse error>
 EXPR_REF_ADD: Right VaApp NoXApp MAdd (Term (Var NoXVar "EXPR_ONE" []) ::: Term (Var NoXVar "EXPR_FORTY_TWO" []) ::: VNil)
 EXPR_CALL_ADD: Right Term (Var NoXVar "FUNC_ADD" [Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))),Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "2", integerLiteralType = Int Signed, integerLiteralValue = 2}))))])
 EXPR_CALL_NESTED: Right VaApp NoXApp MAdd (Term (Var NoXVar "FUNC_ADD" [Term (Var NoXVar "EXPR_ONE" []),Term (Var NoXVar "EXPR_FORTY_TWO" [])]) ::: Term (Literal (ValueLit (ValueInt (IntegerLiteral {integerLiteralText = "1", integerLiteralType = Int Signed, integerLiteralValue = 1})))) ::: VNil)

--- a/c-expr-dsl/test/fixtures/macros.h
+++ b/c-expr-dsl/test/fixtures/macros.h
@@ -151,6 +151,24 @@
 // Ternary operator is not yet in the expression grammar (see below).
 // #define FUNC_MAX(a, b)       ((a) > (b) ? (a) : (b))
 
+// FUNC_MULTILINE is like FUNC_SINGLELINE, but the former's definition is spread
+// over multiple lines. Both macros should lead to the same parse result.
+#define FUNC_SINGLELINE(xx, yy) xx * yy
+#define FUN\
+C_MULTIL\
+\
+INE\
+\
+\
+(\
+xx\
+,\
+yy\
+)\
+x\
+x * y\
+y
+
 // ---------------------------------------------------------------------------
 // Expression macros: references to other macros / typedefs
 //


### PR DESCRIPTION
Branches off #1992