### PR TITLE
`hs-bindgen`: fix changelogs

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -81,6 +81,12 @@
   #1715][is-1715] and [PR #1917][pr-1917].
 * Function-like macro parameters are now resolved to de Bruijn indices at
   parse time and correctly propagated through the backend.
+* Trace messages from frontend passes now capture callstacks at the point where
+  messages are created (in pure code), rather than at the IO emission site.
+  This makes `--log-show-call-stack` output useful for debugging which pass and
+  function produced a given message.
+* A new CLI option `--log-as-error-bugs` changes bug-level trace message to be
+  errors. This is useful when `hs-bindgen` is used in a CI pipeline.
 
 ### Bug fixes
 
@@ -137,6 +143,21 @@
   previously supported but `struct { int x; } * var;` or `struct { int x; }
   var[];` would cause a panic. See [PR #2017][pr-2017].
 
+[is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
+[is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685
+[is-1715]: https://github.com/well-typed/hs-bindgen/issues/1715
+[is-1790]: https://github.com/well-typed/hs-bindgen/issues/1790
+[is-1884]: https://github.com/well-typed/hs-bindgen/issues/1884
+[is-1891]: https://github.com/well-typed/hs-bindgen/issues/1891
+[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
+[pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917
+[pr-1921]: https://github.com/well-typed/hs-bindgen/pull/1921
+[is-1868]: https://github.com/well-typed/hs-bindgen/issues/1868
+[pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
+[pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
+[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
+[pr-2017]: https://github.com/well-typed/hs-bindgen/pull/2017
+
 ## 0.1.0-alpha2 -- 2026-03-27
 
 ### Breaking changes
@@ -185,7 +206,7 @@
   after the global variable. Extern anonymous declarations
   (e.g., `extern struct { .. } config;`) are rejected as unusable.
 * Generate an `IsArray` instance for each newtype of a type with an `IsArray`
-* Support unnamed bit-fields, used for padding.
+* Support unnamed bit-field declarations, used for padding.
 * Generate bindings for nested struct and union declarations even if we failed
   to generate bindings for the enclosing struct or union. See [PR
   #1849][pr-1849].
@@ -202,12 +223,6 @@
   `primitive` are not required by `hs-bindgen` generated code anymore.
 * Improve and disambiguate delayed parse trace messages.
 * Improve error handling in `hs-bindgen` frontend, see [issue #1009][is-1009]
-* Trace messages from frontend passes now capture callstacks at the point where
-  messages are created (in pure code), rather than at the IO emission site.
-  This makes `--log-show-call-stack` output useful for debugging which pass and
-  function produced a given message.
-* A new CLI option `--log-as-error-bugs` changes bug-level trace message to be
-  errors. This is useful when `hs-bindgen` is used in a CI pipeline.
 
 ### Bug fixes
 
@@ -242,28 +257,14 @@
   `MangleNames`; now they are skipped with a warning.
 
 [is-1009]: https://github.com/well-typed/hs-bindgen/issues/1009
-[is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
-[is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685
 [is-1694]: https://github.com/well-typed/hs-bindgen/issues/1694
-[is-1715]: https://github.com/well-typed/hs-bindgen/issues/1715
-[is-1790]: https://github.com/well-typed/hs-bindgen/issues/1790
 [is-1806]: https://github.com/well-typed/hs-bindgen/issues/1806
-[is-1884]: https://github.com/well-typed/hs-bindgen/issues/1884
-[is-1891]: https://github.com/well-typed/hs-bindgen/issues/1891
 [pr-1711]: https://github.com/well-typed/hs-bindgen/pull/1711
 [pr-1712]: https://github.com/well-typed/hs-bindgen/pull/1712
 [pr-1724]: https://github.com/well-typed/hs-bindgen/pull/1724
 [pr-1839]: https://github.com/well-typed/hs-bindgen/pull/1839
 [pr-1849]: https://github.com/well-typed/hs-bindgen/pull/1849
-[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1869]: https://github.com/well-typed/hs-bindgen/pull/1869
-[pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917
-[pr-1921]: https://github.com/well-typed/hs-bindgen/pull/1921
-[is-1868]: https://github.com/well-typed/hs-bindgen/issues/1868
-[pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
-[pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
-[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
-[pr-2017]: https://github.com/well-typed/hs-bindgen/pull/2017
 
 ## 0.1.0-alpha -- 2026-02-06
 


### PR DESCRIPTION
Some new entries had been added to an old release. They are now moved to the current unreleased version.

New links for issues and PRs were also added to an old releases. They are now moved to the current unreleased version.

<details>
<summary>Diff between main and release-0.1-alpha2</summary>

```diff
diff --git a/c-expr-dsl/CHANGELOG.md b/c-expr-dsl/CHANGELOG.md
index 66ce7e005..86ed836af 100644
--- a/c-expr-dsl/CHANGELOG.md
+++ b/c-expr-dsl/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## ?.?.? -- YYYY-mm-dd
 
+### Breaking changes
+
+* Re-export parse-related symbols from `C.Expr.Parse`; demote lower-level
+  modules to `other-modules`.
+* Re-export typecheck-related symbols from `C.Expr.Typecheck`; demote
+  `C.Expr.Typecheck.Expr` to `other-modules`; `C.Expr.Typecheck.Type` is still
+  an exposed module.
+* `Expr` and `Term` gain a `ctx :: Ctx` type index (from `debruijn`) for
+  the local macro parameter scope. `Macro.macroArgs :: [Name]` is replaced
+  by an existential `macroParams :: Vec ctx Name`; `macroExpr` becomes
+  `Expr ctx Ps`. `sameMacro` compares macros structurally, ignoring location.
+* `TypeTagged !TagKind !Name` is now a separate `Literal` constructor
+  instead of a `TypeLit` variant.
+* Some macros that were previously erroneously parsed as function-like are now
+  parsed as object-like. See [PR #1990][pr-1990].
+* Remove the `sameMacro` function. See [PR #1983][pr-1983].
+
+### New features
+
+* Parse macro types in addition to expressions; defer the type-vs-value
+  distinction to the typechecking phase. See [PR #1862][pr-1862].
+* Add test suite covering the parser (token-based and real-world libclang
+  tests) and the typechecker. See [PR #1862][pr-1862].
+* Local macro parameters in function-like macros are resolved to de Bruijn
+  indices (`LocalParam (Idx ctx)`) at parse time, distinguishing them from
+  free variables (`Var`).
+* `tcMacro` now rejects type-like macros that expand to an incomplete type
+  (`void` or `const void` at the top level) with a new `TcIncompleteTypeMacro`
+  error. Pointer-to-incomplete types (e.g. `void *`) are still accepted.
+* Support multi-line macro definitions. See [PR #1993][pr-1993].
+
+### Minor changes
+
+None
+
+### Bug fixes
+
+* In accordance with the C reference, parse macros only as function-like when
+  there is no whitespace between the macro name and the opening parenthesis of
+  the parameter list. See [PR #1990][pr-1990].
+
+[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
+[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
+[pr-1990]: https://github.com/well-typed/hs-bindgen/pull/1990
+[pr-1993]: https://github.com/well-typed/hs-bindgen/pull/1993
+
 ## 0.1.0-alpha -- 2026-02-06
 
 * First version. Released on an unsuspecting world.
diff --git a/hs-bindgen/CHANGELOG.md b/hs-bindgen/CHANGELOG.md
index dfc9e6c3b..268e86c62 100644
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -1,5 +1,138 @@
 # Revision history for hs-bindgen
 
+## ?.?.? -- YYYY-mm-dd
+
+### Breaking changes
+
+* The `LLVM_CONFIG` environment variable is no longer used to locate
+  `llvm-config`.  Configure `PATH` so that the desired `llvm-config` is found
+  instead.
+
+### New features
+
+* A new CLI option `--log-squashed-as-info` (and matching
+  `CustomLogLevelSetting` constructor `MakeMangleNamesSquashedInfo`) demotes
+  the `select-mangle-names-squashed` trace from `Notice` to `Info`, so the
+  per-typedef squash messages no longer appear at the default verbosity.
+  See [#1574](https://github.com/well-typed/hs-bindgen/issues/1574).
+* When using the Template Haskell backend, external types referenced via
+  external binding specifications that are not in scope now produce a helpful
+  compile error suggesting the missing import.
+* Macro handling has been overhauled. Macros are now parsed during the `Parse`
+  pass and typechecked in a dedicated `TypecheckMacros` pass (replacing the old
+  `HandleMacros` pass). A new `ReparseMacroExpansions` pass handles declarations
+  whose bodies contain macro expansions. See [PR #1862][pr-1862].
+* Type-like macro expressions (e.g. `#define A int`) are now parsed and
+  typechecked together with value-like macro expressions (e.q., `#define FOO 1`)
+  using `c-expr-dsl` rather than `language-c`. The typechecked type expression
+  is translated directly to a Haskell type in the backend (see
+  [#1953](https://github.com/well-typed/hs-bindgen/issues/1953)).
+* Scoped reparse: when reparsing a declaration that uses macro expansions, only
+  macros actually expanded by Clang *in that declaration* are substituted,
+  avoiding spurious substitutions.
+* Support macro expansions in global variable declarations
+  ([#831](https://github.com/well-typed/hs-bindgen/issues/831)).
+* `DeclInfo` now carries a sequence number (`seqNr`) when using Clang ≥ 20.1,
+  recording the order in which declarations appear in the translation unit.
+* New `DepsOfDecl` typeclass for precise dependency tracking; dependencies of
+  macros are now included in the `UseDeclGraph`.
+* The `hs-bindgen-cli info doxygen` subcommand dumps the parsed doxygen
+  state (the map of `DoxygenKey` to structured comments), alongside the
+  other `info` dump subcommands.
+* Mirror Doxygen `@defgroup` sections (including nested `@ingroup`
+  groupings) as Haddock section headers in the generated module export
+  lists. The export list is now structured as a recursive `ExportEntry`
+  tree: `ExportSection` carries its title and nested children, with
+  Haddock `*`-depth derived from tree depth. Doxygen-specific export
+  resolution lives in the new internal module
+  `HsBindgen.Backend.HsModule.Translation.Doxygen`.
+* Redefinitions of macros are now considered conflicting even if they are
+  syntactically equal. See [PR #1983][pr-1983].
+* Support mixed uses of macro types and non-type macros. Previously, we would
+  only support type macros in bindings that do not also use non-type macros. See
+  [issue #1225][is-1225] and [PR #1892][pr-1892].
+
+### Minor changes
+
+* The `doxygen-parser` library has been extracted into its own repository
+  ([well-typed/doxygen-parser](https://github.com/well-typed/doxygen-parser))
+  and is no longer published as part of the `hs-bindgen` source tree. The
+  package and its API (`Doxygen.Parser`, `Doxygen.Parser.Types`,
+  `Doxygen.Parser.Warning`, `Doxygen.Parser.Internal`) are unchanged.
+  Downstream consumers that previously depended on `doxygen-parser` as a
+  local package should depend on it via Hackage (or
+  `source-repository-package`) instead. See [#1884][is-1884].
+* Overhaul internal identifier and name representation: `Name ns` and `SomeName`
+  replace `Identifier` and `ExportedName ns` across the pipeline
+* The `enclosing` field in `DeclInfo` is now `[EnclosingRef p]` (a flat nesting
+  chain rather than a single `Maybe (Id p)`)
+* Skip over declarations with unexposed types (such as `malloc`), primarily in
+  support of LLVM/Clang 22.
+* Extract Haddock documentation from C headers using doxygen. When the `doxygen`
+  binary is available on `PATH`, `hs-bindgen` invokes it to parse structured
+  documentation comments (Javadoc/Doxygen-style `/** ... */`) and translates
+  them into Haddock comments on the generated Haskell bindings. If `doxygen`
+  is not installed, `hs-bindgen` silently falls back to generating
+  metadata-only comments (source location and C name) with no documentation
+  content.
+* Print types without redundant parentheses in generated bindings. See [issue
+  #1790][is-1790] and [PR #1917][pr-1917].
+* Print type operators with infix notation in generated bindings. See [issue
+  #1715][is-1715] and [PR #1917][pr-1917].
+* Function-like macro parameters are now resolved to de Bruijn indices at
+  parse time and correctly propagated through the backend.
+
+### Bug fixes
+
+* Unresolved tagged types in macro expressions produce a `Warning`-level
+  diagnostic (`TypecheckMacrosErrorUnresolvedTaggedType`) instead of panicking.
+* Forward-declared (opaque) tagged types are included in `knownTaggedTypes`
+  during macro typechecking.
+* Fixture tests now invoke the same GHC that cabal used to build the test
+  suite, so they no longer fail when `with-compiler` is set to a non-default
+  version and the system's `ghc` on `PATH` is something else. See [issue
+  #1940](https://github.com/well-typed/hs-bindgen/issues/1940).
+* Fix reversed order of Haddock documentation in TH mode
+* Fix `DeclIndex` construction when macros and ordinary declarations share a
+  name.
+* Fix `UseDeclGraph` construction to avoid inserting edges for non-existing
+  vertices, and fix `topSort'` order for include siblings.
+* Generated modules now emit `{-# LANGUAGE FlexibleInstances #-}` when any
+  instance head contains a non-variable argument (e.g. a type-level string
+  literal from a `HasField` instance, or a function-typed argument).  This was
+  previously covered implicitly by `GHC2021`, but broke downstream consumers
+  using `Haskell2010` as the default language.
+* Fix the parsing of primitive types in declarations that involve macro
+  expansions. The bug would, for example, cause `long long int` to be parsed as
+  `long int` in some cases, but that is now fixed. See [issue #1685][is-1685]
+  and [PR #1921][pr-1921].
+* Distinguish anonymous declarations originating from the same macro
+  expansion. libclang reports the same expansion location for all of them,
+  which previously caused them to collide on the same `AnonId` and panic in
+  the `AssignAnonIds` pass; we now also key on the spelling location.
+  Requires `llvm >= 19.1.0`; older toolchains fall back to the previous
+  best-effort behaviour. See
+  [issue #1860](https://github.com/well-typed/hs-bindgen/issues/1860).
+* Fix the reparser to ignore storage class specifiers and function specifiers.
+  Previously, declarations carrying any of these on macro-using function headers
+  or globals failed to reparse and silently fell back to the un-reparsed type,
+  dropping macro typedef names from generated bindings. See
+  [issue #1891][is-1891].
+* Stop emitting the redundant `CApiFFI` language pragma in generated modules.
+  The pragma was previously added unconditionally for every foreign import,
+  even though the generated bindings only use the `ccall` calling convention.
+  See [issue #1868][is-1868].
+* Fix the reparser to ignore attribute specifier sequences. Previously,
+  declarations carrying macro expansions and attribute specifier sequences
+  failed to reparse and silently fell back to the un-reparsed type, dropping
+  macro typedef names from generated bindings. See [PR #1955][pr-1955].
+* Silently ignore `__declspec(dllimport)` and `__declspec(dllexport)` attribute
+  cursors (`CXCursor_DLLImport` / `CXCursor_DLLExport`) when parsing function,
+  variable, and enum declarations. Previously, these cursors triggered a
+  `Bug`-level `Unexpected cursor kind` trace on Windows for every CRT
+  declaration carrying `__declspec(dllimport)`. See [issue
+  #1910](https://github.com/well-typed/hs-bindgen/issues/1910).
+
 ## 0.1.0-alpha2 -- 2026-03-27
 
 ### Breaking changes
@@ -47,8 +180,8 @@
   (e.g., `struct { int x; int y; } point;`). The anonymous type is named
   after the global variable. Extern anonymous declarations
   (e.g., `extern struct { .. } config;`) are rejected as unusable.
-  * Generate an `IsArray` instance for each newtype of a type with an `IsArray`
-* Support unnamed bit-field declarations, used for padding.
+* Generate an `IsArray` instance for each newtype of a type with an `IsArray`
+* Support unnamed bit-fields, used for padding.
 * Generate bindings for nested struct and union declarations even if we failed
   to generate bindings for the enclosing struct or union. See [PR
   #1849][pr-1849].
@@ -65,6 +198,12 @@
   `primitive` are not required by `hs-bindgen` generated code anymore.
 * Improve and disambiguate delayed parse trace messages.
 * Improve error handling in `hs-bindgen` frontend, see [issue #1009][is-1009]
+* Trace messages from frontend passes now capture callstacks at the point where
+  messages are created (in pure code), rather than at the IO emission site.
+  This makes `--log-show-call-stack` output useful for debugging which pass and
+  function produced a given message.
+* A new CLI option `--log-as-error-bugs` changes bug-level trace message to be
+  errors. This is useful when `hs-bindgen` is used in a CI pipeline.
 
 ### Bug fixes
 
@@ -91,7 +230,7 @@
   Haddock documentation of declarations in the included header, we just
   document the filename of the header.
 * Fix `--create-output-dirs` not creating directories for `--gen-binding-spec`
-  output paths. See [issue #1806][issue-1806].
+  output paths. See [issue #1806][is-1806].
 * Skip functions whose parameters reference struct/union declarations that
   will not be visible outside of the function, including both forward
   references and inline definitions. This could indicate a missing `#include`
@@ -99,14 +238,27 @@
   `MangleNames`; now they are skipped with a warning.
 
 [is-1009]: https://github.com/well-typed/hs-bindgen/issues/1009
+[is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
+[is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685
 [is-1694]: https://github.com/well-typed/hs-bindgen/issues/1694
+[is-1715]: https://github.com/well-typed/hs-bindgen/issues/1715
+[is-1790]: https://github.com/well-typed/hs-bindgen/issues/1790
+[is-1806]: https://github.com/well-typed/hs-bindgen/issues/1806
+[is-1884]: https://github.com/well-typed/hs-bindgen/issues/1884
+[is-1891]: https://github.com/well-typed/hs-bindgen/issues/1891
 [pr-1711]: https://github.com/well-typed/hs-bindgen/pull/1711
 [pr-1712]: https://github.com/well-typed/hs-bindgen/pull/1712
 [pr-1724]: https://github.com/well-typed/hs-bindgen/pull/1724
-[issue-1806]: https://github.com/well-typed/hs-bindgen/issues/1806
 [pr-1839]: https://github.com/well-typed/hs-bindgen/pull/1839
 [pr-1849]: https://github.com/well-typed/hs-bindgen/pull/1849
+[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1869]: https://github.com/well-typed/hs-bindgen/pull/1869
+[pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917
+[pr-1921]: https://github.com/well-typed/hs-bindgen/pull/1921
+[is-1868]: https://github.com/well-typed/hs-bindgen/issues/1868
+[pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
+[pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
+[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
 
 ## 0.1.0-alpha -- 2026-02-06
 

```
</details>

<details>
<summary> Diff between jdral/fixup-changelogs and release-0.1-alpha2 </summary>

```diff
diff --git a/c-expr-dsl/CHANGELOG.md b/c-expr-dsl/CHANGELOG.md
index 66ce7e005..86ed836af 100644
--- a/c-expr-dsl/CHANGELOG.md
+++ b/c-expr-dsl/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 ## ?.?.? -- YYYY-mm-dd
 
+### Breaking changes
+
+* Re-export parse-related symbols from `C.Expr.Parse`; demote lower-level
+  modules to `other-modules`.
+* Re-export typecheck-related symbols from `C.Expr.Typecheck`; demote
+  `C.Expr.Typecheck.Expr` to `other-modules`; `C.Expr.Typecheck.Type` is still
+  an exposed module.
+* `Expr` and `Term` gain a `ctx :: Ctx` type index (from `debruijn`) for
+  the local macro parameter scope. `Macro.macroArgs :: [Name]` is replaced
+  by an existential `macroParams :: Vec ctx Name`; `macroExpr` becomes
+  `Expr ctx Ps`. `sameMacro` compares macros structurally, ignoring location.
+* `TypeTagged !TagKind !Name` is now a separate `Literal` constructor
+  instead of a `TypeLit` variant.
+* Some macros that were previously erroneously parsed as function-like are now
+  parsed as object-like. See [PR #1990][pr-1990].
+* Remove the `sameMacro` function. See [PR #1983][pr-1983].
+
+### New features
+
+* Parse macro types in addition to expressions; defer the type-vs-value
+  distinction to the typechecking phase. See [PR #1862][pr-1862].
+* Add test suite covering the parser (token-based and real-world libclang
+  tests) and the typechecker. See [PR #1862][pr-1862].
+* Local macro parameters in function-like macros are resolved to de Bruijn
+  indices (`LocalParam (Idx ctx)`) at parse time, distinguishing them from
+  free variables (`Var`).
+* `tcMacro` now rejects type-like macros that expand to an incomplete type
+  (`void` or `const void` at the top level) with a new `TcIncompleteTypeMacro`
+  error. Pointer-to-incomplete types (e.g. `void *`) are still accepted.
+* Support multi-line macro definitions. See [PR #1993][pr-1993].
+
+### Minor changes
+
+None
+
+### Bug fixes
+
+* In accordance with the C reference, parse macros only as function-like when
+  there is no whitespace between the macro name and the opening parenthesis of
+  the parameter list. See [PR #1990][pr-1990].
+
+[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
+[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
+[pr-1990]: https://github.com/well-typed/hs-bindgen/pull/1990
+[pr-1993]: https://github.com/well-typed/hs-bindgen/pull/1993
+
 ## 0.1.0-alpha -- 2026-02-06
 
 * First version. Released on an unsuspecting world.
diff --git a/hs-bindgen/CHANGELOG.md b/hs-bindgen/CHANGELOG.md
index dfc9e6c3b..2070dd9de 100644
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -1,5 +1,158 @@
 # Revision history for hs-bindgen
 
+## ?.?.? -- YYYY-mm-dd
+
+### Breaking changes
+
+* The `LLVM_CONFIG` environment variable is no longer used to locate
+  `llvm-config`.  Configure `PATH` so that the desired `llvm-config` is found
+  instead.
+
+### New features
+
+* A new CLI option `--log-squashed-as-info` (and matching
+  `CustomLogLevelSetting` constructor `MakeMangleNamesSquashedInfo`) demotes
+  the `select-mangle-names-squashed` trace from `Notice` to `Info`, so the
+  per-typedef squash messages no longer appear at the default verbosity.
+  See [#1574](https://github.com/well-typed/hs-bindgen/issues/1574).
+* When using the Template Haskell backend, external types referenced via
+  external binding specifications that are not in scope now produce a helpful
+  compile error suggesting the missing import.
+* Macro handling has been overhauled. Macros are now parsed during the `Parse`
+  pass and typechecked in a dedicated `TypecheckMacros` pass (replacing the old
+  `HandleMacros` pass). A new `ReparseMacroExpansions` pass handles declarations
+  whose bodies contain macro expansions. See [PR #1862][pr-1862].
+* Type-like macro expressions (e.g. `#define A int`) are now parsed and
+  typechecked together with value-like macro expressions (e.q., `#define FOO 1`)
+  using `c-expr-dsl` rather than `language-c`. The typechecked type expression
+  is translated directly to a Haskell type in the backend (see
+  [#1953](https://github.com/well-typed/hs-bindgen/issues/1953)).
+* Scoped reparse: when reparsing a declaration that uses macro expansions, only
+  macros actually expanded by Clang *in that declaration* are substituted,
+  avoiding spurious substitutions.
+* Support macro expansions in global variable declarations
+  ([#831](https://github.com/well-typed/hs-bindgen/issues/831)).
+* `DeclInfo` now carries a sequence number (`seqNr`) when using Clang ≥ 20.1,
+  recording the order in which declarations appear in the translation unit.
+* New `DepsOfDecl` typeclass for precise dependency tracking; dependencies of
+  macros are now included in the `UseDeclGraph`.
+* The `hs-bindgen-cli info doxygen` subcommand dumps the parsed doxygen
+  state (the map of `DoxygenKey` to structured comments), alongside the
+  other `info` dump subcommands.
+* Mirror Doxygen `@defgroup` sections (including nested `@ingroup`
+  groupings) as Haddock section headers in the generated module export
+  lists. The export list is now structured as a recursive `ExportEntry`
+  tree: `ExportSection` carries its title and nested children, with
+  Haddock `*`-depth derived from tree depth. Doxygen-specific export
+  resolution lives in the new internal module
+  `HsBindgen.Backend.HsModule.Translation.Doxygen`.
+* Redefinitions of macros are now considered conflicting even if they are
+  syntactically equal. See [PR #1983][pr-1983].
+* Support mixed uses of macro types and non-type macros. Previously, we would
+  only support type macros in bindings that do not also use non-type macros. See
+  [issue #1225][is-1225] and [PR #1892][pr-1892].
+
+### Minor changes
+
+* The `doxygen-parser` library has been extracted into its own repository
+  ([well-typed/doxygen-parser](https://github.com/well-typed/doxygen-parser))
+  and is no longer published as part of the `hs-bindgen` source tree. The
+  package and its API (`Doxygen.Parser`, `Doxygen.Parser.Types`,
+  `Doxygen.Parser.Warning`, `Doxygen.Parser.Internal`) are unchanged.
+  Downstream consumers that previously depended on `doxygen-parser` as a
+  local package should depend on it via Hackage (or
+  `source-repository-package`) instead. See [#1884][is-1884].
+* Overhaul internal identifier and name representation: `Name ns` and `SomeName`
+  replace `Identifier` and `ExportedName ns` across the pipeline
+* The `enclosing` field in `DeclInfo` is now `[EnclosingRef p]` (a flat nesting
+  chain rather than a single `Maybe (Id p)`)
+* Skip over declarations with unexposed types (such as `malloc`), primarily in
+  support of LLVM/Clang 22.
+* Extract Haddock documentation from C headers using doxygen. When the `doxygen`
+  binary is available on `PATH`, `hs-bindgen` invokes it to parse structured
+  documentation comments (Javadoc/Doxygen-style `/** ... */`) and translates
+  them into Haddock comments on the generated Haskell bindings. If `doxygen`
+  is not installed, `hs-bindgen` silently falls back to generating
+  metadata-only comments (source location and C name) with no documentation
+  content.
+* Print types without redundant parentheses in generated bindings. See [issue
+  #1790][is-1790] and [PR #1917][pr-1917].
+* Print type operators with infix notation in generated bindings. See [issue
+  #1715][is-1715] and [PR #1917][pr-1917].
+* Function-like macro parameters are now resolved to de Bruijn indices at
+  parse time and correctly propagated through the backend.
+* Trace messages from frontend passes now capture callstacks at the point where
+  messages are created (in pure code), rather than at the IO emission site.
+  This makes `--log-show-call-stack` output useful for debugging which pass and
+  function produced a given message.
+* A new CLI option `--log-as-error-bugs` changes bug-level trace message to be
+  errors. This is useful when `hs-bindgen` is used in a CI pipeline.
+
+### Bug fixes
+
+* Unresolved tagged types in macro expressions produce a `Warning`-level
+  diagnostic (`TypecheckMacrosErrorUnresolvedTaggedType`) instead of panicking.
+* Forward-declared (opaque) tagged types are included in `knownTaggedTypes`
+  during macro typechecking.
+* Fixture tests now invoke the same GHC that cabal used to build the test
+  suite, so they no longer fail when `with-compiler` is set to a non-default
+  version and the system's `ghc` on `PATH` is something else. See [issue
+  #1940](https://github.com/well-typed/hs-bindgen/issues/1940).
+* Fix reversed order of Haddock documentation in TH mode
+* Fix `DeclIndex` construction when macros and ordinary declarations share a
+  name.
+* Fix `UseDeclGraph` construction to avoid inserting edges for non-existing
+  vertices, and fix `topSort'` order for include siblings.
+* Generated modules now emit `{-# LANGUAGE FlexibleInstances #-}` when any
+  instance head contains a non-variable argument (e.g. a type-level string
+  literal from a `HasField` instance, or a function-typed argument).  This was
+  previously covered implicitly by `GHC2021`, but broke downstream consumers
+  using `Haskell2010` as the default language.
+* Fix the parsing of primitive types in declarations that involve macro
+  expansions. The bug would, for example, cause `long long int` to be parsed as
+  `long int` in some cases, but that is now fixed. See [issue #1685][is-1685]
+  and [PR #1921][pr-1921].
+* Distinguish anonymous declarations originating from the same macro
+  expansion. libclang reports the same expansion location for all of them,
+  which previously caused them to collide on the same `AnonId` and panic in
+  the `AssignAnonIds` pass; we now also key on the spelling location.
+  Requires `llvm >= 19.1.0`; older toolchains fall back to the previous
+  best-effort behaviour. See
+  [issue #1860](https://github.com/well-typed/hs-bindgen/issues/1860).
+* Fix the reparser to ignore storage class specifiers and function specifiers.
+  Previously, declarations carrying any of these on macro-using function headers
+  or globals failed to reparse and silently fell back to the un-reparsed type,
+  dropping macro typedef names from generated bindings. See
+  [issue #1891][is-1891].
+* Stop emitting the redundant `CApiFFI` language pragma in generated modules.
+  The pragma was previously added unconditionally for every foreign import,
+  even though the generated bindings only use the `ccall` calling convention.
+  See [issue #1868][is-1868].
+* Fix the reparser to ignore attribute specifier sequences. Previously,
+  declarations carrying macro expansions and attribute specifier sequences
+  failed to reparse and silently fell back to the un-reparsed type, dropping
+  macro typedef names from generated bindings. See [PR #1955][pr-1955].
+* Silently ignore `__declspec(dllimport)` and `__declspec(dllexport)` attribute
+  cursors (`CXCursor_DLLImport` / `CXCursor_DLLExport`) when parsing function,
+  variable, and enum declarations. Previously, these cursors triggered a
+  `Bug`-level `Unexpected cursor kind` trace on Windows for every CRT
+  declaration carrying `__declspec(dllimport)`. See [issue
+  #1910](https://github.com/well-typed/hs-bindgen/issues/1910).
+
+[is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
+[is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685
+[is-1715]: https://github.com/well-typed/hs-bindgen/issues/1715
+[is-1790]: https://github.com/well-typed/hs-bindgen/issues/1790
+[is-1884]: https://github.com/well-typed/hs-bindgen/issues/1884
+[is-1891]: https://github.com/well-typed/hs-bindgen/issues/1891
+[pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
+[pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917
+[pr-1921]: https://github.com/well-typed/hs-bindgen/pull/1921
+[is-1868]: https://github.com/well-typed/hs-bindgen/issues/1868
+[pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
+[pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
+[pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
+
 ## 0.1.0-alpha2 -- 2026-03-27
 
 ### Breaking changes
@@ -47,7 +200,7 @@
   (e.g., `struct { int x; int y; } point;`). The anonymous type is named
   after the global variable. Extern anonymous declarations
   (e.g., `extern struct { .. } config;`) are rejected as unusable.
-  * Generate an `IsArray` instance for each newtype of a type with an `IsArray`
+* Generate an `IsArray` instance for each newtype of a type with an `IsArray`
 * Support unnamed bit-field declarations, used for padding.
 * Generate bindings for nested struct and union declarations even if we failed
   to generate bindings for the enclosing struct or union. See [PR
@@ -91,7 +244,7 @@
   Haddock documentation of declarations in the included header, we just
   document the filename of the header.
 * Fix `--create-output-dirs` not creating directories for `--gen-binding-spec`
-  output paths. See [issue #1806][issue-1806].
+  output paths. See [issue #1806][is-1806].
 * Skip functions whose parameters reference struct/union declarations that
   will not be visible outside of the function, including both forward
   references and inline definitions. This could indicate a missing `#include`
@@ -100,10 +253,10 @@
 
 [is-1009]: https://github.com/well-typed/hs-bindgen/issues/1009
 [is-1694]: https://github.com/well-typed/hs-bindgen/issues/1694
+[is-1806]: https://github.com/well-typed/hs-bindgen/issues/1806
 [pr-1711]: https://github.com/well-typed/hs-bindgen/pull/1711
 [pr-1712]: https://github.com/well-typed/hs-bindgen/pull/1712
 [pr-1724]: https://github.com/well-typed/hs-bindgen/pull/1724
-[issue-1806]: https://github.com/well-typed/hs-bindgen/issues/1806
 [pr-1839]: https://github.com/well-typed/hs-bindgen/pull/1839
 [pr-1849]: https://github.com/well-typed/hs-bindgen/pull/1849
 [pr-1869]: https://github.com/well-typed/hs-bindgen/pull/1869

```

</details
