### PR TITLE
Update `libclang-bindings` and exception handling, remove `LLVM_CONFIG` support

### DIFF
--- a/cabal.project.base
+++ b/cabal.project.base
@@ -5,7 +5,7 @@ index-state: 2026-03-12T10:22:50Z
 source-repository-package
     type: git
     location: https://github.com/well-typed/libclang-bindings
-    tag: 821b62535af96353be6a30baf45a0adcd08770c0
+    tag: 51b4b4972ea7ee8f7848f962e8524b6cd3eb4a84
     subdir: libclang-bindings
 
 source-repository-package

--- a/dev/alpine/Dockerfile
+++ b/dev/alpine/Dockerfile
@@ -47,11 +47,7 @@ RUN apk add --no-cache --virtual .doxygen-build-deps \
     && apk del .doxygen-build-deps \
     && doxygen --version
 
-# libclang.so lives at /usr/lib (symlink to /usr/lib/llvm${LLVM_VERSION}/lib);
-# the hs-bindgen runtime dlopens it via LIBCLANG_PATH. llvm-config ships
-# under the versioned prefix and is not on PATH by default.
-ENV LIBCLANG_PATH=/usr/lib
-ENV LLVM_CONFIG=/usr/lib/llvm${LLVM_VERSION}/bin/llvm-config
+# llvm-config ships under the versioned prefix and is not on PATH by default.
 ENV PATH=/usr/lib/llvm${LLVM_VERSION}/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 WORKDIR /repo

--- a/dev/alpine/README.md
+++ b/dev/alpine/README.md
@@ -38,7 +38,7 @@ runs reuse the layer cache.
   version pinned by the rest of CI)
 - musl-dev, gcc, gmp, ncurses, zlib (with static archives), libpcap-dev,
   libdispatch-dev (for the blocktest example)
-- `LIBCLANG_PATH=/usr/lib`, `LLVM_CONFIG=/usr/lib/llvm19/bin/llvm-config`
+- `/usr/lib/llvm19/bin` is prepended to the `PATH`
 
 The cabal store inside the container lives in a Docker volume
 (`hs-bindgen-alpine-cabal-store`), separate from the host store. This avoids

--- a/dev/dev-environment.md
+++ b/dev/dev-environment.md
@@ -9,7 +9,7 @@ All platforms require (last updated October 9, 2025):
 
 - GHC 9.4.8 or greater (or compatible version)
 - Cabal (latest version)
-- LLVM/Clang (version 14 - 21)
+- LLVM/Clang (version 14 - 22)
 
 ## Linux (Ubuntu)
 
@@ -27,14 +27,25 @@ sudo apt-get install llvm-16 clang-16
 
 ### Environment Variables
 
-Make sure the following environment variables are correctly set after
-installing LLVM and Clang, otherwise set them as follows:
+Make sure that the `llvm-config` for the version of LLVM/Clang that you want
+to use is available.
 
 ```bash
-# Point to your LLVM installation
+llvm-config --version
+```
+
+If the command is not found or is for a different version, prepend the `bin`
+for the LLVM/Clang version that you want to use to your `PATH`.
+
+```
+export PATH="/usr/lib/llvm-16/bin:${PATH}"  # Adjust version as needed
+```
+
+If `llvm-config` is not included in your installation, use the `LLVM_PATH`
+environment variable instead.
+
+```
 export LLVM_PATH=/usr/lib/llvm-16  # Adjust version as needed
-export LLVM_CONFIG=$LLVM_PATH/bin/llvm-config
-export LIBCLANG_PATH=$LLVM_PATH/lib/
 ```
 
 ## NixOS
@@ -63,12 +74,10 @@ brew install llvm@16
 
 ### Environment Setup
 
-1. **Set LLVM paths**:
+1. **Path configuration**:
 
    ```bash
-   export LLVM_PATH=/opt/homebrew/opt/llvm@16  # Adjust for your installation
-   export LLVM_CONFIG=$LLVM_PATH/bin/llvm-config
-   export LIBCLANG_PATH=$LLVM_PATH/lib/
+   export PATH="/opt/homebrew/opt/llvm@16/bin:${PATH}"  # Adjust for your installation
    ```
 
 2. **SDK configuration**:
@@ -92,12 +101,10 @@ and Clang, so no separate LLVM installation is needed.
 
 ### Environment Setup
 
-1. Set LLVM paths (PowerShell):
+1. Set LLVM path (PowerShell):
 
    ```powershell
-   $env:LLVM_PATH = "C:\ghcup\ghc\9.12.2\mingw"
-   $env:LLVM_CONFIG = "$env:LLVM_PATH\bin\llvm-config.exe"
-   $env:LIBCLANG_PATH = "$env:LLVM_PATH\lib"
+   $env:PATH = "C:\ghcup\ghc\9.12.2\mingw\bin;" + $env:PATH
    ```
 
 2. Library paths:

