### PR TITLE
DeclMeta is no annotation anymore

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -168,7 +168,9 @@ library internal
     HsBindgen.Frontend.AST.Decl
     HsBindgen.Frontend.AST.Deps
     HsBindgen.Frontend.AST.PrettyPrinter
+    HsBindgen.Frontend.AST.TranslationUnit
     HsBindgen.Frontend.AST.Type
+    HsBindgen.Frontend.DeclMeta
     HsBindgen.Frontend.LanguageC
     HsBindgen.Frontend.LanguageC.Error
     HsBindgen.Frontend.LanguageC.Monad

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -71,8 +71,9 @@ import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Naming
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Frontend.ProcessIncludes qualified as ProcessIncludes
@@ -363,13 +364,13 @@ getIncludeGraph :: Artefact IncludeGraph
 getIncludeGraph = (.includeGraph) <$> ParseInfoA
 
 getDeclIndex :: Artefact DeclIndex
-getDeclIndex = (.ann.declIndex) <$> FrontendPassA FinalPass
+getDeclIndex = (.meta.declIndex) <$> FrontendPassA FinalPass
 
 getUseDeclGraph :: Artefact UseDeclGraph
-getUseDeclGraph = (.ann.useDeclGraph) <$> FrontendPassA FinalPass
+getUseDeclGraph = (.meta.useDeclGraph) <$> FrontendPassA FinalPass
 
 getDeclUseGraph :: Artefact DeclUseGraph
-getDeclUseGraph = (.ann.declUseGraph) <$> FrontendPassA FinalPass
+getDeclUseGraph = (.meta.declUseGraph) <$> FrontendPassA FinalPass
 
 getOmittedTypes :: Artefact [(DeclId, SourcePath)]
 getOmittedTypes =

--- a/hs-bindgen/src-internal/HsBindgen/Artefact.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Artefact.hs
@@ -22,7 +22,7 @@ import HsBindgen.Boot
 import HsBindgen.Config
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend
-import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass (AdjustTypes)
 import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass (AssignAnonIds)
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass

--- a/hs-bindgen/src-internal/HsBindgen/Backend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend.hs
@@ -17,9 +17,9 @@ import HsBindgen.Cache
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
-import HsBindgen.Frontend.AST.Decl
 import HsBindgen.Frontend.AST.Decl qualified as C
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer
@@ -40,7 +40,7 @@ runBackend tracer config boot frontend = do
       final <- frontend.final
       sizeofs <- boot.sizeofs
       let declIndex :: DeclIndex
-          declIndex = final.ann.declIndex
+          declIndex = final.meta.declIndex
 
           cDecls :: [C.Decl Final]
           cDecls = final.decls

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -23,6 +23,7 @@ import HsBindgen.Frontend.Analysis.AnonUsage (AnonUsageAnalysis)
 import HsBindgen.Frontend.Analysis.AnonUsage qualified as AnonUsageAnalysis
 import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.AdjustTypes (adjustTypes)
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass (AdjustTypes)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Coerce.hs
@@ -106,16 +106,6 @@ instance (
       }
 
 instance (
-      CoercePass C.Decl p p'
-    , Ann "TranslationUnit" p ~ Ann "TranslationUnit" p'
-    ) => CoercePass C.TranslationUnit p p' where
-  coercePass unit = C.TranslationUnit{
-        decls        = map coercePass unit.decls
-      , includeGraph = unit.includeGraph
-      , ann          = unit.ann
-      }
-
-instance (
       CoercePassId p p'
     ) => CoercePass C.CommentRef p p' where
   coercePass (C.CommentRef c hs k) =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Decl.hs
@@ -4,9 +4,8 @@
 --
 -- > import HsBindgen.Frontend.AST.Decl qualified as C
 module HsBindgen.Frontend.AST.Decl (
-    TranslationUnit(..)
     -- * Declarations
-  , Decl(..)
+    Decl(..)
   , Availability(..)
   , EnclosingRef(..)
   , DeclInfo(..)
@@ -37,7 +36,6 @@ import Prelude qualified as P
 
 import Clang.HighLevel.Types
 
-import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
@@ -53,40 +51,6 @@ import Doxygen.Parser.Types qualified as Doxy
   NOTE: Struct and union fields, as well as enum constants, have their /own/
   'SingleLoc' (in addition to the 'SingleLoc' of the enclosing declaration).
 -------------------------------------------------------------------------------}
