### PR TITLE
`Parse`: add `SourceRangeMap` abstraction for recording macro expansions

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -203,6 +203,7 @@ library internal
     HsBindgen.Frontend.Pass.Parse.Decl.Members
     HsBindgen.Frontend.Pass.Parse.IsPass
     HsBindgen.Frontend.Pass.Parse.Monad.Decl
+    HsBindgen.Frontend.Pass.Parse.Monad.SourceRangeMap
     HsBindgen.Frontend.Pass.Parse.Monad.Type
     HsBindgen.Frontend.Pass.Parse.Msg
     HsBindgen.Frontend.Pass.Parse.PrelimDeclId

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -450,18 +450,23 @@ typedefDecl _enclosing ctx info = \curr -> do
 
 macroExpansion :: Parser l
 macroExpansion = \curr -> do
-    range <- fmap multiLocExpansion <$> HighLevel.clang_getCursorExtent curr
-    let loc = range.rangeStart
-    unit <- getTranslationUnit
-    tokens <- HighLevel.clang_tokenize unit range
+    (range, tokens) <- getTokens curr
     case getMacroName tokens of
       -- TODO <https://github.com/well-typed/hs-bindgen/issues/1554>
       --
       -- Attach failed macroName message to declaration.
       Nothing -> traceImmediateGlobal ParseMacroExpansionNoMacroName
-      Just macroName -> recordMacroExpansionAt loc macroName
+      Just macroName -> recordMacroExpansionAt macroName range
     foldContinue
   where
+    getTokens ::
+         CXCursor
+      -> ParseDecl (Range MultiLoc, [Token TokenSpelling])
+    getTokens curr' = do
+        unit'  <- getTranslationUnit
+        range  <- HighLevel.clang_getCursorExtent curr'
+        (range,) <$> HighLevel.clang_tokenize unit' (multiLocExpansion <$> range)
+
     getMacroName :: [Token TokenSpelling] -> Maybe Text
     getMacroName []    = Nothing
     -- The spelling of function macros includes the function parameters. For

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/Decl.hs
@@ -27,8 +27,7 @@ module HsBindgen.Frontend.Pass.Parse.Monad.Decl (
   ) where
 
 import Data.IORef
-import Data.List.NonEmpty qualified as NonEmpty
-import Data.Map.Strict qualified as Map
+import Data.List.NonEmpty qualified as NE
 import Data.Set qualified as Set
 
 import Clang.HighLevel qualified as HighLevel
@@ -43,6 +42,11 @@ import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.Parse.Context
 import HsBindgen.Frontend.Pass.Parse.IsPass
+import HsBindgen.Frontend.Pass.Parse.Monad.SourceRangeMap (LookupResult (..),
+                                                           SourceRangeMap,
+                                                           initSourceRangeMap,
+                                                           lookupRange,
+                                                           recordAt)
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId (PrelimDeclId)
 import HsBindgen.Frontend.Pass.Parse.PrelimDeclId qualified as PrelimDeclId
@@ -114,26 +118,29 @@ data ParseState = ParseState {
       -- | Where did Clang expand macros, and what are their names?
       --
       -- Declarations with expanded macros need to be reparsed.
-      --
-      -- We use a stacked map so we can lookup macro expansions in source
-      -- location ranges reasonably fast.
-    , macroExpansions :: Map SourcePath (Map Int (NonEmpty Text))
+    , macroExpansions :: SourceRangeMap Text
     }
   deriving (Generic)
 
 initParseState :: ParseState
 initParseState = ParseState{
       macroDefinitions = []
-    , macroExpansions = Map.empty
+    , macroExpansions = initSourceRangeMap
     }
+
+getParseState :: ParseDecl ParseState
+getParseState = wrapEff $ \support -> readIORef support.state
+
+modifyParseState :: (ParseState -> ParseState) -> ParseDecl ()
+modifyParseState f = wrapEff $ \support -> modifyIORef support.state f
 
 recordMacroDefinitionAt ::
      Text
   -> Range MultiLoc
   -> [Token TokenSpelling]
   -> ParseDecl ()