--- a/examples/cross-compilation/generate-and-run.sh
+++ b/examples/cross-compilation/generate-and-run.sh
@@ -314,10 +314,7 @@ echo "  Successfully ran aarch64 Haskell executable under QEMU"
 #   * PATH with the stub prepended - so libclang-bindings's configure script
 #   (run during cross-build of hs-bindgen) finds our target llvm-config stub
 #   via the normal AC_PATH_PROG search instead of picking up the host's
-#   llvm-config and failing with "Cannot find libclang headers". We
-#   intentionally avoid setting the LLVM_CONFIG env var: using PATH keeps
-#   libclang-bindings's existing configure flow on its normal path and leaves
-#   LLVM_CONFIG free for other potential uses.
+#   llvm-config and failing with "Cannot find libclang headers".
 #
 #   * BINDGEN_BUILTIN_INCLUDE_DIR=disable - hygiene, not strictly required for
 #   arch_types.h (it has no system #includes). With it unset, the splice falls
@@ -346,7 +343,7 @@ write_iserv_wrapper "$TH_ISERV_WRAPPER" "$th_iserv_ld_path"
 # place a stub named exactly `llvm-config` in a dedicated bin directory
 # and prepend that directory to PATH for the cabal build below, so the
 # configure script finds our target-aware stub instead of the host's
-# llvm-config, without us having to set the LLVM_CONFIG env var.
+# llvm-config.
 #
 # The four flags below are the subset of llvm-config's interface our
 # consumers actually call:

--- a/flake.lock
+++ b/flake.lock
@@ -38,17 +38,17 @@
     "libclang-bindings-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778673321,
-        "narHash": "sha256-33M7uwqgEStJkAxlUkqqix97BtvHowGnv92b/SqAWqY=",
+        "lastModified": 1779428609,
+        "narHash": "sha256-e/if9oauLLOQ0KSwsuEkTHhVKpWVs/ta+Ey5Oqh0BCo=",
         "owner": "well-typed",
         "repo": "libclang-bindings",
