### PR TITLE
`PrepareReparse`: deduplicate trace callstacks

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
@@ -31,8 +31,7 @@ import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass (CheckedMacro (..),
                                                        TypecheckMacros)
 import HsBindgen.Imports (Star, Symbol)
 import HsBindgen.Util.Tracer (IsTrace (..), Level (Bug, Debug, Info, Warning),
-                              PrettyForTrace (..), Source (HsBindgen),
-                              WithCallStack)
+                              PrettyForTrace (..), Source (HsBindgen))
 
 {-------------------------------------------------------------------------------
   Definition
@@ -53,7 +52,7 @@ type family AnnPrepareReparse (ix :: Symbol) :: Star where
 instance IsPass PrepareReparse where
   type MacroBody   PrepareReparse = CheckedMacro PrepareReparse
   type Ann ix      PrepareReparse = AnnPrepareReparse ix
-  type Msg         PrepareReparse = WithCallStack PrepareReparseMsg
+  type Msg         PrepareReparse = PrepareReparseMsg
   type MacroId     PrepareReparse = Id PrepareReparse
   type CommentDecl PrepareReparse = Maybe (C.Comment PrepareReparse)
   macroIdId _ = id

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Tracer.hs
@@ -8,14 +8,15 @@
 --
 module HsBindgen.Frontend.Pass.PrepareReparse.Tracer (
     traceImmediate
+  , traceBelated
   ) where
 
-import HsBindgen.Frontend.Pass (IsPass (Msg))
-import HsBindgen.Frontend.Pass.PrepareReparse.IsPass (PrepareReparse,
-                                                      PrepareReparseMsg)
-import HsBindgen.Util.Tracer (Contravariant (contramap), Tracer, traceWith,
-                              withCallStack)
+import HsBindgen.Frontend.Pass (AMsg, IsPass (Msg))
+import HsBindgen.Frontend.Pass.PrepareReparse.IsPass (PrepareReparse)
+import HsBindgen.Util.Tracer (Tracer, traceWith, withCallStack)
 
-traceImmediate :: Tracer (Msg PrepareReparse) -> PrepareReparseMsg -> IO ()
-traceImmediate tracer msg = traceWith (contramap withCallStack tracer) $
-    withCallStack msg
+traceImmediate :: Tracer (Msg PrepareReparse) -> Msg PrepareReparse -> IO ()
+traceImmediate tracer msg = traceWith tracer $ withCallStack msg
+
+traceBelated :: Tracer (Msg PrepareReparse) -> AMsg PrepareReparse -> IO ()
+traceBelated tracer amsg = traceWith tracer amsg


### PR DESCRIPTION
Follow-up to #1934. We probably overlooked deduplicating trace callstacks in `PrepareReparse` because it is a new pass that was merged around the same time as #1934.
