### PR TITLE
Split `SHs.AST.Expr` out of `SHs.AST`

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -124,6 +124,7 @@ library internal
     HsBindgen.Backend.HsModule.Translation.Doxygen
     HsBindgen.Backend.Level
     HsBindgen.Backend.SHs.AST
+    HsBindgen.Backend.SHs.AST.Expr
     HsBindgen.Backend.SHs.AST.Type
     HsBindgen.Backend.SHs.Macro
     HsBindgen.Backend.SHs.Simplify
@@ -240,6 +241,7 @@ library internal
     HsBindgen.TraceMsg
     HsBindgen.Util.Monad
     HsBindgen.Util.Process
+    HsBindgen.Util.Rational
     HsBindgen.Util.TH
     HsBindgen.Util.Tracer
     Text.SimplePrettyPrint

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -30,8 +30,6 @@ module HsBindgen.Backend.Hs.AST (
   , Var(..)
     -- ** Variable declarations
   , MacroValue(..)
-  , VarDeclRHS(..)
-  , VarDeclRHSAppHead(..)
     -- ** Deriving instances
   , Strategy(..)
     -- ** Foreign imports
@@ -93,10 +91,6 @@ module HsBindgen.Backend.Hs.AST (
 import Data.Type.Nat (SNat, SNatI, snat)
 import Data.Type.Nat qualified as Fin
 import DeBruijn (Add (..), Ctx, EmptyCtx, Idx (..), Wk (..))
-
-import C.Char qualified as CExpr.Runtime
-
-import C.Expr.Syntax qualified as CExpr
 
 import HsBindgen.Backend.Hs.AST.Strategy
 import HsBindgen.Backend.Hs.AST.Type
@@ -306,32 +300,6 @@ data MacroValue = MacroValue {
     , comment :: Maybe HsDoc.Comment
     }
   deriving stock (Generic, Show)
-
--- | RHS of a variable or function declaration.
---
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1757>
--- Do we need this, or could we just use SExpr instead?
-type VarDeclRHS :: Ctx -> Star
-data VarDeclRHS ctx
-  = VarDeclIntegral Integer HsPrimType
-  | VarDeclFloat Float
-  | VarDeclDouble Double
-  | VarDeclChar   CExpr.Runtime.CharValue
-  | VarDeclString ByteArray
-  | VarDeclLambda (Lambda VarDeclRHS ctx)
-  | VarDeclApp VarDeclRHSAppHead [VarDeclRHS ctx]
-  | VarDeclVar (Idx ctx)
-  deriving stock (Generic, Show)
-
--- | The function at the head of an application in the Haskell translation
--- of a C macro.
-data VarDeclRHSAppHead
-  -- | The translation of a built-in C infix function such as @*@ or @&&@.
-  = forall arity. InfixAppHead (CExpr.VaFun arity)
-  -- | A function name, or the name of a function-like macro.
-  | VarAppHead (Hs.Name Hs.NsVar)
-
-deriving stock instance Show VarDeclRHSAppHead
 
 {-------------------------------------------------------------------------------
   Pattern Synonyms

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Expr.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Expr.hs
@@ -18,8 +18,6 @@ import Text.SimplePrettyPrint qualified as PP
 
 import C.Char qualified as CExpr.Runtime
 
-import C.Expr.Syntax qualified as CExpr
-
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.HsModule.Names
 import HsBindgen.Backend.HsModule.Pretty.Common
@@ -29,6 +27,7 @@ import HsBindgen.Backend.SHs.AST
 import HsBindgen.Backend.SHs.Translation.Common
 import HsBindgen.Imports
 import HsBindgen.NameHint
+import HsBindgen.Util.Rational (canBeRepresentedAsRational)
 
 import Numeric (showHex)
 
@@ -89,7 +88,7 @@ prettyRolledExpr env prec expr = case expr of
         ]
 
     EFloat f t -> PP.parens $ PP.hcat [
-        if CExpr.canBeRepresentedAsRational f then
+        if canBeRepresentedAsRational f then
           PP.show f
         else
           prettyExpr env prec $
@@ -100,7 +99,7 @@ prettyRolledExpr env prec expr = case expr of
       , prettyType EmptyEnv 0 t
       ]
     EDouble f t -> PP.parens $ PP.hcat [
-        if CExpr.canBeRepresentedAsRational f then
+        if canBeRepresentedAsRational f then
           PP.show f
         else
           prettyExpr env  prec $

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
@@ -36,11 +36,6 @@ module HsBindgen.Backend.SHs.AST (
   , PatternSynonym(..)
   ) where
 
-import Data.Type.Nat (Nat1)
-import DeBruijn (Add, Ctx, EmptyCtx, Idx)
-
-import C.Char qualified as CExpr.Runtime
-
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.Hs.AST.Strategy qualified as Hs
 import HsBindgen.Backend.Hs.CallConv
@@ -48,110 +43,25 @@ import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Backend.Hs.Origin qualified as Origin
 import HsBindgen.Backend.Level
+import HsBindgen.Backend.SHs.AST.Expr
 import HsBindgen.Backend.SHs.AST.Type
 import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.NameHint
+
+{-------------------------------------------------------------------------------
+  Re-exports from SHs.AST.Expr and SHs.AST.Type
+-------------------------------------------------------------------------------}
+
+-- SExpr, ClosedExpr, SAlt, PatExpr, InfixOp, Binding, Parameter, Result,
+-- Pragma are re-exported from SHs.AST.Expr (imported above).
+-- SType, ClosedType, Plus2, applyPlus2, tBindgenGlobal are re-exported from
+-- SHs.AST.Type (imported above).
 
 {-------------------------------------------------------------------------------
   Backend representation
 -------------------------------------------------------------------------------}
-
-type ClosedExpr = SExpr EmptyCtx
-
--- | Simple expressions
-type SExpr :: Ctx -> Star
-data SExpr ctx =
-    EGlobal (Global LvlTerm)
-  | EBound (Idx ctx)
-  | EFree Hs.TermName
-  | ECon (Hs.Name Hs.NsConstr)
-  | EUnboxedIntegral Integer
-  | EIntegral Integer (Maybe ClosedType)
-  | EFloat Float ClosedType   -- ^ Type annotation to distinguish Float/CFloat
-  | EDouble Double ClosedType -- ^ Type annotation to distinguish Double/CDouble
-  | EChar CExpr.Runtime.CharValue
-  | EString String
-  | ECString ByteArray
-  | EApp (SExpr ctx) (SExpr ctx)
-  | EInfix InfixOp (SExpr ctx) (SExpr ctx)
-  | ELam NameHint (SExpr (S ctx))
-  | EUnusedLam (SExpr ctx)
-  | ECase (SExpr ctx) [SAlt ctx]
-  | EUnit
-  | EBoxedTup Plus2
-  | EUnboxedTup Plus2
-  | EList [SExpr ctx]
-    -- | Type application using \@
-  | ETypeApp (SExpr ctx) ClosedType
-  deriving stock (Show)
-
-eBindgenGlobal :: BindgenGlobalTerm -> SExpr ctx
-eBindgenGlobal = EGlobal . bindgenGlobalTerm
-
--- | Pattern&Expressions
---
--- There is common sublanguage between term and pattern expressions.
--- This is that common sublanguage.
--- Expressions ('SExpr') and full patterns (may) have more cases,
--- but for bidirectional pattern synonyms only the common bases
--- can be used.
---
--- For now 'PatExpr' is quite small, as we don't need much.
-type PatExpr :: Star
-data PatExpr
-  = PEApps (Hs.Name Hs.NsConstr) [PatExpr] -- head of pattern application cannot be variable.
-  | PELit Integer
-  deriving stock (Show)
-
-eInt :: Int -> SExpr be
-eInt i = EIntegral (fromIntegral i) (Just $ tBindgenGlobal Int_type)
-
--- | Supported infix operators.
-data InfixOp =
-    InfixApplicative_seq
-  | InfixMonad_seq
-  | InfixNonEmpty_constructor
-  deriving stock (Show, Eq)
-
-infixOpGlobal :: InfixOp -> Global LvlTerm
-infixOpGlobal = bindgenGlobalTerm . \case
-  InfixApplicative_seq      -> Applicative_seq
-  InfixMonad_seq            -> Monad_seq
-  InfixNonEmpty_constructor -> NonEmpty_constructor
-
--- | Case alternatives
---
--- Represents different kinds of pattern matching alternatives in case expressions.
---
--- Examples:
---
--- > case x of
--- >   Just y -> ...     -- SAlt with constructor "Just"
--- >   5# -> ...         -- SAltNoConstr for primitive literal
--- >   (# a, b #) -> ... -- SAltUnboxedTuple
---
-data SAlt ctx where
-    -- | Constructor pattern: @Con x y z -> body@
-    --
-    -- Pattern matches against a data constructor with fields.
-    SAlt
-      :: Hs.Name Hs.NsConstr -> Add n ctx ctx' -> Vec n NameHint -> SExpr ctx' -> SAlt ctx
-    -- | Non-constructor pattern: @5# -> body@ or @x -> body@
-    --
-    -- Used for matching primitive values, literals, or catch-all variables.
-    -- Always binds exactly one variable (hence Vec Nat1).
-    SAltNoConstr
-      :: Vec Nat1 NameHint -> SExpr (S ctx) -> SAlt ctx
-    -- | Unboxed tuple pattern: @(# x, y #) -> body@
-    --
-    -- Pattern matches against unboxed tuples.
-    SAltUnboxedTuple
-      :: Add n ctx ctx' -> Vec n NameHint -> SExpr ctx' -> SAlt ctx
-
-deriving stock instance Show (SAlt ctx)
 
 -- | Simple declarations
 data SDecl =
@@ -165,12 +75,6 @@ data SDecl =
   | DBinding Binding
   | DPatternSynonym PatternSynonym
   deriving stock (Show)
-
-tBindgenGlobal :: BindgenGlobalType -> SType ctx
-tBindgenGlobal = TGlobal . bindgenGlobalType
-
-data Pragma = NOINLINE
-  deriving stock Show
 
 data TypeSynonym = TypeSynonym{
       name    :: Hs.Name Hs.NsTypeConstr
@@ -232,10 +136,6 @@ data Newtype = Newtype{
     }
   deriving stock (Show, Generic)
 
--- | We might want to reconsider the decision of 'HsBindgen.Backend.Hs.AST.foreignImportParameters' as
--- well as 'HsBindgen.Backend.Hs.AST.foreignImportResultType' being 'ClosedType's if we ever want to
--- generate polymorphic type signatures.
---
 data ForeignImport = ForeignImport{
       name       :: Hs.TermName
     , parameters :: [Parameter]
@@ -254,28 +154,6 @@ data Safety = Safe | Unsafe
 
 instance Default Safety where
   def = Safe
-
-data Binding = Binding{
-      name       :: Hs.TermName
-    , parameters :: [Parameter]
-    , result     :: Result
-    , body       :: ClosedExpr
-    , pragmas    :: [Pragma]
-    , comment    :: Maybe HsDoc.Comment
-    }
-  deriving stock (Show, Generic)
-
-data Parameter = Parameter{
-      typ     :: ClosedType
-    , comment :: Maybe HsDoc.Comment
-    }
-  deriving stock (Show, Generic)
-
-data Result = Result{
-      typ     :: ClosedType
-    , comment :: Maybe HsDoc.Comment
-    }
-  deriving stock (Show, Generic)
 
 data PatternSynonym = PatternSynonym{
       name    :: Hs.Name Hs.NsConstr

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST/Expr.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST/Expr.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE MagicHash #-}
+
+-- | Expression and binding types for the simplified Haskell AST
+--
+-- These types have no dependency on 'HsBindgen.Backend.Hs.Origin' and can
+-- therefore be imported from 'HsBindgen.Macro.Interface' without creating a
+-- module cycle.
+--
+-- Intended for qualified import.
+module HsBindgen.Backend.SHs.AST.Expr (
+    -- * Expressions
+    ClosedExpr
+  , SExpr(..)
+  , eBindgenGlobal
+  , eInt
+  , InfixOp(..)
+  , infixOpGlobal
+  , SAlt(..)
+  , PatExpr(..)
+    -- * Bindings
+  , Binding(..)
+  , Parameter(..)
+  , Result(..)
+  , Pragma(..)
+  ) where
+
+import Data.Type.Nat (Nat1)
+import DeBruijn (Add, Ctx, EmptyCtx, Idx)
+
+import C.Char qualified as CExpr.Runtime
+
+import HsBindgen.Backend.Global
+import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
+import HsBindgen.Backend.Hs.Name qualified as Hs
+import HsBindgen.Backend.Level
+import HsBindgen.Backend.SHs.AST.Type
+import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
+import HsBindgen.NameHint
+
+{-------------------------------------------------------------------------------
+  Expressions
+-------------------------------------------------------------------------------}
+
+type ClosedExpr = SExpr EmptyCtx
+
+-- | Simple expressions
+type SExpr :: Ctx -> Star
+data SExpr ctx =
+    EGlobal (Global LvlTerm)
+  | EBound (Idx ctx)
+  | EFree Hs.TermName
+  | ECon (Hs.Name Hs.NsConstr)
+  | EUnboxedIntegral Integer
+  | EIntegral Integer (Maybe ClosedType)
+  | EFloat Float ClosedType
+  | EDouble Double ClosedType
+  | EChar CExpr.Runtime.CharValue
+  | EString String
+  | ECString ByteArray
+  | EApp (SExpr ctx) (SExpr ctx)
+  | EInfix InfixOp (SExpr ctx) (SExpr ctx)
+  | ELam NameHint (SExpr (S ctx))
+  | EUnusedLam (SExpr ctx)
+  | ECase (SExpr ctx) [SAlt ctx]
+  | EUnit
+  | EBoxedTup Plus2
+  | EUnboxedTup Plus2
+  | EList [SExpr ctx]
+  | ETypeApp (SExpr ctx) ClosedType
+  deriving stock (Show)
+
+eBindgenGlobal :: BindgenGlobalTerm -> SExpr ctx
+eBindgenGlobal = EGlobal . bindgenGlobalTerm
+
+-- | Pattern&Expressions
+type PatExpr :: Star
+data PatExpr
+  = PEApps (Hs.Name Hs.NsConstr) [PatExpr]
+  | PELit Integer
+  deriving stock (Show)
+
+eInt :: Int -> SExpr be
+eInt i = EIntegral (fromIntegral i) (Just $ tBindgenGlobal Int_type)
+
+-- | Supported infix operators.
+data InfixOp =
+    InfixApplicative_seq
+  | InfixMonad_seq
+  | InfixNonEmpty_constructor
+  deriving stock (Show, Eq)
+
+infixOpGlobal :: InfixOp -> Global LvlTerm
+infixOpGlobal = bindgenGlobalTerm . \case
+  InfixApplicative_seq      -> Applicative_seq
+  InfixMonad_seq            -> Monad_seq
+  InfixNonEmpty_constructor -> NonEmpty_constructor
+
+-- | Case alternatives
+data SAlt ctx where
+    SAlt
+      :: Hs.Name Hs.NsConstr -> Add n ctx ctx' -> Vec n NameHint -> SExpr ctx' -> SAlt ctx
+    SAltNoConstr
+      :: Vec Nat1 NameHint -> SExpr (S ctx) -> SAlt ctx
+    SAltUnboxedTuple
+      :: Add n ctx ctx' -> Vec n NameHint -> SExpr ctx' -> SAlt ctx
+
+deriving stock instance Show (SAlt ctx)
+
+{-------------------------------------------------------------------------------
+  Bindings
+-------------------------------------------------------------------------------}
+
+data Pragma = NOINLINE
+  deriving stock Show
+
+data Binding = Binding{
+      name       :: Hs.TermName
+    , parameters :: [Parameter]
+    , result     :: Result
+    , body       :: ClosedExpr
+    , pragmas    :: [Pragma]
+    , comment    :: Maybe HsDoc.Comment
+    }
+  deriving stock (Show, Generic)
+
+data Parameter = Parameter{
+      typ     :: ClosedType
+    , comment :: Maybe HsDoc.Comment
+    }
+  deriving stock (Show, Generic)
+
+data Result = Result{
+      typ     :: ClosedType
+    , comment :: Maybe HsDoc.Comment
+    }
+  deriving stock (Show, Generic)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST/Type.hs
@@ -8,6 +8,7 @@
 module HsBindgen.Backend.SHs.AST.Type (
     ClosedType
   , SType (.., TApps)
+  , tBindgenGlobal
     -- * Plus2
   , Plus2 (..)
   , applyPlus2
@@ -28,6 +29,9 @@ import HsBindgen.NameHint
 -------------------------------------------------------------------------------}
 
 type ClosedType = SType EmptyCtx
+
+tBindgenGlobal :: BindgenGlobalType -> SType ctx
+tBindgenGlobal = TGlobal . bindgenGlobalType
 
 -- | Simple types
 type SType :: Ctx -> Star

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -20,8 +20,6 @@ import Language.Haskell.TH (Quote)
 import Language.Haskell.TH qualified as TH
 import Language.Haskell.TH.Syntax qualified as TH
 
-import C.Expr.Syntax qualified as CExpr
-
 import HsBindgen.Backend.Global
 import HsBindgen.Backend.Hs.AST qualified as Hs
 import HsBindgen.Backend.Hs.CallConv
@@ -38,6 +36,7 @@ import HsBindgen.Imports
 import HsBindgen.Instances as Inst
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.NameHint
+import HsBindgen.Util.Rational (canBeRepresentedAsRational)
 
 {-------------------------------------------------------------------------------
   Backend definition
@@ -77,14 +76,14 @@ mkRolledExpr env expr = case expr of
     -- Word32/Word64 and then cast back.
     EFloat f t ->
       TH.sigE
-        ( if CExpr.canBeRepresentedAsRational f
+        ( if canBeRepresentedAsRational f
             then [| f |]
             else [| Foreign.C.Types.CFloat $ castWord32ToFloat  $( TH.lift $ castFloatToWord32  f ) |]
         )
         (mkType EmptyEnv t)
     EDouble d t ->
       TH.sigE
-        ( if CExpr.canBeRepresentedAsRational d
+        ( if canBeRepresentedAsRational d
             then [| d |]
             else [| Foreign.C.Types.CDouble $ castWord64ToDouble $( TH.lift $ castDoubleToWord64 d ) |]
         )

--- a/hs-bindgen/src-internal/HsBindgen/Util/Rational.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Rational.hs
@@ -1,0 +1,15 @@
+module HsBindgen.Util.Rational (
+    canBeRepresentedAsRational
+  ) where
+
+{-# SPECIALISE canBeRepresentedAsRational :: Float  -> Bool #-}
+{-# SPECIALISE canBeRepresentedAsRational :: Double -> Bool #-}
+
+-- | Can this floating-point value be represented (losslessly) as a 'Rational'?
+canBeRepresentedAsRational :: RealFloat a => a -> Bool
+canBeRepresentedAsRational f = not $ or
+  [ isNaN f
+  , isInfinite f
+  , isNegativeZero f
+  , isDenormalized f -- not strictly necessary, but let's be conservative
+  ]


### PR DESCRIPTION
Extract expression and binding types into `HsBindgen.Backend.SHs.AST.Expr`

Remove unused `VarDeclRHS` and `VarDeclRHSAppHead` types from `Hs.AST`.

Reduce dependencies on `c-expr-dsl` (`canBeRepresentedAsRational`).

Prerequisite for #942 