-
-data TranslationUnit p = TranslationUnit{
-      -- | Declarations in the unit
-      --
-      -- Declarations from all headers that we have processed. Passes may remove
-      -- some declarations. For example,
-      --
-      -- * The 'HsBindgen.Frontend.Pass.Parse.IsPass.Parse' pass filters out declarations not matching the selection
-      --   predicate (without program slicing).
-      --
-      -- * If program slicing is enabled, the @Select@ pass filters selected
-      --   declarations and their transitive dependencies.
-      --
-      -- * The 'HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass.ResolveBindingSpecs' pass removes declarations for which we have
-      --   existing external bindings, as well as declarations omitted by a
-      --   prescriptive binding specification.
-      decls :: [Decl p]
-
-      -- | Include graph
-      --
-      -- This is used to declare TH dependencies.
-      --
-      -- It can also be useful for users to see this graph, as it may provide
-      -- insight into the binding generation process. For example, suppose we
-      -- have a large library (say Gtk), with a few main entry points (for which
-      -- we should generate separate Haskell modules) and a core of "common"
-      -- definitions; it may be quite useful to look at the include graph to
-      -- figure out what this set of "core" headers is.
-    , includeGraph :: IncludeGraph
-
-      -- | Pass-specific annotation
-    , ann :: Ann "TranslationUnit" p
-    }
-  deriving stock (Generic)
 
 data Decl p = Decl {
       info :: DeclInfo p
@@ -407,7 +371,6 @@ deriving stock instance IsPass p => Show (FunctionArg      p)
 deriving stock instance IsPass p => Show (Global           p)
 deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (Struct           p)
 deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (StructField      p)
-deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (TranslationUnit  p)
 deriving stock instance IsPass p => Show (Typedef          p)
 deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (Union            p)
 deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (UnionField       p)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/Deps.hs
@@ -26,7 +26,7 @@ import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
-import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass (ResolveBindingSpecs)
+import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/TranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/TranslationUnit.hs
@@ -1,0 +1,62 @@
+-- Intended for qualified import
+--
+-- @
+-- import HsBindgen.Frontend.AST.TranslationUnit qualified as C
+-- @
+module HsBindgen.Frontend.AST.TranslationUnit (
+    TranslationUnit(..)
+
+  ) where
+
+import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
+import HsBindgen.Frontend.AST.Coerce
+import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.DeclMeta
+import HsBindgen.Frontend.Pass
+import HsBindgen.Imports
+
+data TranslationUnit p = TranslationUnit{
+      -- | Declarations in the unit
+      --
+      -- Declarations from all headers that we have processed. Passes may remove
+      -- some declarations. For example,
+      --
+      -- * The 'HsBindgen.Frontend.Pass.Parse.IsPass.Parse' pass filters out declarations not matching the selection
+      --   predicate (without program slicing).
+      --
+      -- * If program slicing is enabled, the @Select@ pass filters selected
+      --   declarations and their transitive dependencies.
+      --
+      -- * The 'HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass.ResolveBindingSpecs' pass removes declarations for which we have
+      --   existing external bindings, as well as declarations omitted by a
+      --   prescriptive binding specification.
+      decls :: [C.Decl p]
+
+      -- | Include graph
+      --
+      -- This is used to declare TH dependencies.
+      --
+      -- It can also be useful for users to see this graph, as it may provide
+      -- insight into the binding generation process. For example, suppose we
+      -- have a large library (say Gtk), with a few main entry points (for which
+      -- we should generate separate Haskell modules) and a core of "common"
+      -- definitions; it may be quite useful to look at the include graph to
+      -- figure out what this set of "core" headers is.
+    , includeGraph :: IncludeGraph
+
+      -- | Pass-specific annotation
+    , meta :: DeclMeta
+    }
+  deriving stock (Generic)
+
+deriving stock instance (IsPass p, Show (CommentDecl p)) => Show (TranslationUnit  p)
+
+instance (
+      CoercePass C.Decl p p'
+    , Ann "TranslationUnit" p ~ Ann "TranslationUnit" p'
+    ) => CoercePass TranslationUnit p p' where
+  coercePass unit = TranslationUnit{
+        decls        = map coercePass unit.decls
+      , includeGraph = unit.includeGraph
+      , meta         = unit.meta
+      }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/DeclMeta.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/DeclMeta.hs
@@ -1,0 +1,20 @@
+-- Intended for unqualified import
+module HsBindgen.Frontend.DeclMeta (
+    DeclMeta(..)
+  ) where
+
+import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
+import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition (DeclUseGraph)
+import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
+import HsBindgen.Imports
+
+{-------------------------------------------------------------------------------
+  Information about the declarations
+-------------------------------------------------------------------------------}
+
+data DeclMeta = DeclMeta {
+      declIndex    :: DeclIndex
+    , useDeclGraph :: UseDeclGraph
+    , declUseGraph :: DeclUseGraph
+    }
+  deriving stock (Show, Generic)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
@@ -6,6 +6,7 @@ import Numeric.Natural (Natural)
 
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
@@ -39,7 +40,7 @@ adjustTypes unit =
         unit' =  C.TranslationUnit {
               decls        = decls'
             , includeGraph = unit.includeGraph
-            , ann          = unit.ann
+            , meta         = unit.meta
             }
       in
         unit'

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
@@ -9,7 +9,6 @@ import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
@@ -23,7 +22,6 @@ type AdjustTypes :: Pass
 data AdjustTypes a
 
 type family AnnAdjustTypes ix where