-        "rev": "821b62535af96353be6a30baf45a0adcd08770c0",
+        "rev": "51b4b4972ea7ee8f7848f962e8524b6cd3eb4a84",
         "type": "github"
       },
       "original": {
         "owner": "well-typed",
         "repo": "libclang-bindings",
-        "rev": "821b62535af96353be6a30baf45a0adcd08770c0",
+        "rev": "51b4b4972ea7ee8f7848f962e8524b6cd3eb4a84",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     libclang-bindings-src = {
-      url = "github:well-typed/libclang-bindings?rev=821b62535af96353be6a30baf45a0adcd08770c0";
+      url = "github:well-typed/libclang-bindings?rev=51b4b4972ea7ee8f7848f962e8524b6cd3eb4a84";
       flake = false;
     };
     doxygen-parser-src = {

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking changes
 
+* The `LLVM_CONFIG` environment variable is no longer used to locate
+  `llvm-config`.  Configure `PATH` so that the desired `llvm-config` is found
+  instead.
+
 ### New features
 
 * A new CLI option `--log-squashed-as-info` (and matching

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs
@@ -63,8 +63,6 @@ data DiscoverMsg =
   | DiscoverEnvSet BuiltinIncDirConfig
   | DiscoverEnvInvalid String
   | DiscoverLlvmPathNotFound FilePath
-  | DiscoverLlvmConfigEnvNotFound FilePath
-  | DiscoverLlvmConfigEnvFound FilePath
   | DiscoverLlvmConfigPathFound FilePath
   | DiscoverLlvmConfigPrefixUnexpected String
   | DiscoverLlvmConfigPrefixIOError IOError
@@ -93,10 +91,6 @@ instance PrettyForTrace DiscoverMsg where
       PP.string envName <+> "invalid:" <+> PP.string (show s) <+> "(ignored)"
     DiscoverLlvmPathNotFound path ->
       "$LLVM_PATH path not found or not directory (skipping):" <+> string path
-    DiscoverLlvmConfigEnvNotFound path ->
-      "$LLVM_CONFIG path not found or not file (skipping):" <+> string path
-    DiscoverLlvmConfigEnvFound path ->
-      "llvm-config found using $LLVM_CONFIG:" <+> string path
     DiscoverLlvmConfigPathFound path ->
       "llvm-config found using $PATH:" <+> string path
     DiscoverLlvmConfigPrefixUnexpected s ->
@@ -140,8 +134,6 @@ instance IsTrace Level DiscoverMsg where
     DiscoverEnvSet{}                          -> Info
     DiscoverEnvInvalid{}                      -> Warning
     DiscoverLlvmPathNotFound{}                -> Warning
-    DiscoverLlvmConfigEnvNotFound{}           -> Warning
-    DiscoverLlvmConfigEnvFound{}              -> Debug
     DiscoverLlvmConfigPathFound{}             -> Debug
     DiscoverLlvmConfigPrefixUnexpected{}      -> Warning
     DiscoverLlvmConfigPrefixIOError{}         -> Warning
@@ -200,9 +192,8 @@ discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
 -- the first successful result of the following strategies:
 --
 -- 1. @${LLVM_PATH}/bin/clang@
--- 2. @$(${LLVM_CONFIG} --prefix)/bin/clang@
--- 3. @$(llvm-config --prefix)/bin/clang@
--- 4. Search @${PATH}@
+-- 2. @$(llvm-config --prefix)/bin/clang@ (llvm-config is found using PATH)
+-- 3. @clang@ (clang is found using PATH)
 --
 -- === Builtin include directory
 --
@@ -221,17 +212,8 @@ discoverState = unsafePerformIO $ IORef.newIORef DiscoverStateInitial
 -- contains the executables, headers, and libraries used by the Clang compiler.
 --
 -- When 'BuiltinIncDirClang' is used, this function tries to determine the
--- builtin include directory using the first successful result of the following
--- strategies:
---
--- 1. @$(${LLVM_PATH}/bin/clang -print-resource-dir)/include@
--- 2. @$($(${LLVM_CONFIG} --prefix)/bin/clang -print-resource-dir)/include@
--- 3. @$($(llvm-config --prefix)/bin/clang -print-resource-dir)/include@
--- 4. @$(clang -print-resource-dir)/include@
---
--- Note that this uses the @clang@ executable that we discovered before (see the
--- "Clang executable" section).
---
+-- builtin include directory using the @clang@ executable discovered as
+-- described above, using @$(clang -print-resource-dir)/include@.
 getPaths ::
      Tracer DiscoverMsg
   -> BuiltinIncDirConfig
@@ -320,9 +302,8 @@ getBuiltinIncDirWithClang tracer getExe = do
 -- | Find the @clang@ executable
 --
 -- 1. @${LLVM_PATH}/bin/clang@
--- 2. @$(${LLVM_CONFIG} --prefix)/bin/clang@
--- 3. @$(llvm-config --prefix)/bin/clang@
--- 4. Search @${PATH}@
+-- 2. @$(llvm-config --prefix)/bin/clang@ (llvm-config is found using PATH)
+-- 3. @clang@ (clang is found using PATH)
 findClangExe :: Tracer DiscoverMsg -> MaybeT IO ClangExe
 findClangExe tracer = asum [auxLlvmPath, auxLlvmConfig, auxPath]
   where
@@ -372,28 +353,12 @@ lookupLlvmPath tracer = do
         traceWith tracer (withCallStack $ DiscoverLlvmPathNotFound prefix)
         return Nothing
 
--- | Find the @llvm-config@ executable
---
--- 1. @${LLVM_CONFIG}@
--- 2. Search @${PATH}@
+-- | Find the @llvm-config@ executable using @PATH@
 findLlvmConfigExe :: Tracer DiscoverMsg -> MaybeT IO FilePath
-findLlvmConfigExe tracer = asum [auxLlvmConfigEnv, auxPath]
-  where
-    auxLlvmConfigEnv :: MaybeT IO FilePath
-    auxLlvmConfigEnv = do
-      exe <- MaybeT $ fmap normWinPath <$> Env.lookupEnv "LLVM_CONFIG"
-      ifM
-        tracer
-        DiscoverLlvmConfigEnvNotFound
-        DiscoverLlvmConfigEnvFound
-        Dir.doesFileExist
-        exe
-
-    auxPath :: MaybeT IO FilePath
-    auxPath = do
-      exe <- MaybeT $ Dir.findExecutable llvmConfigExe
-      traceWith tracer (withCallStack $ DiscoverLlvmConfigPathFound exe)
-      return exe
+findLlvmConfigExe tracer = do
+    exe <- MaybeT $ Dir.findExecutable llvmConfigExe
+    traceWith tracer (withCallStack $ DiscoverLlvmConfigPathFound exe)
+    return exe
 
 -- | @llvm-config@ executable name for the current platform
 llvmConfigExe :: FilePath

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -54,12 +54,12 @@ topLevelDecl = foldWithHandler handleParseExceptions parseDeclTopLevel
     handleParseExceptions ::
          CXCursor
       -> SomeException
-      -> ParseDecl (Maybe (CXSourceLocation, [ParseResult Parse]))
+      -> ParseDecl (HandlerResult (Maybe (CXSourceLocation, [ParseResult Parse])))
     handleParseExceptions curr err
       | Just e <- fromException @(ExceptionInCtx DelayedParseMsg) err = do
           loc <- clang_getCursorLocation curr
-          Just . (loc,) <$> parseFailNoInfo e.ctx e.exception curr
-      | otherwise = liftIO $ throwIO err
+          HandlerResult . Just . (loc,) <$> parseFailNoInfo e.ctx e.exception curr
+      | otherwise = return HandlerRethrow
 
 {-------------------------------------------------------------------------------
   Functions for each kind of declaration

--- a/manual/low-level/usage/cross-compilation.md
+++ b/manual/low-level/usage/cross-compilation.md
@@ -607,18 +607,6 @@ chmod +x llvm-stub-bin/llvm-config
 PATH=$(pwd)/llvm-stub-bin:$PATH cabal build ...
 ```
 
-The configure script also declares
-
-```
-AC_ARG_VAR(LLVM_CONFIG, [Location of llvm-config])
-```
-
-so as a fallback you can set `LLVM_CONFIG=/path/to/stub`
-([`AC_ARG_VAR`][autoconf:docs:AC_ARG_VAR] is autoconf's "precious" env-var
-mechanism, which overrides any `AC_PATH_PROG` search). The `PATH` approach above
-is preferred because it keeps the configure flow on its normal path and avoids
-reserving an env var for this single purpose.
-
 The four flags above are the subset that our consumers actually call:
 
 - `--version` -- libclang-bindings's configure.ac sanity check (output
@@ -638,25 +626,11 @@ provides the `.so` files that go in `--libdir`.
 #### Skipping clang's builtin-headers discovery
 
 When the splice runs, hs-bindgen tries to locate clang's builtin
-include directory. In a normal install this lives at
-`<llvm-prefix>/lib/clang/<ver>/include/`.
-
-The discovery flow (see
-[`hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs`][source:Discover.hs])
-checks, in order:
-
-1. The `BINDGEN_BUILTIN_INCLUDE_DIR` environment variable
-   (`disable` skips discovery; `clang` selects the discovery path below)
-2. `$(${LLVM_CONFIG} --prefix)/bin/clang -print-resource-dir` then
-   `<resource-dir>/include`
-3. `$(clang -print-resource-dir)/include` from `PATH`
-
-If your header has no system `#include`s, the splice does not need any of
-these, discovery falls through to host-clang and the splice still produces
-correct bindings. Setting `BINDGEN_BUILTIN_INCLUDE_DIR=disable` is still
-recommended though: it skips discovery entirely, so the splice cannot
-accidentally pick up host builtin includes that would be architecturally
-wrong if the header started using `<stdint.h>` etc.
+include directory by default.  (See
+[`hs-bindgen/src-internal/HsBindgen/Clang/Discover.hs`][source:Discover.hs]
+for details.)  Setting `BINDGEN_BUILTIN_INCLUDE_DIR=disable` is recommended
+so that the splice does not accidentally pick up host builtin includes that
+would be architecturally wrong if the header started using `<stdint.h>` etc.
 
 ### Working example
 
@@ -751,7 +725,6 @@ Verify the binary architecture with `file ./your-app`.
 
 <!-- sources and references -->
 
-[autoconf:docs:AC_ARG_VAR]: https://www.gnu.org/software/autoconf/manual/html_node/Setting-Output-Variables.html
 [blog:zw3rk]: https://log.zw3rk.com/
 [clang:docs:cli-llvm-config]: https://llvm.org/docs/CommandGuide/llvm-config.html
 [clang:docs:cross-compilation]: https://clang.llvm.org/docs/CrossCompilation.html

--- a/manual/low-level/usage/includes.md
+++ b/manual/low-level/usage/includes.md
@@ -168,9 +168,8 @@ it does not have to be done manually.
   match.
 
     1. `$(${LLVM_PATH}/bin/clang -print-resource-dir)/include`
-    2. `$($(${LLVM_CONFIG} --prefix)/bin/clang -print-resource-dir)/include`
-    3. `$($(llvm-config --prefix)/bin/clang -print-resource-dir)/include`
-    4. `$(clang -print-resource-dir)/include`
+    2. `$($(llvm-config --prefix)/bin/clang -print-resource-dir)/include`
+    3. `$(clang -print-resource-dir)/include`
 
 * Configuration can be disabled (`disable`).  In this case, the builtin include
   directory can be configured using CLI options or environment variables when


### PR DESCRIPTION
See https://github.com/well-typed/libclang-bindings/pull/63 and https://github.com/well-typed/libclang-bindings/pull/62 for details.