-recordMacroDefinitionAt macroName locRange tokens = wrapEff $ \support -> do
-    modifyIORef support.state $ #macroDefinitions %~ addMacroDefinition
+recordMacroDefinitionAt macroName locRange tokens =
+    modifyParseState $ #macroDefinitions %~ addMacroDefinition
   where
     macroDefinition :: MacroDefinition
     macroDefinition = MacroDefinition {
@@ -148,53 +155,30 @@ recordMacroDefinitionAt macroName locRange tokens = wrapEff $ \support -> do
     addMacroDefinition defs = macroDefinition : defs
 
 getMacroDefinitions :: ParseDecl [MacroDefinition]
-getMacroDefinitions = wrapEff $ \support -> do
-    reverse . (.macroDefinitions) <$> readIORef support.state
+getMacroDefinitions = reverse . (.macroDefinitions) <$> getParseState
 
-recordMacroExpansionAt :: SingleLoc -> Text -> ParseDecl ()
-recordMacroExpansionAt loc macroName = wrapEff $ \support -> do
-    modifyIORef support.state $ #macroExpansions %~ addMacro
+recordMacroExpansionAt ::
+     Text
+  -> Range MultiLoc
+  -> ParseDecl ()
+recordMacroExpansionAt macroName locRange =
+    modifyParseState $ #macroExpansions %~ recordAt loc macroName
   where
-    addMacro ::
-         Map SourcePath (Map Int (NonEmpty Text))
-      -> Map SourcePath (Map Int (NonEmpty Text))
-    addMacro = Map.alter addMacroAtFile loc.singleLocPath
-
-    addMacroAtFile ::
-         Maybe (Map Int (NonEmpty Text))
-      -> Maybe (Map Int (NonEmpty Text))
-    addMacroAtFile = Just . \case
-      Nothing ->
-        Map.singleton loc.singleLocLine $ NonEmpty.singleton macroName
-      Just lineMap ->
-        Map.alter addMacroAtLine loc.singleLocLine lineMap
-
-    addMacroAtLine :: Maybe (NonEmpty Text) -> Maybe (NonEmpty Text)
-    addMacroAtLine = Just . \case
-      Nothing     -> NonEmpty.singleton macroName
-      Just macros -> NonEmpty.cons      macroName macros
+    loc :: SingleLoc
+    loc = locRange.rangeStart.multiLocExpansion
 
 getMacroExpansions :: Range SingleLoc -> ParseDecl (Set Text)
-getMacroExpansions range
-  -- We do not support getting macro expansions for declarations spanning
-  -- multiple files.
-  | range.rangeStart.singleLocPath /= range.rangeEnd.singleLocPath = do
-      traceImmediateGlobal (ParseGetMacroExpansionsMultipleFiles range)
-      pure $ Set.empty
-  | otherwise = do
-    wrapEff $ \support ->
-      aux . (.macroExpansions) <$> readIORef support.state
-  where
-    sourcePath :: SourcePath
-    sourcePath = range.rangeStart.singleLocPath
-
-    aux :: Map SourcePath (Map Int (NonEmpty Text)) -> Set Text
-    aux fileMap = case Map.lookup sourcePath fileMap of
-      Nothing      -> Set.empty
-      Just lineMap ->
-        Set.fromList $ concatMap NonEmpty.toList $ Map.elems $
-          Map.takeWhileAntitone (range.rangeEnd.singleLocLine >=) $
-            Map.dropWhileAntitone (range.rangeStart.singleLocLine >) lineMap
+getMacroExpansions range = do
+    macroExpansions <- (.macroExpansions) <$> getParseState
+    case lookupRange range macroExpansions of
+      -- We do not support getting macro expansions for declarations spanning
+      -- multiple files.
+      LookupErrorMultipleFiles -> do
+        traceImmediateGlobal (ParseGetMacroExpansionsMultipleFiles range)
+        pure Set.empty
+      LookupNotFound ->
+        pure Set.empty
+      LookupFound macroNames -> pure $ Set.fromList $ NE.toList macroNames
 
 {-------------------------------------------------------------------------------
   Logging

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/SourceRangeMap.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/SourceRangeMap.hs
@@ -1,0 +1,82 @@
+-- | Mapping of source location ranges in C code to @a@ values
+--
+-- Intended for unqualified import (unless context is unambiguous).
+--
+-- > import HsBindgen.Frontend.Pass.Parse.Monad.SourceRangeMap
+module HsBindgen.Frontend.Pass.Parse.Monad.SourceRangeMap (
+    SourceRangeMap
+  , initSourceRangeMap
+  , recordAt
+  , LookupResult (..)
+  , lookupRange
+  ) where
+
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NE
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Semigroup (Semigroup (sconcat))
+
+import Clang.HighLevel.Types (Range (rangeEnd, rangeStart),
+                              SingleLoc (singleLocLine, singleLocPath))
+import Clang.Paths (SourcePath)
+
+-- | Mapping of source location ranges in C code to @a@ values
+newtype SourceRangeMap a = SRM {
+    -- | We use a stacked map so we can lookup values in source location ranges
+    -- reasonably fast.
+    unwrap :: Map SourcePath (Map Int (NonEmpty a))
+  }
+
+-- | An empty 'SourceRangeMap'
+initSourceRangeMap :: SourceRangeMap a
+initSourceRangeMap = SRM Map.empty
+
+-- | Map the given location to a value of type @a@
+recordAt :: forall a. SingleLoc -> a -> SourceRangeMap a -> SourceRangeMap a
+recordAt loc new srm = SRM (addMacro srm.unwrap)
+  where
+    addMacro ::
+         Map SourcePath (Map Int (NonEmpty a))
+      -> Map SourcePath (Map Int (NonEmpty a))
+    addMacro = Map.alter addMacroAtFile loc.singleLocPath
+
+    addMacroAtFile ::
+         Maybe (Map Int (NonEmpty a))
+      -> Maybe (Map Int (NonEmpty a))
+    addMacroAtFile = Just . \case
+      Nothing ->
+        Map.singleton loc.singleLocLine $ NonEmpty.singleton new
+      Just lineMap ->
+        Map.alter addMacroAtLine loc.singleLocLine lineMap
+
+    addMacroAtLine :: Maybe (NonEmpty a) -> Maybe (NonEmpty a)
+    addMacroAtLine = Just . \case
+      Nothing     -> NonEmpty.singleton new
+      Just macros -> NonEmpty.cons      new macros
+
+data LookupResult a =
+    -- | Ranges that span multiple files are not supported in lookups
+    LookupErrorMultipleFiles
+  | LookupNotFound
+  | LookupFound a
+
+-- | Lookup values in the given source location range
+lookupRange :: forall a. Range SingleLoc -> SourceRangeMap a -> LookupResult (NonEmpty a)
+lookupRange range srm
+  | range.rangeStart.singleLocPath /= range.rangeEnd.singleLocPath
+  = LookupErrorMultipleFiles
+  | otherwise
+  = maybe LookupNotFound LookupFound aux
+  where
+    sourcePath :: SourcePath
+    sourcePath = range.rangeStart.singleLocPath
+
+    aux :: Maybe (NonEmpty a)
+    aux = do
+        let fileMap = srm.unwrap
+        lineMap <- Map.lookup sourcePath fileMap
+        fmap sconcat $ NE.nonEmpty $ Map.elems $
+          Map.takeWhileAntitone (range.rangeEnd.singleLocLine >=) $
+            Map.dropWhileAntitone (range.rangeStart.singleLocLine >) lineMap


### PR DESCRIPTION
Builds on top of #2031, so that PR should be merged first.

This PR is made in preparation for #2012.

In the spirit of encapsulating functionality, we add a an abstraction for (performantly) recording the source location ranges for macro expansions. We are likely to modify this abstraction in the future in the context of other changes to macros.