-  AnnAdjustTypes "TranslationUnit"  = DeclMeta
   AnnAdjustTypes "Decl"             = PrescriptiveDeclSpec
   AnnAdjustTypes "Struct"           = StructNames
   AnnAdjustTypes "Union"            = NewtypeNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
@@ -10,7 +10,8 @@ import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Coerce
-import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.EnrichComments.IsPass
 import HsBindgen.Frontend.Pass.Parse.Result
@@ -31,7 +32,7 @@ constructTranslationUnit parseResults includeGraph = C.TranslationUnit{
                              declMeta.declIndex
                              declMeta.declUseGraph
     , includeGraph = includeGraph
-    , ann          = declMeta
+    , meta         = declMeta
     }
   where
     declMeta :: DeclMeta

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -1,11 +1,7 @@
 module HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass (
     ConstructTranslationUnit
-  , DeclMeta(..)
   ) where
 
-import HsBindgen.Frontend.Analysis.DeclIndex
-import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition (DeclUseGraph)
-import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.Pass
@@ -24,7 +20,6 @@ type ConstructTranslationUnit :: Pass
 data ConstructTranslationUnit a
 
 type family AnnConstructTranslationUnit (ix :: Symbol) :: Star where
-  AnnConstructTranslationUnit "TranslationUnit" = DeclMeta
   AnnConstructTranslationUnit "StructField"     = ReparseInfo
   AnnConstructTranslationUnit "UnionField"      = ReparseInfo
   AnnConstructTranslationUnit "Typedef"         = ReparseInfo
@@ -38,17 +33,6 @@ instance IsPass ConstructTranslationUnit where
   type Ann ix      ConstructTranslationUnit = AnnConstructTranslationUnit ix
   type Msg         ConstructTranslationUnit = NoMsg Level
   type CommentDecl ConstructTranslationUnit = Maybe (C.Comment ConstructTranslationUnit)
