### PR TITLE
Prevent unnecessary reparse error messages for macro invocations in nested declarations

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -161,8 +161,15 @@
   referenced by global variables. For example, `struct { int x; } var;` was
   previously supported but `struct { int x; } * var;` or `struct { int x; }
   var[];` would cause a panic. See [PR #2017][pr-2017].
+* Prevent confusing info-level messages for reparse errors involving
+  declarations that contain nested declarations. For example, for a nested
+  declaration such as `typedef struct { MyInt x; } * foo;` where `MyInt` is a
+  macro type, a message would be traced that the `foo` could not be reparsed,
+  even though the struct field `x` is still reparsed successfully. See [issue
+  #1382][is-1382] and [PR #2021][pr-2021].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
+[is-1382]: https://github.com/well-typed/hs-bindgen/issues/1382
 [is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685
 [is-1715]: https://github.com/well-typed/hs-bindgen/issues/1715
 [is-1790]: https://github.com/well-typed/hs-bindgen/issues/1790
@@ -176,6 +183,7 @@
 [pr-1955]: https://github.com/well-typed/hs-bindgen/pull/1955
 [pr-1983]: https://github.com/well-typed/hs-bindgen/pull/1983
 [pr-2017]: https://github.com/well-typed/hs-bindgen/pull/2017
+[pr-2021]: https://github.com/well-typed/hs-bindgen/pull/2021
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -487,6 +487,7 @@ test-suite test-hs-bindgen
     Test.HsBindgen.Golden.Infra.Check.PP
     Test.HsBindgen.Golden.Infra.Check.TH
     Test.HsBindgen.Golden.Infra.TestCase
+    Test.HsBindgen.Golden.Infra.TestCaseTree
     Test.HsBindgen.Golden.Macros
     Test.HsBindgen.Golden.Macros.Reparse
     Test.HsBindgen.Golden.ProgramAnalysis

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Error.hs
@@ -27,6 +27,50 @@ data Error =
     -- it's simply something we haven't considered yet, the former is a
     -- conscious decision about features we currently don't want to support.
   | UpdateUnsupported String
+
+    -- | We encountered something in the language-c AST that allows us to skip
+    -- the current reparse
+    --
+    -- The reparser constructs an hs-bindgen AST from a language-c AST,
+    -- inserting references to macro types. We can skip the current reparse if
+    -- we are in a known case where no references to macro types can be inserted
+    -- anymore, which would mean reparsing is just the identity funcion. Such is
+    -- the case when we try to reparse a type that references a struct or union.
+    -- In such cases skipping is useful because a reference to a *nested*
+    -- struct\/union would otherwise incur an 'UpdateUnsupported' or
+    -- 'UpdateUnexpected' error.
+    --
+    -- We reparse four types of declarations:
+    -- * global variable declarations
+    -- * typedef declarations
+    -- * function declarations
+    -- * struct/union field declarations
+    --
+    -- The types of nesting that can occur are:
+    -- * struct/union (field) nested in global variable
+    -- * struct/union (field) nested in typedef
+    -- * struct/union (field) nested in function
+    -- * struct/union (field) nested in struct/union field
+    --
+    -- An enclosing declaration can not contain both a reference to a (nested)
+    -- struct or (nested) union, and a reference to a macro type. Therefore, we
+    -- know that we can skip reparsing if we identify a reference to a struct or
+    -- union.
+    --
+    -- === Example
+    --
+    -- For example, if we are reparsing typedef @foo@:
+    --
+    -- > #define MyInt int
+    -- > #define MyConst const
+    -- > typedef MyConst struct S { MyInt x; } * foo;
+    --
+    -- Even though @MyConst@ is referenced from @foo@, it is not parsed as a
+    -- macro, so there is nothing to do for the reparser there. Then we can skip
+    -- reparsing @foo@ once we see that @foo@ references struct @S@, because we
+    -- will reparse the @x@ field of struct @S@ separately.
+    --
+  | UpdateSkipped String
   deriving stock (Show)
 
 instance PrettyForTrace Error where
@@ -42,3 +86,17 @@ instance PrettyForTrace Error where
             "Unsupported: "
           , PP.string err
           ]
+  prettyForTrace (UpdateSkipped msg) =
+        PP.hsep [
+            "Skipped: "
+          , PP.string msg
+          ]
+
+-- | Unsupported features are warnings
+instance IsTrace Level Error where
+  getDefaultLogLevel = \case
+      UpdateUnexpected{}  -> Info
+      UpdateUnsupported{} -> Info
+      UpdateSkipped{}     -> Debug
+  getSource  = const HsBindgen
+  getTraceId _ = "parse-macro"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Monad.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/Monad.hs
@@ -11,6 +11,7 @@ module HsBindgen.Frontend.LanguageC.Monad (
     -- * Throwing errors
   , unexpected
   , unsupported
+  , skipped
   , nodeOmitted
   , unexpectedF
     -- * Util
@@ -106,6 +107,9 @@ unexpected = throwError . UpdateUnexpected callStack
 
 unsupported :: String -> FromLanC x
 unsupported = throwError . UpdateUnsupported
+
+skipped :: String -> FromLanC x
+skipped = throwError . UpdateSkipped
 
 data NodeOmitted = NodeOmitted
   deriving (Show)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
@@ -224,11 +224,11 @@ instance Apply (LanC.CTypeSpecifier a) PartialType where
             Just name ->
               return $ CDeclName (mkCName name) (CNameKindTagged cTagKind)
             Nothing ->
-              unsupported $ "Anonymous " ++ show cTagKind
+              skipped $ "Anonymous " ++ show cTagKind
 
       checkNoDef :: String -> Maybe def -> FromLanC ()
       checkNoDef _   Nothing  = return ()
-      checkNoDef err (Just _) = unsupported err
+      checkNoDef err (Just _) = skipped err
 
 instance Apply (LanC.CTypeQualifier a) PartialType where
   apply qual = \case

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/LanguageC/PartialAST/FromLanC.hs
@@ -198,8 +198,8 @@ instance Apply (LanC.CTypeSpecifier a) PartialType where
         let tagKind = case su of
                         LanC.CStructTag -> CTagKindStruct
                         LanC.CUnionTag  -> CTagKindUnion
-        name <- checkNotAnon mTag tagKind
         checkNoDef "struct or union definition" mDef
+        name <- checkNotAnon mTag tagKind
         notFun (typeRef name) partial
       LanC.CEnumType (LanC.CEnum mTag mDef _attrs _a) _a' -> \partial -> do
         name <- checkNotAnon mTag CTagKindEnum

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -503,7 +503,7 @@ instance IsTrace Level DelayedParseMsg where
       ParseImplicitFieldFailed    x     -> getDefaultLogLevel x
       ParseMacroEmpty{}                 -> Info
       ParseMacroErrorParse{}            -> Info
-      ParseMacroErrorReparse{}          -> Info
+      ParseMacroErrorReparse x          -> getDefaultLogLevel x
       ParseMacroErrorReparseZip x       -> getDefaultLogLevel x
       ParseMacroReparseUnknownType{}    -> Info
       ParsePotentialDuplicateSymbol{}   -> Notice

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -291,17 +291,8 @@ processTypedef ::
   -> C.Typedef PrepareReparse
   -> M (C.Decl l ReparseMacroExpansions)
 processTypedef info typedef = do
-    -- If the @typedef@ refers to another type, we do not reparse the
-    -- typedef, but instead defer reparsing to that other type.
-    -- See https://github.com/well-typed/hs-bindgen/issues/707.
-    --
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1382>
-    -- We should allow for pointers.
-    let reparseInfo = case typedef.typ of
-          C.TypeRef _ -> ReparseNotNeeded
-          _otherwise  -> typedef.ann
     reparsedType :: CType <-
-      reparseWith info.id LanC.reparseTypedef reparseInfo
+      reparseWith info.id LanC.reparseTypedef typedef.ann
         (coercePass typedef.typ)
         pure
     pure C.Decl{

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
@@ -110,7 +110,7 @@ instance HasCField.HasCField T "unwrapT" where
     __exported by:__ @macros\/reparse\/defer_wrong.h@
 -}
 newtype Foo = Foo
-  { unwrapFoo :: S
+  { unwrapFoo :: T
   }
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype
@@ -120,13 +120,13 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
-instance (ty ~ S) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance (ty ~ T) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
 
 instance HasCField.HasCField Foo "unwrapFoo" where
 
-  type CFieldType Foo "unwrapFoo" = S
+  type CFieldType Foo "unwrapFoo" = T
 
   offset# = \_ -> \_ -> 0
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
@@ -1,0 +1,160 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.S(..)
+    , Example.T(..)
+    , Example.Foo(..)
+    , Example.Bar(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 11:8@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+data S = S
+  { s_x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/defer_wrong.h 11:16@
+
+         __exported by:__ @macros\/reparse\/defer_wrong.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize S where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw S where
+
+  readRaw =
+    \ptr0 ->
+          pure S
+      <*> HasCField.readRaw (RIP.Proxy @"s_x") ptr0
+
+instance Marshal.WriteRaw S where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          S s_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"s_x") ptr0 s_x2
+
+deriving via Marshal.EquivStorable S instance RIP.Storable S
+
+instance HasCField.HasCField S "s_x" where
+
+  type CFieldType S "s_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
+
+{-| __C declaration:__ @macro T@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 13:9@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype T = T
+  { unwrapT :: S
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+  deriving newtype
+    ( Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
+
+instance HasCField.HasCField T "unwrapT" where
+
+  type CFieldType T "unwrapT" = S
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @foo@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 15:11@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype Foo = Foo
+  { unwrapFoo :: S
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+  deriving newtype
+    ( Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ S) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
+
+instance HasCField.HasCField Foo "unwrapFoo" where
+
+  type CFieldType Foo "unwrapFoo" = S
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 16:13@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype Bar = Bar
+  { unwrapBar :: RIP.Ptr T
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr T
+         ) => RIP.HasField "unwrapBar" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapBar")
+
+instance HasCField.HasCField Bar "unwrapBar" where
+
+  type CFieldType Bar "unwrapBar" = RIP.Ptr T
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/bindingspec.yaml
@@ -1,0 +1,84 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/defer_wrong.h
+  cname: struct S
+  hsname: S
+- headers: macros/reparse/defer_wrong.h
+  cname: macro T
+  hsname: T
+- headers: macros/reparse/defer_wrong.h
+  cname: foo
+  hsname: Foo
+- headers: macros/reparse/defer_wrong.h
+  cname: bar
+  hsname: Bar
+hstypes:
+- hsname: Bar
+  representation:
+    newtype:
+      constructor: Bar
+      fields:
+      - unwrapBar
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo
+  representation:
+    newtype:
+      constructor: Foo
+      fields:
+      - unwrapFoo
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: S
+  representation:
+    record:
+      constructor: S
+      fields:
+      - s_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T
+  representation:
+    newtype:
+      constructor: T
+      fields:
+      - unwrapT
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
@@ -50,13 +50,13 @@ instance HasCField T "unwrapT"
     __exported by:__ @macros\/reparse\/defer_wrong.h@
 -}
 newtype Foo
-    = Foo {unwrapFoo :: S}
+    = Foo {unwrapFoo :: T}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty S => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+instance (~) ty T => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
-    where type CFieldType Foo "unwrapFoo" = S
+    where type CFieldType Foo "unwrapFoo" = T
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @bar@
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
@@ -1,0 +1,79 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/defer_wrong.h
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 11:8@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+data S
+    = S {s_x :: CInt
+         {- ^ __C declaration:__ @x@
+
+              __defined at:__ @macros\/reparse\/defer_wrong.h 11:16@
+
+              __exported by:__ @macros\/reparse\/defer_wrong.h@
+         -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize S
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw S
+    where readRaw = \ptr_0 -> pure S <*> readRaw (Proxy @"s_x") ptr_0
+instance WriteRaw S
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       S s_x_2 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2
+deriving via (EquivStorable S) instance Storable S
+instance HasCField S "s_x"
+    where type CFieldType S "s_x" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_x")
+{-| __C declaration:__ @macro T@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 13:9@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype T
+    = T {unwrapT :: S}
+    deriving stock (Eq, Generic, Show)
+    deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT")
+instance HasCField T "unwrapT"
+    where type CFieldType T "unwrapT" = S
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @foo@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 15:11@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype Foo
+    = Foo {unwrapFoo :: S}
+    deriving stock (Eq, Generic, Show)
+    deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty S => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapFoo")
+instance HasCField Foo "unwrapFoo"
+    where type CFieldType Foo "unwrapFoo" = S
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @macros\/reparse\/defer_wrong.h 16:13@
+
+    __exported by:__ @macros\/reparse\/defer_wrong.h@
+-}
+newtype Bar
+    = Bar {unwrapBar :: (Ptr T)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr T) => HasField "unwrapBar" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapBar")
+instance HasCField Bar "unwrapBar"
+    where type CFieldType Bar "unwrapBar" = Ptr T
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T2(..)
+    , Example.T3(..)
+    , Example.T4(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct TS1@
+
+    __defined at:__ @macros\/reparse\/nesting.h 5:16@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T2 = T2
+  { t2_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting.h 5:28@
+
+         __exported by:__ @macros\/reparse\/nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T2 where
+
+  readRaw =
+    \ptr0 ->
+          pure T2
+      <*> HasCField.readRaw (RIP.Proxy @"t2_x") ptr0
+
+instance Marshal.WriteRaw T2 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2 t2_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_x") ptr0 t2_x2
+
+deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+{-| __C declaration:__ @struct TS3@
+
+    __defined at:__ @macros\/reparse\/nesting.h 6:16@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T3 = T3
+  { t3_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting.h 6:28@
+
+         __exported by:__ @macros\/reparse\/nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T3 where
+
+  readRaw =
+    \ptr0 ->
+          pure T3
+      <*> HasCField.readRaw (RIP.Proxy @"t3_x") ptr0
+
+instance Marshal.WriteRaw T3 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3 t3_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_x") ptr0 t3_x2
+
+deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+{-| __C declaration:__ @struct T4@
+
+    __defined at:__ @macros\/reparse\/nesting.h 7:9@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T4 = T4
+  { t4_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting.h 7:28@
+
+         __exported by:__ @macros\/reparse\/nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T4 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T4 where
+
+  readRaw =
+    \ptr0 ->
+          pure T4
+      <*> HasCField.readRaw (RIP.Proxy @"t4_x") ptr0
+
+instance Marshal.WriteRaw T4 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T4 t4_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t4_x") ptr0 t4_x2
+
+deriving via Marshal.EquivStorable T4 instance RIP.Storable T4
+
+instance HasCField.HasCField T4 "t4_x" where
+
+  type CFieldType T4 "t4_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t4_x" (RIP.Ptr T4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t4_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/bindingspec.yaml
@@ -1,0 +1,104 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting.h
+  cname: struct TS1
+  hsname: T2
+- headers: macros/reparse/nesting.h
+  cname: T2
+  hsname: T2
+- headers: macros/reparse/nesting.h
+  cname: struct TS3
+  hsname: T3
+- headers: macros/reparse/nesting.h
+  cname: T3
+  hsname: T3
+- headers: macros/reparse/nesting.h
+  cname: struct T4
+  hsname: T4
+- headers: macros/reparse/nesting.h
+  cname: T4
+  hsname: T4
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    record:
+      constructor: T2
+      fields:
+      - t2_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    record:
+      constructor: T3
+      fields:
+      - t3_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T4
+  representation:
+    record:
+      constructor: T4
+      fields:
+      - t4_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1_x(..)
+    , Example.T1(..)
+    , Example.T2(..)
+    , Example.T2_x(..)
+    , Example.T3(..)
+    , Example.T3_x(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T1_x = T1_x
+  { t1_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:25@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T1_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T1_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T1_x
+      <*> HasCField.readRaw (RIP.Proxy @"t1_x_x") ptr0
+
+instance Marshal.WriteRaw T1_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T1_x t1_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t1_x_x") ptr0 t1_x_x2
+
+deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+{-| __C declaration:__ @struct \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T1 = T1
+  { t1_x :: T1_x
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:33@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T1 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T1 where
+
+  readRaw =
+    \ptr0 ->
+          pure T1
+      <*> HasCField.readRaw (RIP.Proxy @"t1_x") ptr0
+
+instance Marshal.WriteRaw T1 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T1 t1_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t1_x") ptr0 t1_x2
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @struct \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T2 = T2
+  { t2_x :: RIP.Ptr T2_x
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:33@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2 where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw T2 where
+
+  readRaw =
+    \ptr0 ->
+          pure T2
+      <*> HasCField.readRaw (RIP.Proxy @"t2_x") ptr0
+
+instance Marshal.WriteRaw T2 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2 t2_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_x") ptr0 t2_x2
+
+deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+{-| __C declaration:__ @struct \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T2_x = T2_x
+  { t2_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:25@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T2_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T2_x
+      <*> HasCField.readRaw (RIP.Proxy @"t2_x_x") ptr0
+
+instance Marshal.WriteRaw T2_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2_x t2_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_x_x") ptr0 t2_x_x2
+
+deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+{-| __C declaration:__ @struct \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T3 = T3
+  { t3_x :: RIP.Ptr (RIP.Ptr T3_x)
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:33@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3 where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw T3 where
+
+  readRaw =
+    \ptr0 ->
+          pure T3
+      <*> HasCField.readRaw (RIP.Proxy @"t3_x") ptr0
+
+instance Marshal.WriteRaw T3 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3 t3_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_x") ptr0 t3_x2
+
+deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+{-| __C declaration:__ @struct \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T3_x = T3_x
+  { t3_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:25@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T3_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T3_x
+      <*> HasCField.readRaw (RIP.Proxy @"t3_x_x") ptr0
+
+instance Marshal.WriteRaw T3_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3_x t3_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_x_x") ptr0 t3_x_x2
+
+deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.t1
+    , Example.Global.t2
+    , Example.Global.t3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/struct_in_struct.h>"
+  , "/* test_macrosreparsenestingstruct__Example_get_T1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_2ac02abef90be65b (void)"
+  , "{"
+  , "  return &T1;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_T2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_ce4ed8cb010301fc (void)"
+  , "{"
+  , "  return &T2;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_T3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_9d78eb12f80bd5a1 (void)"
+  , "{"
+  , "  return &T3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b :: IO (RIP.Ptr T1)
+hs_bindgen_2ac02abef90be65b =
+  RIP.fromFFIType hs_bindgen_2ac02abef90be65b_base
+
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t1 :: RIP.Ptr T1
+t1 = RIP.unsafePerformIO hs_bindgen_2ac02abef90be65b
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_ce4ed8cb010301fc" hs_bindgen_ce4ed8cb010301fc_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc :: IO (RIP.Ptr T2)
+hs_bindgen_ce4ed8cb010301fc =
+  RIP.fromFFIType hs_bindgen_ce4ed8cb010301fc_base
+
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t2 :: RIP.Ptr T2
+t2 = RIP.unsafePerformIO hs_bindgen_ce4ed8cb010301fc
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_9d78eb12f80bd5a1" hs_bindgen_9d78eb12f80bd5a1_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 :: IO (RIP.Ptr T3)
+hs_bindgen_9d78eb12f80bd5a1 =
+  RIP.fromFFIType hs_bindgen_9d78eb12f80bd5a1_base
+
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t3 :: RIP.Ptr T3
+t3 = RIP.unsafePerformIO hs_bindgen_9d78eb12f80bd5a1

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/bindingspec.yaml
@@ -1,0 +1,152 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T1
+  hsname: T1
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T1_x
+  hsname: T1_x
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T2
+  hsname: T2
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T2_x
+  hsname: T2_x
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T3
+  hsname: T3
+- headers: macros/reparse/nesting/struct_in_struct.h
+  cname: struct @T3_x
+  hsname: T3_x
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    record:
+      constructor: T1
+      fields:
+      - t1_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1_x
+  representation:
+    record:
+      constructor: T1_x
+      fields:
+      - t1_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    record:
+      constructor: T2
+      fields:
+      - t2_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_x
+  representation:
+    record:
+      constructor: T2_x
+      fields:
+      - t2_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    record:
+      constructor: T3
+      fields:
+      - t3_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_x
+  representation:
+    record:
+      constructor: T3_x
+      fields:
+      - t3_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
@@ -1,0 +1,290 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/struct_in_struct.h
+-- #include <macros/reparse/nesting/struct_in_struct.h>
+-- /* test_macrosreparsenestingstruct__Example_get_T1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_2ac02abef90be65b (void)
+-- {
+--   return &T1;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_T2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_ce4ed8cb010301fc (void)
+-- {
+--   return &T2;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_T3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_9d78eb12f80bd5a1 (void)
+-- {
+--   return &T3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T1_x
+    = T1_x {t1_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:25@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T1_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T1_x
+    where readRaw = \ptr_0 -> pure T1_x <*> readRaw (Proxy @"t1_x_x") ptr_0
+instance WriteRaw T1_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T1_x t1_x_x_2 -> writeRaw (Proxy @"t1_x_x") ptr_0 t1_x_x_2
+deriving via (EquivStorable T1_x) instance Storable T1_x
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+{-| __C declaration:__ @struct \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T1
+    = T1 {t1_x :: T1_x
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:33@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T1
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T1
+    where readRaw = \ptr_0 -> pure T1 <*> readRaw (Proxy @"t1_x") ptr_0
+instance WriteRaw T1
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
+deriving via (EquivStorable T1) instance Storable T1
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @struct \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T2
+    = T2 {t2_x :: (Ptr T2_x)
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:33@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw T2
+    where readRaw = \ptr_0 -> pure T2 <*> readRaw (Proxy @"t2_x") ptr_0
+instance WriteRaw T2
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
+deriving via (EquivStorable T2) instance Storable T2
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+{-| __C declaration:__ @struct \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T2_x
+    = T2_x {t2_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:25@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T2_x
+    where readRaw = \ptr_0 -> pure T2_x <*> readRaw (Proxy @"t2_x_x") ptr_0
+instance WriteRaw T2_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2_x t2_x_x_2 -> writeRaw (Proxy @"t2_x_x") ptr_0 t2_x_x_2
+deriving via (EquivStorable T2_x) instance Storable T2_x
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+{-| __C declaration:__ @struct \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T3
+    = T3 {t3_x :: (Ptr (Ptr T3_x))
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:33@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw T3
+    where readRaw = \ptr_0 -> pure T3 <*> readRaw (Proxy @"t3_x") ptr_0
+instance WriteRaw T3
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
+deriving via (EquivStorable T3) instance Storable T3
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+{-| __C declaration:__ @struct \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+data T3_x
+    = T3_x {t3_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:25@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T3_x
+    where readRaw = \ptr_0 -> pure T3_x <*> readRaw (Proxy @"t3_x_x") ptr_0
+instance WriteRaw T3_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3_x t3_x_x_2 -> writeRaw (Proxy @"t3_x_x") ptr_0 t3_x_x_2
+deriving via (EquivStorable T3_x) instance Storable T3_x
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b :: IO (Ptr T1)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b = fromFFIType hs_bindgen_2ac02abef90be65b_base
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t1 :: Ptr T1
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t1 = unsafePerformIO hs_bindgen_2ac02abef90be65b
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_ce4ed8cb010301fc" hs_bindgen_ce4ed8cb010301fc_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc :: IO (Ptr T2)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc = fromFFIType hs_bindgen_ce4ed8cb010301fc_base
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t2 :: Ptr T2
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t2 = unsafePerformIO hs_bindgen_ce4ed8cb010301fc
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_9d78eb12f80bd5a1" hs_bindgen_9d78eb12f80bd5a1_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 :: IO (Ptr T3)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 = fromFFIType hs_bindgen_9d78eb12f80bd5a1_base
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t3 :: Ptr T3
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:38@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_struct.h@
+-}
+t3 = unsafePerformIO hs_bindgen_9d78eb12f80bd5a1

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
@@ -1,0 +1,283 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1(..)
+    , Example.T2_Aux(..)
+    , Example.T2(..)
+    , Example.T3_Aux(..)
+    , Example.T3(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T1 = T1
+  { t1_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 3:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T1 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T1 where
+
+  readRaw =
+    \ptr0 ->
+          pure T1
+      <*> HasCField.readRaw (RIP.Proxy @"t1_x") ptr0
+
+instance Marshal.WriteRaw T1 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T1 t1_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t1_x") ptr0 t1_x2
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @struct \@T2_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T2_Aux = T2_Aux
+  { t2_Aux_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2_Aux where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T2_Aux where
+
+  readRaw =
+    \ptr0 ->
+          pure T2_Aux
+      <*> HasCField.readRaw (RIP.Proxy @"t2_Aux_x") ptr0
+
+instance Marshal.WriteRaw T2_Aux where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2_Aux t2_Aux_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_Aux_x") ptr0 t2_Aux_x2
+
+deriving via Marshal.EquivStorable T2_Aux instance RIP.Storable T2_Aux
+
+instance HasCField.HasCField T2_Aux "t2_Aux_x" where
+
+  type CFieldType T2_Aux "t2_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
+
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype T2 = T2
+  { unwrapT2 :: RIP.Ptr T2_Aux
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr T2_Aux
+         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
+
+instance HasCField.HasCField T2 "unwrapT2" where
+
+  type CFieldType T2 "unwrapT2" = RIP.Ptr T2_Aux
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@T3_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T3_Aux = T3_Aux
+  { t3_Aux_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3_Aux where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T3_Aux where
+
+  readRaw =
+    \ptr0 ->
+          pure T3_Aux
+      <*> HasCField.readRaw (RIP.Proxy @"t3_Aux_x") ptr0
+
+instance Marshal.WriteRaw T3_Aux where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3_Aux t3_Aux_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_Aux_x") ptr0 t3_Aux_x2
+
+deriving via Marshal.EquivStorable T3_Aux instance RIP.Storable T3_Aux
+
+instance HasCField.HasCField T3_Aux "t3_Aux_x" where
+
+  type CFieldType T3_Aux "t3_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
+
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype T3 = T3
+  { unwrapT3 :: RIP.Ptr (RIP.Ptr T3_Aux)
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
+         ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
+
+instance HasCField.HasCField T3 "unwrapT3" where
+
+  type CFieldType T3 "unwrapT3" =
+    RIP.Ptr (RIP.Ptr T3_Aux)
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/bindingspec.yaml
@@ -1,0 +1,140 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: struct T1
+  hsname: T1
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: T1
+  hsname: T1
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: struct @T2_Aux
+  hsname: T2_Aux
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: T2
+  hsname: T2
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: struct @T3_Aux
+  hsname: T3_Aux
+- headers: macros/reparse/nesting/struct_in_typedef.h
+  cname: T3
+  hsname: T3
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    record:
+      constructor: T1
+      fields:
+      - t1_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    newtype:
+      constructor: T2
+      fields:
+      - unwrapT2
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_Aux
+  representation:
+    record:
+      constructor: T2_Aux
+      fields:
+      - t2_Aux_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    newtype:
+      constructor: T3
+      fields:
+      - unwrapT3
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_Aux
+  representation:
+    record:
+      constructor: T3_Aux
+      fields:
+      - t3_Aux_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
@@ -1,0 +1,157 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/struct_in_typedef.h
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T1
+    = T1 {t1_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 3:24@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T1
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T1
+    where readRaw = \ptr_0 -> pure T1 <*> readRaw (Proxy @"t1_x") ptr_0
+instance WriteRaw T1
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
+deriving via (EquivStorable T1) instance Storable T1
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @struct \@T2_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T2_Aux
+    = T2_Aux {t2_Aux_x :: MyInt
+              {- ^ __C declaration:__ @x@
+
+                   __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:24@
+
+                   __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2_Aux
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T2_Aux
+    where readRaw = \ptr_0 -> pure T2_Aux <*> readRaw (Proxy @"t2_Aux_x") ptr_0
+instance WriteRaw T2_Aux
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2_Aux t2_Aux_x_2 -> writeRaw (Proxy @"t2_Aux_x") ptr_0 t2_Aux_x_2
+deriving via (EquivStorable T2_Aux) instance Storable T2_Aux
+instance HasCField T2_Aux "t2_Aux_x"
+    where type CFieldType T2_Aux "t2_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_Aux_x")
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype T2
+    = T2 {unwrapT2 :: (Ptr T2_Aux)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr T2_Aux) =>
+         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT2")
+instance HasCField T2 "unwrapT2"
+    where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@T3_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+data T3_Aux
+    = T3_Aux {t3_Aux_x :: MyInt
+              {- ^ __C declaration:__ @x@
+
+                   __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:24@
+
+                   __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3_Aux
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T3_Aux
+    where readRaw = \ptr_0 -> pure T3_Aux <*> readRaw (Proxy @"t3_Aux_x") ptr_0
+instance WriteRaw T3_Aux
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3_Aux t3_Aux_x_2 -> writeRaw (Proxy @"t3_Aux_x") ptr_0 t3_Aux_x_2
+deriving via (EquivStorable T3_Aux) instance Storable T3_Aux
+instance HasCField T3_Aux "t3_Aux_x"
+    where type CFieldType T3_Aux "t3_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_Aux_x")
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_typedef.h@
+-}
+newtype T3
+    = T3 {unwrapT3 :: (Ptr (Ptr T3_Aux))}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr (Ptr T3_Aux)) =>
+         HasField "unwrapT3" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT3")
+instance HasCField T3 "unwrapT3"
+    where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
@@ -1,0 +1,393 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1_x(..)
+    , Example.T1(..)
+    , Example.get_t1_x
+    , Example.set_t1_x
+    , Example.T2(..)
+    , Example.get_t2_x
+    , Example.set_t2_x
+    , Example.T2_x(..)
+    , Example.T3(..)
+    , Example.get_t3_x
+    , Example.set_t3_x
+    , Example.T3_x(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T1_x = T1_x
+  { t1_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T1_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T1_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T1_x
+      <*> HasCField.readRaw (RIP.Proxy @"t1_x_x") ptr0
+
+instance Marshal.WriteRaw T1_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T1_x t1_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t1_x_x") ptr0 t1_x_x2
+
+deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+{-| __C declaration:__ @union \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T1 = T1
+  { unwrapT1 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T1
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t1_x ::
+     T1
+  -> T1_x
+get_t1_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x ::
+     T1_x
+  -> T1
+set_t1_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @union \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T2 = T2
+  { unwrapT2 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.StaticSize T2
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.ReadRaw T2
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.WriteRaw T2
+
+deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
+
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t2_x ::
+     T2
+  -> RIP.Ptr T2_x
+get_t2_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x ::
+     RIP.Ptr T2_x
+  -> T2
+set_t2_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+{-| __C declaration:__ @struct \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T2_x = T2_x
+  { t2_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T2_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T2_x
+      <*> HasCField.readRaw (RIP.Proxy @"t2_x_x") ptr0
+
+instance Marshal.WriteRaw T2_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2_x t2_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_x_x") ptr0 t2_x_x2
+
+deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+{-| __C declaration:__ @union \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T3 = T3
+  { unwrapT3 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.StaticSize T3
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.ReadRaw T3
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.WriteRaw T3
+
+deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
+
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t3_x ::
+     T3
+  -> RIP.Ptr (RIP.Ptr T3_x)
+get_t3_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x ::
+     RIP.Ptr (RIP.Ptr T3_x)
+  -> T3
+set_t3_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+{-| __C declaration:__ @struct \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T3_x = T3_x
+  { t3_x_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:24@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3_x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T3_x where
+
+  readRaw =
+    \ptr0 ->
+          pure T3_x
+      <*> HasCField.readRaw (RIP.Proxy @"t3_x_x") ptr0
+
+instance Marshal.WriteRaw T3_x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3_x t3_x_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_x_x") ptr0 t3_x_x2
+
+deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.t1
+    , Example.Global.t2
+    , Example.Global.t3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/struct_in_union.h>"
+  , "/* test_macrosreparsenestingstruct__Example_get_T1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_2ac02abef90be65b (void)"
+  , "{"
+  , "  return &T1;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_T2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_ce4ed8cb010301fc (void)"
+  , "{"
+  , "  return &T2;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_T3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_9d78eb12f80bd5a1 (void)"
+  , "{"
+  , "  return &T3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b :: IO (RIP.Ptr T1)
+hs_bindgen_2ac02abef90be65b =
+  RIP.fromFFIType hs_bindgen_2ac02abef90be65b_base
+
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t1 :: RIP.Ptr T1
+t1 = RIP.unsafePerformIO hs_bindgen_2ac02abef90be65b
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_ce4ed8cb010301fc" hs_bindgen_ce4ed8cb010301fc_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc :: IO (RIP.Ptr T2)
+hs_bindgen_ce4ed8cb010301fc =
+  RIP.fromFFIType hs_bindgen_ce4ed8cb010301fc_base
+
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t2 :: RIP.Ptr T2
+t2 = RIP.unsafePerformIO hs_bindgen_ce4ed8cb010301fc
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_9d78eb12f80bd5a1" hs_bindgen_9d78eb12f80bd5a1_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 :: IO (RIP.Ptr T3)
+hs_bindgen_9d78eb12f80bd5a1 =
+  RIP.fromFFIType hs_bindgen_9d78eb12f80bd5a1_base
+
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t3 :: RIP.Ptr T3
+t3 = RIP.unsafePerformIO hs_bindgen_9d78eb12f80bd5a1

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/bindingspec.yaml
@@ -1,0 +1,146 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: union @T1
+  hsname: T1
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: struct @T1_x
+  hsname: T1_x
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: union @T2
+  hsname: T2
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: struct @T2_x
+  hsname: T2_x
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: union @T3
+  hsname: T3
+- headers: macros/reparse/nesting/struct_in_union.h
+  cname: struct @T3_x
+  hsname: T3_x
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    newtype:
+      constructor: T1
+      fields:
+      - unwrapT1
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1_x
+  representation:
+    record:
+      constructor: T1_x
+      fields:
+      - t1_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    newtype:
+      constructor: T2
+      fields:
+      - unwrapT2
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_x
+  representation:
+    record:
+      constructor: T2_x
+      fields:
+      - t2_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    newtype:
+      constructor: T3
+      fields:
+      - unwrapT3
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_x
+  representation:
+    record:
+      constructor: T3_x
+      fields:
+      - t3_x_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
@@ -1,0 +1,353 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/struct_in_union.h
+-- #include <macros/reparse/nesting/struct_in_union.h>
+-- /* test_macrosreparsenestingstruct__Example_get_T1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_2ac02abef90be65b (void)
+-- {
+--   return &T1;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_T2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_ce4ed8cb010301fc (void)
+-- {
+--   return &T2;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_T3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_9d78eb12f80bd5a1 (void)
+-- {
+--   return &T3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T1_x
+    = T1_x {t1_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:24@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T1_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T1_x
+    where readRaw = \ptr_0 -> pure T1_x <*> readRaw (Proxy @"t1_x_x") ptr_0
+instance WriteRaw T1_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T1_x t1_x_x_2 -> writeRaw (Proxy @"t1_x_x") ptr_0 t1_x_x_2
+deriving via (EquivStorable T1_x) instance Storable T1_x
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+{-| __C declaration:__ @union \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T1 = T1 {unwrapT1 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T1
+deriving via (SizedByteArray 4 4) instance ReadRaw T1
+deriving via (SizedByteArray 4 4) instance WriteRaw T1
+deriving via (EquivStorable T1) instance Storable T1
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t1_x :: T1 -> T1_x
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t1_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x :: T1_x -> T1
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x = setUnionPayload
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @union \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T2 = T2 {unwrapT2 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize T2
+deriving via (SizedByteArray 8 8) instance ReadRaw T2
+deriving via (SizedByteArray 8 8) instance WriteRaw T2
+deriving via (EquivStorable T2) instance Storable T2
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t2_x :: T2 -> Ptr T2_x
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t2_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x :: Ptr T2_x -> T2
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x = setUnionPayload
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+{-| __C declaration:__ @struct \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T2_x
+    = T2_x {t2_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:24@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T2_x
+    where readRaw = \ptr_0 -> pure T2_x <*> readRaw (Proxy @"t2_x_x") ptr_0
+instance WriteRaw T2_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2_x t2_x_x_2 -> writeRaw (Proxy @"t2_x_x") ptr_0 t2_x_x_2
+deriving via (EquivStorable T2_x) instance Storable T2_x
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+{-| __C declaration:__ @union \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+newtype T3 = T3 {unwrapT3 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize T3
+deriving via (SizedByteArray 8 8) instance ReadRaw T3
+deriving via (SizedByteArray 8 8) instance WriteRaw T3
+deriving via (EquivStorable T3) instance Storable T3
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t3_x :: T3 -> Ptr (Ptr T3_x)
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:32@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+get_t3_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x :: Ptr (Ptr T3_x) -> T3
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x = setUnionPayload
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+{-| __C declaration:__ @struct \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+data T3_x
+    = T3_x {t3_x_x :: MyInt
+            {- ^ __C declaration:__ @x@
+
+                 __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:24@
+
+                 __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+            -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3_x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T3_x
+    where readRaw = \ptr_0 -> pure T3_x <*> readRaw (Proxy @"t3_x_x") ptr_0
+instance WriteRaw T3_x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3_x t3_x_x_2 -> writeRaw (Proxy @"t3_x_x") ptr_0 t3_x_x_2
+deriving via (EquivStorable T3_x) instance Storable T3_x
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b :: IO (Ptr T1)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
+hs_bindgen_2ac02abef90be65b = fromFFIType hs_bindgen_2ac02abef90be65b_base
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t1 :: Ptr T1
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t1 = unsafePerformIO hs_bindgen_2ac02abef90be65b
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_ce4ed8cb010301fc" hs_bindgen_ce4ed8cb010301fc_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc :: IO (Ptr T2)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T2@
+hs_bindgen_ce4ed8cb010301fc = fromFFIType hs_bindgen_ce4ed8cb010301fc_base
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t2 :: Ptr T2
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t2 = unsafePerformIO hs_bindgen_ce4ed8cb010301fc
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_9d78eb12f80bd5a1" hs_bindgen_9d78eb12f80bd5a1_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 :: IO (Ptr T3)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_T3@
+hs_bindgen_9d78eb12f80bd5a1 = fromFFIType hs_bindgen_9d78eb12f80bd5a1_base
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t3 :: Ptr T3
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_union.h@
+-}
+t3 = unsafePerformIO hs_bindgen_9d78eb12f80bd5a1

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
@@ -1,0 +1,220 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.G1(..)
+    , Example.G2(..)
+    , Example.G3(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G1 = G1
+  { g1_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:16@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize G1 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw G1 where
+
+  readRaw =
+    \ptr0 ->
+          pure G1
+      <*> HasCField.readRaw (RIP.Proxy @"g1_x") ptr0
+
+instance Marshal.WriteRaw G1 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          G1 g1_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"g1_x") ptr0 g1_x2
+
+deriving via Marshal.EquivStorable G1 instance RIP.Storable G1
+
+instance HasCField.HasCField G1 "g1_x" where
+
+  type CFieldType G1 "g1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
+
+{-| __C declaration:__ @struct \@G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G2 = G2
+  { g2_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:16@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize G2 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw G2 where
+
+  readRaw =
+    \ptr0 ->
+          pure G2
+      <*> HasCField.readRaw (RIP.Proxy @"g2_x") ptr0
+
+instance Marshal.WriteRaw G2 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          G2 g2_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"g2_x") ptr0 g2_x2
+
+deriving via Marshal.EquivStorable G2 instance RIP.Storable G2
+
+instance HasCField.HasCField G2 "g2_x" where
+
+  type CFieldType G2 "g2_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
+
+{-| __C declaration:__ @struct \@G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G3 = G3
+  { g3_x :: MyInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:16@
+
+         __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize G3 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw G3 where
+
+  readRaw =
+    \ptr0 ->
+          pure G3
+      <*> HasCField.readRaw (RIP.Proxy @"g3_x") ptr0
+
+instance Marshal.WriteRaw G3 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          G3 g3_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"g3_x") ptr0 g3_x2
+
+deriving via Marshal.EquivStorable G3 instance RIP.Storable G3
+
+instance HasCField.HasCField G3 "g3_x" where
+
+  type CFieldType G3 "g3_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.g1
+    , Example.Global.g2
+    , Example.Global.g3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/struct_in_variable.h>"
+  , "/* test_macrosreparsenestingstruct__Example_get_G1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_7b488cf23d974403 (void)"
+  , "{"
+  , "  return &G1;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_G2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_be835215a4ac0819 (void)"
+  , "{"
+  , "  return &G2;"
+  , "}"
+  , "/* test_macrosreparsenestingstruct__Example_get_G3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_dad785bf89d140bb (void)"
+  , "{"
+  , "  return &G3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
+foreign import ccall unsafe "hs_bindgen_7b488cf23d974403" hs_bindgen_7b488cf23d974403_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
+hs_bindgen_7b488cf23d974403 :: IO (RIP.Ptr G1)
+hs_bindgen_7b488cf23d974403 =
+  RIP.fromFFIType hs_bindgen_7b488cf23d974403_base
+
+{-# NOINLINE g1 #-}
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g1 :: RIP.Ptr G1
+g1 = RIP.unsafePerformIO hs_bindgen_7b488cf23d974403
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G2@
+foreign import ccall unsafe "hs_bindgen_be835215a4ac0819" hs_bindgen_be835215a4ac0819_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G2@
+hs_bindgen_be835215a4ac0819 :: IO (RIP.Ptr (RIP.Ptr G2))
+hs_bindgen_be835215a4ac0819 =
+  RIP.fromFFIType hs_bindgen_be835215a4ac0819_base
+
+{-# NOINLINE g2 #-}
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g2 :: RIP.Ptr (RIP.Ptr G2)
+g2 = RIP.unsafePerformIO hs_bindgen_be835215a4ac0819
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G3@
+foreign import ccall unsafe "hs_bindgen_dad785bf89d140bb" hs_bindgen_dad785bf89d140bb_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G3@
+hs_bindgen_dad785bf89d140bb :: IO (RIP.Ptr (RIP.Ptr (RIP.Ptr G3)))
+hs_bindgen_dad785bf89d140bb =
+  RIP.fromFFIType hs_bindgen_dad785bf89d140bb_base
+
+{-# NOINLINE g3 #-}
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g3 :: RIP.Ptr (RIP.Ptr (RIP.Ptr G3))
+g3 = RIP.unsafePerformIO hs_bindgen_dad785bf89d140bb

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/bindingspec.yaml
@@ -1,0 +1,95 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/struct_in_variable.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/struct_in_variable.h
+  cname: struct @G1
+  hsname: G1
+- headers: macros/reparse/nesting/struct_in_variable.h
+  cname: struct @G2
+  hsname: G2
+- headers: macros/reparse/nesting/struct_in_variable.h
+  cname: struct @G3
+  hsname: G3
+hstypes:
+- hsname: G1
+  representation:
+    record:
+      constructor: G1
+      fields:
+      - g1_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: G2
+  representation:
+    record:
+      constructor: G2
+      fields:
+      - g2_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: G3
+  representation:
+    record:
+      constructor: G3
+      fields:
+      - g3_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
@@ -1,0 +1,202 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/struct_in_variable.h
+-- #include <macros/reparse/nesting/struct_in_variable.h>
+-- /* test_macrosreparsenestingstruct__Example_get_G1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_7b488cf23d974403 (void)
+-- {
+--   return &G1;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_G2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_be835215a4ac0819 (void)
+-- {
+--   return &G2;
+-- }
+-- /* test_macrosreparsenestingstruct__Example_get_G3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_dad785bf89d140bb (void)
+-- {
+--   return &G3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G1
+    = G1 {g1_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:16@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize G1
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw G1
+    where readRaw = \ptr_0 -> pure G1 <*> readRaw (Proxy @"g1_x") ptr_0
+instance WriteRaw G1
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       G1 g1_x_2 -> writeRaw (Proxy @"g1_x") ptr_0 g1_x_2
+deriving via (EquivStorable G1) instance Storable G1
+instance HasCField G1 "g1_x"
+    where type CFieldType G1 "g1_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+    where getField = fromPtr (Proxy @"g1_x")
+{-| __C declaration:__ @struct \@G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G2
+    = G2 {g2_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:16@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize G2
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw G2
+    where readRaw = \ptr_0 -> pure G2 <*> readRaw (Proxy @"g2_x") ptr_0
+instance WriteRaw G2
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       G2 g2_x_2 -> writeRaw (Proxy @"g2_x") ptr_0 g2_x_2
+deriving via (EquivStorable G2) instance Storable G2
+instance HasCField G2 "g2_x"
+    where type CFieldType G2 "g2_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+    where getField = fromPtr (Proxy @"g2_x")
+{-| __C declaration:__ @struct \@G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+data G3
+    = G3 {g3_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:16@
+
+               __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize G3
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw G3
+    where readRaw = \ptr_0 -> pure G3 <*> readRaw (Proxy @"g3_x") ptr_0
+instance WriteRaw G3
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       G3 g3_x_2 -> writeRaw (Proxy @"g3_x") ptr_0 g3_x_2
+deriving via (EquivStorable G3) instance Storable G3
+instance HasCField G3 "g3_x"
+    where type CFieldType G3 "g3_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+    where getField = fromPtr (Proxy @"g3_x")
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
+foreign import ccall unsafe "hs_bindgen_7b488cf23d974403" hs_bindgen_7b488cf23d974403_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
+hs_bindgen_7b488cf23d974403 :: IO (Ptr G1)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
+hs_bindgen_7b488cf23d974403 = fromFFIType hs_bindgen_7b488cf23d974403_base
+{-# NOINLINE g1 #-}
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g1 :: Ptr G1
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g1 = unsafePerformIO hs_bindgen_7b488cf23d974403
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G2@
+foreign import ccall unsafe "hs_bindgen_be835215a4ac0819" hs_bindgen_be835215a4ac0819_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G2@
+hs_bindgen_be835215a4ac0819 :: IO (Ptr (Ptr G2))
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G2@
+hs_bindgen_be835215a4ac0819 = fromFFIType hs_bindgen_be835215a4ac0819_base
+{-# NOINLINE g2 #-}
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g2 :: Ptr (Ptr G2)
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g2 = unsafePerformIO hs_bindgen_be835215a4ac0819
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G3@
+foreign import ccall unsafe "hs_bindgen_dad785bf89d140bb" hs_bindgen_dad785bf89d140bb_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G3@
+hs_bindgen_dad785bf89d140bb :: IO (Ptr (Ptr (Ptr G3)))
+-- __unique:__ @test_macrosreparsenestingstruct__Example_get_G3@
+hs_bindgen_dad785bf89d140bb = fromFFIType hs_bindgen_dad785bf89d140bb_base
+{-# NOINLINE g3 #-}
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g3 :: Ptr (Ptr (Ptr G3))
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/struct_in_variable.h@
+-}
+g3 = unsafePerformIO hs_bindgen_dad785bf89d140bb

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
@@ -1,0 +1,117 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting.h
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct TS1@
+
+    __defined at:__ @macros\/reparse\/nesting.h 5:16@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T2
+    = T2 {t2_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting.h 5:28@
+
+               __exported by:__ @macros\/reparse\/nesting.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T2
+    where readRaw = \ptr_0 -> pure T2 <*> readRaw (Proxy @"t2_x") ptr_0
+instance WriteRaw T2
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
+deriving via (EquivStorable T2) instance Storable T2
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+{-| __C declaration:__ @struct TS3@
+
+    __defined at:__ @macros\/reparse\/nesting.h 6:16@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T3
+    = T3 {t3_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting.h 6:28@
+
+               __exported by:__ @macros\/reparse\/nesting.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T3
+    where readRaw = \ptr_0 -> pure T3 <*> readRaw (Proxy @"t3_x") ptr_0
+instance WriteRaw T3
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
+deriving via (EquivStorable T3) instance Storable T3
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+{-| __C declaration:__ @struct T4@
+
+    __defined at:__ @macros\/reparse\/nesting.h 7:9@
+
+    __exported by:__ @macros\/reparse\/nesting.h@
+-}
+data T4
+    = T4 {t4_x :: MyInt
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting.h 7:28@
+
+               __exported by:__ @macros\/reparse\/nesting.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T4
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T4
+    where readRaw = \ptr_0 -> pure T4 <*> readRaw (Proxy @"t4_x") ptr_0
+instance WriteRaw T4
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T4 t4_x_2 -> writeRaw (Proxy @"t4_x") ptr_0 t4_x_2
+deriving via (EquivStorable T4) instance Storable T4
+instance HasCField T4 "t4_x"
+    where type CFieldType T4 "t4_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t4_x" (Ptr T4) (Ptr ty)
+    where getField = fromPtr (Proxy @"t4_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
@@ -1,0 +1,393 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1_x(..)
+    , Example.get_t1_x_x
+    , Example.set_t1_x_x
+    , Example.T1(..)
+    , Example.T2(..)
+    , Example.T2_x(..)
+    , Example.get_t2_x_x
+    , Example.set_t2_x_x
+    , Example.T3(..)
+    , Example.T3_x(..)
+    , Example.get_t3_x_x
+    , Example.set_t3_x_x
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T1_x = T1_x
+  { unwrapT1_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T1_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T1_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T1_x
+
+deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
+
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t1_x_x ::
+     T1_x
+  -> MyInt
+get_t1_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x ::
+     MyInt
+  -> T1_x
+set_t1_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+{-| __C declaration:__ @struct \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T1 = T1
+  { t1_x :: T1_x
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:32@
+
+         __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize T1 where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw T1 where
+
+  readRaw =
+    \ptr0 ->
+          pure T1
+      <*> HasCField.readRaw (RIP.Proxy @"t1_x") ptr0
+
+instance Marshal.WriteRaw T1 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T1 t1_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t1_x") ptr0 t1_x2
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @struct \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T2 = T2
+  { t2_x :: RIP.Ptr T2_x
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:32@
+
+         __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T2 where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw T2 where
+
+  readRaw =
+    \ptr0 ->
+          pure T2
+      <*> HasCField.readRaw (RIP.Proxy @"t2_x") ptr0
+
+instance Marshal.WriteRaw T2 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T2 t2_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t2_x") ptr0 t2_x2
+
+deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+{-| __C declaration:__ @union \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T2_x = T2_x
+  { unwrapT2_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T2_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T2_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T2_x
+
+deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
+
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t2_x_x ::
+     T2_x
+  -> MyInt
+get_t2_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x ::
+     MyInt
+  -> T2_x
+set_t2_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+{-| __C declaration:__ @struct \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T3 = T3
+  { t3_x :: RIP.Ptr (RIP.Ptr T3_x)
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:32@
+
+         __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize T3 where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw T3 where
+
+  readRaw =
+    \ptr0 ->
+          pure T3
+      <*> HasCField.readRaw (RIP.Proxy @"t3_x") ptr0
+
+instance Marshal.WriteRaw T3 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          T3 t3_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t3_x") ptr0 t3_x2
+
+deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+{-| __C declaration:__ @union \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T3_x = T3_x
+  { unwrapT3_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T3_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T3_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T3_x
+
+deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
+
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t3_x_x ::
+     T3_x
+  -> MyInt
+get_t3_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x ::
+     MyInt
+  -> T3_x
+set_t3_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.t1
+    , Example.Global.t2
+    , Example.Global.t3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/union_in_struct.h>"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_44a1ef54c1044601 (void)"
+  , "{"
+  , "  return &T1;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_915293812630a04d (void)"
+  , "{"
+  , "  return &T2;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_e20a6c1bc9b97a9e (void)"
+  , "{"
+  , "  return &T3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 :: IO (RIP.Ptr T1)
+hs_bindgen_44a1ef54c1044601 =
+  RIP.fromFFIType hs_bindgen_44a1ef54c1044601_base
+
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t1 :: RIP.Ptr T1
+t1 = RIP.unsafePerformIO hs_bindgen_44a1ef54c1044601
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_915293812630a04d" hs_bindgen_915293812630a04d_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d :: IO (RIP.Ptr T2)
+hs_bindgen_915293812630a04d =
+  RIP.fromFFIType hs_bindgen_915293812630a04d_base
+
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t2 :: RIP.Ptr T2
+t2 = RIP.unsafePerformIO hs_bindgen_915293812630a04d
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_e20a6c1bc9b97a9e" hs_bindgen_e20a6c1bc9b97a9e_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e :: IO (RIP.Ptr T3)
+hs_bindgen_e20a6c1bc9b97a9e =
+  RIP.fromFFIType hs_bindgen_e20a6c1bc9b97a9e_base
+
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t3 :: RIP.Ptr T3
+t3 = RIP.unsafePerformIO hs_bindgen_e20a6c1bc9b97a9e

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/bindingspec.yaml
@@ -1,0 +1,144 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: struct @T1
+  hsname: T1
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: union @T1_x
+  hsname: T1_x
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: struct @T2
+  hsname: T2
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: union @T2_x
+  hsname: T2_x
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: struct @T3
+  hsname: T3
+- headers: macros/reparse/nesting/union_in_struct.h
+  cname: union @T3_x
+  hsname: T3_x
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    record:
+      constructor: T1
+      fields:
+      - t1_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1_x
+  representation:
+    newtype:
+      constructor: T1_x
+      fields:
+      - unwrapT1_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    record:
+      constructor: T2
+      fields:
+      - t2_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_x
+  representation:
+    newtype:
+      constructor: T2_x
+      fields:
+      - unwrapT2_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    record:
+      constructor: T3
+      fields:
+      - t3_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_x
+  representation:
+    newtype:
+      constructor: T3_x
+      fields:
+      - unwrapT3_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
@@ -1,0 +1,359 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/union_in_struct.h
+-- #include <macros/reparse/nesting/union_in_struct.h>
+-- /* test_macrosreparsenestingunion_i_Example_get_T1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_44a1ef54c1044601 (void)
+-- {
+--   return &T1;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_T2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_915293812630a04d (void)
+-- {
+--   return &T2;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_T3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_e20a6c1bc9b97a9e (void)
+-- {
+--   return &T3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T1_x
+    = T1_x {unwrapT1_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T1_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T1_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T1_x
+deriving via (EquivStorable T1_x) instance Storable T1_x
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t1_x_x :: T1_x -> MyInt
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t1_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x :: MyInt -> T1_x
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x = setUnionPayload
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+{-| __C declaration:__ @struct \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T1
+    = T1 {t1_x :: T1_x
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:32@
+
+               __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+          -}}
+    deriving stock Generic
+instance StaticSize T1
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw T1
+    where readRaw = \ptr_0 -> pure T1 <*> readRaw (Proxy @"t1_x") ptr_0
+instance WriteRaw T1
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
+deriving via (EquivStorable T1) instance Storable T1
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @struct \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T2
+    = T2 {t2_x :: (Ptr T2_x)
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:32@
+
+               __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T2
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw T2
+    where readRaw = \ptr_0 -> pure T2 <*> readRaw (Proxy @"t2_x") ptr_0
+instance WriteRaw T2
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
+deriving via (EquivStorable T2) instance Storable T2
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+{-| __C declaration:__ @union \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T2_x
+    = T2_x {unwrapT2_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T2_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T2_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T2_x
+deriving via (EquivStorable T2_x) instance Storable T2_x
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t2_x_x :: T2_x -> MyInt
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t2_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x :: MyInt -> T2_x
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x = setUnionPayload
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+{-| __C declaration:__ @struct \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+data T3
+    = T3 {t3_x :: (Ptr (Ptr T3_x))
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:32@
+
+               __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize T3
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw T3
+    where readRaw = \ptr_0 -> pure T3 <*> readRaw (Proxy @"t3_x") ptr_0
+instance WriteRaw T3
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
+deriving via (EquivStorable T3) instance Storable T3
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+{-| __C declaration:__ @union \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:10@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+newtype T3_x
+    = T3_x {unwrapT3_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T3_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T3_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T3_x
+deriving via (EquivStorable T3_x) instance Storable T3_x
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t3_x_x :: T3_x -> MyInt
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:24@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+get_t3_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x :: MyInt -> T3_x
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x = setUnionPayload
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 :: IO (Ptr T1)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 = fromFFIType hs_bindgen_44a1ef54c1044601_base
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t1 :: Ptr T1
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t1 = unsafePerformIO hs_bindgen_44a1ef54c1044601
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_915293812630a04d" hs_bindgen_915293812630a04d_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d :: IO (Ptr T2)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d = fromFFIType hs_bindgen_915293812630a04d_base
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t2 :: Ptr T2
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t2 = unsafePerformIO hs_bindgen_915293812630a04d
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_e20a6c1bc9b97a9e" hs_bindgen_e20a6c1bc9b97a9e_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e :: IO (Ptr T3)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e = fromFFIType hs_bindgen_e20a6c1bc9b97a9e_base
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t3 :: Ptr T3
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:37@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_struct.h@
+-}
+t3 = unsafePerformIO hs_bindgen_e20a6c1bc9b97a9e

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
@@ -1,0 +1,298 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1(..)
+    , Example.get_t1_x
+    , Example.set_t1_x
+    , Example.T2_Aux(..)
+    , Example.get_t2_Aux_x
+    , Example.set_t2_Aux_x
+    , Example.T2(..)
+    , Example.T3_Aux(..)
+    , Example.get_t3_Aux_x
+    , Example.set_t3_Aux_x
+    , Example.T3(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T1 = T1
+  { unwrapT1 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T1
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t1_x ::
+     T1
+  -> MyInt
+get_t1_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x ::
+     MyInt
+  -> T1
+set_t1_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @union \@T2_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T2_Aux = T2_Aux
+  { unwrapT2_Aux :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T2_Aux
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T2_Aux
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T2_Aux
+
+deriving via Marshal.EquivStorable T2_Aux instance RIP.Storable T2_Aux
+
+{-|
+
+    __See:__ 'set_t2_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t2_Aux_x ::
+     T2_Aux
+  -> MyInt
+get_t2_Aux_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t2_Aux_x'
+
+-}
+set_t2_Aux_x ::
+     MyInt
+  -> T2_Aux
+set_t2_Aux_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T2_Aux "t2_Aux_x" where
+
+  type CFieldType T2_Aux "t2_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
+
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T2 = T2
+  { unwrapT2 :: RIP.Ptr T2_Aux
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr T2_Aux
+         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
+
+instance HasCField.HasCField T2 "unwrapT2" where
+
+  type CFieldType T2 "unwrapT2" = RIP.Ptr T2_Aux
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@T3_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T3_Aux = T3_Aux
+  { unwrapT3_Aux :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T3_Aux
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T3_Aux
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T3_Aux
+
+deriving via Marshal.EquivStorable T3_Aux instance RIP.Storable T3_Aux
+
+{-|
+
+    __See:__ 'set_t3_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t3_Aux_x ::
+     T3_Aux
+  -> MyInt
+get_t3_Aux_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t3_Aux_x'
+
+-}
+set_t3_Aux_x ::
+     MyInt
+  -> T3_Aux
+set_t3_Aux_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T3_Aux "t3_Aux_x" where
+
+  type CFieldType T3_Aux "t3_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
+
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T3 = T3
+  { unwrapT3 :: RIP.Ptr (RIP.Ptr T3_Aux)
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
+         ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
+
+instance HasCField.HasCField T3 "unwrapT3" where
+
+  type CFieldType T3 "unwrapT3" =
+    RIP.Ptr (RIP.Ptr T3_Aux)
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/bindingspec.yaml
@@ -1,0 +1,134 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: union T1
+  hsname: T1
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: T1
+  hsname: T1
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: union @T2_Aux
+  hsname: T2_Aux
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: T2
+  hsname: T2
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: union @T3_Aux
+  hsname: T3_Aux
+- headers: macros/reparse/nesting/union_in_typedef.h
+  cname: T3
+  hsname: T3
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    newtype:
+      constructor: T1
+      fields:
+      - unwrapT1
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    newtype:
+      constructor: T2
+      fields:
+      - unwrapT2
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_Aux
+  representation:
+    newtype:
+      constructor: T2_Aux
+      fields:
+      - unwrapT2_Aux
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    newtype:
+      constructor: T3
+      fields:
+      - unwrapT3
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_Aux
+  representation:
+    newtype:
+      constructor: T3_Aux
+      fields:
+      - unwrapT3_Aux
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
@@ -1,0 +1,224 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/union_in_typedef.h
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T1 = T1 {unwrapT1 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T1
+deriving via (SizedByteArray 4 4) instance ReadRaw T1
+deriving via (SizedByteArray 4 4) instance WriteRaw T1
+deriving via (EquivStorable T1) instance Storable T1
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t1_x :: T1 -> MyInt
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t1_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x :: MyInt -> T1
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x = setUnionPayload
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @union \@T2_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T2_Aux
+    = T2_Aux {unwrapT2_Aux :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T2_Aux
+deriving via (SizedByteArray 4 4) instance ReadRaw T2_Aux
+deriving via (SizedByteArray 4 4) instance WriteRaw T2_Aux
+deriving via (EquivStorable T2_Aux) instance Storable T2_Aux
+{-|
+
+    __See:__ 'set_t2_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t2_Aux_x :: T2_Aux -> MyInt
+{-|
+
+    __See:__ 'set_t2_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t2_Aux_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t2_Aux_x'
+
+-}
+set_t2_Aux_x :: MyInt -> T2_Aux
+{-|
+
+    __See:__ 'get_t2_Aux_x'
+
+-}
+set_t2_Aux_x = setUnionPayload
+instance HasCField T2_Aux "t2_Aux_x"
+    where type CFieldType T2_Aux "t2_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_Aux_x")
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T2
+    = T2 {unwrapT2 :: (Ptr T2_Aux)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr T2_Aux) =>
+         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT2")
+instance HasCField T2 "unwrapT2"
+    where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@T3_Aux@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T3_Aux
+    = T3_Aux {unwrapT3_Aux :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T3_Aux
+deriving via (SizedByteArray 4 4) instance ReadRaw T3_Aux
+deriving via (SizedByteArray 4 4) instance WriteRaw T3_Aux
+deriving via (EquivStorable T3_Aux) instance Storable T3_Aux
+{-|
+
+    __See:__ 'set_t3_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t3_Aux_x :: T3_Aux -> MyInt
+{-|
+
+    __See:__ 'set_t3_Aux_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+get_t3_Aux_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t3_Aux_x'
+
+-}
+set_t3_Aux_x :: MyInt -> T3_Aux
+{-|
+
+    __See:__ 'get_t3_Aux_x'
+
+-}
+set_t3_Aux_x = setUnionPayload
+instance HasCField T3_Aux "t3_Aux_x"
+    where type CFieldType T3_Aux "t3_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_Aux_x")
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_typedef.h@
+-}
+newtype T3
+    = T3 {unwrapT3 :: (Ptr (Ptr T3_Aux))}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr (Ptr T3_Aux)) =>
+         HasField "unwrapT3" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT3")
+instance HasCField T3 "unwrapT3"
+    where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
@@ -1,0 +1,408 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.T1_x(..)
+    , Example.get_t1_x_x
+    , Example.set_t1_x_x
+    , Example.T1(..)
+    , Example.get_t1_x
+    , Example.set_t1_x
+    , Example.T2(..)
+    , Example.get_t2_x
+    , Example.set_t2_x
+    , Example.T2_x(..)
+    , Example.get_t2_x_x
+    , Example.set_t2_x_x
+    , Example.T3(..)
+    , Example.get_t3_x
+    , Example.set_t3_x
+    , Example.T3_x(..)
+    , Example.get_t3_x_x
+    , Example.set_t3_x_x
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T1_x = T1_x
+  { unwrapT1_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T1_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T1_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T1_x
+
+deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
+
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x_x ::
+     T1_x
+  -> MyInt
+get_t1_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x ::
+     MyInt
+  -> T1_x
+set_t1_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+{-| __C declaration:__ @union \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T1 = T1
+  { unwrapT1 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T1
+
+deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
+
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x ::
+     T1
+  -> T1_x
+get_t1_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x ::
+     T1_x
+  -> T1
+set_t1_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+{-| __C declaration:__ @union \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T2 = T2
+  { unwrapT2 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.StaticSize T2
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.ReadRaw T2
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.WriteRaw T2
+
+deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
+
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x ::
+     T2
+  -> RIP.Ptr T2_x
+get_t2_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x ::
+     RIP.Ptr T2_x
+  -> T2
+set_t2_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+{-| __C declaration:__ @union \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T2_x = T2_x
+  { unwrapT2_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T2_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T2_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T2_x
+
+deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
+
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x_x ::
+     T2_x
+  -> MyInt
+get_t2_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x ::
+     MyInt
+  -> T2_x
+set_t2_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+{-| __C declaration:__ @union \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T3 = T3
+  { unwrapT3 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.StaticSize T3
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.ReadRaw T3
+
+deriving via RIP.SizedByteArray 8 8 instance Marshal.WriteRaw T3
+
+deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
+
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x ::
+     T3
+  -> RIP.Ptr (RIP.Ptr T3_x)
+get_t3_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x ::
+     RIP.Ptr (RIP.Ptr T3_x)
+  -> T3
+set_t3_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+{-| __C declaration:__ @union \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T3_x = T3_x
+  { unwrapT3_x :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T3_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T3_x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T3_x
+
+deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
+
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x_x ::
+     T3_x
+  -> MyInt
+get_t3_x_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x ::
+     MyInt
+  -> T3_x
+set_t3_x_x = RIP.setUnionPayload
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.t1
+    , Example.Global.t2
+    , Example.Global.t3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/union_in_union.h>"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_44a1ef54c1044601 (void)"
+  , "{"
+  , "  return &T1;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_915293812630a04d (void)"
+  , "{"
+  , "  return &T2;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_T3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_e20a6c1bc9b97a9e (void)"
+  , "{"
+  , "  return &T3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 :: IO (RIP.Ptr T1)
+hs_bindgen_44a1ef54c1044601 =
+  RIP.fromFFIType hs_bindgen_44a1ef54c1044601_base
+
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t1 :: RIP.Ptr T1
+t1 = RIP.unsafePerformIO hs_bindgen_44a1ef54c1044601
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_915293812630a04d" hs_bindgen_915293812630a04d_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d :: IO (RIP.Ptr T2)
+hs_bindgen_915293812630a04d =
+  RIP.fromFFIType hs_bindgen_915293812630a04d_base
+
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t2 :: RIP.Ptr T2
+t2 = RIP.unsafePerformIO hs_bindgen_915293812630a04d
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_e20a6c1bc9b97a9e" hs_bindgen_e20a6c1bc9b97a9e_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e :: IO (RIP.Ptr T3)
+hs_bindgen_e20a6c1bc9b97a9e =
+  RIP.fromFFIType hs_bindgen_e20a6c1bc9b97a9e_base
+
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t3 :: RIP.Ptr T3
+t3 = RIP.unsafePerformIO hs_bindgen_e20a6c1bc9b97a9e

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/bindingspec.yaml
@@ -1,0 +1,140 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T1
+  hsname: T1
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T1_x
+  hsname: T1_x
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T2
+  hsname: T2
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T2_x
+  hsname: T2_x
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T3
+  hsname: T3
+- headers: macros/reparse/nesting/union_in_union.h
+  cname: union @T3_x
+  hsname: T3_x
+hstypes:
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1
+  representation:
+    newtype:
+      constructor: T1
+      fields:
+      - unwrapT1
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T1_x
+  representation:
+    newtype:
+      constructor: T1_x
+      fields:
+      - unwrapT1_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2
+  representation:
+    newtype:
+      constructor: T2
+      fields:
+      - unwrapT2
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T2_x
+  representation:
+    newtype:
+      constructor: T2_x
+      fields:
+      - unwrapT2_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3
+  representation:
+    newtype:
+      constructor: T3
+      fields:
+      - unwrapT3
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: T3_x
+  representation:
+    newtype:
+      constructor: T3_x
+      fields:
+      - unwrapT3_x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
@@ -1,0 +1,422 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/union_in_union.h
+-- #include <macros/reparse/nesting/union_in_union.h>
+-- /* test_macrosreparsenestingunion_i_Example_get_T1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_44a1ef54c1044601 (void)
+-- {
+--   return &T1;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_T2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_915293812630a04d (void)
+-- {
+--   return &T2;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_T3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_e20a6c1bc9b97a9e (void)
+-- {
+--   return &T3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@T1_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T1_x
+    = T1_x {unwrapT1_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T1_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T1_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T1_x
+deriving via (EquivStorable T1_x) instance Storable T1_x
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x_x :: T1_x -> MyInt
+{-|
+
+    __See:__ 'set_t1_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x :: MyInt -> T1_x
+{-|
+
+    __See:__ 'get_t1_x_x'
+
+-}
+set_t1_x_x = setUnionPayload
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+{-| __C declaration:__ @union \@T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T1 = T1 {unwrapT1 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T1
+deriving via (SizedByteArray 4 4) instance ReadRaw T1
+deriving via (SizedByteArray 4 4) instance WriteRaw T1
+deriving via (EquivStorable T1) instance Storable T1
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x :: T1 -> T1_x
+{-|
+
+    __See:__ 'set_t1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t1_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x :: T1_x -> T1
+{-|
+
+    __See:__ 'get_t1_x'
+
+-}
+set_t1_x = setUnionPayload
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+{-| __C declaration:__ @union \@T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T2 = T2 {unwrapT2 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize T2
+deriving via (SizedByteArray 8 8) instance ReadRaw T2
+deriving via (SizedByteArray 8 8) instance WriteRaw T2
+deriving via (EquivStorable T2) instance Storable T2
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x :: T2 -> Ptr T2_x
+{-|
+
+    __See:__ 'set_t2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x :: Ptr T2_x -> T2
+{-|
+
+    __See:__ 'get_t2_x'
+
+-}
+set_t2_x = setUnionPayload
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+{-| __C declaration:__ @union \@T2_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T2_x
+    = T2_x {unwrapT2_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T2_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T2_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T2_x
+deriving via (EquivStorable T2_x) instance Storable T2_x
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x_x :: T2_x -> MyInt
+{-|
+
+    __See:__ 'set_t2_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t2_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x :: MyInt -> T2_x
+{-|
+
+    __See:__ 'get_t2_x_x'
+
+-}
+set_t2_x_x = setUnionPayload
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+{-| __C declaration:__ @union \@T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T3 = T3 {unwrapT3 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize T3
+deriving via (SizedByteArray 8 8) instance ReadRaw T3
+deriving via (SizedByteArray 8 8) instance WriteRaw T3
+deriving via (EquivStorable T3) instance Storable T3
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x :: T3 -> Ptr (Ptr T3_x)
+{-|
+
+    __See:__ 'set_t3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:31@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x :: Ptr (Ptr T3_x) -> T3
+{-|
+
+    __See:__ 'get_t3_x'
+
+-}
+set_t3_x = setUnionPayload
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+{-| __C declaration:__ @union \@T3_x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+newtype T3_x
+    = T3_x {unwrapT3_x :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T3_x
+deriving via (SizedByteArray 4 4) instance ReadRaw T3_x
+deriving via (SizedByteArray 4 4) instance WriteRaw T3_x
+deriving via (EquivStorable T3_x) instance Storable T3_x
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x_x :: T3_x -> MyInt
+{-|
+
+    __See:__ 'set_t3_x_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+get_t3_x_x = getUnionPayload
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x :: MyInt -> T3_x
+{-|
+
+    __See:__ 'get_t3_x_x'
+
+-}
+set_t3_x_x = setUnionPayload
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 :: IO (Ptr T1)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
+hs_bindgen_44a1ef54c1044601 = fromFFIType hs_bindgen_44a1ef54c1044601_base
+{-# NOINLINE t1 #-}
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t1 :: Ptr T1
+{-| __C declaration:__ @T1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t1 = unsafePerformIO hs_bindgen_44a1ef54c1044601
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+foreign import ccall unsafe "hs_bindgen_915293812630a04d" hs_bindgen_915293812630a04d_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d :: IO (Ptr T2)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T2@
+hs_bindgen_915293812630a04d = fromFFIType hs_bindgen_915293812630a04d_base
+{-# NOINLINE t2 #-}
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t2 :: Ptr T2
+{-| __C declaration:__ @T2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t2 = unsafePerformIO hs_bindgen_915293812630a04d
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+foreign import ccall unsafe "hs_bindgen_e20a6c1bc9b97a9e" hs_bindgen_e20a6c1bc9b97a9e_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e :: IO (Ptr T3)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T3@
+hs_bindgen_e20a6c1bc9b97a9e = fromFFIType hs_bindgen_e20a6c1bc9b97a9e_base
+{-# NOINLINE t3 #-}
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t3 :: Ptr T3
+{-| __C declaration:__ @T3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:36@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_union.h@
+-}
+t3 = unsafePerformIO hs_bindgen_e20a6c1bc9b97a9e

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
@@ -1,0 +1,235 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.MyInt(..)
+    , Example.G1(..)
+    , Example.get_g1_x
+    , Example.set_g1_x
+    , Example.G2(..)
+    , Example.get_g2_x
+    , Example.set_g2_x
+    , Example.G3(..)
+    , Example.get_g3_x
+    , Example.set_g3_x
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype MyInt = MyInt
+  { unwrapMyInt :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
+
+instance HasCField.HasCField MyInt "unwrapMyInt" where
+
+  type CFieldType MyInt "unwrapMyInt" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G1 = G1
+  { unwrapG1 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize G1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw G1
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw G1
+
+deriving via Marshal.EquivStorable G1 instance RIP.Storable G1
+
+{-|
+
+    __See:__ 'set_g1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g1_x ::
+     G1
+  -> MyInt
+get_g1_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_g1_x'
+
+-}
+set_g1_x ::
+     MyInt
+  -> G1
+set_g1_x = RIP.setUnionPayload
+
+instance HasCField.HasCField G1 "g1_x" where
+
+  type CFieldType G1 "g1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
+
+{-| __C declaration:__ @union \@G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G2 = G2
+  { unwrapG2 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize G2
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw G2
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw G2
+
+deriving via Marshal.EquivStorable G2 instance RIP.Storable G2
+
+{-|
+
+    __See:__ 'set_g2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g2_x ::
+     G2
+  -> MyInt
+get_g2_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_g2_x'
+
+-}
+set_g2_x ::
+     MyInt
+  -> G2
+set_g2_x = RIP.setUnionPayload
+
+instance HasCField.HasCField G2 "g2_x" where
+
+  type CFieldType G2 "g2_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
+
+{-| __C declaration:__ @union \@G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G3 = G3
+  { unwrapG3 :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize G3
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw G3
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw G3
+
+deriving via Marshal.EquivStorable G3 instance RIP.Storable G3
+
+{-|
+
+    __See:__ 'set_g3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g3_x ::
+     G3
+  -> MyInt
+get_g3_x = RIP.getUnionPayload
+
+{-|
+
+    __See:__ 'get_g3_x'
+
+-}
+set_g3_x ::
+     MyInt
+  -> G3
+set_g3_x = RIP.setUnionPayload
+
+instance HasCField.HasCField G3 "g3_x" where
+
+  type CFieldType G3 "g3_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example/Global.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example/Global.hs
@@ -1,0 +1,92 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Global
+    ( Example.Global.g1
+    , Example.Global.g2
+    , Example.Global.g3
+    )
+  where
+
+import qualified HsBindgen.Runtime.Internal.CAPI
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import Example
+
+$(HsBindgen.Runtime.Internal.CAPI.addCSource (HsBindgen.Runtime.Internal.CAPI.unlines
+  [ "#include <macros/reparse/nesting/union_in_variable.h>"
+  , "/* test_macrosreparsenestingunion_i_Example_get_G1 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_4b01ee4d60407c60 (void)"
+  , "{"
+  , "  return &G1;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_G2 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_2290f6729b2485e1 (void)"
+  , "{"
+  , "  return &G2;"
+  , "}"
+  , "/* test_macrosreparsenestingunion_i_Example_get_G3 */"
+  , "__attribute__ ((const))"
+  , "void *hs_bindgen_1be42b84691d63f3 (void)"
+  , "{"
+  , "  return &G3;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
+foreign import ccall unsafe "hs_bindgen_4b01ee4d60407c60" hs_bindgen_4b01ee4d60407c60_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
+hs_bindgen_4b01ee4d60407c60 :: IO (RIP.Ptr G1)
+hs_bindgen_4b01ee4d60407c60 =
+  RIP.fromFFIType hs_bindgen_4b01ee4d60407c60_base
+
+{-# NOINLINE g1 #-}
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g1 :: RIP.Ptr G1
+g1 = RIP.unsafePerformIO hs_bindgen_4b01ee4d60407c60
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G2@
+foreign import ccall unsafe "hs_bindgen_2290f6729b2485e1" hs_bindgen_2290f6729b2485e1_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G2@
+hs_bindgen_2290f6729b2485e1 :: IO (RIP.Ptr (RIP.Ptr G2))
+hs_bindgen_2290f6729b2485e1 =
+  RIP.fromFFIType hs_bindgen_2290f6729b2485e1_base
+
+{-# NOINLINE g2 #-}
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g2 :: RIP.Ptr (RIP.Ptr G2)
+g2 = RIP.unsafePerformIO hs_bindgen_2290f6729b2485e1
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G3@
+foreign import ccall unsafe "hs_bindgen_1be42b84691d63f3" hs_bindgen_1be42b84691d63f3_base ::
+     IO (RIP.Ptr RIP.Void)
+
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G3@
+hs_bindgen_1be42b84691d63f3 :: IO (RIP.Ptr (RIP.Ptr (RIP.Ptr G3)))
+hs_bindgen_1be42b84691d63f3 =
+  RIP.fromFFIType hs_bindgen_1be42b84691d63f3_base
+
+{-# NOINLINE g3 #-}
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g3 :: RIP.Ptr (RIP.Ptr (RIP.Ptr G3))
+g3 = RIP.unsafePerformIO hs_bindgen_1be42b84691d63f3

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/bindingspec.yaml
@@ -1,0 +1,89 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/reparse/nesting/union_in_variable.h
+  cname: macro MyInt
+  hsname: MyInt
+- headers: macros/reparse/nesting/union_in_variable.h
+  cname: union @G1
+  hsname: G1
+- headers: macros/reparse/nesting/union_in_variable.h
+  cname: union @G2
+  hsname: G2
+- headers: macros/reparse/nesting/union_in_variable.h
+  cname: union @G3
+  hsname: G3
+hstypes:
+- hsname: G1
+  representation:
+    newtype:
+      constructor: G1
+      fields:
+      - unwrapG1
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: G2
+  representation:
+    newtype:
+      constructor: G2
+      fields:
+      - unwrapG2
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: G3
+  representation:
+    newtype:
+      constructor: G3
+      fields:
+      - unwrapG3
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: MyInt
+  representation:
+    newtype:
+      constructor: MyInt
+      fields:
+      - unwrapMyInt
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
@@ -1,0 +1,265 @@
+-- addDependentFile test-artefacts/headers/golden/macros/reparse/nesting/union_in_variable.h
+-- #include <macros/reparse/nesting/union_in_variable.h>
+-- /* test_macrosreparsenestingunion_i_Example_get_G1 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_4b01ee4d60407c60 (void)
+-- {
+--   return &G1;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_G2 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_2290f6729b2485e1 (void)
+-- {
+--   return &G2;
+-- }
+-- /* test_macrosreparsenestingunion_i_Example_get_G3 */
+-- __attribute__ ((const))
+-- void *hs_bindgen_1be42b84691d63f3 (void)
+-- {
+--   return &G3;
+-- }
+{-| __C declaration:__ @macro MyInt@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 1:9@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype MyInt
+    = MyInt {unwrapMyInt :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapMyInt")
+instance HasCField MyInt "unwrapMyInt"
+    where type CFieldType MyInt "unwrapMyInt" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G1 = G1 {unwrapG1 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize G1
+deriving via (SizedByteArray 4 4) instance ReadRaw G1
+deriving via (SizedByteArray 4 4) instance WriteRaw G1
+deriving via (EquivStorable G1) instance Storable G1
+{-|
+
+    __See:__ 'set_g1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g1_x :: G1 -> MyInt
+{-|
+
+    __See:__ 'set_g1_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g1_x = getUnionPayload
+{-|
+
+    __See:__ 'get_g1_x'
+
+-}
+set_g1_x :: MyInt -> G1
+{-|
+
+    __See:__ 'get_g1_x'
+
+-}
+set_g1_x = setUnionPayload
+instance HasCField G1 "g1_x"
+    where type CFieldType G1 "g1_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+    where getField = fromPtr (Proxy @"g1_x")
+{-| __C declaration:__ @union \@G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G2 = G2 {unwrapG2 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize G2
+deriving via (SizedByteArray 4 4) instance ReadRaw G2
+deriving via (SizedByteArray 4 4) instance WriteRaw G2
+deriving via (EquivStorable G2) instance Storable G2
+{-|
+
+    __See:__ 'set_g2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g2_x :: G2 -> MyInt
+{-|
+
+    __See:__ 'set_g2_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g2_x = getUnionPayload
+{-|
+
+    __See:__ 'get_g2_x'
+
+-}
+set_g2_x :: MyInt -> G2
+{-|
+
+    __See:__ 'get_g2_x'
+
+-}
+set_g2_x = setUnionPayload
+instance HasCField G2 "g2_x"
+    where type CFieldType G2 "g2_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+    where getField = fromPtr (Proxy @"g2_x")
+{-| __C declaration:__ @union \@G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:1@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+newtype G3 = G3 {unwrapG3 :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize G3
+deriving via (SizedByteArray 4 4) instance ReadRaw G3
+deriving via (SizedByteArray 4 4) instance WriteRaw G3
+deriving via (EquivStorable G3) instance Storable G3
+{-|
+
+    __See:__ 'set_g3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g3_x :: G3 -> MyInt
+{-|
+
+    __See:__ 'set_g3_x'
+
+    __C declaration:__ @x@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:15@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+get_g3_x = getUnionPayload
+{-|
+
+    __See:__ 'get_g3_x'
+
+-}
+set_g3_x :: MyInt -> G3
+{-|
+
+    __See:__ 'get_g3_x'
+
+-}
+set_g3_x = setUnionPayload
+instance HasCField G3 "g3_x"
+    where type CFieldType G3 "g3_x" = MyInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+    where getField = fromPtr (Proxy @"g3_x")
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
+foreign import ccall unsafe "hs_bindgen_4b01ee4d60407c60" hs_bindgen_4b01ee4d60407c60_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
+hs_bindgen_4b01ee4d60407c60 :: IO (Ptr G1)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
+hs_bindgen_4b01ee4d60407c60 = fromFFIType hs_bindgen_4b01ee4d60407c60_base
+{-# NOINLINE g1 #-}
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g1 :: Ptr G1
+{-| __C declaration:__ @G1@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g1 = unsafePerformIO hs_bindgen_4b01ee4d60407c60
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G2@
+foreign import ccall unsafe "hs_bindgen_2290f6729b2485e1" hs_bindgen_2290f6729b2485e1_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G2@
+hs_bindgen_2290f6729b2485e1 :: IO (Ptr (Ptr G2))
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G2@
+hs_bindgen_2290f6729b2485e1 = fromFFIType hs_bindgen_2290f6729b2485e1_base
+{-# NOINLINE g2 #-}
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g2 :: Ptr (Ptr G2)
+{-| __C declaration:__ @G2@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g2 = unsafePerformIO hs_bindgen_2290f6729b2485e1
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G3@
+foreign import ccall unsafe "hs_bindgen_1be42b84691d63f3" hs_bindgen_1be42b84691d63f3_base ::
+    IO (Ptr Void)
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G3@
+hs_bindgen_1be42b84691d63f3 :: IO (Ptr (Ptr (Ptr G3)))
+-- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G3@
+hs_bindgen_1be42b84691d63f3 = fromFFIType hs_bindgen_1be42b84691d63f3_base
+{-# NOINLINE g3 #-}
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g3 :: Ptr (Ptr (Ptr G3))
+{-| __C declaration:__ @G3@
+
+    __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:23@
+
+    __exported by:__ @macros\/reparse\/nesting\/union_in_variable.h@
+-}
+g3 = unsafePerformIO hs_bindgen_1be42b84691d63f3

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/defer_wrong.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/defer_wrong.h
@@ -1,0 +1,16 @@
+/*
+In case a typedef references another type, we defer reparsing to the referenced
+type. This was done to resolve issue #707. However, it now turns out that this
+introduced a new bug. A typedef may reference a struct indirectly via a macro
+type, in which case we need to reparse the typedef to insert a referene to the
+macro type.
+
+<https://github.com/well-typed/hs-bindgen/issues/707>
+*/
+
+struct S { int x; }; // CORRECT: data S = ...
+
+#define T struct S // CORRECT: newtype T = T S
+
+typedef T foo; // WRONG: newtype Foo = Foo S
+typedef T * bar; // CORRECT: newtype Bar = Bar (Ptr T)

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting.h
@@ -1,0 +1,7 @@
+#define MyInt int
+
+// reparsing works the same regardless of whether the nested declaration is
+// named or unnamed
+typedef struct TS1 { MyInt x; } T2;
+typedef struct TS3 { MyInt x; } T3;
+typedef struct     { MyInt x; } T4;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_struct.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_struct.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+struct { struct { MyInt x; }    x; } T1;
+struct { struct { MyInt x; } *  x; } T2;
+struct { struct { MyInt x; } ** x; } T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_typedef.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_typedef.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+typedef struct { MyInt x; }    T1;
+typedef struct { MyInt x; } *  T2;
+typedef struct { MyInt x; } ** T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_union.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_union.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+union { struct { MyInt x; }    x; } T1;
+union { struct { MyInt x; } *  x; } T2;
+union { struct { MyInt x; } ** x; } T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_variable.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/struct_in_variable.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+struct { MyInt x; }    G1;
+struct { MyInt x; } *  G2;
+struct { MyInt x; } ** G3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_struct.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_struct.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+struct { union { MyInt x; }    x; } T1;
+struct { union { MyInt x; } *  x; } T2;
+struct { union { MyInt x; } ** x; } T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_typedef.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_typedef.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+typedef union { MyInt x; }    T1;
+typedef union { MyInt x; } *  T2;
+typedef union { MyInt x; } ** T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_union.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_union.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+union { union { MyInt x; }    x; } T1;
+union { union { MyInt x; } *  x; } T2;
+union { union { MyInt x; } ** x; } T3;

--- a/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_variable.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/reparse/nesting/union_in_variable.h
@@ -1,0 +1,5 @@
+#define MyInt int
+
+union { MyInt x; }    G1;
+union { MyInt x; } *  G2;
+union { MyInt x; } ** G3;

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Frontend/LanguageC.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Frontend/LanguageC.hs
@@ -300,6 +300,7 @@ prop_reparseGlobal input expectedOutput =
     removeCallstack = \case
         LanC.UpdateUnexpected _ str -> UpdateUnexpected str
         LanC.UpdateUnsupported str  -> UpdateUnsupported str
+        LanC.UpdateSkipped str      -> UpdateSkipped str
 
     getLocation :: [Token a] -> MultiLoc
     getLocation []    = panicPure "Unexpected empty list of tokens"
@@ -314,8 +315,9 @@ type PrePass = PrepareReparse
 -- field, and 'CallStack' does not have an 'Eq' instance. So we define our own
 -- version of 'LanC.Error' without the callstack.
 data Error =
-    UpdateUnexpected String
+    UpdateUnexpected  String
   | UpdateUnsupported String
+  | UpdateSkipped     String
   deriving stock (Show, Eq)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden.hs
@@ -5,10 +5,7 @@ module Test.HsBindgen.Golden (
   , module Test.HsBindgen.Golden.Infra.TestCase
   ) where
 
-import System.Directory (createDirectoryIfMissing)
 import Test.Tasty
-
-import Clang.Version
 
 import Test.HsBindgen.Golden.Arrays qualified as Arrays
 import Test.HsBindgen.Golden.Attributes qualified as Attributes
@@ -19,12 +16,8 @@ import Test.HsBindgen.Golden.Documentation qualified as Documentation
 import Test.HsBindgen.Golden.EdgeCases qualified as EdgeCases
 import Test.HsBindgen.Golden.Functions qualified as Functions
 import Test.HsBindgen.Golden.Globals qualified as Globals
-import Test.HsBindgen.Golden.Infra.Check.BindingSpec qualified as BindingSpec
-import Test.HsBindgen.Golden.Infra.Check.FailureBindgen qualified as FailureBindgen
-import Test.HsBindgen.Golden.Infra.Check.FailureLibclang qualified as FailureLibclang
-import Test.HsBindgen.Golden.Infra.Check.PP qualified as PP
-import Test.HsBindgen.Golden.Infra.Check.TH qualified as TH
 import Test.HsBindgen.Golden.Infra.TestCase
+import Test.HsBindgen.Golden.Infra.TestCaseTree
 import Test.HsBindgen.Golden.Macros qualified as Macros
 import Test.HsBindgen.Golden.Macros.Reparse qualified as Macros.Reparse
 import Test.HsBindgen.Golden.ProgramAnalysis qualified as ProgramAnalysis
@@ -36,7 +29,10 @@ import Test.HsBindgen.Resources
 -------------------------------------------------------------------------------}
 
 tests :: IO TestResources -> TestTree
-tests getTestResources = testTreeFor getTestResources $
+tests getTestResources = testTreeFor getTestResources testCaseTree
+
+testCaseTree :: TestCaseTree
+testCaseTree =
     TestCaseSection "Test.HsBindgen.Golden" [
         TestCases "arrays"          Arrays.testCases
       , TestCases "attributes"      Attributes.testCases
@@ -49,7 +45,7 @@ tests getTestResources = testTreeFor getTestResources $
       , TestCases "globals"         Globals.testCases
       , TestCaseSection "macros" $ concat [
            TestCaseLeafs Macros.testCases
-          , [ TestCases "reparse" Macros.Reparse.testCases ]
+          , Macros.Reparse.testCases
           ]
       , TestCases "programAnalysis" ProgramAnalysis.testCases
       , TestCases "types"           Types.testCases
@@ -57,69 +53,4 @@ tests getTestResources = testTreeFor getTestResources $
 
 -- | All test cases, for use by TH fixture compilation
 allTestCases :: [TestCase]
-allTestCases = concat [
-      Arrays.testCases
-    , Attributes.testCases
-    , BindingSpecs.testCases
-    , Comprehensive.testCases
-    , Declarations.testCases
-    , Documentation.testCases
-    , EdgeCases.testCases
-    , Functions.testCases
-    , Globals.testCases
-    , Macros.testCases
-    , Macros.Reparse.testCases
-    , ProgramAnalysis.testCases
-    , Types.testCases
-    ]
-
-{-------------------------------------------------------------------------------
-  Construct tasty test tree
--------------------------------------------------------------------------------}
-
-data TestCaseTree =
-    TestCaseSection String [TestCaseTree]
-  | TestCaseLeaf TestCase
-
-pattern TestCases :: String -> [TestCase] -> TestCaseTree
-pattern TestCases label cases = TestCaseSection label (TestCaseLeafs cases)
-
-pattern TestCaseLeafs :: [TestCase] -> [TestCaseTree]
-pattern TestCaseLeafs cases <- (fmap (\(TestCaseLeaf test) -> test) -> cases)
-  where TestCaseLeafs cases = fmap TestCaseLeaf cases
-
-testTreeFor :: IO TestResources -> TestCaseTree -> TestTree
-testTreeFor getTestResources = goTree
-  where
-    goTree :: TestCaseTree -> TestTree
-    goTree (TestCaseSection label sections) =
-        testGroup label $ map goTree sections
-    goTree (TestCaseLeaf test) = goCase test
-
-    goCase :: TestCase -> TestTree
-    goCase test
-      | Just versionPred <- test.clangVersion
-      , case runtimeClangVersion of
-          ClangVersion version  -> not (versionPred version)
-          ClangVersionUnknown _ -> True
-      = testGroup test.name []
-
-      | otherwise
-      = case test.outcome of
-          Success ->
-            withTestOutputDir test.outputDir $ testGroup test.name [
-                TH.check          getTestResources test
-              , PP.check          getTestResources test
-              , BindingSpec.check getTestResources test
-              ]
-          FailureBindgen ->
-            FailureBindgen.check getTestResources test
-          FailureLibclang ->
-            FailureLibclang.check getTestResources test
-
-    withTestOutputDir :: FilePath -> TestTree -> TestTree
-    withTestOutputDir outputDir k =
-        withResource
-          (createDirectoryIfMissing True outputDir)
-          (\_ -> pure ())
-          (\_ -> k)
+allTestCases = flatten testCaseTree

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCaseTree.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCaseTree.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE CPP #-}
+
+#if defined(MIN_VERSION_GLASGOW_HASKELL)
+#if MIN_VERSION_GLASGOW_HASKELL(9,14,0,0)
+#define exportPattern data
+#else
+#define exportPattern pattern
+#endif
+#else
+#define exportPattern pattern
+#endif
+
+-- | Construct tasty test tree
+module Test.HsBindgen.Golden.Infra.TestCaseTree (
+    TestCaseTree (..)
+  , exportPattern TestCases
+  , exportPattern TestCaseLeafs
+  , testTreeFor
+  , flatten
+  ) where
+
+import System.Directory (createDirectoryIfMissing)
+import Test.Tasty (TestTree, testGroup, withResource)
+
+import Clang.Version (ClangVersion (ClangVersion, ClangVersionUnknown),
+                      runtimeClangVersion)
+
+import Test.HsBindgen.Golden.Infra.Check.BindingSpec qualified as BindingSpec
+import Test.HsBindgen.Golden.Infra.Check.FailureBindgen qualified as FailureBindgen
+import Test.HsBindgen.Golden.Infra.Check.FailureLibclang qualified as FailureLibclang
+import Test.HsBindgen.Golden.Infra.Check.PP qualified as PP
+import Test.HsBindgen.Golden.Infra.Check.TH qualified as TH
+import Test.HsBindgen.Golden.Infra.TestCase (Outcome (FailureBindgen, FailureLibclang, Success),
+                                             TestCase (clangVersion, name, outcome, outputDir))
+import Test.HsBindgen.Resources (TestResources)
+
+data TestCaseTree =
+    TestCaseSection String [TestCaseTree]
+  | TestCaseLeaf TestCase
+
+pattern TestCases :: String -> [TestCase] -> TestCaseTree
+pattern TestCases label cases = TestCaseSection label (TestCaseLeafs cases)
+
+pattern TestCaseLeafs :: [TestCase] -> [TestCaseTree]
+pattern TestCaseLeafs cases <- (fmap (\(TestCaseLeaf test) -> test) -> cases)
+  where TestCaseLeafs cases = fmap TestCaseLeaf cases
+
+testTreeFor :: IO TestResources -> TestCaseTree -> TestTree
+testTreeFor getTestResources = goTree
+  where
+    goTree :: TestCaseTree -> TestTree
+    goTree (TestCaseSection label sections) =
+        testGroup label $ map goTree sections
+    goTree (TestCaseLeaf test) = goCase test
+
+    goCase :: TestCase -> TestTree
+    goCase test
+      | Just versionPred <- test.clangVersion
+      , case runtimeClangVersion of
+          ClangVersion version  -> not (versionPred version)
+          ClangVersionUnknown _ -> True
+      = testGroup test.name []
+
+      | otherwise
+      = case test.outcome of
+          Success ->
+            withTestOutputDir test.outputDir $ testGroup test.name [
+                TH.check          getTestResources test
+              , PP.check          getTestResources test
+              , BindingSpec.check getTestResources test
+              ]
+          FailureBindgen ->
+            FailureBindgen.check getTestResources test
+          FailureLibclang ->
+            FailureLibclang.check getTestResources test
+
+    withTestOutputDir :: FilePath -> TestTree -> TestTree
+    withTestOutputDir outputDir k =
+        withResource
+          (createDirectoryIfMissing True outputDir)
+          (\_ -> pure ())
+          (\_ -> k)
+
+flatten :: TestCaseTree -> [TestCase]
+flatten = \case
+    TestCaseSection _ subTrees -> concatMap flatten subTrees
+    TestCaseLeaf leaf          -> [leaf]

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
@@ -16,40 +16,28 @@ import Test.HsBindgen.Resources
 
 testCases :: [TestCase]
 testCases = [
-      -- Default tests
-
-      -- Bespoke tests
-      test_macros_reparse
-    , test_macros_reparse_arithmetic_types
-    , test_macros_reparse_cref_attributes
-    , test_macros_reparse_gnu_attributes
-    , test_macros_reparse_functions
+      test
+    , test_arithmetic_types
+    , test_cref_attributes
+    , test_defer_wrong
+    , test_functions
+    , test_gnu_attributes
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_macros_reparse :: TestCase
-test_macros_reparse =
+test :: TestCase
+test =
     defaultTest "macros/reparse"
         -- `bool` is a keyword.
       & #clangVersion   .~ Just (>= (15, 0, 0))
         -- `bool` is a keyword.
       & #cStandard      .~ c23
 
-test_macros_reparse_gnu_attributes :: TestCase
-test_macros_reparse_gnu_attributes =
-    defaultTest "macros/reparse/gnu_attributes"
-      & #cStandard      .~ c23
-
-test_macros_reparse_cref_attributes :: TestCase
-test_macros_reparse_cref_attributes =
-    defaultTest "macros/reparse/cref_attributes"
-      & #cStandard      .~ c23
-
-test_macros_reparse_arithmetic_types :: TestCase
-test_macros_reparse_arithmetic_types =
+test_arithmetic_types :: TestCase
+test_arithmetic_types =
     defaultTest "macros/reparse/arithmetic_types"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchSelect name@"f29" (SelectParseFailure ParseUnsupportedLongDouble) ->
@@ -60,8 +48,22 @@ test_macros_reparse_arithmetic_types =
   where
     declsWithMsgs = ["f29"]
 
-test_macros_reparse_functions :: TestCase
-test_macros_reparse_functions =
+test_cref_attributes :: TestCase
+test_cref_attributes =
+    defaultTest "macros/reparse/cref_attributes"
+      & #cStandard      .~ c23
+
+test_defer_wrong :: TestCase
+test_defer_wrong =
+    defaultTest "macros/reparse/defer_wrong"
+
+test_functions :: TestCase
+test_functions =
     defaultTest "macros/reparse/functions"
       -- C99 required for inline functions
       & #cStandard .~ c99
+
+test_gnu_attributes :: TestCase
+test_gnu_attributes =
+    defaultTest "macros/reparse/gnu_attributes"
+      & #cStandard      .~ c23

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
@@ -1,27 +1,42 @@
 -- | Golden tests: macro reparsing
 module Test.HsBindgen.Golden.Macros.Reparse (testCases) where
 
+import Control.Applicative
+
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
 import HsBindgen.TraceMsg
+import HsBindgen.Util.Tracer
 
 import Test.Common.HsBindgen.Trace.Patterns
 import Test.Common.HsBindgen.Trace.Predicate
 import Test.HsBindgen.Golden.Infra.TestCase
+import Test.HsBindgen.Golden.Infra.TestCaseTree
 import Test.HsBindgen.Resources
 
 {-------------------------------------------------------------------------------
   Test cases
 -------------------------------------------------------------------------------}
 
-testCases :: [TestCase]
+testCases :: [TestCaseTree]
 testCases = [
-      test
-    , test_arithmetic_types
-    , test_cref_attributes
-    , test_defer_wrong
-    , test_functions
-    , test_gnu_attributes
+      TestCaseLeaf test
+    , TestCaseLeaf test_arithmetic_types
+    , TestCaseLeaf test_cref_attributes
+    , TestCaseLeaf test_defer_wrong
+    , TestCaseLeaf test_functions
+    , TestCaseLeaf test_gnu_attributes
+    , TestCases "nesting" [
+          defaultTest_nesting "macros/reparse/nesting"
+        , defaultTest_nesting "macros/reparse/nesting/struct_in_struct"
+        , defaultTest_nesting "macros/reparse/nesting/struct_in_typedef"
+        , defaultTest_nesting "macros/reparse/nesting/struct_in_union"
+        , defaultTest_nesting "macros/reparse/nesting/struct_in_variable"
+        , defaultTest_nesting "macros/reparse/nesting/union_in_struct"
+        , defaultTest_nesting "macros/reparse/nesting/union_in_typedef"
+        , defaultTest_nesting "macros/reparse/nesting/union_in_union"
+        , defaultTest_nesting "macros/reparse/nesting/union_in_variable"
+        ]
     ]
 
 {-------------------------------------------------------------------------------
@@ -67,3 +82,34 @@ test_gnu_attributes :: TestCase
 test_gnu_attributes =
     defaultTest "macros/reparse/gnu_attributes"
       & #cStandard      .~ c23
+
+{-------------------------------------------------------------------------------
+  Nesting
+-------------------------------------------------------------------------------}
+
+defaultTest_nesting :: FilePath -> TestCase
+defaultTest_nesting path =
+    defaultTest path
+      & #tracePredicate .~ defaultTracePredicate_nesting
+
+defaultTracePredicate_nesting :: TracePredicate Level TraceMsg
+defaultTracePredicate_nesting = multiTracePredicate_nesting @() [] (const Nothing)
+
+multiTracePredicate_nesting :: forall b.
+     (Ord b, RenderLabel b)
+  => [b]
+  -> (TraceMsg -> Maybe (TraceExpectation b))
+  -> TracePredicate Level TraceMsg
+multiTracePredicate_nesting expected predicate = multiTracePredicate expected predicate'
+  where
+    predicate' x = predicate x <|> defaultPredicate x
+
+    defaultPredicate :: TraceMsg -> Maybe (TraceExpectation b)
+    defaultPredicate = \case
+        MatchDelayed _info ParseMacroErrorParse{} ->
+          Just Unexpected
+        MatchDelayed _info ParseMacroErrorReparse{} ->
+          Just Unexpected
+        MatchDelayed _info ParseMacroErrorReparseZip{} ->
+          Just Unexpected
+        _ -> Nothing


### PR DESCRIPTION
Resolves #1382

See the Haddock comment on the `UpdateSkipped` constructor for a description of the solution: https://github.com/well-typed/hs-bindgen/pull/2021/files#diff-2e306ab847ec8d698e281b01d0c891adb7c9954a3ec5704ae6d3cddf559d70c1