-
-{-------------------------------------------------------------------------------
-  Information about the declarations
--------------------------------------------------------------------------------}
-
-data DeclMeta = DeclMeta {
-      declIndex    :: DeclIndex
-    , useDeclGraph :: UseDeclGraph
-    , declUseGraph :: DeclUseGraph
-    }
-  deriving stock (Show, Generic)
 
 {-------------------------------------------------------------------------------
   CoercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -28,11 +28,12 @@ import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.Typedefs (TypedefAnalysis)
 import HsBindgen.Frontend.Analysis.Typedefs qualified as TypedefAnalysis
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
@@ -62,17 +63,17 @@ mangleNames fieldNaming unit = (
          C.TranslationUnit{
            decls        = decls2
          , includeGraph = unit.includeGraph
-         , ann          = updateDeclMeta
+         , meta         = updateDeclMeta
                             nameMap
                             (failures1 ++ failures2)
                             squashes
-                            unit.ann
+                            unit.meta
         }
     , msgs1 ++ msgs2
     )
   where
     typedefAnalysis :: TypedefAnalysis
-    typedefAnalysis = TypedefAnalysis.fromDecls unit.ann.declUseGraph unit.decls
+    typedefAnalysis = TypedefAnalysis.fromDecls unit.meta.declUseGraph unit.decls
 
     mangleCandidateConfig :: MangleCandidate Maybe
     mangleCandidateConfig = MangleCandidate.mangleCandidateDefault

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -15,7 +15,6 @@ import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -31,7 +30,6 @@ type MangleNames :: Pass
 data MangleNames a
 
 type family AnnMangleNames ix where
-  AnnMangleNames "TranslationUnit"  = DeclMeta
   AnnMangleNames "Decl"             = PrescriptiveDeclSpec
   AnnMangleNames "Struct"           = StructNames
   AnnMangleNames "Union"            = NewtypeNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -18,11 +18,12 @@ import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.LanguageC qualified as LanC
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
@@ -67,7 +68,7 @@ reconstructAfterReparse unit reparseState decls =
     C.TranslationUnit{
         decls        = decls
       , includeGraph = unit.includeGraph
-      , ann          = unit.ann{
+      , meta         = unit.meta{
             declIndex    = updatedDeclIndex
           , useDeclGraph = UseDeclGraph.fromDeclUseGraph updatedDeclUseGraph
           , declUseGraph = updatedDeclUseGraph
@@ -86,14 +87,14 @@ reconstructAfterReparse unit reparseState decls =
       -- warnings.
       foldr
         DeclIndex.registerDelayedParseMsg
-        unit.ann.declIndex
+        unit.meta.declIndex
         reparseState.reparseWarnings
 
     updatedDeclUseGraph :: DeclUseGraph
     updatedDeclUseGraph =
       Foldable.foldl'
         (flip updateDeps)
-        unit.ann.declUseGraph
+        unit.meta.declUseGraph
         successfulReparses
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/IsPass.hs
@@ -4,8 +4,8 @@ module HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass (
 
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
 import HsBindgen.Util.Tracer

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -26,10 +26,11 @@ import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
@@ -64,12 +65,12 @@ resolveBindingSpecs hsModuleName extSpecs pSpec unit =
             extSpecs
             pSpec'
             unit.includeGraph
-            unit.ann.declIndex
+            unit.meta.declIndex
             (resolveDecls unit.decls)
         declUseGraph =
             DeclUseGraph.deleteRevDeps (Map.keysSet state.extTypes)
           . DeclUseGraph.deleteDeps state.opqTypes
-          $ unit.ann.declUseGraph
+          $ unit.meta.declUseGraph
         notUsedErrs = map (withCallStack . ResolveBindingSpecsTypeNotUsed) $ Map.keys state.noPTypes
     in  ( reconstruct decls declUseGraph state
         , pSpecErrs ++ reverse state.traces ++ notUsedErrs
@@ -88,10 +89,10 @@ resolveBindingSpecs hsModuleName extSpecs pSpec unit =
           index' =
                 DeclIndex.registerExternalDeclarations externalIds
               . DeclIndex.registerOmittedDeclarations state.omitTypes
-              $ unit.ann.declIndex
+              $ unit.meta.declIndex
 
-          unitAnn' :: DeclMeta
-          unitAnn' = DeclMeta {
+          unitMeta' :: DeclMeta
+          unitMeta' = DeclMeta {
                 declIndex    = index'
               , useDeclGraph = UseDeclGraph.fromDeclUseGraph declUseGraph
               , declUseGraph = declUseGraph
@@ -100,7 +101,7 @@ resolveBindingSpecs hsModuleName extSpecs pSpec unit =
       in C.TranslationUnit{
              decls        = decls'
            , includeGraph = unit.includeGraph
-           , ann          = unitAnn'
+           , meta         = unitMeta'
            }
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -13,7 +13,6 @@ import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass (DeclMeta)
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -38,9 +37,8 @@ type ResolveBindingSpecs :: Pass
 data ResolveBindingSpecs a
 
 type family AnnResolveBindingSpecs ix where
-  AnnResolveBindingSpecs "TranslationUnit" = DeclMeta
-  AnnResolveBindingSpecs "Decl"            = PrescriptiveDeclSpec
-  AnnResolveBindingSpecs _                 = NoAnn
+  AnnResolveBindingSpecs "Decl" = PrescriptiveDeclSpec
+  AnnResolveBindingSpecs _      = NoAnn
 
 instance IsPass ResolveBindingSpecs where
   type MacroBody   ResolveBindingSpecs = CheckedMacro ResolveBindingSpecs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -26,12 +26,13 @@ import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.AST.Coerce (CoercePass (coercePass))
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
@@ -98,7 +99,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
     let -- Directly match the select predicate on the 'DeclIndex', obtaining
         -- information about succeeded _and failed_ selection roots.
         selectionRootsIndex :: DeclIndex
-        selectionRootsIndex = selectDeclIndex unit.ann.declUseGraph match index
+        selectionRootsIndex = selectDeclIndex unit.meta.declUseGraph match index
 
         -- Identifiers of selection roots. Some of them may be unavailable
         -- (i.e., not in the 'succeeded' map, and hence, not in the list of
@@ -198,7 +199,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
         unitSelect = C.TranslationUnit {
                 decls        = selectedUnitDecls
               , includeGraph = unit.includeGraph
-              , ann          = unit.ann
+              , meta         = unit.meta
               }
 
         -- If there were no predicate matches we issue a warning to the user.
@@ -226,10 +227,10 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
         )
   where
     index :: DeclIndex
-    index = unit.ann.declIndex
+    index = unit.meta.declIndex
 
     useDeclGraph :: UseDeclGraph
-    useDeclGraph = unit.ann.useDeclGraph
+    useDeclGraph = unit.meta.useDeclGraph
 
     match :: Match
     match name loc availability =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -23,7 +23,6 @@ import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.Error (MangleNamesError)
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
@@ -42,7 +41,6 @@ type Select :: Pass
 data Select a
 
 type family AnnSelect ix where
-  AnnSelect "TranslationUnit"  = DeclMeta
   AnnSelect "Decl"             = PrescriptiveDeclSpec
   AnnSelect "Struct"           = StructNames
   AnnSelect "Union"            = NewtypeNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
@@ -9,7 +9,9 @@ import Data.Map qualified as Map
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.AST.TranslationUnit qualified as C
 import HsBindgen.Frontend.AST.Type qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.LanguageC qualified as LanC
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
@@ -60,11 +62,11 @@ reconstructAfterTypecheck unit failedMacros decls =
     C.TranslationUnit{
         decls        = decls
       , includeGraph = unit.includeGraph
-      , ann          = unit.ann{
+      , meta         = unit.meta{
             declIndex =
               Foldable.foldl'
                 (flip DeclIndex.registerMacroTypecheckFailure)
-                unit.ann.declIndex
+                unit.meta.declIndex
                 failedMacros
           }
       }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -14,6 +14,7 @@ import C.Expr.Typecheck qualified as CExpr
 
 import HsBindgen.Frontend.AST.Coerce
 import HsBindgen.Frontend.AST.Decl qualified as C
+import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass


### PR DESCRIPTION
Prerequisite for separating the macro framework (simplifies handling of macro type parameters).
