### PR TITLE
Consistently check for duplicate names

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -17,6 +17,23 @@
   instead.
 * `EChar` is renamed to `ECChar` in `HsBindgen.Backend.SHs.AST.Expr`.
 * `ECString` now carries a `ByteString` instead of a `ByteArray`.
+* Tagged types that would clash with the name of an enclosing typedef are now
+  disambiguated with a `_struct`/`_union`/`_enum` suffix (mirroring the C
+  keyword) instead of the previous `_Aux`. Clash detection now also covers
+  arrays, blocks, and function types (argument and result types), not just
+  pointers, so e.g. `typedef struct {…} foo[10];` no longer produces clashing
+  names. Qualifiers (e.g. `const`) are treated as transparent, so
+  `typedef const struct {…} foo;` is now squashed like its unqualified
+  counterpart. This renames affected generated identifiers. See
+  [#1445](https://github.com/well-typed/hs-bindgen/issues/1445).
+* The `MangleNames` pass now checks names minted in its second pass (data
+  constructors, record-field selectors, union getters/setters, enum constants,
+  and `_Aux` types for FLAMs and function pointers) for collisions. A
+  declaration whose derived names collide is now deselected with an warning
+  instead of producing uncompilable Haskell. Relatedly, under
+  `OmitFieldPrefixes`, a struct with two fields that mangle to the same Haskell
+  name is now deselected (`MangleNamesDuplicateFieldName`). See
+  [#1432](https://github.com/well-typed/hs-bindgen/issues/1432).
 
 ### New features
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -199,6 +199,7 @@ library internal
     HsBindgen.Frontend.Pass.MangleNames
     HsBindgen.Frontend.Pass.MangleNames.Error
     HsBindgen.Frontend.Pass.MangleNames.IsPass
+    HsBindgen.Frontend.Pass.MangleNames.Names
     HsBindgen.Frontend.Pass.Parse
     HsBindgen.Frontend.Pass.Parse.Context
     HsBindgen.Frontend.Pass.Parse.Decl

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
@@ -151,45 +151,82 @@ analyseTypedef ::
   -> C.Typedef ResolveBindingSpecs
   -> TypedefAnalysis
 analyseTypedef declUseGraph typedefInfo typedef =
-    case taggedPayload typedef.typ of
-      Nothing      -> mempty
-      Just payload ->
-        typedefOfTagged typedefInfo payload $
-          DeclUseGraph.getUseSitesNoSelfReferences declUseGraph payload.id
-
--- | Typedef around tagged payload
-typedefOfTagged ::
-     C.DeclInfo ResolveBindingSpecs    -- ^ Typedef info
-  -> TaggedPayload                     -- ^ Payload
-  -> [(DeclId, usage)]                 -- ^ Use sites of the payload
-  -> TypedefAnalysis
-typedefOfTagged typedefInfo payload useSites
-  | shouldSquash
-  = mconcat [
-        conclude typedefInfo.id $ Squash $ SquashTypedef {
-            typedefLoc = typedefInfo.loc
-          , targetId   = payload.id
-          }
-      , conclude payload.id $ UseNameOf typedefInfo.id
-      ]
-
-  | shouldAddSuffix
-  = conclude payload.id $ AddSuffix "_Aux"
-
-  | otherwise
-  = mempty
-  where
-    shouldSquash, shouldAddSuffix :: Bool
-    shouldSquash = and [
-          payload.isDirect
-        , or [ typedefInfo.id.name.text == payload.id.name.text
-             , length useSites == 1
+    case directPayload of
+      -- The typedef is a direct alias of a tagged type: a candidate for
+      -- squashing.
+      Just payload
+        | shouldSquash payload
+        -> mconcat [
+               conclude typedefInfo.id $ Squash $ SquashTypedef {
+                   typedefLoc = typedefInfo.loc
+                 , targetId   = payload.id
+                 }
+             , conclude payload.id $ UseNameOf typedefInfo.id
              ]
+
+      -- Otherwise, suffix every tagged type that is referenced /within/ the
+      -- typedef's own type and that would mangle to the same Haskell name as the
+      -- typedef itself.
+      --
+      -- This is a purely /local/ decision: it depends only on this typedef's
+      -- name and its own type structure, never on which other declarations
+      -- happen to be in scope. We can only resolve a name clash here when the
+      -- clashing tagged type is syntactically referenced by the typedef; clashes
+      -- with unrelated declarations of the same name are detected (and reported)
+      -- by the collision check in "HsBindgen.Frontend.Pass.MangleNames".
+      _otherwise ->
+        foldMap suffixClashingPayload clashingPayloads
+  where
+    typedefName :: Text
+    typedefName = typedefInfo.id.name.text
+
+    -- All tagged types referenced anywhere within the typedef's type.
+    payloads :: [TaggedPayload]
+    payloads = taggedPayloads typedef.typ
+
+    -- The tagged type the typedef is a direct alias of (the head of the type,
+    -- reached without any indirection), if any.
+    directPayload :: Maybe TaggedPayload
+    directPayload = case [ p | p <- payloads, p.isDirect ] of
+        p : _      -> Just p
+        _otherwise -> Nothing
+
+    -- Tagged types referenced /through indirection/ within the typedef's type
+    -- whose name clashes with the typedef itself.
+    clashingPayloads :: [TaggedPayload]
+    clashingPayloads = [
+          p
+        | p <- payloads
+        , not p.isDirect
+        , p.id.name.text == typedefName
         ]
-    shouldAddSuffix = and [
-          not payload.isDirect
-        , typedefInfo.id.name.text == payload.id.name.text
+
+    shouldSquash :: TaggedPayload -> Bool
+    shouldSquash payload = or [
+          payload.id.name.text == typedefName
+        , length useSites == 1
         ]
+      where
+        useSites :: [(DeclId, C.ValOrRef)]
+        useSites = DeclUseGraph.getUseSitesNoSelfReferences declUseGraph payload.id
+
+    suffixClashingPayload :: TaggedPayload -> TypedefAnalysis
+    suffixClashingPayload payload =
+        conclude payload.id $ AddSuffix $ tagSuffix payload.id.name.kind
+
+-- | The (deterministic) suffix used to disambiguate a tagged type from a
+-- same-named typedef.
+--
+-- We suffix the /tagged/ type (and not the typedef) because C code refers to a
+-- typedef by its bare name, but to a tagged type via its @struct@\/@union@\/
+-- @enum@ keyword; the suffix mirrors that keyword.
+tagSuffix :: CNameKind -> Text
+tagSuffix = \case
+    CNameKindTagged CTagKindStruct -> "_struct"
+    CNameKindTagged CTagKindUnion  -> "_union"
+    CNameKindTagged CTagKindEnum   -> "_enum"
+    -- Only tagged types are ever suffixed (see 'taggedPayloads').
+    _otherwise                     -> "_Aux"
 
 {-------------------------------------------------------------------------------
   Internal auxiliary: typedefs around "tagged" decls (structs, unions, enums)
@@ -204,27 +241,67 @@ data TaggedPayload = TaggedPayload{
     , id       :: DeclId
     }
 
--- | Tagged declaration (struct, union, enum) wrapped by this typedef, if any
-taggedPayload :: C.Type ResolveBindingSpecs -> Maybe TaggedPayload
-taggedPayload = go True
+-- | All tagged declarations (struct, union, enum) referenced within a type.
+--
+-- The 'isDirect' flag is 'True' only for a tagged type that the typedef is a
+-- direct alias of, i.e. one reached without going through any indirection
+-- (pointer, array, function, block). A qualifier (such as @const@) is
+-- transparent: it changes neither the Haskell representation nor the mangled
+-- name, so a tagged type underneath it stays direct.
+--
+-- Any layer of indirection means the tagged type and the typedef are
+-- /different/ types that nonetheless mangle to the same Haskell name, so the
+-- tagged type must be given a suffix. This covers
+--
+-- > typedef struct {..} * foo;
+-- > typedef struct {..} foo[10];
+-- > typedef struct foo (*foo)(struct bar arg);
+-- > typedef const struct foo * foo;
+--
+-- See <https://github.com/well-typed/hs-bindgen/issues/1445>. Note that we
+-- recurse into /function/ types (both the result and the argument types), so a
+-- tagged type referenced there is detected as well.
+taggedPayloads :: C.Type ResolveBindingSpecs -> [TaggedPayload]
+taggedPayloads = go True
   where
-    go :: Bool -> C.Type ResolveBindingSpecs -> Maybe TaggedPayload
+    go :: Bool -> C.Type ResolveBindingSpecs -> [TaggedPayload]
     go direct = \case
-        C.TypeRef declId     -> typeRef direct declId
-        C.TypeEnum ref       -> typeRef direct ref.name
-        C.TypePointers _n ty -> go False ty
-        _otherwise ->
-          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1445>
-          -- This is wrong. This deals with
-          --
-          -- > typedef struct {..} * foo;
-          --
-          -- but not, for example
-          --
-          -- > typedef struct {..} foo[10];
-          Nothing
+        C.TypeRef declId         -> typeRef direct declId
+        C.TypeEnum ref           -> typeRef direct ref.name
 
-    typeRef :: Bool -> DeclId -> Maybe TaggedPayload
-    typeRef isDirect declId = do
-        void $ checkIsTagged declId.name.kind
-        return TaggedPayload{isDirect = isDirect, id = declId}
+        -- A qualifier (e.g. @const@) is transparent: it changes neither the
+        -- Haskell representation nor the mangled name, so the tagged type
+        -- underneath is reached with the /same/ directness.
+        C.TypeQual _qual ty      -> go direct ty
+
+        -- Indirection: the tagged type underneath is a /different/ type that
+        -- merely mangles to the same name, so it is no longer direct.
+        C.TypePointers _n ty     -> go False ty
+        C.TypeConstArray _n ty   -> go False ty
+        C.TypeIncompleteArray ty -> go False ty
+        C.TypeBlock ty           -> go False ty
+        C.TypeFun args res       ->
+          concatMap (go False . (.typ)) args ++ go False res
+
+        -- No tagged type to find.
+        C.TypePrim{}             -> []
+        C.TypeComplex{}          -> []
+        C.TypeVoid               -> []
+
+        -- A macro type and another typedef each have their own name; the tagged
+        -- type they may wrap is not /syntactically/ referenced by this typedef,
+        -- so resolving such a clash is out of scope for this local analysis.
+        C.TypeMacro{}            -> []
+        C.TypeTypedef{}          -> []
+        C.TypeExtBinding{}       -> []
+
+    typeRef :: Bool -> DeclId -> [TaggedPayload]
+    typeRef isDirect declId =
+        case checkIsTagged declId.name.kind of
+          Nothing -> []
+          Just _  -> [TaggedPayload{isDirect = isDirect, id = declId}]
+
+-- TODO-D: Check assumption of locality. How does this come together with
+-- squashing and the statement from above:
+--
+-- 2. The typedef is the /only/ reference to the underlying decl:

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -12,6 +12,7 @@ import Data.Foldable qualified as Foldable
 import Data.Function
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map qualified as Map
+import Data.Maybe (maybeToList)
 import Data.Proxy
 import Data.Set qualified as Set
 
@@ -34,6 +35,7 @@ import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
+import HsBindgen.Frontend.Pass.MangleNames.Names
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -42,6 +44,9 @@ import HsBindgen.Macro.Type
 import HsBindgen.Util.Tracer (WithCallStack, withCallStack)
 
 import Doxygen.Parser.Types qualified as Doxy
+
+-- TODO-D: Three traversals/passes? Mangle names (top-level and within
+-- declarations), clash detection, assign names in declarations.
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -68,7 +73,11 @@ mangleNames fieldNaming unit = (
                             squashes
                             unit.meta
         }
-    , msgs1 ++ msgs2
+    , msgs1 ++ [
+          debugMsg $ MangleNamesNameMap nameMap
+        , debugMsg $ MangleNamesNameRegistry "Pass 1" registry1
+        , debugMsg $ MangleNamesNameRegistry "Pass 2" registry2
+        ]
     )
   where
     typedefAnalysis :: TypedefAnalysis
@@ -77,29 +86,48 @@ mangleNames fieldNaming unit = (
     mangleCandidateConfig :: MangleCandidate Maybe
     mangleCandidateConfig = MangleCandidate.mangleCandidateDefault
 
-    -- Pass 1.
+    -- Pass 1: choose top-level names, detect top-level collisions (sweep 1), and
+    -- seed the name registry with the surviving names.
     nameMap   :: NameMap
+    registry1 :: NameRegistry
     failures1 :: [MangleNamesFailure]
     msgs1     :: [AMsg MangleNames]
-    (decls1, nameMap, failures1, msgs1) =
+    (decls1, nameMap, registry1, failures1, msgs1) =
       chooseNames typedefAnalysis mangleCandidateConfig unit.decls
 
-    -- Pass 2.
+    -- Pass 2: apply the name map and mint derived names (recorded in the
+    -- registry, seeded with the surviving pass 1 names).
     env :: Env
     env = Env{
           typedefAnalysis     = typedefAnalysis
         , mangleCandidate     = mangleCandidateConfig
         , nameMap             = nameMap
         , fieldNamingStrategy = fieldNaming
+        , currentDecl         = Nothing
         }
 
     mangleDeclResults :: [MangleDeclResult l]
-    msgs2             :: [AMsg MangleNames]
-    (mangleDeclResults, msgs2) = runM env $ mapM mangleDecl decls1
+    registry2         :: NameRegistry
+    (mangleDeclResults, registry2) = runM env registry1 $ mapM mangleDecl decls1
+
+    mangleFailures :: [MangleNamesFailure]
+    squashes       :: [MangleNamesSquash]
+    mangledDecls   :: [C.Decl l MangleNames]
+    (mangleFailures, squashes, mangledDecls) = partitionResults mangleDeclResults
+
+    -- Sweep 2: collisions involving names minted in pass 2 (derived vs. derived,
+    -- or derived vs. a surviving pass 1 name).
+    collisionFailures2 :: [MangleNamesFailure]
+    collisionFailures2 = collisionFailures (collisions registry2)
+
+    collidingIds2 :: Set DeclId
+    collidingIds2 = Set.fromList $ map (.id) collisionFailures2
 
     failures2 :: [MangleNamesFailure]
-    squashes  :: [MangleNamesSquash]
-    (failures2, squashes, decls2) = partitionResults mangleDeclResults
+    failures2 = mangleFailures ++ collisionFailures2
+
+    decls2 :: [C.Decl l MangleNames]
+    decls2 = filter (\d -> Set.notMember d.info.id.cName collidingIds2) mangledDecls
 
     partitionResults ::
          [MangleDeclResult l]
@@ -150,7 +178,12 @@ chooseNames ::
   => TypedefAnalysis
   -> MangleCandidate Maybe
   -> [C.Decl l ResolveBindingSpecs]
-  -> ([C.Decl l ResolveBindingSpecs], NameMap, [MangleNamesFailure], [AMsg MangleNames])
+  -> ( [C.Decl l ResolveBindingSpecs]
+     , NameMap
+     , NameRegistry
+     , [MangleNamesFailure]
+     , [AMsg MangleNames]
+     )
 chooseNames td mc decls =
     let specifiedNames :: Map DeclId (Hs.Name Hs.NsTypeConstr)
         specifiedNames = Map.fromList $ mapMaybe getSpecifiedName decls
@@ -171,31 +204,57 @@ chooseNames td mc decls =
         nameInfosOriginal :: [NameInfo]
         nameInfosOriginal = filter (not . (.squashed)) nameInfos
 
-        collisions :: Map Hs.SomeName [(DeclId, SingleLoc)]
-        collisions = getDuplicates $ Map.fromList $
-          map (\n -> ((n.cName, n.loc), n.hsName)) nameInfosOriginal
+        -- Sweep 1: collisions among top-level names.
+        sweepRegistry :: NameRegistry
+        sweepRegistry = registerInfos nameInfosOriginal
 
-        collisionFailures :: [MangleNamesFailure]
-        collisionFailures = concatMap getCollisionFailures $ Map.toList collisions
+        collisionFs :: [MangleNamesFailure]
+        collisionFs = collisionFailures (collisions sweepRegistry)
 
         collidingDeclIds :: Set DeclId
-        collidingDeclIds = Set.fromList $ map (.id) collisionFailures
+        collidingDeclIds = Set.fromList $ map (.id) collisionFs
 
         okDecls :: [C.Decl l ResolveBindingSpecs]
         okDecls = filter (\x -> Set.notMember x.info.id collidingDeclIds) decls
 
-    in  (okDecls, nameMap, failures ++ collisionFailures, messages)
+        -- Seed the pass 2 registry with the surviving (non-colliding) top-level
+        -- names, so derived names can be checked against them in sweep 2.
+        registry1 :: NameRegistry
+        registry1 = registerInfos $
+          filter (\n -> Set.notMember n.cName collidingDeclIds) nameInfosOriginal
+
+    in  (okDecls, nameMap, registry1, failures ++ collisionFs, messages)
   where
     getSpecifiedName ::
       C.Decl l ResolveBindingSpecs -> Maybe (DeclId, Hs.Name Hs.NsTypeConstr)
     getSpecifiedName decl = (decl.info.id,) <$> ((.hsName) =<< decl.ann.cSpec)
 
-getCollisionFailures :: (Hs.SomeName, [(DeclId, SingleLoc)]) -> [MangleNamesFailure]
-getCollisionFailures (i, xs) =
-    [ MangleNamesFailure d l $ MangleNamesCollision i idsWithLocs | (d, l) <- xs ]
+    registerInfos :: [NameInfo] -> NameRegistry
+    registerInfos = Foldable.foldl'
+      (\r n -> registerSomeName Declaration n.cName n.loc n.hsName r)
+      emptyNameRegistry
+
+-- | Turn registry collisions into per-declaration failures
+--
+-- Shared by both collision sweeps.
+collisionFailures :: [Collision] -> [MangleNamesFailure]
+collisionFailures = concatMap getCollisionFailures
   where
-    idsWithLocs :: [WithLocationInfo DeclId]
-    idsWithLocs = map (\(d, l) -> WithLocationInfo (declIdLocationInfo d [l]) d) xs
+    getCollisionFailures :: Collision -> [MangleNamesFailure]
+    getCollisionFailures c =
+        [ MangleNamesFailure o.owner o.loc (MangleNamesCollision c.name idsWithLocs)
+        | o <- origins
+        ]
+      where
+        -- One failure per distinct declaration.
+        origins :: [NameOrigin]
+        origins = Map.elems $ Map.fromList $ map (\o -> (o.owner, o)) c.origins
+
+        idsWithLocs :: [WithLocationInfo DeclId]
+        idsWithLocs =
+          [ WithLocationInfo (declIdLocationInfo o.owner [o.loc]) o.owner
+          | o <- origins
+          ]
 
 -- | Internal.
 data NameInfo = NameInfo {
@@ -216,6 +275,7 @@ nameForDecl ::
   -> C.Decl l ResolveBindingSpecs
   -> (Either MangleNamesFailure NameInfo, [AMsg MangleNames])
 nameForDecl td mc specifiedNames decl =
+    second toMs $
     withDeclNamespace decl.kind $ \(nsProxy :: Proxy ns) ->
       let mangleCandidate' :: Text -> Either MangleNamesError (Hs.Name ns)
           mangleCandidate' d = runExcept $ mangleCandidate mc nsProxy d
@@ -247,20 +307,19 @@ nameForDecl td mc specifiedNames decl =
                 Left err -> failWith err
                 Right hsNm ->
                   ( Right $ NameInfo declId (Hs.demoteNs hsNm) loc False
-                  , (toMs [MangleNamesAssignedName (Hs.demoteNs hsNm)])
-                  )
+                  , [MangleNamesAssignedName (Hs.demoteNs hsNm)] )
             Just (TypedefAnalysis.UseNameOf declId') ->
               case Map.lookup declId' specifiedNames of
                 Just hsNm ->
                   ( Right $ NameInfo declId (Hs.demoteNs hsNm) loc False
-                  , [] )
+                  , [ MangleNamesReusedAssignedName (Hs.demoteNs hsNm) ] )
                 Nothing ->
                   mangleCandidate' declId'.name.text & \case
                     Left err -> failWith err
                     Right hsNm ->
                       ( Right $ NameInfo declId (Hs.demoteNs hsNm) loc False
-                      , toMs [ MangleNamesAssignedName (Hs.demoteNs hsNm)
-                             | declId.name.text /= declId'.name.text ] )
+                      , [ MangleNamesAssignedName (Hs.demoteNs hsNm)
+                        | declId.name.text /= declId'.name.text ] )
             Just (TypedefAnalysis.Squash s) ->
               case Map.lookup s.targetId specifiedNames of
                 Just hsNm ->
@@ -282,7 +341,7 @@ nameForDecl td mc specifiedNames decl =
     loc :: SingleLoc
     loc = decl.info.loc
 
-    failWith :: MangleNamesError -> (Either MangleNamesFailure a, [AMsg MangleNames])
+    failWith :: MangleNamesError -> (Either MangleNamesFailure a, [MangleNamesMsg])
     failWith err = (Left $ toFailure info err, [])
 
     toMs :: HasCallStack => [a] -> [WithCallStack (WithLocationInfo a)]
@@ -310,13 +369,14 @@ mangleCandidate mc _ cName =
 type E m a = ExceptT MangleNamesError m a
 
 newtype M a = WrapM (
-      StateT [AMsg MangleNames] (Reader Env) a
+      StateT NameRegistry (Reader Env) a
     )
   deriving newtype (
       Functor
     , Applicative
     , Monad
     , MonadReader Env
+    , MonadState NameRegistry
     )
 
 data MangleNamesFailure = MangleNamesFailure {
@@ -340,11 +400,14 @@ data Env = Env{
     , nameMap             :: NameMap
     , mangleCandidate     :: MangleCandidate Maybe
     , fieldNamingStrategy :: FieldNamingStrategy
+      -- | The declaration currently being mangled, to blame for any derived
+      -- names minted while processing it. Set by 'mangleDecl'.
+    , currentDecl         :: Maybe (DeclId, SingleLoc)
     }
   deriving stock (Generic)
 
-runM :: Env -> M a -> (a, [AMsg MangleNames])
-runM env (WrapM ma) = second reverse . flip runReader env $ runStateT ma mempty
+runM :: Env -> NameRegistry -> M a -> (a, NameRegistry)
+runM env reg0 (WrapM ma) = flip runReader env $ runStateT ma reg0
 
 checkTypedefAnalysis :: DeclId -> M (Maybe TypedefAnalysis.Conclusion)
 checkTypedefAnalysis declId = do
@@ -352,36 +415,12 @@ checkTypedefAnalysis declId = do
     return $ Map.lookup declId td.map
 
 {-------------------------------------------------------------------------------
-  Name map
+  Name map: resolving references
+
+  The 'NameMap' itself (and the registry used for collision detection) lives in
+  "HsBindgen.Frontend.Pass.MangleNames.Names"; here we provide the 'E M'
+  wrappers that resolve references against it.
 -------------------------------------------------------------------------------}
-
-data NameMap = NameMap {
-      typeConstrs :: Map DeclId (Hs.Name Hs.NsTypeConstr)
-    , dataConstrs :: Map DeclId (Hs.Name Hs.NsConstr)
-    , vars        :: Map DeclId (Hs.Name Hs.NsVar)
-    }
-  deriving stock (Show, Eq, Generic)
-
-emptyNameMap :: NameMap
-emptyNameMap = NameMap Map.empty Map.empty Map.empty
-
-fromDeclIdPairs :: [DeclIdPair] -> NameMap
-fromDeclIdPairs = Foldable.foldl' aux emptyNameMap
-  where
-    aux :: NameMap -> DeclIdPair -> NameMap
-    aux nameMap pair = case pair.hsName.ns of
-      Hs.NsTypeConstr ->
-        nameMap & #typeConstrs %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsTypeConstr) pair.hsName)
-      Hs.NsConstr ->
-        nameMap & #dataConstrs %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsConstr) pair.hsName)
-      Hs.NsVar ->
-        nameMap & #vars %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsVar) pair.hsName)
-
-lookupType :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsTypeConstr)
-lookupType declId nameMap = Map.lookup declId nameMap.typeConstrs
 
 lookupTypeE :: DeclId -> E M (Hs.Name Hs.NsTypeConstr)
 lookupTypeE declId = do
@@ -401,9 +440,6 @@ lookupTypePair declId = do
         , hsName = Hs.demoteNs hsName
       }
 
-lookupData :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsConstr)
-lookupData declId nameMap = Map.lookup declId nameMap.dataConstrs
-
 lookupDataE :: DeclId -> E M (Hs.Name Hs.NsConstr)
 lookupDataE declId = do
     nameMap <- asks (.nameMap)
@@ -413,9 +449,6 @@ lookupDataE declId = do
           MangleNamesUnderlyingDeclNotMangled declId (NonEmpty.singleton Hs.NsConstr)
       Just hsNm ->
         pure hsNm
-
-lookupVar :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsVar)
-lookupVar declId nameMap = Map.lookup declId nameMap.vars
 
 lookupVarE :: DeclId -> E M (Hs.Name Hs.NsVar)
 lookupVarE declId = do
@@ -435,13 +468,13 @@ lookupVarPair declId = lookupVarE declId >>= \hsName -> pure $ DeclIdPair{
 
 {-------------------------------------------------------------------------------
   Pass 2: Apply NameMap
--------------------------------------------------------------------------------}
 
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1432>
---
--- Names created in this second pass are not checked for duplicates! For
--- example, the name of the auxiliary @typedef@ for @struct@s containing a FLAM
--- could clash with another type constructor name.
+  Every name minted here (via 'mintName') is recorded in the 'NameRegistry'
+  under the declaration currently being mangled, so that 'mangleNames' can
+  detect collisions in sweep 2 (see issue #1432). Names that are not emitted as
+  top-level Haskell identifiers (function arguments, the intermediate base used
+  to build union accessors) are minted with 'mkIdentifier' and not recorded.
+-------------------------------------------------------------------------------}
 
 class Mangle a where
   mangle ::
@@ -464,7 +497,9 @@ data MangleDeclResult l =
     | MdrMangled (C.Decl l MangleNames)
 
 mangleDecl :: HasMacroTypes l => C.Decl l ResolveBindingSpecs -> M (MangleDeclResult l)
-mangleDecl decl = do
+mangleDecl decl =
+    -- Blame any derived names minted below on this declaration.
+    local ( #currentDecl .~ Just (decl.info.id, decl.info.loc) ) $ do
     mConclusion <- checkTypedefAnalysis decl.info.id
     case mConclusion of
       Just (TypedefAnalysis.Squash s) ->
@@ -472,6 +507,9 @@ mangleDecl decl = do
         -- `Select` pass.
         pure $ MdrSquashed $ MangleNamesSquash decl.info.id s
       _otherwise -> withDeclNamespace decl.kind $ \(nsProxy :: Proxy ns) -> do
+        -- Snapshot the registry so a failed declaration does not leave its
+        -- partially-minted names behind to cause spurious sweep 2 collisions.
+        registryBefore <- get
         eDecl' <- runExceptT $ do
           (hsName, info') <- mangleDeclInfo nsProxy decl.info
           let hsId :: Text
@@ -491,21 +529,71 @@ mangleDecl decl = do
             , kind = kind'
             , ann  = decl.ann
             }
-        pure $ case eDecl' of
-          Left err    -> MdrFailure $ toFailure decl.info err
-          Right decl' -> MdrMangled decl'
+        case eDecl' of
+          Left err -> do
+            put registryBefore
+            pure $ MdrFailure $ toFailure decl.info err
+          Right decl' ->
+            pure $ MdrMangled decl'
 
 {-------------------------------------------------------------------------------
   Scoped names
 -------------------------------------------------------------------------------}
 
 -- | Apply Haskell naming rules
+--
+-- This does /not/ record the name in the registry; use it only for names that
+-- are not emitted as top-level Haskell identifiers.
 mkIdentifier ::
      Hs.SingNamespace ns
   => Proxy ns -> Text -> E M (Hs.Name ns)
 mkIdentifier ns candidate = do
     mc <- asks (.mangleCandidate)
     liftEither . runExcept $ mangleCandidate mc ns candidate
+
+-- | Record a minted name in the registry, blaming the current declaration
+recordName :: Hs.SingNamespace ns => NameRole -> Hs.Name ns -> E M ()
+recordName role name = do
+    mDecl <- asks (.currentDecl)
+    case mDecl of
+      -- Only happens outside of 'mangleDecl', where there is nothing to blame.
+      Nothing           -> pure ()
+      Just (owner, loc) -> modify' (registerName role owner loc name)
+
+-- | Mint a name and record it in the registry under the given 'NameRole'
+mintName ::
+     Hs.SingNamespace ns
+  => NameRole -> Proxy ns -> Text -> E M (Hs.Name ns)
+mintName role ns candidate = do
+    name <- mkIdentifier ns candidate
+    recordName role name
+    pure name
+
+-- | Mint a record field name
+--
+-- Under 'OmitFieldPrefixes' the generated code enables @DuplicateRecordFields@,
+-- so duplicate field selectors are legal and we do /not/ record them for
+-- collision detection. Under 'AddFieldPrefixes' field selectors are ordinary
+-- top-level names and must be unique, so we record them.
+mintFieldName :: FieldNamingStrategy -> Text -> E M (Hs.Name Hs.NsVar)
+mintFieldName strategy candidate = case strategy of
+    AddFieldPrefixes  -> mintName Field (Proxy @Hs.NsVar) candidate
+    OmitFieldPrefixes -> mkIdentifier   (Proxy @Hs.NsVar) candidate
+
+-- | Detect within-record duplicate field names after mangling.
+--
+-- Under 'AddFieldPrefixes' field names are injective, so this never fires.
+-- Under 'OmitFieldPrefixes' two C fields can mangle to the same Haskell name
+-- (e.g. @Bar@ and @bar@ both become @bar@), producing uncompilable Haskell.
+checkDuplicateFieldNames :: [C.StructField MangleNames] -> E M ()
+checkDuplicateFieldNames fields =
+    case Map.toList duplicates of
+      []         -> pure ()
+      (n, ls):_  -> throwError $ MangleNamesDuplicateFieldName n ls
+  where
+    duplicates :: Map Hs.SomeName [SingleLoc]
+    duplicates = Map.filter (\ls -> length ls >= 2) $
+        Map.fromListWith (++) [ (f.info.name.hsName, [f.info.loc]) | f <- fields ]
 
 mangleFieldName ::
      Text
@@ -519,7 +607,7 @@ mangleFieldName hsName fieldCName = do
             hsName <> "_" <> fieldCName.text
           OmitFieldPrefixes ->
             fieldCName.text
-    name <- mkIdentifier (Proxy @Hs.NsVar) candidate
+    name <- mintFieldName strategy candidate
     return ScopedNamePair{
         cName  = fieldCName
       , hsName = Hs.demoteNs name
@@ -543,8 +631,27 @@ mangleAccessorName hsName fieldCName =
 mangleEnumConstant ::
      CScopedName
   -> E M ScopedNamePair
-mangleEnumConstant cName = do
-    name <- mkIdentifier (Proxy @Hs.NsConstr) cName.text
+mangleEnumConstant = mangleEnumConstantWith $
+    mintName Constructor (Proxy @Hs.NsConstr)
+
+-- | Mangle an /anonymous/ (top-level) enum constant name
+--
+-- Unlike the constants of a named enum, an anonymous enum constant is a
+-- top-level declaration in its own right: its name was already chosen and
+-- registered as a 'Declaration' in pass 1. We must therefore /not/ record it
+-- again here, or the declaration would appear to collide with itself.
+mangleAnonEnumConstant ::
+     CScopedName
+  -> E M ScopedNamePair
+mangleAnonEnumConstant = mangleEnumConstantWith $
+    mkIdentifier (Proxy @Hs.NsConstr)
+
+mangleEnumConstantWith ::
+     (Text -> E M (Hs.Name Hs.NsConstr))
+  -> CScopedName
+  -> E M ScopedNamePair
+mangleEnumConstantWith mint cName = do
+    name <- mint cName.text
     return ScopedNamePair{
         cName  = cName
       , hsName = Hs.demoteNs name
@@ -571,11 +678,11 @@ mangleArgumentName argName = do
 
 mkStructNames :: Maybe a -> Text -> E M StructNames
 mkStructNames mFlam name = do
-    constrName <- mkIdentifier (Proxy @Hs.NsConstr) name
+    constrName <- mintName Constructor (Proxy @Hs.NsConstr) name
     let auxName = name <> "_Aux"
     mFlamAux <- case mFlam of
       Nothing -> pure Nothing
-      Just _  -> Just <$> mkIdentifier (Proxy @Hs.NsTypeConstr) auxName
+      Just _  -> Just <$> mintName AuxType (Proxy @Hs.NsTypeConstr) auxName
     pure StructNames{
         constr  = constrName
       , flamAux = mFlamAux
@@ -583,7 +690,7 @@ mkStructNames mFlam name = do
 
 mkFieldName ::
   FieldNamingStrategy -> Text -> E M (Hs.Name Hs.NsVar)
-mkFieldName strategy name = mkIdentifier (Proxy @Hs.NsVar) $ case strategy of
+mkFieldName strategy name = mintFieldName strategy $ case strategy of
     AddFieldPrefixes  -> "unwrap" <> name
     OmitFieldPrefixes -> "unwrap"
 
@@ -591,7 +698,7 @@ mkFieldName strategy name = mkIdentifier (Proxy @Hs.NsVar) $ case strategy of
 mkNewtypeNames ::
   FieldNamingStrategy -> Text -> E M NewtypeNames
 mkNewtypeNames strategy name = do
-    constrName <- mkIdentifier (Proxy @Hs.NsConstr) name
+    constrName <- mintName Constructor (Proxy @Hs.NsConstr) name
     fieldName  <- mkFieldName strategy name
     pure $ NewtypeNames{
       dataConstr = constrName
@@ -622,7 +729,7 @@ mkTypedefNames mFunPtr strategy name = do
     aux  <- case mFunPtr of
       Nothing -> pure Nothing
       Just _  -> do
-        auxName  <- mkIdentifier (Proxy @Hs.NsTypeConstr) $ name <> "_Aux"
+        auxName  <- mintName AuxType (Proxy @Hs.NsTypeConstr) $ name <> "_Aux"
         auxNames <- mkNewtypeNames strategy auxName.text
         pure $ Just (auxName, auxNames)
     pure TypedefNames{
@@ -707,6 +814,7 @@ instance MangleWithDeclName C.Struct where
   mangleWithDeclName hsName struct = do
       fields <- mapM (mangleWithDeclName hsName) struct.fields
       flam   <- mapM (mangleWithDeclName hsName) struct.flam
+      checkDuplicateFieldNames (fields ++ maybeToList flam)
       names  <- mkStructNames struct.flam hsName
       pure $ reconstruct fields flam names
     where
@@ -768,8 +876,8 @@ instance MangleWithDeclName C.UnionField where
       fieldType    <- mangle field.typ
       fieldComment <- mapM mangle field.info.comment
       accessorName <- mangleAccessorName hsName field.info.name
-      getterName   <- mkIdentifier (Proxy @Hs.NsVar) $ "get_" <> accessorName.text
-      setterName   <- mkIdentifier (Proxy @Hs.NsVar) $ "set_" <> accessorName.text
+      getterName   <- mintName Accessor (Proxy @Hs.NsVar) $ "get_" <> accessorName.text
+      setterName   <- mintName Accessor (Proxy @Hs.NsVar) $ "set_" <> accessorName.text
       pure $
         C.UnionField {
             info = C.FieldInfo {
@@ -807,7 +915,7 @@ instance MangleWithDeclName C.Enum where
 
 instance Mangle C.AnonEnumConstant where
   mangle (C.AnonEnumConstant primTyp constant') = do
-      reconstruct <$> mangle constant'
+      reconstruct <$> mangleEnumConstantDecl mangleAnonEnumConstant constant'
     where
       reconstruct :: C.EnumConstant MangleNames -> C.AnonEnumConstant MangleNames
       reconstruct enumConstants' = C.AnonEnumConstant{
@@ -816,9 +924,18 @@ instance Mangle C.AnonEnumConstant where
           }
 
 instance Mangle C.EnumConstant where
-  mangle constant = do
+  mangle = mangleEnumConstantDecl mangleEnumConstant
+
+-- | Mangle an enum constant declaration, choosing its name with the given
+-- mangling action (recording or non-recording, see 'mangleEnumConstant' and
+-- 'mangleAnonEnumConstant').
+mangleEnumConstantDecl ::
+     (CScopedName -> E M ScopedNamePair)
+  -> C.EnumConstant ResolveBindingSpecs
+  -> E M (C.EnumConstant MangleNames)
+mangleEnumConstantDecl mangleName constant =
       reconstruct
-        <$> mangleEnumConstant constant.info.name
+        <$> mangleName constant.info.name
         <*> mapM mangle constant.info.comment
     where
       reconstruct ::
@@ -1060,23 +1177,9 @@ withDeclLoc info msg = WithLocationInfo{
     , msg = msg
     }
 
-invert :: Ord v => Map k v -> Map v [k]
-invert = Map.foldlWithKey' aux Map.empty
-  where
-    aux :: Ord a => Map a [b] -> b -> a -> Map a [b]
-    aux acc k v = Map.alter (insertOrPrepend k) v acc
-
-    insertOrPrepend :: k -> Maybe [k] -> Maybe [k]
-    insertOrPrepend k Nothing   = Just [k]
-    insertOrPrepend k (Just ks) = Just $ k : ks
-
-getDuplicates :: forall k v. (Ord v) => Map k v -> Map v [k]
-getDuplicates = Map.filter isDup . invert
-  where
-    isDup :: [a] -> Bool
-    isDup (_:_:_) = True
-    isDup _       = False
-
 -- The function 'tryError' is only available in `mtl` versions 2.3 and newer.
 tryError :: MonadError e m => m a -> m (Either e a)
 tryError action = (Right <$> action) `catchError` (pure . Left)
+
+debugMsg :: MangleNamesMsg -> AMsg MangleNames
+debugMsg = withCallStack . WithLocationInfo LocationUnavailable

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
@@ -6,6 +6,8 @@ import Data.List qualified as List
 import Data.List.NonEmpty qualified as NonEmpty
 import Text.SimplePrettyPrint qualified as PP
 
+import Clang.HighLevel.Types
+
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Imports
@@ -17,6 +19,11 @@ data MangleNamesError =
   | MangleNamesCouldNotMangle               Text
   | MangleNamesCouldNotMangleSpecifiedName  Text
   | MangleNamesUnderlyingDeclNotMangled     DeclId (NonEmpty Hs.Namespace)
+    -- | Two fields in the same struct mangle to the same Haskell name.
+    --
+    -- Only fires under 'OmitFieldPrefixes'; under 'AddFieldPrefixes' mangling
+    -- is injective within a record.
+  | MangleNamesDuplicateFieldName           Hs.SomeName [SingleLoc]
   deriving stock (Show, Eq, Ord)
 
 instance PrettyForTrace MangleNamesError where
@@ -43,3 +50,10 @@ instance PrettyForTrace MangleNamesError where
         , "not mangled:"
         , prettyForTrace declId
         ]
+      MangleNamesDuplicateFieldName x locs ->
+        let intro = PP.hcat [
+                "Duplicate record field name "
+              , prettyForTrace x
+              , ":"
+              ]
+        in  PP.hang intro 2 $ PP.vcat $ map PP.show locs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -16,6 +16,7 @@ import HsBindgen.Frontend.AST.Type qualified as C
 import HsBindgen.Frontend.LocationInfo
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass
+import HsBindgen.Frontend.Pass.MangleNames.Names
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -102,7 +103,10 @@ data TypedefNames = TypedefNames {
 -------------------------------------------------------------------------------}
 
 data MangleNamesMsg =
-    MangleNamesAssignedName Hs.SomeName
+    MangleNamesAssignedName       Hs.SomeName
+  | MangleNamesReusedAssignedName Hs.SomeName
+  | MangleNamesNameMap            NameMap
+  | MangleNamesNameRegistry       String NameRegistry
   deriving stock (Show)
 
 instance PrettyForTrace MangleNamesMsg where
@@ -111,11 +115,31 @@ instance PrettyForTrace MangleNamesMsg where
           "Assigned name"
         , PP.text newName.text
         ]
+      MangleNamesReusedAssignedName newName -> PP.hsep [
+          "Reused assigned name"
+        , PP.text newName.text
+        ]
+      MangleNamesNameMap nm -> PP.hsep [
+          "The name map is:"
+        , PP.show nm
+        ]
+      MangleNamesNameRegistry cmt rg -> PP.hcat [
+          "The name registry is ("
+        , PP.string cmt
+        , ") "
+        , PP.show rg
+        ]
 
 instance IsTrace Level MangleNamesMsg where
   getDefaultLogLevel = \case
-      MangleNamesAssignedName{} -> Info
+      MangleNamesAssignedName{}       -> Info
+      MangleNamesReusedAssignedName{} -> Info
+      MangleNamesNameMap{}            -> Debug
+      MangleNamesNameRegistry{}       -> Debug
 
   getSource  = const HsBindgen
   getTraceId = \case
-    MangleNamesAssignedName{} -> "mangle-names-assigned-name"
+    MangleNamesAssignedName{}       -> "mangle-names-assigned-name"
+    MangleNamesReusedAssignedName{} -> "mangle-names-reused-assigned-name"
+    MangleNamesNameMap{}            -> "mangle-names-name-map"
+    MangleNamesNameRegistry{}       -> "mangle-names-name-registry"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Names.hs
@@ -1,0 +1,220 @@
+-- | Name bookkeeping for the name mangler
+--
+-- The name mangler maintains /two/ indices over the set of Haskell names it
+-- mints. They answer opposite questions and are keyed differently, so they are
+-- distinct structures:
+--
+-- * 'NameMap' is the /resolution index/: @'DeclId' -> 'Hs.Name'@. Pass 2 uses
+--   it to resolve a /reference/ (it holds a target 'DeclId' and wants the
+--   Haskell name that was assigned to it). It only ever contains the top-level,
+--   'DeclId'-addressable names.
+--
+-- * 'NameRegistry' is the /collision index/: @'Hs.Name' -> ['NameOrigin']@. It
+--   records minted names that may collide (top-level and derived) -- together
+--   with the declaration responsible for it. Hence, we can detect when the same
+--   Haskell name is produced more than once in the same namespace, whether by
+--   two distinct declarations (e.g. two structs) or by a single declaration via
+--   two of its members (e.g. an enum tag and one of its enumerators).
+--
+-- Both hold three maps, one per Haskell namespace ('Hs.NsTypeConstr',
+-- 'Hs.NsConstr', 'Hs.NsVar') with types ensuring that names cannot collide
+-- spuriously across namespaces.
+--
+-- Intended for unqualified import.
+module HsBindgen.Frontend.Pass.MangleNames.Names (
+    -- * Resolution index
+    NameMap(..)
+  , emptyNameMap
+  , fromDeclIdPairs
+  , lookupType
+  , lookupData
+  , lookupVar
+    -- * Collision index
+  , NameRole(..)
+  , NameOrigin(..)
+  , NameRegistry
+  , emptyNameRegistry
+  , registerName
+  , registerSomeName
+  , Collision(..)
+  , collisions
+  ) where
+
+import Data.Foldable qualified as Foldable
+import Data.Map qualified as Map
+
+import Clang.HighLevel.Types (SingleLoc)
+
+import HsBindgen.Frontend.Naming
+import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
+
+{-------------------------------------------------------------------------------
+  Resolution index
+-------------------------------------------------------------------------------}
+
+-- | Maps each declaration to the Haskell name assigned to it
+--
+-- One map per Haskell namespace.
+data NameMap = NameMap {
+      typeConstrs :: Map DeclId (Hs.Name Hs.NsTypeConstr)
+    , dataConstrs :: Map DeclId (Hs.Name Hs.NsConstr)
+    , vars        :: Map DeclId (Hs.Name Hs.NsVar)
+    }
+  deriving stock (Show, Eq, Generic)
+
+emptyNameMap :: NameMap
+emptyNameMap = NameMap Map.empty Map.empty Map.empty
+
+fromDeclIdPairs :: [DeclIdPair] -> NameMap
+fromDeclIdPairs = Foldable.foldl' aux emptyNameMap
+  where
+    aux :: NameMap -> DeclIdPair -> NameMap
+    aux nameMap pair = case pair.hsName.ns of
+      Hs.NsTypeConstr ->
+        nameMap & #typeConstrs %~
+          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsTypeConstr) pair.hsName)
+      Hs.NsConstr ->
+        nameMap & #dataConstrs %~
+          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsConstr)     pair.hsName)
+      Hs.NsVar ->
+        nameMap & #vars %~
+          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsVar)        pair.hsName)
+
+lookupType :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsTypeConstr)
+lookupType declId nameMap = Map.lookup declId nameMap.typeConstrs
+
+lookupData :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsConstr)
+lookupData declId nameMap = Map.lookup declId nameMap.dataConstrs
+
+lookupVar :: DeclId -> NameMap -> Maybe (Hs.Name Hs.NsVar)
+lookupVar declId nameMap = Map.lookup declId nameMap.vars
+
+{-------------------------------------------------------------------------------
+  Collision index
+-------------------------------------------------------------------------------}
+
+-- | What a registered Haskell name denotes
+--
+-- Stored with every 'NameOrigin' to document what was minted and to give
+-- collision diagnostics something to say.
+data NameRole =
+    -- | A top-level declaration's own name (chosen in pass 1)
+    Declaration
+    -- | A generated data constructor (including enum constants)
+  | Constructor
+    -- | A generated record field selector or newtype unwrapper
+  | Field
+    -- | A generated union getter or setter
+  | Accessor
+    -- | A generated auxiliary type constructor (FLAM or function pointer)
+  | AuxType
+  deriving stock (Show, Eq, Ord, Generic)
+
+-- | A single site at which a Haskell name was minted
+data NameOrigin = NameOrigin {
+      -- | The declaration to blame should this name collide
+      owner :: DeclId
+    , loc   :: SingleLoc
+    , role  :: NameRole
+    }
+  deriving stock (Show, Eq, Ord, Generic)
+
+-- | Records every minted Haskell name and the sites that minted it
+--
+-- One map per Haskell namespace, keyed by the fully-typed name.
+data NameRegistry = NameRegistry {
+      typeConstrs :: Map (Hs.Name Hs.NsTypeConstr) [NameOrigin]
+    , dataConstrs :: Map (Hs.Name Hs.NsConstr)     [NameOrigin]
+    , vars        :: Map (Hs.Name Hs.NsVar)        [NameOrigin]
+    }
+  deriving stock (Show, Eq, Generic)
+
+emptyNameRegistry :: NameRegistry
+emptyNameRegistry = NameRegistry Map.empty Map.empty Map.empty
+
+-- | Register a minted name, retaining its type-level namespace
+registerName :: forall ns.
+     Hs.SingNamespace ns
+  => NameRole
+  -> DeclId
+  -> SingleLoc
+  -> Hs.Name ns
+  -> NameRegistry
+  -> NameRegistry
+registerName role owner loc name reg = case Hs.singNamespace @ns of
+    Hs.SNsTypeConstr -> reg & #typeConstrs %~ Map.alter prepend name
+    Hs.SNsConstr     -> reg & #dataConstrs %~ Map.alter prepend name
+    Hs.SNsVar        -> reg & #vars        %~ Map.alter prepend name
+  where
+    origin :: NameOrigin
+    origin = NameOrigin{
+        owner = owner
+      , loc   = loc
+      , role  = role
+      }
+
+    prepend :: Maybe [NameOrigin] -> Maybe [NameOrigin]
+    prepend = \case
+      Nothing -> Just [origin]
+      Just xs -> Just $ origin:xs
+
+-- | Register a name whose namespace is only known at the value level
+--
+-- Used to seed the registry with pass 1 names (which are stored as
+-- 'Hs.SomeName'). The namespace is re-asserted at the type level.
+registerSomeName ::
+     NameRole
+  -> DeclId
+  -> SingleLoc
+  -> Hs.SomeName
+  -> NameRegistry
+  -> NameRegistry
+registerSomeName role owner loc sname = case sname.ns of
+    Hs.NsTypeConstr ->
+      registerName role owner loc (Hs.assertNs (Proxy @Hs.NsTypeConstr) sname)
+    Hs.NsConstr ->
+      registerName role owner loc (Hs.assertNs (Proxy @Hs.NsConstr) sname)
+    Hs.NsVar ->
+      registerName role owner loc (Hs.assertNs (Proxy @Hs.NsVar) sname)
+
+-- | A Haskell name minted by two or more distinct declarations
+data Collision = Collision {
+      name    :: Hs.SomeName
+    , origins :: [NameOrigin]
+    }
+  deriving stock (Show, Eq, Generic)
+
+-- | All collisions in the registry, across all three namespaces
+--
+-- A name collides when it was minted at least twice in the same namespace.
+collisions :: NameRegistry -> [Collision]
+collisions reg = concat [
+      collisionsFor reg.typeConstrs
+    , collisionsFor reg.dataConstrs
+    , collisionsFor reg.vars
+    ]
+  where
+    collisionsFor :: forall ns.
+         Hs.SingNamespace ns
+      => Map (Hs.Name ns) [NameOrigin]
+      -> [Collision]
+    collisionsFor m =
+        [ Collision (Hs.demoteNs name) origins
+        | (name, origins) <- Map.toList m
+        , isCollision origins
+        ]
+
+    -- A name is registered once per emitted top-level Haskell entity that wants
+    -- it: top-level declaration names are seeded once each (redeclarations are
+    -- deduplicated by 'DeclId' before this pass), and derived names are minted
+    -- once each. So two or more registrations of the same name in the same
+    -- namespace always mean two or more distinct entities competing for it --
+    -- be they different declarations or members of the same declaration.
+    --
+    -- We must not deduplicate by 'NameOrigin' here: derived names are recorded
+    -- with their /owner's/ location, so e.g. an enum's data constructor and one
+    -- of its enumerators share the same owner, location, and 'NameRole', and
+    -- would collapse into one.
+    isCollision :: [NameOrigin] -> Bool
+    isCollision origins = length origins >= 2

--- a/hs-bindgen/src-internal/HsBindgen/Language/Haskell.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Language/Haskell.hs
@@ -194,7 +194,7 @@ data SomeName = UnsafeSomeName {
 
 instance PrettyForTrace SomeName where
   prettyForTrace x = PP.hsep [
-      PP.text x.text
+      "'" >< PP.text x.text >< "'"
     , "(" >< prettyForTrace x.ns >< ")"
     ]
 

--- a/hs-bindgen/test-artefacts/fixtures/declarations/duplicate_field_name_omit/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/duplicate_field_name_omit/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/declarations/duplicate_field_name_omit/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/duplicate_field_name_omit/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile test-artefacts/headers/golden/declarations/duplicate_field_name_omit.h

--- a/hs-bindgen/test-artefacts/fixtures/declarations/name_collision_aux/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/name_collision_aux/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/declarations/name_collision_aux/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/name_collision_aux/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile test-artefacts/headers/golden/declarations/name_collision_aux.h

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -14,8 +13,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
-    ( Example.S(..)
-    , Example.T(..)
+    ( Example.T(..)
     )
   where
 
@@ -29,8 +27,8 @@ import qualified HsBindgen.Runtime.Marshal as Marshal
 
     __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
 -}
-data S = S
-  { s_x :: RIP.CInt
+data T = T
+  { t_x :: RIP.CInt
     {- ^ __C declaration:__ @x@
 
          __defined at:__ @functions\/heap_types\/struct_const_typedef.h 4:7@
@@ -40,63 +38,36 @@ data S = S
   }
   deriving stock (Eq, RIP.Generic, Show)
 
-instance Marshal.StaticSize S where
+instance Marshal.StaticSize T where
 
   staticSizeOf = \_ -> (4 :: Int)
 
   staticAlignment = \_ -> (4 :: Int)
 
-instance Marshal.ReadRaw S where
+instance Marshal.ReadRaw T where
 
   readRaw =
     \ptr0 ->
-          pure S
-      <*> HasCField.readRaw (RIP.Proxy @"s_x") ptr0
+          pure T
+      <*> HasCField.readRaw (RIP.Proxy @"t_x") ptr0
 
-instance Marshal.WriteRaw S where
+instance Marshal.WriteRaw T where
 
   writeRaw =
     \ptr0 ->
       \s1 ->
         case s1 of
-          S s_x2 ->
-            HasCField.writeRaw (RIP.Proxy @"s_x") ptr0 s_x2
+          T t_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"t_x") ptr0 t_x2
 
-deriving via Marshal.EquivStorable S instance RIP.Storable S
+deriving via Marshal.EquivStorable T instance RIP.Storable T
 
-instance HasCField.HasCField S "s_x" where
+instance HasCField.HasCField T "t_x" where
 
-  type CFieldType S "s_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
-
-{-| __C declaration:__ @T@
-
-    __defined at:__ @functions\/heap_types\/struct_const_typedef.h 7:24@
-
-    __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
--}
-newtype T = T
-  { unwrapT :: S
-  }
-  deriving stock (Eq, RIP.Generic, Show)
-  deriving newtype
-    ( Marshal.ReadRaw
-    , Marshal.StaticSize
-    , RIP.Storable
-    , Marshal.WriteRaw
-    )
-
-instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
-
-instance HasCField.HasCField T "unwrapT" where
-
-  type CFieldType T "unwrapT" = S
+  type CFieldType T "t_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
+
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
@@ -5,33 +5,17 @@ hsmodule: Example
 ctypes:
 - headers: functions/heap_types/struct_const_typedef.h
   cname: struct S
-  hsname: S
+  hsname: T
 - headers: functions/heap_types/struct_const_typedef.h
   cname: T
   hsname: T
 hstypes:
-- hsname: S
-  representation:
-    record:
-      constructor: S
-      fields:
-      - s_x
-  instances:
-  - Eq
-  - Generic
-  - HasCField
-  - HasField
-  - ReadRaw
-  - Show
-  - StaticSize
-  - Storable
-  - WriteRaw
 - hsname: T
   representation:
-    newtype:
+    record:
       constructor: T
       fields:
-      - unwrapT
+      - t_x
   instances:
   - Eq
   - Generic

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -28,8 +28,8 @@
 
     __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
 -}
-data S
-    = S {s_x :: CInt
+data T
+    = T {t_x :: CInt
          {- ^ __C declaration:__ @x@
 
               __defined at:__ @functions\/heap_types\/struct_const_typedef.h 4:7@
@@ -37,35 +37,20 @@ data S
               __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
          -}}
     deriving stock (Eq, Generic, Show)
-instance StaticSize S
+instance StaticSize T
     where staticSizeOf = \_ -> 4 :: Int
           staticAlignment = \_ -> 4 :: Int
-instance ReadRaw S
-    where readRaw = \ptr_0 -> pure S <*> readRaw (Proxy @"s_x") ptr_0
-instance WriteRaw S
+instance ReadRaw T
+    where readRaw = \ptr_0 -> pure T <*> readRaw (Proxy @"t_x") ptr_0
+instance WriteRaw T
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
-                                       S s_x_2 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2
-deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_x"
-    where type CFieldType S "s_x" = CInt
+                                       T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
+deriving via (EquivStorable T) instance Storable T
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_x")
-{-| __C declaration:__ @T@
-
-    __defined at:__ @functions\/heap_types\/struct_const_typedef.h 7:24@
-
-    __exported by:__ @functions\/heap_types\/struct_const_typedef.h@
--}
-newtype T
-    = T {unwrapT :: S}
-    deriving stock (Eq, Generic, Show)
-    deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"unwrapT")
-instance HasCField T "unwrapT"
-    where type CFieldType T "unwrapT" = S
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -14,10 +13,9 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
-    ( Example.U(..)
-    , Example.get_u_x
-    , Example.set_u_x
-    , Example.T(..)
+    ( Example.T(..)
+    , Example.get_t_x
+    , Example.set_t_x
     )
   where
 
@@ -31,22 +29,22 @@ import qualified HsBindgen.Runtime.Marshal as Marshal
 
     __exported by:__ @functions\/heap_types\/union_const_typedef.h@
 -}
-newtype U = U
-  { unwrapU :: RIP.ByteArray
+newtype T = T
+  { unwrapT :: RIP.ByteArray
   }
   deriving stock (RIP.Generic)
 
-deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize U
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize T
 
-deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw U
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw T
 
-deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw U
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw T
 
-deriving via Marshal.EquivStorable U instance RIP.Storable U
+deriving via Marshal.EquivStorable T instance RIP.Storable T
 
 {-|
 
-    __See:__ 'set_u_x'
+    __See:__ 'set_t_x'
 
     __C declaration:__ @x@
 
@@ -54,54 +52,27 @@ deriving via Marshal.EquivStorable U instance RIP.Storable U
 
     __exported by:__ @functions\/heap_types\/union_const_typedef.h@
 -}
-get_u_x ::
-     U
+get_t_x ::
+     T
   -> RIP.CInt
-get_u_x = RIP.getUnionPayload
+get_t_x = RIP.getUnionPayload
 
 {-|
 
-    __See:__ 'get_u_x'
+    __See:__ 'get_t_x'
 
 -}
-set_u_x ::
+set_t_x ::
      RIP.CInt
-  -> U
-set_u_x = RIP.setUnionPayload
+  -> T
+set_t_x = RIP.setUnionPayload
 
-instance HasCField.HasCField U "u_x" where
+instance HasCField.HasCField T "t_x" where
 
-  type CFieldType U "u_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u_x")
-
-{-| __C declaration:__ @T@
-
-    __defined at:__ @functions\/heap_types\/union_const_typedef.h 7:23@
-
-    __exported by:__ @functions\/heap_types\/union_const_typedef.h@
--}
-newtype T = T
-  { unwrapT :: U
-  }
-  deriving stock (RIP.Generic)
-  deriving newtype
-    ( Marshal.ReadRaw
-    , Marshal.StaticSize
-    , RIP.Storable
-    , Marshal.WriteRaw
-    )
-
-instance (ty ~ U) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
-
-instance HasCField.HasCField T "unwrapT" where
-
-  type CFieldType T "unwrapT" = U
+  type CFieldType T "t_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
+
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
@@ -5,7 +5,7 @@ hsmodule: Example
 ctypes:
 - headers: functions/heap_types/union_const_typedef.h
   cname: union U
-  hsname: U
+  hsname: T
 - headers: functions/heap_types/union_const_typedef.h
   cname: T
   hsname: T
@@ -16,20 +16,6 @@ hstypes:
       constructor: T
       fields:
       - unwrapT
-  instances:
-  - Generic
-  - HasCField
-  - HasField
-  - ReadRaw
-  - StaticSize
-  - Storable
-  - WriteRaw
-- hsname: U
-  representation:
-    newtype:
-      constructor: U
-      fields:
-      - unwrapU
   instances:
   - Generic
   - HasCField

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -28,14 +28,14 @@
 
     __exported by:__ @functions\/heap_types\/union_const_typedef.h@
 -}
-newtype U = U {unwrapU :: ByteArray} deriving stock Generic
-deriving via (SizedByteArray 4 4) instance StaticSize U
-deriving via (SizedByteArray 4 4) instance ReadRaw U
-deriving via (SizedByteArray 4 4) instance WriteRaw U
-deriving via (EquivStorable U) instance Storable U
+newtype T = T {unwrapT :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize T
+deriving via (SizedByteArray 4 4) instance ReadRaw T
+deriving via (SizedByteArray 4 4) instance WriteRaw T
+deriving via (EquivStorable T) instance Storable T
 {-|
 
-    __See:__ 'set_u_x'
+    __See:__ 'set_t_x'
 
     __C declaration:__ @x@
 
@@ -43,10 +43,10 @@ deriving via (EquivStorable U) instance Storable U
 
     __exported by:__ @functions\/heap_types\/union_const_typedef.h@
 -}
-get_u_x :: U -> CInt
+get_t_x :: T -> CInt
 {-|
 
-    __See:__ 'set_u_x'
+    __See:__ 'set_t_x'
 
     __C declaration:__ @x@
 
@@ -54,39 +54,24 @@ get_u_x :: U -> CInt
 
     __exported by:__ @functions\/heap_types\/union_const_typedef.h@
 -}
-get_u_x = getUnionPayload
+get_t_x = getUnionPayload
 {-|
 
-    __See:__ 'get_u_x'
+    __See:__ 'get_t_x'
 
 -}
-set_u_x :: CInt -> U
+set_t_x :: CInt -> T
 {-|
 
-    __See:__ 'get_u_x'
+    __See:__ 'get_t_x'
 
 -}
-set_u_x = setUnionPayload
-instance HasCField U "u_x"
-    where type CFieldType U "u_x" = CInt
+set_t_x = setUnionPayload
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
-    where getField = fromPtr (Proxy @"u_x")
-{-| __C declaration:__ @T@
-
-    __defined at:__ @functions\/heap_types\/union_const_typedef.h 7:23@
-
-    __exported by:__ @functions\/heap_types\/union_const_typedef.h@
--}
-newtype T
-    = T {unwrapT :: U}
-    deriving stock Generic
-    deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty U => HasField "unwrapT" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"unwrapT")
-instance HasCField T "unwrapT"
-    where type CFieldType T "unwrapT" = U
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -21,8 +21,10 @@ module Example
     , Example.Struct4_t
     , Example.Struct5(..)
     , Example.Struct5_t(..)
-    , Example.Struct6_Aux(..)
-    , Example.Struct6(..)
+    , Example.Struct6a_struct(..)
+    , Example.Struct6a(..)
+    , Example.Struct6b_struct(..)
+    , Example.Struct6b(..)
     , Example.Struct7(..)
     , Example.Struct7a(..)
     , Example.Struct7b(..)
@@ -35,16 +37,28 @@ module Example
     , Example.Struct11_t(..)
     , Example.Struct12_t(..)
     , Example.Use_sites(..)
+    , Example.Foo_struct(..)
+    , Example.Foo_Aux(..)
+    , Example.Foo(..)
+    , Example.Bar_struct(..)
+    , Example.Bar_Aux(..)
+    , Example.Bar(..)
+    , Example.Struct15(..)
+    , Example.Struct16_struct(..)
+    , Example.Struct16(..)
+    , Example.Use_sites_qual(..)
     )
   where
 
+import qualified HsBindgen.Runtime.ConstantArray as CA
 import qualified HsBindgen.Runtime.HasCField as HasCField
 import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.IsArray as IsA
 import qualified HsBindgen.Runtime.Marshal as Marshal
 
 {-| __C declaration:__ @struct struct1@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 7:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 41:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -74,7 +88,7 @@ deriving via Marshal.EquivStorable Struct1_t instance RIP.Storable Struct1_t
 
 {-| __C declaration:__ @struct struct2@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 11:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 45:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -104,7 +118,7 @@ deriving via Marshal.EquivStorable Struct2_t instance RIP.Storable Struct2_t
 
 {-| __C declaration:__ @struct struct3@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 14:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 49:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -112,7 +126,7 @@ data Struct3_t
 
 {-| __C declaration:__ @struct struct4@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 18:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 53:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -120,7 +134,7 @@ data Struct4_t
 
 {-| __C declaration:__ @struct struct5@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 21:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 56:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -150,7 +164,7 @@ deriving via Marshal.EquivStorable Struct5 instance RIP.Storable Struct5
 
 {-| __C declaration:__ @struct5_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 22:25@
+    __defined at:__ @program-analysis\/typedef_analysis.h 57:25@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -179,44 +193,44 @@ instance HasCField.HasCField Struct5_t "unwrapStruct5_t" where
 
   offset# = \_ -> \_ -> 0
 
-{-| __C declaration:__ @struct struct6@
+{-| __C declaration:__ @struct struct6a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 25:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 60:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
-data Struct6_Aux = Struct6_Aux
+data Struct6a_struct = Struct6a_struct
   {}
   deriving stock (Eq, RIP.Generic, Show)
 
-instance Marshal.StaticSize Struct6_Aux where
+instance Marshal.StaticSize Struct6a_struct where
 
   staticSizeOf = \_ -> (0 :: Int)
 
   staticAlignment = \_ -> (1 :: Int)
 
-instance Marshal.ReadRaw Struct6_Aux where
+instance Marshal.ReadRaw Struct6a_struct where
 
-  readRaw = \ptr0 -> pure Struct6_Aux
+  readRaw = \ptr0 -> pure Struct6a_struct
 
-instance Marshal.WriteRaw Struct6_Aux where
+instance Marshal.WriteRaw Struct6a_struct where
 
   writeRaw =
     \ptr0 ->
       \s1 ->
         case s1 of
-          Struct6_Aux -> return ()
+          Struct6a_struct -> return ()
 
-deriving via Marshal.EquivStorable Struct6_Aux instance RIP.Storable Struct6_Aux
+deriving via Marshal.EquivStorable Struct6a_struct instance RIP.Storable Struct6a_struct
 
-{-| __C declaration:__ @struct6@
+{-| __C declaration:__ @struct6a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 25:28@
+    __defined at:__ @program-analysis\/typedef_analysis.h 61:4@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
-newtype Struct6 = Struct6
-  { unwrapStruct6 :: RIP.Ptr Struct6_Aux
+newtype Struct6a = Struct6a
+  { unwrapStruct6a :: RIP.Ptr Struct6a_struct
   }
   deriving stock (Eq, RIP.Generic, Ord, Show)
   deriving newtype
@@ -227,22 +241,83 @@ newtype Struct6 = Struct6
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Struct6_Aux
-         ) => RIP.HasField "unwrapStruct6" (RIP.Ptr Struct6) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr Struct6a_struct
+         ) => RIP.HasField "unwrapStruct6a" (RIP.Ptr Struct6a) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"unwrapStruct6")
+    HasCField.fromPtr (RIP.Proxy @"unwrapStruct6a")
 
-instance HasCField.HasCField Struct6 "unwrapStruct6" where
+instance HasCField.HasCField Struct6a "unwrapStruct6a" where
 
-  type CFieldType Struct6 "unwrapStruct6" =
-    RIP.Ptr Struct6_Aux
+  type CFieldType Struct6a "unwrapStruct6a" =
+    RIP.Ptr Struct6a_struct
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct struct6b@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 68:16@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct6b_struct = Struct6b_struct
+  {}
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Struct6b_struct where
+
+  staticSizeOf = \_ -> (0 :: Int)
+
+  staticAlignment = \_ -> (1 :: Int)
+
+instance Marshal.ReadRaw Struct6b_struct where
+
+  readRaw = \ptr0 -> pure Struct6b_struct
+
+instance Marshal.WriteRaw Struct6b_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Struct6b_struct -> return ()
+
+deriving via Marshal.EquivStorable Struct6b_struct instance RIP.Storable Struct6b_struct
+
+{-| __C declaration:__ @struct6b@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 69:3@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Struct6b = Struct6b
+  { unwrapStruct6b :: CA.ConstantArray 50 Struct6b_struct
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+  deriving newtype
+    ( IsA.IsArray
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ CA.ConstantArray 50 Struct6b_struct
+         ) => RIP.HasField "unwrapStruct6b" (RIP.Ptr Struct6b) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapStruct6b")
+
+instance HasCField.HasCField Struct6b "unwrapStruct6b" where
+
+  type CFieldType Struct6b "unwrapStruct6b" =
+    CA.ConstantArray 50 Struct6b_struct
 
   offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct struct7@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 28:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 72:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -272,7 +347,7 @@ deriving via Marshal.EquivStorable Struct7 instance RIP.Storable Struct7
 
 {-| __C declaration:__ @struct7a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 29:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 73:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -301,7 +376,7 @@ instance HasCField.HasCField Struct7a "unwrapStruct7a" where
 
 {-| __C declaration:__ @struct7b@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 30:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 74:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -330,7 +405,7 @@ instance HasCField.HasCField Struct7b "unwrapStruct7b" where
 
 {-| __C declaration:__ @struct struct8@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 33:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 77:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -360,7 +435,7 @@ deriving via Marshal.EquivStorable Struct8 instance RIP.Storable Struct8
 
 {-| __C declaration:__ @struct8b@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 35:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 79:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -389,7 +464,7 @@ instance HasCField.HasCField Struct8b "unwrapStruct8b" where
 
 {-| __C declaration:__ @struct struct9@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 38:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 82:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -419,7 +494,7 @@ deriving via Marshal.EquivStorable Struct9 instance RIP.Storable Struct9
 
 {-| __C declaration:__ @struct9_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 40:17@
+    __defined at:__ @program-analysis\/typedef_analysis.h 84:17@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -448,7 +523,7 @@ instance HasCField.HasCField Struct9_t "unwrapStruct9_t" where
 
 {-| __C declaration:__ @struct struct10@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 46:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 90:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -478,7 +553,7 @@ deriving via Marshal.EquivStorable Struct10_t instance RIP.Storable Struct10_t
 
 {-| __C declaration:__ @struct10_t_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 48:20@
+    __defined at:__ @program-analysis\/typedef_analysis.h 92:20@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -508,7 +583,7 @@ instance HasCField.HasCField Struct10_t_t "unwrapStruct10_t_t" where
 
 {-| __C declaration:__ @struct struct11@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 51:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 95:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -516,14 +591,14 @@ data Struct11_t = Struct11_t
   { struct11_t_x :: RIP.CInt
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 52:7@
+         __defined at:__ @program-analysis\/typedef_analysis.h 96:7@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , struct11_t_self :: RIP.Ptr Struct11_t
     {- ^ __C declaration:__ @self@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 53:20@
+         __defined at:__ @program-analysis\/typedef_analysis.h 97:20@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
@@ -583,7 +658,7 @@ instance ( ty ~ RIP.Ptr Struct11_t
 
 {-| __C declaration:__ @struct struct12@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 60:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 104:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -591,14 +666,14 @@ data Struct12_t = Struct12_t
   { struct12_t_x :: RIP.CInt
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 61:7@
+         __defined at:__ @program-analysis\/typedef_analysis.h 105:7@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , struct12_t_self :: RIP.Ptr Struct12_t
     {- ^ __C declaration:__ @self@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 62:15@
+         __defined at:__ @program-analysis\/typedef_analysis.h 106:15@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
@@ -658,7 +733,7 @@ instance ( ty ~ RIP.Ptr Struct12_t
 
 {-| __C declaration:__ @struct use_sites@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 66:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 110:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -666,126 +741,140 @@ data Use_sites = Use_sites
   { use_sites_useTypedef_struct1_t :: Struct1_t
     {- ^ __C declaration:__ @useTypedef_struct1_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 68:13@
+         __defined at:__ @program-analysis\/typedef_analysis.h 112:13@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct2_t :: Struct2_t
     {- ^ __C declaration:__ @useTypedef_struct2_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 71:13@
+         __defined at:__ @program-analysis\/typedef_analysis.h 115:13@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct3_t :: RIP.Ptr Struct3_t
     {- ^ __C declaration:__ @useTypedef_struct3_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 74:14@
+         __defined at:__ @program-analysis\/typedef_analysis.h 118:14@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct4_t :: RIP.Ptr Struct4_t
     {- ^ __C declaration:__ @useTypedef_struct4_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 75:14@
+         __defined at:__ @program-analysis\/typedef_analysis.h 119:14@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useStruct_struct5 :: Struct5
     {- ^ __C declaration:__ @useStruct_struct5@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 78:18@
+         __defined at:__ @program-analysis\/typedef_analysis.h 122:18@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct5_t :: Struct5_t
     {- ^ __C declaration:__ @useTypedef_struct5_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 79:13@
+         __defined at:__ @program-analysis\/typedef_analysis.h 123:13@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
-  , use_sites_useStruct_struct6 :: Struct6_Aux
-    {- ^ __C declaration:__ @useStruct_struct6@
+  , use_sites_useStruct_struct6a :: Struct6a_struct
+    {- ^ __C declaration:__ @useStruct_struct6a@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 82:18@
+         __defined at:__ @program-analysis\/typedef_analysis.h 126:19@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
-  , use_sites_useTypedef_struct6 :: Struct6
-    {- ^ __C declaration:__ @useTypedef_struct6@
+  , use_sites_useTypedef_struct6a :: Struct6a
+    {- ^ __C declaration:__ @useTypedef_struct6a@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 83:11@
+         __defined at:__ @program-analysis\/typedef_analysis.h 127:12@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , use_sites_useStruct_struct6b :: Struct6b_struct
+    {- ^ __C declaration:__ @useStruct_struct6b@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 130:19@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , use_sites_useTypedef_struct6b :: Struct6b
+    {- ^ __C declaration:__ @useTypedef_struct6b@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 131:12@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct7a :: Struct7a
     {- ^ __C declaration:__ @useTypedef_struct7a@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 86:12@
+         __defined at:__ @program-analysis\/typedef_analysis.h 134:12@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct7b :: Struct7b
     {- ^ __C declaration:__ @useTypedef_struct7b@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 87:12@
+         __defined at:__ @program-analysis\/typedef_analysis.h 135:12@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct8 :: Struct8
     {- ^ __C declaration:__ @useTypedef_struct8@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 91:11@
+         __defined at:__ @program-analysis\/typedef_analysis.h 139:11@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct8b :: Struct8b
     {- ^ __C declaration:__ @useTypedef_struct8b@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 92:12@
+         __defined at:__ @program-analysis\/typedef_analysis.h 140:12@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct9 :: Struct9
     {- ^ __C declaration:__ @useTypedef_struct9@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 96:11@
+         __defined at:__ @program-analysis\/typedef_analysis.h 144:11@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct9_t :: Struct9_t
     {- ^ __C declaration:__ @useTypedef_struct9_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 97:13@
+         __defined at:__ @program-analysis\/typedef_analysis.h 145:13@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct10_t :: Struct10_t
     {- ^ __C declaration:__ @useTypedef_struct10_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 98:14@
+         __defined at:__ @program-analysis\/typedef_analysis.h 146:14@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct10_t_t :: Struct10_t_t
     {- ^ __C declaration:__ @useTypedef_struct10_t_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 99:16@
+         __defined at:__ @program-analysis\/typedef_analysis.h 147:16@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct11_t :: Struct11_t
     {- ^ __C declaration:__ @useTypedef_struct11_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 102:14@
+         __defined at:__ @program-analysis\/typedef_analysis.h 150:14@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
   , use_sites_useTypedef_struct12_t :: Struct12_t
     {- ^ __C declaration:__ @useTypedef_struct12_t@
 
-         __defined at:__ @program-analysis\/typedef_analysis.h 103:14@
+         __defined at:__ @program-analysis\/typedef_analysis.h 151:14@
 
          __exported by:__ @program-analysis\/typedef_analysis.h@
     -}
@@ -809,8 +898,10 @@ instance Marshal.ReadRaw Use_sites where
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct4_t") ptr0
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useStruct_struct5") ptr0
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct5_t") ptr0
-      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useStruct_struct6") ptr0
-      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct6") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useStruct_struct6a") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct6a") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useStruct_struct6b") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct6b") ptr0
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct7a") ptr0
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct7b") ptr0
       <*> HasCField.readRaw (RIP.Proxy @"use_sites_useTypedef_struct8") ptr0
@@ -835,36 +926,40 @@ instance Marshal.WriteRaw Use_sites where
             use_sites_useTypedef_struct4_t5
             use_sites_useStruct_struct56
             use_sites_useTypedef_struct5_t7
-            use_sites_useStruct_struct68
-            use_sites_useTypedef_struct69
-            use_sites_useTypedef_struct7a10
-            use_sites_useTypedef_struct7b11
-            use_sites_useTypedef_struct812
-            use_sites_useTypedef_struct8b13
-            use_sites_useTypedef_struct914
-            use_sites_useTypedef_struct9_t15
-            use_sites_useTypedef_struct10_t16
-            use_sites_useTypedef_struct10_t_t17
-            use_sites_useTypedef_struct11_t18
-            use_sites_useTypedef_struct12_t19 ->
+            use_sites_useStruct_struct6a8
+            use_sites_useTypedef_struct6a9
+            use_sites_useStruct_struct6b10
+            use_sites_useTypedef_struct6b11
+            use_sites_useTypedef_struct7a12
+            use_sites_useTypedef_struct7b13
+            use_sites_useTypedef_struct814
+            use_sites_useTypedef_struct8b15
+            use_sites_useTypedef_struct916
+            use_sites_useTypedef_struct9_t17
+            use_sites_useTypedef_struct10_t18
+            use_sites_useTypedef_struct10_t_t19
+            use_sites_useTypedef_struct11_t20
+            use_sites_useTypedef_struct12_t21 ->
                  HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct1_t") ptr0 use_sites_useTypedef_struct1_t2
               >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct2_t") ptr0 use_sites_useTypedef_struct2_t3
               >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct3_t") ptr0 use_sites_useTypedef_struct3_t4
               >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct4_t") ptr0 use_sites_useTypedef_struct4_t5
               >> HasCField.writeRaw (RIP.Proxy @"use_sites_useStruct_struct5") ptr0 use_sites_useStruct_struct56
               >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct5_t") ptr0 use_sites_useTypedef_struct5_t7
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useStruct_struct6") ptr0 use_sites_useStruct_struct68
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct6") ptr0 use_sites_useTypedef_struct69
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct7a") ptr0 use_sites_useTypedef_struct7a10
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct7b") ptr0 use_sites_useTypedef_struct7b11
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct8") ptr0 use_sites_useTypedef_struct812
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct8b") ptr0 use_sites_useTypedef_struct8b13
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct9") ptr0 use_sites_useTypedef_struct914
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct9_t") ptr0 use_sites_useTypedef_struct9_t15
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct10_t") ptr0 use_sites_useTypedef_struct10_t16
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct10_t_t") ptr0 use_sites_useTypedef_struct10_t_t17
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct11_t") ptr0 use_sites_useTypedef_struct11_t18
-              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct12_t") ptr0 use_sites_useTypedef_struct12_t19
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useStruct_struct6a") ptr0 use_sites_useStruct_struct6a8
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct6a") ptr0 use_sites_useTypedef_struct6a9
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useStruct_struct6b") ptr0 use_sites_useStruct_struct6b10
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct6b") ptr0 use_sites_useTypedef_struct6b11
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct7a") ptr0 use_sites_useTypedef_struct7a12
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct7b") ptr0 use_sites_useTypedef_struct7b13
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct8") ptr0 use_sites_useTypedef_struct814
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct8b") ptr0 use_sites_useTypedef_struct8b15
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct9") ptr0 use_sites_useTypedef_struct916
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct9_t") ptr0 use_sites_useTypedef_struct9_t17
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct10_t") ptr0 use_sites_useTypedef_struct10_t18
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct10_t_t") ptr0 use_sites_useTypedef_struct10_t_t19
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct11_t") ptr0 use_sites_useTypedef_struct11_t20
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_useTypedef_struct12_t") ptr0 use_sites_useTypedef_struct12_t21
 
 deriving via Marshal.EquivStorable Use_sites instance RIP.Storable Use_sites
 
@@ -946,31 +1041,57 @@ instance ( ty ~ Struct5_t
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct5_t")
 
-instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6" where
+instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6a" where
 
-  type CFieldType Use_sites "use_sites_useStruct_struct6" =
-    Struct6_Aux
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ Struct6_Aux
-         ) => RIP.HasField "use_sites_useStruct_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6")
-
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct6" =
-    Struct6
+  type CFieldType Use_sites "use_sites_useStruct_struct6a" =
+    Struct6a_struct
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ Struct6
-         ) => RIP.HasField "use_sites_useTypedef_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct6a_struct
+         ) => RIP.HasField "use_sites_useStruct_struct6a" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6a")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6a" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct6a" =
+    Struct6a
+
+  offset# = \_ -> \_ -> 24
+
+instance ( ty ~ Struct6a
+         ) => RIP.HasField "use_sites_useTypedef_struct6a" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6a")
+
+instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6b" where
+
+  type CFieldType Use_sites "use_sites_useStruct_struct6b" =
+    Struct6b_struct
+
+  offset# = \_ -> \_ -> 32
+
+instance ( ty ~ Struct6b_struct
+         ) => RIP.HasField "use_sites_useStruct_struct6b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6b")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6b" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct6b" =
+    Struct6b
+
+  offset# = \_ -> \_ -> 32
+
+instance ( ty ~ Struct6b
+         ) => RIP.HasField "use_sites_useTypedef_struct6b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6b")
 
 instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7a" where
 
@@ -1101,3 +1222,453 @@ instance ( ty ~ Struct12_t
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct12_t")
+
+{-| __C declaration:__ @struct foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 163:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Foo_struct = Foo_struct
+  { foo_struct_x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 164:7@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , foo_struct_y :: RIP.CInt
+    {- ^ __C declaration:__ @y@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 165:7@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Foo_struct where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Foo_struct where
+
+  readRaw =
+    \ptr0 ->
+          pure Foo_struct
+      <*> HasCField.readRaw (RIP.Proxy @"foo_struct_x") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"foo_struct_y") ptr0
+
+instance Marshal.WriteRaw Foo_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Foo_struct foo_struct_x2 foo_struct_y3 ->
+               HasCField.writeRaw (RIP.Proxy @"foo_struct_x") ptr0 foo_struct_x2
+            >> HasCField.writeRaw (RIP.Proxy @"foo_struct_y") ptr0 foo_struct_y3
+
+deriving via Marshal.EquivStorable Foo_struct instance RIP.Storable Foo_struct
+
+instance HasCField.HasCField Foo_struct "foo_struct_x" where
+
+  type CFieldType Foo_struct "foo_struct_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_struct_x" (RIP.Ptr Foo_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"foo_struct_x")
+
+instance HasCField.HasCField Foo_struct "foo_struct_y" where
+
+  type CFieldType Foo_struct "foo_struct_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_struct_y" (RIP.Ptr Foo_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"foo_struct_y")
+
+{-| Auxiliary type used by 'Foo'
+
+    __C declaration:__ @foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 167:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Foo_Aux = Foo_Aux
+  { unwrapFoo_Aux :: IO Foo_struct
+  }
+  deriving stock (RIP.Generic)
+
+instance ( ty ~ IO Foo_struct
+         ) => RIP.HasField "unwrapFoo_Aux" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapFoo_Aux")
+
+instance HasCField.HasCField Foo_Aux "unwrapFoo_Aux" where
+
+  type CFieldType Foo_Aux "unwrapFoo_Aux" =
+    IO Foo_struct
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 167:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Foo = Foo
+  { unwrapFoo :: RIP.FunPtr Foo_Aux
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.FunPtr Foo_Aux
+         ) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
+
+instance HasCField.HasCField Foo "unwrapFoo" where
+
+  type CFieldType Foo "unwrapFoo" = RIP.FunPtr Foo_Aux
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 171:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Bar_struct = Bar_struct
+  { bar_struct_a :: RIP.CInt
+    {- ^ __C declaration:__ @a@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 172:7@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , bar_struct_b :: RIP.CInt
+    {- ^ __C declaration:__ @b@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 173:7@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Bar_struct where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Bar_struct where
+
+  readRaw =
+    \ptr0 ->
+          pure Bar_struct
+      <*> HasCField.readRaw (RIP.Proxy @"bar_struct_a") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"bar_struct_b") ptr0
+
+instance Marshal.WriteRaw Bar_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Bar_struct bar_struct_a2 bar_struct_b3 ->
+               HasCField.writeRaw (RIP.Proxy @"bar_struct_a") ptr0 bar_struct_a2
+            >> HasCField.writeRaw (RIP.Proxy @"bar_struct_b") ptr0 bar_struct_b3
+
+deriving via Marshal.EquivStorable Bar_struct instance RIP.Storable Bar_struct
+
+instance HasCField.HasCField Bar_struct "bar_struct_a" where
+
+  type CFieldType Bar_struct "bar_struct_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_struct_a" (RIP.Ptr Bar_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"bar_struct_a")
+
+instance HasCField.HasCField Bar_struct "bar_struct_b" where
+
+  type CFieldType Bar_struct "bar_struct_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_struct_b" (RIP.Ptr Bar_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"bar_struct_b")
+
+{-| Auxiliary type used by 'Bar'
+
+    __C declaration:__ @bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 175:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Bar_Aux = Bar_Aux
+  { unwrapBar_Aux :: Bar_struct -> IO Foo_struct
+  }
+  deriving stock (RIP.Generic)
+
+instance ( ty ~ (Bar_struct -> IO Foo_struct)
+         ) => RIP.HasField "unwrapBar_Aux" (RIP.Ptr Bar_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapBar_Aux")
+
+instance HasCField.HasCField Bar_Aux "unwrapBar_Aux" where
+
+  type CFieldType Bar_Aux "unwrapBar_Aux" =
+    Bar_struct -> IO Foo_struct
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 175:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Bar = Bar
+  { unwrapBar :: RIP.FunPtr Bar_Aux
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.FunPtr Bar_Aux
+         ) => RIP.HasField "unwrapBar" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapBar")
+
+instance HasCField.HasCField Bar "unwrapBar" where
+
+  type CFieldType Bar "unwrapBar" = RIP.FunPtr Bar_Aux
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct struct15@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 182:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct15 = Struct15
+  {}
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Struct15 where
+
+  staticSizeOf = \_ -> (0 :: Int)
+
+  staticAlignment = \_ -> (1 :: Int)
+
+instance Marshal.ReadRaw Struct15 where
+
+  readRaw = \ptr0 -> pure Struct15
+
+instance Marshal.WriteRaw Struct15 where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Struct15 -> return ()
+
+deriving via Marshal.EquivStorable Struct15 instance RIP.Storable Struct15
+
+{-| __C declaration:__ @struct struct16@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 191:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct16_struct = Struct16_struct
+  {}
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Struct16_struct where
+
+  staticSizeOf = \_ -> (0 :: Int)
+
+  staticAlignment = \_ -> (1 :: Int)
+
+instance Marshal.ReadRaw Struct16_struct where
+
+  readRaw = \ptr0 -> pure Struct16_struct
+
+instance Marshal.WriteRaw Struct16_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Struct16_struct -> return ()
+
+deriving via Marshal.EquivStorable Struct16_struct instance RIP.Storable Struct16_struct
+
+{-| __C declaration:__ @struct16@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 192:32@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Struct16 = Struct16
+  { unwrapStruct16 :: RIP.Ptr Struct16_struct
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Show)
+  deriving newtype
+    ( RIP.HasFFIType
+    , Marshal.ReadRaw
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance ( ty ~ RIP.Ptr Struct16_struct
+         ) => RIP.HasField "unwrapStruct16" (RIP.Ptr Struct16) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapStruct16")
+
+instance HasCField.HasCField Struct16 "unwrapStruct16" where
+
+  type CFieldType Struct16 "unwrapStruct16" =
+    RIP.Ptr Struct16_struct
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct use_sites_qual@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 195:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Use_sites_qual = Use_sites_qual
+  { use_sites_qual_useTypedef_struct15 :: Struct15
+    {- ^ __C declaration:__ @useTypedef_struct15@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 197:12@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , use_sites_qual_useStruct_struct16 :: Struct16_struct
+    {- ^ __C declaration:__ @useStruct_struct16@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 200:19@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  , use_sites_qual_useTypedef_struct16 :: Struct16
+    {- ^ __C declaration:__ @useTypedef_struct16@
+
+         __defined at:__ @program-analysis\/typedef_analysis.h 201:12@
+
+         __exported by:__ @program-analysis\/typedef_analysis.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Use_sites_qual where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw Use_sites_qual where
+
+  readRaw =
+    \ptr0 ->
+          pure Use_sites_qual
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_qual_useTypedef_struct15") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_qual_useStruct_struct16") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"use_sites_qual_useTypedef_struct16") ptr0
+
+instance Marshal.WriteRaw Use_sites_qual where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Use_sites_qual
+            use_sites_qual_useTypedef_struct152
+            use_sites_qual_useStruct_struct163
+            use_sites_qual_useTypedef_struct164 ->
+                 HasCField.writeRaw (RIP.Proxy @"use_sites_qual_useTypedef_struct15") ptr0 use_sites_qual_useTypedef_struct152
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_qual_useStruct_struct16") ptr0 use_sites_qual_useStruct_struct163
+              >> HasCField.writeRaw (RIP.Proxy @"use_sites_qual_useTypedef_struct16") ptr0 use_sites_qual_useTypedef_struct164
+
+deriving via Marshal.EquivStorable Use_sites_qual instance RIP.Storable Use_sites_qual
+
+instance HasCField.HasCField Use_sites_qual "use_sites_qual_useTypedef_struct15" where
+
+  type CFieldType Use_sites_qual "use_sites_qual_useTypedef_struct15" =
+    Struct15
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ Struct15
+         ) => RIP.HasField "use_sites_qual_useTypedef_struct15" (RIP.Ptr Use_sites_qual) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_qual_useTypedef_struct15")
+
+instance HasCField.HasCField Use_sites_qual "use_sites_qual_useStruct_struct16" where
+
+  type CFieldType Use_sites_qual "use_sites_qual_useStruct_struct16" =
+    Struct16_struct
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ Struct16_struct
+         ) => RIP.HasField "use_sites_qual_useStruct_struct16" (RIP.Ptr Use_sites_qual) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_qual_useStruct_struct16")
+
+instance HasCField.HasCField Use_sites_qual "use_sites_qual_useTypedef_struct16" where
+
+  type CFieldType Use_sites_qual "use_sites_qual_useTypedef_struct16" =
+    Struct16
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ Struct16
+         ) => RIP.HasField "use_sites_qual_useTypedef_struct16" (RIP.Ptr Use_sites_qual) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_qual_useTypedef_struct16")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
@@ -34,11 +34,17 @@ ctypes:
   cname: struct5_t
   hsname: Struct5_t
 - headers: program-analysis/typedef_analysis.h
-  cname: struct struct6
-  hsname: Struct6_Aux
+  cname: struct struct6a
+  hsname: Struct6a_struct
 - headers: program-analysis/typedef_analysis.h
-  cname: struct6
-  hsname: Struct6
+  cname: struct6a
+  hsname: Struct6a
+- headers: program-analysis/typedef_analysis.h
+  cname: struct struct6b
+  hsname: Struct6b_struct
+- headers: program-analysis/typedef_analysis.h
+  cname: struct6b
+  hsname: Struct6b
 - headers: program-analysis/typedef_analysis.h
   cname: struct struct7
   hsname: Struct7
@@ -90,7 +96,104 @@ ctypes:
 - headers: program-analysis/typedef_analysis.h
   cname: struct use_sites
   hsname: Use_sites
+- headers: program-analysis/typedef_analysis.h
+  cname: struct foo
+  hsname: Foo_struct
+- headers: program-analysis/typedef_analysis.h
+  cname: foo
+  hsname: Foo
+- headers: program-analysis/typedef_analysis.h
+  cname: struct bar
+  hsname: Bar_struct
+- headers: program-analysis/typedef_analysis.h
+  cname: bar
+  hsname: Bar
+- headers: program-analysis/typedef_analysis.h
+  cname: struct struct15
+  hsname: Struct15
+- headers: program-analysis/typedef_analysis.h
+  cname: struct15
+  hsname: Struct15
+- headers: program-analysis/typedef_analysis.h
+  cname: struct struct16
+  hsname: Struct16_struct
+- headers: program-analysis/typedef_analysis.h
+  cname: struct16
+  hsname: Struct16
+- headers: program-analysis/typedef_analysis.h
+  cname: struct use_sites_qual
+  hsname: Use_sites_qual
 hstypes:
+- hsname: Bar
+  representation:
+    newtype:
+      constructor: Bar
+      fields:
+      - unwrapBar
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Bar_struct
+  representation:
+    record:
+      constructor: Bar_struct
+      fields:
+      - bar_struct_a
+      - bar_struct_b
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo
+  representation:
+    newtype:
+      constructor: Foo
+      fields:
+      - unwrapFoo
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_struct
+  representation:
+    record:
+      constructor: Foo_struct
+      fields:
+      - foo_struct_x
+      - foo_struct_y
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
 - hsname: Struct10_t
   representation:
     record:
@@ -149,6 +252,50 @@ hstypes:
   - Generic
   - HasCField
   - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Struct15
+  representation:
+    record:
+      constructor: Struct15
+      fields: []
+  instances:
+  - Eq
+  - Generic
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Struct16
+  representation:
+    newtype:
+      constructor: Struct16
+      fields:
+      - unwrapStruct16
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - Ord
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Struct16_struct
+  representation:
+    record:
+      constructor: Struct16_struct
+      fields: []
+  instances:
+  - Eq
+  - Generic
   - ReadRaw
   - Show
   - StaticSize
@@ -215,12 +362,12 @@ hstypes:
   - StaticSize
   - Storable
   - WriteRaw
-- hsname: Struct6
+- hsname: Struct6a
   representation:
     newtype:
-      constructor: Struct6
+      constructor: Struct6a
       fields:
-      - unwrapStruct6
+      - unwrapStruct6a
   instances:
   - Eq
   - Generic
@@ -233,10 +380,40 @@ hstypes:
   - StaticSize
   - Storable
   - WriteRaw
-- hsname: Struct6_Aux
+- hsname: Struct6a_struct
   representation:
     record:
-      constructor: Struct6_Aux
+      constructor: Struct6a_struct
+      fields: []
+  instances:
+  - Eq
+  - Generic
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Struct6b
+  representation:
+    newtype:
+      constructor: Struct6b
+      fields:
+      - unwrapStruct6b
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - IsArray
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Struct6b_struct
+  representation:
+    record:
+      constructor: Struct6b_struct
       fields: []
   instances:
   - Eq
@@ -360,8 +537,10 @@ hstypes:
       - use_sites_useTypedef_struct4_t
       - use_sites_useStruct_struct5
       - use_sites_useTypedef_struct5_t
-      - use_sites_useStruct_struct6
-      - use_sites_useTypedef_struct6
+      - use_sites_useStruct_struct6a
+      - use_sites_useTypedef_struct6a
+      - use_sites_useStruct_struct6b
+      - use_sites_useTypedef_struct6b
       - use_sites_useTypedef_struct7a
       - use_sites_useTypedef_struct7b
       - use_sites_useTypedef_struct8
@@ -372,6 +551,24 @@ hstypes:
       - use_sites_useTypedef_struct10_t_t
       - use_sites_useTypedef_struct11_t
       - use_sites_useTypedef_struct12_t
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Use_sites_qual
+  representation:
+    record:
+      constructor: Use_sites_qual
+      fields:
+      - use_sites_qual_useTypedef_struct15
+      - use_sites_qual_useStruct_struct16
+      - use_sites_qual_useTypedef_struct16
   instances:
   - Eq
   - Generic

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
@@ -1,7 +1,7 @@
 -- addDependentFile test-artefacts/headers/golden/program-analysis/typedef_analysis.h
 {-| __C declaration:__ @struct struct1@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 7:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 41:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -17,7 +17,7 @@ instance WriteRaw Struct1_t
 deriving via (EquivStorable Struct1_t) instance Storable Struct1_t
 {-| __C declaration:__ @struct struct2@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 11:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 45:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -33,21 +33,21 @@ instance WriteRaw Struct2_t
 deriving via (EquivStorable Struct2_t) instance Storable Struct2_t
 {-| __C declaration:__ @struct struct3@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 14:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 49:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
 data Struct3_t
 {-| __C declaration:__ @struct struct4@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 18:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 53:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
 data Struct4_t
 {-| __C declaration:__ @struct struct5@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 21:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 56:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -63,7 +63,7 @@ instance WriteRaw Struct5
 deriving via (EquivStorable Struct5) instance Storable Struct5
 {-| __C declaration:__ @struct5_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 22:25@
+    __defined at:__ @program-analysis\/typedef_analysis.h 57:25@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -81,47 +81,83 @@ instance (~) ty (Ptr Struct5) =>
 instance HasCField Struct5_t "unwrapStruct5_t"
     where type CFieldType Struct5_t "unwrapStruct5_t" = Ptr Struct5
           offset# = \_ -> \_ -> 0
-{-| __C declaration:__ @struct struct6@
+{-| __C declaration:__ @struct struct6a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 25:16@
+    __defined at:__ @program-analysis\/typedef_analysis.h 60:16@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
-data Struct6_Aux
-    = Struct6_Aux {}
+data Struct6a_struct
+    = Struct6a_struct {}
     deriving stock (Eq, Generic, Show)
-instance StaticSize Struct6_Aux
+instance StaticSize Struct6a_struct
     where staticSizeOf = \_ -> 0 :: Int
           staticAlignment = \_ -> 1 :: Int
-instance ReadRaw Struct6_Aux
-    where readRaw = \ptr_0 -> pure Struct6_Aux
-instance WriteRaw Struct6_Aux
+instance ReadRaw Struct6a_struct
+    where readRaw = \ptr_0 -> pure Struct6a_struct
+instance WriteRaw Struct6a_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
-                                       Struct6_Aux -> return ()
-deriving via (EquivStorable Struct6_Aux) instance Storable Struct6_Aux
-{-| __C declaration:__ @struct6@
+                                       Struct6a_struct -> return ()
+deriving via (EquivStorable Struct6a_struct) instance Storable Struct6a_struct
+{-| __C declaration:__ @struct6a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 25:28@
+    __defined at:__ @program-analysis\/typedef_analysis.h 61:4@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
-newtype Struct6
-    = Struct6 {unwrapStruct6 :: (Ptr Struct6_Aux)}
+newtype Struct6a
+    = Struct6a {unwrapStruct6a :: (Ptr Struct6a_struct)}
     deriving stock (Eq, Generic, Ord, Show)
     deriving newtype (HasFFIType,
                       ReadRaw,
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Struct6_Aux) =>
-         HasField "unwrapStruct6" (Ptr Struct6) (Ptr ty)
-    where getField = fromPtr (Proxy @"unwrapStruct6")
-instance HasCField Struct6 "unwrapStruct6"
-    where type CFieldType Struct6 "unwrapStruct6" = Ptr Struct6_Aux
+instance (~) ty (Ptr Struct6a_struct) =>
+         HasField "unwrapStruct6a" (Ptr Struct6a) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapStruct6a")
+instance HasCField Struct6a "unwrapStruct6a"
+    where type CFieldType Struct6a
+                          "unwrapStruct6a" = Ptr Struct6a_struct
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct struct6b@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 68:16@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct6b_struct
+    = Struct6b_struct {}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Struct6b_struct
+    where staticSizeOf = \_ -> 0 :: Int
+          staticAlignment = \_ -> 1 :: Int
+instance ReadRaw Struct6b_struct
+    where readRaw = \ptr_0 -> pure Struct6b_struct
+instance WriteRaw Struct6b_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Struct6b_struct -> return ()
+deriving via (EquivStorable Struct6b_struct) instance Storable Struct6b_struct
+{-| __C declaration:__ @struct6b@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 69:3@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Struct6b
+    = Struct6b {unwrapStruct6b :: (ConstantArray 50 Struct6b_struct)}
+    deriving stock (Eq, Generic, Show)
+    deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 50 Struct6b_struct) =>
+         HasField "unwrapStruct6b" (Ptr Struct6b) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapStruct6b")
+instance HasCField Struct6b "unwrapStruct6b"
+    where type CFieldType Struct6b "unwrapStruct6b" = ConstantArray 50
+                                                                    Struct6b_struct
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct7@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 28:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 72:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -137,7 +173,7 @@ instance WriteRaw Struct7
 deriving via (EquivStorable Struct7) instance Storable Struct7
 {-| __C declaration:__ @struct7a@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 29:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 73:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -153,7 +189,7 @@ instance HasCField Struct7a "unwrapStruct7a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct7b@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 30:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 74:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -169,7 +205,7 @@ instance HasCField Struct7b "unwrapStruct7b"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct8@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 33:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 77:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -185,7 +221,7 @@ instance WriteRaw Struct8
 deriving via (EquivStorable Struct8) instance Storable Struct8
 {-| __C declaration:__ @struct8b@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 35:24@
+    __defined at:__ @program-analysis\/typedef_analysis.h 79:24@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -201,7 +237,7 @@ instance HasCField Struct8b "unwrapStruct8b"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct9@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 38:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 82:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -217,7 +253,7 @@ instance WriteRaw Struct9
 deriving via (EquivStorable Struct9) instance Storable Struct9
 {-| __C declaration:__ @struct9_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 40:17@
+    __defined at:__ @program-analysis\/typedef_analysis.h 84:17@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -233,7 +269,7 @@ instance HasCField Struct9_t "unwrapStruct9_t"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct10@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 46:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 90:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -249,7 +285,7 @@ instance WriteRaw Struct10_t
 deriving via (EquivStorable Struct10_t) instance Storable Struct10_t
 {-| __C declaration:__ @struct10_t_t@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 48:20@
+    __defined at:__ @program-analysis\/typedef_analysis.h 92:20@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -266,7 +302,7 @@ instance HasCField Struct10_t_t "unwrapStruct10_t_t"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct11@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 51:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 95:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -274,14 +310,14 @@ data Struct11_t
     = Struct11_t {struct11_t_x :: CInt
                   {- ^ __C declaration:__ @x@
 
-                       __defined at:__ @program-analysis\/typedef_analysis.h 52:7@
+                       __defined at:__ @program-analysis\/typedef_analysis.h 96:7@
 
                        __exported by:__ @program-analysis\/typedef_analysis.h@
                   -},
                   struct11_t_self :: (Ptr Struct11_t)
                   {- ^ __C declaration:__ @self@
 
-                       __defined at:__ @program-analysis\/typedef_analysis.h 53:20@
+                       __defined at:__ @program-analysis\/typedef_analysis.h 97:20@
 
                        __exported by:__ @program-analysis\/typedef_analysis.h@
                   -}}
@@ -310,7 +346,7 @@ instance (~) ty (Ptr Struct11_t) =>
     where getField = fromPtr (Proxy @"struct11_t_self")
 {-| __C declaration:__ @struct struct12@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 60:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 104:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -318,14 +354,14 @@ data Struct12_t
     = Struct12_t {struct12_t_x :: CInt
                   {- ^ __C declaration:__ @x@
 
-                       __defined at:__ @program-analysis\/typedef_analysis.h 61:7@
+                       __defined at:__ @program-analysis\/typedef_analysis.h 105:7@
 
                        __exported by:__ @program-analysis\/typedef_analysis.h@
                   -},
                   struct12_t_self :: (Ptr Struct12_t)
                   {- ^ __C declaration:__ @self@
 
-                       __defined at:__ @program-analysis\/typedef_analysis.h 62:15@
+                       __defined at:__ @program-analysis\/typedef_analysis.h 106:15@
 
                        __exported by:__ @program-analysis\/typedef_analysis.h@
                   -}}
@@ -354,7 +390,7 @@ instance (~) ty (Ptr Struct12_t) =>
     where getField = fromPtr (Proxy @"struct12_t_self")
 {-| __C declaration:__ @struct use_sites@
 
-    __defined at:__ @program-analysis\/typedef_analysis.h 66:8@
+    __defined at:__ @program-analysis\/typedef_analysis.h 110:8@
 
     __exported by:__ @program-analysis\/typedef_analysis.h@
 -}
@@ -362,126 +398,140 @@ data Use_sites
     = Use_sites {use_sites_useTypedef_struct1_t :: Struct1_t
                  {- ^ __C declaration:__ @useTypedef_struct1_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 68:13@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 112:13@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct2_t :: Struct2_t
                  {- ^ __C declaration:__ @useTypedef_struct2_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 71:13@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 115:13@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct3_t :: (Ptr Struct3_t)
                  {- ^ __C declaration:__ @useTypedef_struct3_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 74:14@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 118:14@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct4_t :: (Ptr Struct4_t)
                  {- ^ __C declaration:__ @useTypedef_struct4_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 75:14@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 119:14@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useStruct_struct5 :: Struct5
                  {- ^ __C declaration:__ @useStruct_struct5@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 78:18@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 122:18@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct5_t :: Struct5_t
                  {- ^ __C declaration:__ @useTypedef_struct5_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 79:13@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 123:13@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
-                 use_sites_useStruct_struct6 :: Struct6_Aux
-                 {- ^ __C declaration:__ @useStruct_struct6@
+                 use_sites_useStruct_struct6a :: Struct6a_struct
+                 {- ^ __C declaration:__ @useStruct_struct6a@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 82:18@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 126:19@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
-                 use_sites_useTypedef_struct6 :: Struct6
-                 {- ^ __C declaration:__ @useTypedef_struct6@
+                 use_sites_useTypedef_struct6a :: Struct6a
+                 {- ^ __C declaration:__ @useTypedef_struct6a@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 83:11@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 127:12@
+
+                      __exported by:__ @program-analysis\/typedef_analysis.h@
+                 -},
+                 use_sites_useStruct_struct6b :: Struct6b_struct
+                 {- ^ __C declaration:__ @useStruct_struct6b@
+
+                      __defined at:__ @program-analysis\/typedef_analysis.h 130:19@
+
+                      __exported by:__ @program-analysis\/typedef_analysis.h@
+                 -},
+                 use_sites_useTypedef_struct6b :: Struct6b
+                 {- ^ __C declaration:__ @useTypedef_struct6b@
+
+                      __defined at:__ @program-analysis\/typedef_analysis.h 131:12@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct7a :: Struct7a
                  {- ^ __C declaration:__ @useTypedef_struct7a@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 86:12@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 134:12@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct7b :: Struct7b
                  {- ^ __C declaration:__ @useTypedef_struct7b@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 87:12@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 135:12@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct8 :: Struct8
                  {- ^ __C declaration:__ @useTypedef_struct8@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 91:11@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 139:11@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct8b :: Struct8b
                  {- ^ __C declaration:__ @useTypedef_struct8b@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 92:12@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 140:12@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct9 :: Struct9
                  {- ^ __C declaration:__ @useTypedef_struct9@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 96:11@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 144:11@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct9_t :: Struct9_t
                  {- ^ __C declaration:__ @useTypedef_struct9_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 97:13@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 145:13@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct10_t :: Struct10_t
                  {- ^ __C declaration:__ @useTypedef_struct10_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 98:14@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 146:14@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct10_t_t :: Struct10_t_t
                  {- ^ __C declaration:__ @useTypedef_struct10_t_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 99:16@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 147:16@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct11_t :: Struct11_t
                  {- ^ __C declaration:__ @useTypedef_struct11_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 102:14@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 150:14@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -},
                  use_sites_useTypedef_struct12_t :: Struct12_t
                  {- ^ __C declaration:__ @useTypedef_struct12_t@
 
-                      __defined at:__ @program-analysis\/typedef_analysis.h 103:14@
+                      __defined at:__ @program-analysis\/typedef_analysis.h 151:14@
 
                       __exported by:__ @program-analysis\/typedef_analysis.h@
                  -}}
@@ -490,7 +540,7 @@ instance StaticSize Use_sites
     where staticSizeOf = \_ -> 64 :: Int
           staticAlignment = \_ -> 8 :: Int
 instance ReadRaw Use_sites
-    where readRaw = \ptr_0 -> (((((((((((((((((pure Use_sites <*> readRaw (Proxy @"use_sites_useTypedef_struct1_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct2_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct3_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct4_t") ptr_0) <*> readRaw (Proxy @"use_sites_useStruct_struct5") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct5_t") ptr_0) <*> readRaw (Proxy @"use_sites_useStruct_struct6") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct6") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct7a") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct7b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct8") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct8b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct9") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct9_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct10_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct10_t_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct11_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct12_t") ptr_0
+    where readRaw = \ptr_0 -> (((((((((((((((((((pure Use_sites <*> readRaw (Proxy @"use_sites_useTypedef_struct1_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct2_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct3_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct4_t") ptr_0) <*> readRaw (Proxy @"use_sites_useStruct_struct5") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct5_t") ptr_0) <*> readRaw (Proxy @"use_sites_useStruct_struct6a") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct6a") ptr_0) <*> readRaw (Proxy @"use_sites_useStruct_struct6b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct6b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct7a") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct7b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct8") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct8b") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct9") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct9_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct10_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct10_t_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct11_t") ptr_0) <*> readRaw (Proxy @"use_sites_useTypedef_struct12_t") ptr_0
 instance WriteRaw Use_sites
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Use_sites use_sites_useTypedef_struct1_t_2
@@ -499,18 +549,20 @@ instance WriteRaw Use_sites
                                                  use_sites_useTypedef_struct4_t_5
                                                  use_sites_useStruct_struct5_6
                                                  use_sites_useTypedef_struct5_t_7
-                                                 use_sites_useStruct_struct6_8
-                                                 use_sites_useTypedef_struct6_9
-                                                 use_sites_useTypedef_struct7a_10
-                                                 use_sites_useTypedef_struct7b_11
-                                                 use_sites_useTypedef_struct8_12
-                                                 use_sites_useTypedef_struct8b_13
-                                                 use_sites_useTypedef_struct9_14
-                                                 use_sites_useTypedef_struct9_t_15
-                                                 use_sites_useTypedef_struct10_t_16
-                                                 use_sites_useTypedef_struct10_t_t_17
-                                                 use_sites_useTypedef_struct11_t_18
-                                                 use_sites_useTypedef_struct12_t_19 -> writeRaw (Proxy @"use_sites_useTypedef_struct1_t") ptr_0 use_sites_useTypedef_struct1_t_2 >> (writeRaw (Proxy @"use_sites_useTypedef_struct2_t") ptr_0 use_sites_useTypedef_struct2_t_3 >> (writeRaw (Proxy @"use_sites_useTypedef_struct3_t") ptr_0 use_sites_useTypedef_struct3_t_4 >> (writeRaw (Proxy @"use_sites_useTypedef_struct4_t") ptr_0 use_sites_useTypedef_struct4_t_5 >> (writeRaw (Proxy @"use_sites_useStruct_struct5") ptr_0 use_sites_useStruct_struct5_6 >> (writeRaw (Proxy @"use_sites_useTypedef_struct5_t") ptr_0 use_sites_useTypedef_struct5_t_7 >> (writeRaw (Proxy @"use_sites_useStruct_struct6") ptr_0 use_sites_useStruct_struct6_8 >> (writeRaw (Proxy @"use_sites_useTypedef_struct6") ptr_0 use_sites_useTypedef_struct6_9 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7a") ptr_0 use_sites_useTypedef_struct7a_10 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7b") ptr_0 use_sites_useTypedef_struct7b_11 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8") ptr_0 use_sites_useTypedef_struct8_12 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8b") ptr_0 use_sites_useTypedef_struct8b_13 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9") ptr_0 use_sites_useTypedef_struct9_14 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9_t") ptr_0 use_sites_useTypedef_struct9_t_15 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t") ptr_0 use_sites_useTypedef_struct10_t_16 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t_t") ptr_0 use_sites_useTypedef_struct10_t_t_17 >> (writeRaw (Proxy @"use_sites_useTypedef_struct11_t") ptr_0 use_sites_useTypedef_struct11_t_18 >> writeRaw (Proxy @"use_sites_useTypedef_struct12_t") ptr_0 use_sites_useTypedef_struct12_t_19))))))))))))))))
+                                                 use_sites_useStruct_struct6a_8
+                                                 use_sites_useTypedef_struct6a_9
+                                                 use_sites_useStruct_struct6b_10
+                                                 use_sites_useTypedef_struct6b_11
+                                                 use_sites_useTypedef_struct7a_12
+                                                 use_sites_useTypedef_struct7b_13
+                                                 use_sites_useTypedef_struct8_14
+                                                 use_sites_useTypedef_struct8b_15
+                                                 use_sites_useTypedef_struct9_16
+                                                 use_sites_useTypedef_struct9_t_17
+                                                 use_sites_useTypedef_struct10_t_18
+                                                 use_sites_useTypedef_struct10_t_t_19
+                                                 use_sites_useTypedef_struct11_t_20
+                                                 use_sites_useTypedef_struct12_t_21 -> writeRaw (Proxy @"use_sites_useTypedef_struct1_t") ptr_0 use_sites_useTypedef_struct1_t_2 >> (writeRaw (Proxy @"use_sites_useTypedef_struct2_t") ptr_0 use_sites_useTypedef_struct2_t_3 >> (writeRaw (Proxy @"use_sites_useTypedef_struct3_t") ptr_0 use_sites_useTypedef_struct3_t_4 >> (writeRaw (Proxy @"use_sites_useTypedef_struct4_t") ptr_0 use_sites_useTypedef_struct4_t_5 >> (writeRaw (Proxy @"use_sites_useStruct_struct5") ptr_0 use_sites_useStruct_struct5_6 >> (writeRaw (Proxy @"use_sites_useTypedef_struct5_t") ptr_0 use_sites_useTypedef_struct5_t_7 >> (writeRaw (Proxy @"use_sites_useStruct_struct6a") ptr_0 use_sites_useStruct_struct6a_8 >> (writeRaw (Proxy @"use_sites_useTypedef_struct6a") ptr_0 use_sites_useTypedef_struct6a_9 >> (writeRaw (Proxy @"use_sites_useStruct_struct6b") ptr_0 use_sites_useStruct_struct6b_10 >> (writeRaw (Proxy @"use_sites_useTypedef_struct6b") ptr_0 use_sites_useTypedef_struct6b_11 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7a") ptr_0 use_sites_useTypedef_struct7a_12 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7b") ptr_0 use_sites_useTypedef_struct7b_13 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8") ptr_0 use_sites_useTypedef_struct8_14 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8b") ptr_0 use_sites_useTypedef_struct8b_15 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9") ptr_0 use_sites_useTypedef_struct9_16 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9_t") ptr_0 use_sites_useTypedef_struct9_t_17 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t") ptr_0 use_sites_useTypedef_struct10_t_18 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t_t") ptr_0 use_sites_useTypedef_struct10_t_t_19 >> (writeRaw (Proxy @"use_sites_useTypedef_struct11_t") ptr_0 use_sites_useTypedef_struct11_t_20 >> writeRaw (Proxy @"use_sites_useTypedef_struct12_t") ptr_0 use_sites_useTypedef_struct12_t_21))))))))))))))))))
 deriving via (EquivStorable Use_sites) instance Storable Use_sites
 instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
     where type CFieldType Use_sites
@@ -554,20 +606,34 @@ instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
 instance (~) ty Struct5_t =>
          HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
-instance HasCField Use_sites "use_sites_useStruct_struct6"
+instance HasCField Use_sites "use_sites_useStruct_struct6a"
     where type CFieldType Use_sites
-                          "use_sites_useStruct_struct6" = Struct6_Aux
+                          "use_sites_useStruct_struct6a" = Struct6a_struct
           offset# = \_ -> \_ -> 24
-instance (~) ty Struct6_Aux =>
-         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
-instance HasCField Use_sites "use_sites_useTypedef_struct6"
+instance (~) ty Struct6a_struct =>
+         HasField "use_sites_useStruct_struct6a" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useStruct_struct6a")
+instance HasCField Use_sites "use_sites_useTypedef_struct6a"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct6" = Struct6
+                          "use_sites_useTypedef_struct6a" = Struct6a
           offset# = \_ -> \_ -> 24
-instance (~) ty Struct6 =>
-         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
+instance (~) ty Struct6a =>
+         HasField "use_sites_useTypedef_struct6a" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6a")
+instance HasCField Use_sites "use_sites_useStruct_struct6b"
+    where type CFieldType Use_sites
+                          "use_sites_useStruct_struct6b" = Struct6b_struct
+          offset# = \_ -> \_ -> 32
+instance (~) ty Struct6b_struct =>
+         HasField "use_sites_useStruct_struct6b" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useStruct_struct6b")
+instance HasCField Use_sites "use_sites_useTypedef_struct6b"
+    where type CFieldType Use_sites
+                          "use_sites_useTypedef_struct6b" = Struct6b
+          offset# = \_ -> \_ -> 32
+instance (~) ty Struct6b =>
+         HasField "use_sites_useTypedef_struct6b" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6b")
 instance HasCField Use_sites "use_sites_useTypedef_struct7a"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7a" = Struct7a
@@ -640,3 +706,291 @@ instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
 instance (~) ty Struct12_t =>
          HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")
+{-| __C declaration:__ @struct foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 163:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Foo_struct
+    = Foo_struct {foo_struct_x :: CInt
+                  {- ^ __C declaration:__ @x@
+
+                       __defined at:__ @program-analysis\/typedef_analysis.h 164:7@
+
+                       __exported by:__ @program-analysis\/typedef_analysis.h@
+                  -},
+                  foo_struct_y :: CInt
+                  {- ^ __C declaration:__ @y@
+
+                       __defined at:__ @program-analysis\/typedef_analysis.h 165:7@
+
+                       __exported by:__ @program-analysis\/typedef_analysis.h@
+                  -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Foo_struct
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Foo_struct
+    where readRaw = \ptr_0 -> (pure Foo_struct <*> readRaw (Proxy @"foo_struct_x") ptr_0) <*> readRaw (Proxy @"foo_struct_y") ptr_0
+instance WriteRaw Foo_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Foo_struct foo_struct_x_2
+                                                  foo_struct_y_3 -> writeRaw (Proxy @"foo_struct_x") ptr_0 foo_struct_x_2 >> writeRaw (Proxy @"foo_struct_y") ptr_0 foo_struct_y_3
+deriving via (EquivStorable Foo_struct) instance Storable Foo_struct
+instance HasCField Foo_struct "foo_struct_x"
+    where type CFieldType Foo_struct "foo_struct_x" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "foo_struct_x" (Ptr Foo_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_struct_x")
+instance HasCField Foo_struct "foo_struct_y"
+    where type CFieldType Foo_struct "foo_struct_y" = CInt
+          offset# = \_ -> \_ -> 4
+instance (~) ty CInt =>
+         HasField "foo_struct_y" (Ptr Foo_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_struct_y")
+{-| Auxiliary type used by 'Foo'
+
+    __C declaration:__ @foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 167:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Foo_Aux
+    = Foo_Aux {unwrapFoo_Aux :: (IO Foo_struct)}
+    deriving stock Generic
+instance (~) ty (IO Foo_struct) =>
+         HasField "unwrapFoo_Aux" (Ptr Foo_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapFoo_Aux")
+instance HasCField Foo_Aux "unwrapFoo_Aux"
+    where type CFieldType Foo_Aux "unwrapFoo_Aux" = IO Foo_struct
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @foo@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 167:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Foo
+    = Foo {unwrapFoo :: (FunPtr Foo_Aux)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (FunPtr Foo_Aux) =>
+         HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapFoo")
+instance HasCField Foo "unwrapFoo"
+    where type CFieldType Foo "unwrapFoo" = FunPtr Foo_Aux
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 171:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Bar_struct
+    = Bar_struct {bar_struct_a :: CInt
+                  {- ^ __C declaration:__ @a@
+
+                       __defined at:__ @program-analysis\/typedef_analysis.h 172:7@
+
+                       __exported by:__ @program-analysis\/typedef_analysis.h@
+                  -},
+                  bar_struct_b :: CInt
+                  {- ^ __C declaration:__ @b@
+
+                       __defined at:__ @program-analysis\/typedef_analysis.h 173:7@
+
+                       __exported by:__ @program-analysis\/typedef_analysis.h@
+                  -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Bar_struct
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Bar_struct
+    where readRaw = \ptr_0 -> (pure Bar_struct <*> readRaw (Proxy @"bar_struct_a") ptr_0) <*> readRaw (Proxy @"bar_struct_b") ptr_0
+instance WriteRaw Bar_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Bar_struct bar_struct_a_2
+                                                  bar_struct_b_3 -> writeRaw (Proxy @"bar_struct_a") ptr_0 bar_struct_a_2 >> writeRaw (Proxy @"bar_struct_b") ptr_0 bar_struct_b_3
+deriving via (EquivStorable Bar_struct) instance Storable Bar_struct
+instance HasCField Bar_struct "bar_struct_a"
+    where type CFieldType Bar_struct "bar_struct_a" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "bar_struct_a" (Ptr Bar_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_struct_a")
+instance HasCField Bar_struct "bar_struct_b"
+    where type CFieldType Bar_struct "bar_struct_b" = CInt
+          offset# = \_ -> \_ -> 4
+instance (~) ty CInt =>
+         HasField "bar_struct_b" (Ptr Bar_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_struct_b")
+{-| Auxiliary type used by 'Bar'
+
+    __C declaration:__ @bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 175:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Bar_Aux
+    = Bar_Aux {unwrapBar_Aux :: (Bar_struct -> IO Foo_struct)}
+    deriving stock Generic
+instance (~) ty (Bar_struct -> IO Foo_struct) =>
+         HasField "unwrapBar_Aux" (Ptr Bar_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapBar_Aux")
+instance HasCField Bar_Aux "unwrapBar_Aux"
+    where type CFieldType Bar_Aux "unwrapBar_Aux" = Bar_struct ->
+                                                    IO Foo_struct
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 175:22@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Bar
+    = Bar {unwrapBar :: (FunPtr Bar_Aux)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (FunPtr Bar_Aux) =>
+         HasField "unwrapBar" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapBar")
+instance HasCField Bar "unwrapBar"
+    where type CFieldType Bar "unwrapBar" = FunPtr Bar_Aux
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct struct15@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 182:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct15 = Struct15 {} deriving stock (Eq, Generic, Show)
+instance StaticSize Struct15
+    where staticSizeOf = \_ -> 0 :: Int
+          staticAlignment = \_ -> 1 :: Int
+instance ReadRaw Struct15
+    where readRaw = \ptr_0 -> pure Struct15
+instance WriteRaw Struct15
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Struct15 -> return ()
+deriving via (EquivStorable Struct15) instance Storable Struct15
+{-| __C declaration:__ @struct struct16@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 191:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Struct16_struct
+    = Struct16_struct {}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Struct16_struct
+    where staticSizeOf = \_ -> 0 :: Int
+          staticAlignment = \_ -> 1 :: Int
+instance ReadRaw Struct16_struct
+    where readRaw = \ptr_0 -> pure Struct16_struct
+instance WriteRaw Struct16_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Struct16_struct -> return ()
+deriving via (EquivStorable Struct16_struct) instance Storable Struct16_struct
+{-| __C declaration:__ @struct16@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 192:32@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+newtype Struct16
+    = Struct16 {unwrapStruct16 :: (Ptr Struct16_struct)}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving newtype (HasFFIType,
+                      ReadRaw,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty (Ptr Struct16_struct) =>
+         HasField "unwrapStruct16" (Ptr Struct16) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapStruct16")
+instance HasCField Struct16 "unwrapStruct16"
+    where type CFieldType Struct16
+                          "unwrapStruct16" = Ptr Struct16_struct
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct use_sites_qual@
+
+    __defined at:__ @program-analysis\/typedef_analysis.h 195:8@
+
+    __exported by:__ @program-analysis\/typedef_analysis.h@
+-}
+data Use_sites_qual
+    = Use_sites_qual {use_sites_qual_useTypedef_struct15 :: Struct15
+                      {- ^ __C declaration:__ @useTypedef_struct15@
+
+                           __defined at:__ @program-analysis\/typedef_analysis.h 197:12@
+
+                           __exported by:__ @program-analysis\/typedef_analysis.h@
+                      -},
+                      use_sites_qual_useStruct_struct16 :: Struct16_struct
+                      {- ^ __C declaration:__ @useStruct_struct16@
+
+                           __defined at:__ @program-analysis\/typedef_analysis.h 200:19@
+
+                           __exported by:__ @program-analysis\/typedef_analysis.h@
+                      -},
+                      use_sites_qual_useTypedef_struct16 :: Struct16
+                      {- ^ __C declaration:__ @useTypedef_struct16@
+
+                           __defined at:__ @program-analysis\/typedef_analysis.h 201:12@
+
+                           __exported by:__ @program-analysis\/typedef_analysis.h@
+                      -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Use_sites_qual
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw Use_sites_qual
+    where readRaw = \ptr_0 -> ((pure Use_sites_qual <*> readRaw (Proxy @"use_sites_qual_useTypedef_struct15") ptr_0) <*> readRaw (Proxy @"use_sites_qual_useStruct_struct16") ptr_0) <*> readRaw (Proxy @"use_sites_qual_useTypedef_struct16") ptr_0
+instance WriteRaw Use_sites_qual
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Use_sites_qual use_sites_qual_useTypedef_struct15_2
+                                                      use_sites_qual_useStruct_struct16_3
+                                                      use_sites_qual_useTypedef_struct16_4 -> writeRaw (Proxy @"use_sites_qual_useTypedef_struct15") ptr_0 use_sites_qual_useTypedef_struct15_2 >> (writeRaw (Proxy @"use_sites_qual_useStruct_struct16") ptr_0 use_sites_qual_useStruct_struct16_3 >> writeRaw (Proxy @"use_sites_qual_useTypedef_struct16") ptr_0 use_sites_qual_useTypedef_struct16_4)
+deriving via (EquivStorable Use_sites_qual) instance Storable Use_sites_qual
+instance HasCField Use_sites_qual
+                   "use_sites_qual_useTypedef_struct15"
+    where type CFieldType Use_sites_qual
+                          "use_sites_qual_useTypedef_struct15" = Struct15
+          offset# = \_ -> \_ -> 0
+instance (~) ty Struct15 =>
+         HasField "use_sites_qual_useTypedef_struct15"
+                  (Ptr Use_sites_qual)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_qual_useTypedef_struct15")
+instance HasCField Use_sites_qual
+                   "use_sites_qual_useStruct_struct16"
+    where type CFieldType Use_sites_qual
+                          "use_sites_qual_useStruct_struct16" = Struct16_struct
+          offset# = \_ -> \_ -> 0
+instance (~) ty Struct16_struct =>
+         HasField "use_sites_qual_useStruct_struct16"
+                  (Ptr Use_sites_qual)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_qual_useStruct_struct16")
+instance HasCField Use_sites_qual
+                   "use_sites_qual_useTypedef_struct16"
+    where type CFieldType Use_sites_qual
+                          "use_sites_qual_useTypedef_struct16" = Struct16
+          offset# = \_ -> \_ -> 0
+instance (~) ty Struct16 =>
+         HasField "use_sites_qual_useTypedef_struct16"
+                  (Ptr Use_sites_qual)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_qual_useTypedef_struct16")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/Example.hs
@@ -1,0 +1,180 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Blk_struct(..)
+    , Example.Blk(..)
+    , Example.Blkarg_struct(..)
+    , Example.Blkarg(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.Block as Block
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @struct blk@
+
+    __defined at:__ @program-analysis\/typedef_block.h 13:8@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+data Blk_struct = Blk_struct
+  { blk_struct_x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @program-analysis\/typedef_block.h 13:18@
+
+         __exported by:__ @program-analysis\/typedef_block.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Blk_struct where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Blk_struct where
+
+  readRaw =
+    \ptr0 ->
+          pure Blk_struct
+      <*> HasCField.readRaw (RIP.Proxy @"blk_struct_x") ptr0
+
+instance Marshal.WriteRaw Blk_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Blk_struct blk_struct_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"blk_struct_x") ptr0 blk_struct_x2
+
+deriving via Marshal.EquivStorable Blk_struct instance RIP.Storable Blk_struct
+
+instance HasCField.HasCField Blk_struct "blk_struct_x" where
+
+  type CFieldType Blk_struct "blk_struct_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "blk_struct_x" (RIP.Ptr Blk_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"blk_struct_x")
+
+{-| __C declaration:__ @blk@
+
+    __defined at:__ @program-analysis\/typedef_block.h 14:22@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+newtype Blk = Blk
+  { unwrapBlk :: Block.Block (IO Blk_struct)
+  }
+  deriving stock (RIP.Generic)
+
+instance ( ty ~ Block.Block (IO Blk_struct)
+         ) => RIP.HasField "unwrapBlk" (RIP.Ptr Blk) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapBlk")
+
+instance HasCField.HasCField Blk "unwrapBlk" where
+
+  type CFieldType Blk "unwrapBlk" =
+    Block.Block (IO Blk_struct)
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct blkarg@
+
+    __defined at:__ @program-analysis\/typedef_block.h 17:8@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+data Blkarg_struct = Blkarg_struct
+  { blkarg_struct_y :: RIP.CInt
+    {- ^ __C declaration:__ @y@
+
+         __defined at:__ @program-analysis\/typedef_block.h 17:21@
+
+         __exported by:__ @program-analysis\/typedef_block.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Blkarg_struct where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Blkarg_struct where
+
+  readRaw =
+    \ptr0 ->
+          pure Blkarg_struct
+      <*> HasCField.readRaw (RIP.Proxy @"blkarg_struct_y") ptr0
+
+instance Marshal.WriteRaw Blkarg_struct where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Blkarg_struct blkarg_struct_y2 ->
+            HasCField.writeRaw (RIP.Proxy @"blkarg_struct_y") ptr0 blkarg_struct_y2
+
+deriving via Marshal.EquivStorable Blkarg_struct instance RIP.Storable Blkarg_struct
+
+instance HasCField.HasCField Blkarg_struct "blkarg_struct_y" where
+
+  type CFieldType Blkarg_struct "blkarg_struct_y" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "blkarg_struct_y" (RIP.Ptr Blkarg_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"blkarg_struct_y")
+
+{-| __C declaration:__ @blkarg@
+
+    __defined at:__ @program-analysis\/typedef_block.h 18:15@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+newtype Blkarg = Blkarg
+  { unwrapBlkarg :: Block.Block (Blkarg_struct -> IO RIP.CInt)
+  }
+  deriving stock (RIP.Generic)
+
+instance ( ty ~ Block.Block (Blkarg_struct -> IO RIP.CInt)
+         ) => RIP.HasField "unwrapBlkarg" (RIP.Ptr Blkarg) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unwrapBlkarg")
+
+instance HasCField.HasCField Blkarg "unwrapBlkarg" where
+
+  type CFieldType Blkarg "unwrapBlkarg" =
+    Block.Block (Blkarg_struct -> IO RIP.CInt)
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/bindingspec.yaml
@@ -1,0 +1,70 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: program-analysis/typedef_block.h
+  cname: struct blk
+  hsname: Blk_struct
+- headers: program-analysis/typedef_block.h
+  cname: blk
+  hsname: Blk
+- headers: program-analysis/typedef_block.h
+  cname: struct blkarg
+  hsname: Blkarg_struct
+- headers: program-analysis/typedef_block.h
+  cname: blkarg
+  hsname: Blkarg
+hstypes:
+- hsname: Blk
+  representation:
+    newtype:
+      constructor: Blk
+      fields:
+      - unwrapBlk
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+- hsname: Blk_struct
+  representation:
+    record:
+      constructor: Blk_struct
+      fields:
+      - blk_struct_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Blkarg
+  representation:
+    newtype:
+      constructor: Blkarg
+      fields:
+      - unwrapBlkarg
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+- hsname: Blkarg_struct
+  representation:
+    record:
+      constructor: Blkarg_struct
+      fields:
+      - blkarg_struct_y
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_block/th.txt
@@ -1,0 +1,92 @@
+-- addDependentFile test-artefacts/headers/golden/program-analysis/typedef_block.h
+{-| __C declaration:__ @struct blk@
+
+    __defined at:__ @program-analysis\/typedef_block.h 13:8@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+data Blk_struct
+    = Blk_struct {blk_struct_x :: CInt
+                  {- ^ __C declaration:__ @x@
+
+                       __defined at:__ @program-analysis\/typedef_block.h 13:18@
+
+                       __exported by:__ @program-analysis\/typedef_block.h@
+                  -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Blk_struct
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Blk_struct
+    where readRaw = \ptr_0 -> pure Blk_struct <*> readRaw (Proxy @"blk_struct_x") ptr_0
+instance WriteRaw Blk_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Blk_struct blk_struct_x_2 -> writeRaw (Proxy @"blk_struct_x") ptr_0 blk_struct_x_2
+deriving via (EquivStorable Blk_struct) instance Storable Blk_struct
+instance HasCField Blk_struct "blk_struct_x"
+    where type CFieldType Blk_struct "blk_struct_x" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "blk_struct_x" (Ptr Blk_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"blk_struct_x")
+{-| __C declaration:__ @blk@
+
+    __defined at:__ @program-analysis\/typedef_block.h 14:22@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+newtype Blk
+    = Blk {unwrapBlk :: (Block (IO Blk_struct))}
+    deriving stock Generic
+instance (~) ty (Block (IO Blk_struct)) =>
+         HasField "unwrapBlk" (Ptr Blk) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapBlk")
+instance HasCField Blk "unwrapBlk"
+    where type CFieldType Blk "unwrapBlk" = Block (IO Blk_struct)
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct blkarg@
+
+    __defined at:__ @program-analysis\/typedef_block.h 17:8@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+data Blkarg_struct
+    = Blkarg_struct {blkarg_struct_y :: CInt
+                     {- ^ __C declaration:__ @y@
+
+                          __defined at:__ @program-analysis\/typedef_block.h 17:21@
+
+                          __exported by:__ @program-analysis\/typedef_block.h@
+                     -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Blkarg_struct
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Blkarg_struct
+    where readRaw = \ptr_0 -> pure Blkarg_struct <*> readRaw (Proxy @"blkarg_struct_y") ptr_0
+instance WriteRaw Blkarg_struct
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Blkarg_struct blkarg_struct_y_2 -> writeRaw (Proxy @"blkarg_struct_y") ptr_0 blkarg_struct_y_2
+deriving via (EquivStorable Blkarg_struct) instance Storable Blkarg_struct
+instance HasCField Blkarg_struct "blkarg_struct_y"
+    where type CFieldType Blkarg_struct "blkarg_struct_y" = CInt
+          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "blkarg_struct_y" (Ptr Blkarg_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"blkarg_struct_y")
+{-| __C declaration:__ @blkarg@
+
+    __defined at:__ @program-analysis\/typedef_block.h 18:15@
+
+    __exported by:__ @program-analysis\/typedef_block.h@
+-}
+newtype Blkarg
+    = Blkarg {unwrapBlkarg :: (Block (Blkarg_struct -> IO CInt))}
+    deriving stock Generic
+instance (~) ty (Block (Blkarg_struct -> IO CInt)) =>
+         HasField "unwrapBlkarg" (Ptr Blkarg) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapBlkarg")
+instance HasCField Blkarg "unwrapBlkarg"
+    where type CFieldType Blkarg
+                          "unwrapBlkarg" = Block (Blkarg_struct -> IO CInt)
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_name_clash/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_name_clash/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_name_clash/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_name_clash/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile test-artefacts/headers/golden/program-analysis/typedef_name_clash.h

--- a/hs-bindgen/test-artefacts/headers/golden/declarations/duplicate_field_name_omit.h
+++ b/hs-bindgen/test-artefacts/headers/golden/declarations/duplicate_field_name_omit.h
@@ -1,0 +1,1 @@
+struct S { int Bar; int bar; };

--- a/hs-bindgen/test-artefacts/headers/golden/declarations/name_collision.h
+++ b/hs-bindgen/test-artefacts/headers/golden/declarations/name_collision.h
@@ -1,7 +1,17 @@
-/* The C identifiers `y` and `Y` lead to a single colliding Haskell identifier
-   `Y`. */
+/* Cross-declaration collision: the C identifiers `y` and `Y` lead to a single
+   colliding Haskell identifier `Y`. */
 union y;
 union Y {
   int m;
   int o;
 };
+
+/* Intra-declaration collision: the enum tag `Color` and its enumerator `Color`
+   both yield the Haskell name `Color` in the data-constructor namespace (the
+   newtype data constructor and the enumerator's pattern synonym). */
+enum Color { Color };
+
+/* Cross-declaration field/function collision: the struct field selector `s_x`
+   (from `struct S`) collides with the function `S_x` (also mangled to `s_x`). */
+struct S { int x; };
+void S_x(void);

--- a/hs-bindgen/test-artefacts/headers/golden/declarations/name_collision_aux.h
+++ b/hs-bindgen/test-artefacts/headers/golden/declarations/name_collision_aux.h
@@ -1,0 +1,10 @@
+/* Sweep-2 collision: struct foo generates the auxiliary type Foo_Aux (for its
+   flexible array member), which clashes with the top-level declaration foo_Aux
+   that also mangles to Foo_Aux. */
+struct foo { int len; char data[]; };
+typedef int foo_Aux;
+
+/* Sweep-2 collision: function-pointer typedef bar generates the auxiliary type
+   Bar_Aux, which clashes with the top-level declaration bar_Aux. */
+typedef void (*bar)(int x);
+typedef int bar_Aux;

--- a/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_analysis.h
+++ b/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_analysis.h
@@ -1,6 +1,40 @@
 
 /** @file
- * Examples for the various cases in by `HsBindgen.Frontend.Analysis.Typedefs`
+ * Examples for the various cases in `HsBindgen.Frontend.Analysis.Typedefs`
+ *
+ * A C typedef and a tagged type (struct/union/enum) can share a name because
+ * they live in different C namespaces, but they collide in Haskell. The typedef
+ * analysis resolves this locally -- using only a single declaration's own name
+ * and type structure -- and so can only act on clashes that are visible from
+ * the typedef itself. Clashes that are not locally visible are detected and
+ * reported as failures by the name mangler instead (see the companion fixture
+ * for those).
+ *
+ *   Form of clash                                     Example  Conclusion
+ *   -------------------------------------------------------------------------
+ *   Typedef is a direct alias, sole use               1,3,4,10 squash
+ *   Typedef is a direct alias, declared together      2        squash
+ *   Typedef is a direct alias, same name              8,9      squash
+ *   Typedef is a direct alias, self-referential       11,12    squash
+ *   Direct alias (const-qualified), same name         15       squash
+ *   Direct alias used by more than one typedef        7        keep both
+ *   Indirection, name mismatch                        5        keep both
+ *   Eponymous tag via pointer                         6a       suffix tag
+ *   Eponymous tag via array                           6b       suffix tag
+ *   Eponymous tag via function return type            13       suffix tag
+ *   Eponymous tag via function argument type          14       suffix tag
+ *   Eponymous tag via const pointer                   16       suffix tag
+ *   Eponymous tag via block return type               blk*     suffix tag
+ *   Eponymous tag via block argument type             blkarg*  suffix tag
+ *
+ * (*) Block examples are in typedef_block.h (requires -fblocks).
+ *
+ * A type qualifier (`const`) is transparent for this analysis: it changes
+ * neither the Haskell representation nor the mangled name, so the tagged type
+ * underneath it keeps its directness (examples 15 and 16).
+ *
+ * The suffix added to a tagged type mirrors its C tag keyword: `_struct`,
+ * `_union`, or `_enum`.
  */
 
 // Example 1: struct only used in typedef
@@ -8,7 +42,8 @@ struct struct1 {};
 typedef struct struct1 struct1_t;
 
 // Example 2: like example 1, but declared together
-typedef struct struct2 {} struct2_t;
+typedef struct struct2 {
+} struct2_t;
 
 // Example 3: like example1, but opaque struct
 struct struct3;
@@ -21,8 +56,17 @@ typedef struct struct4 struct4_t;
 struct struct5 {};
 typedef struct struct5 *struct5_t;
 
-// Example 6: typedef pointer to eponymous struct
-typedef struct struct6 {} *struct6;
+// Example 6a: typedef pointer to eponymous struct
+typedef struct struct6a {
+} *struct6a;
+
+// Example 6b: like example 6a, but an array rather than a pointer
+//
+// See <https://github.com/well-typed/hs-bindgen/issues/1445>: as with the
+// pointer case, the eponymous struct must be assigned a new name (suffixed)
+// rather than clashing with the typedef.
+typedef struct struct6b {
+} struct6b[50];
 
 // Example 7: struct used in more than one typedef
 struct struct7 {};
@@ -71,16 +115,20 @@ struct use_sites {
   struct2_t useTypedef_struct2_t;
 
   // similarly for struct3 and struct4, but must be pointers (opaque types)
-  struct3_t* useTypedef_struct3_t;
-  struct4_t* useTypedef_struct4_t;
+  struct3_t *useTypedef_struct3_t;
+  struct4_t *useTypedef_struct4_t;
 
   // for struct5 both types continue to exist
   struct struct5 useStruct_struct5;
   struct5_t useTypedef_struct5_t;
 
-  // similarly for struct6, except here the Haskell type is assigned a new name
-  struct struct6 useStruct_struct6;
-  struct6 useTypedef_struct6;
+  // similarly for struct6a, except here the Haskell type is assigned a new name
+  struct struct6a useStruct_struct6a;
+  struct6a useTypedef_struct6a;
+
+  // similarly for struct6b (array typedef): the struct gets a new name
+  struct struct6b useStruct_struct6b;
+  struct6b useTypedef_struct6b;
 
   // for struct7a and struct7b there are multiple typedefs, so not squashed
   struct7a useTypedef_struct7a;
@@ -103,3 +151,52 @@ struct use_sites {
   struct12_t useTypedef_struct12_t;
 };
 
+// Mind bending self-referential definitions.
+//
+// A typedef and a tagged type can share a name (they live in different C
+// namespaces), but they clash in Haskell. We can resolve such a clash locally
+// (suffixing the tagged type) precisely when the typedef's own type references
+// the eponymous tagged type, regardless of /where/ in the type it appears.
+
+// Example 13: the typedef references the eponymous struct in its return type;
+// 'struct foo' is suffixed.
+struct foo {
+  int x;
+  int y;
+};
+typedef struct foo (*foo)(void);
+
+// Example 14: the typedef references the eponymous struct in an argument type;
+// 'struct bar' is suffixed.
+struct bar {
+  int a;
+  int b;
+};
+typedef struct foo (*bar)(struct bar arg);
+
+// Example 15: const-qualified direct alias with the same name as its tag.
+//
+// The qualifier sits at the head of the type (a 'TypeQual'), but it is
+// transparent: 'struct struct15' is still reached /directly/, so -- exactly as
+// in the unqualified same-name case (example 8) -- the typedef is squashed.
+struct struct15 {};
+typedef const struct struct15 struct15;
+
+// Example 16: eponymous tag reached through a const pointer.
+//
+// Here the head of the type is a qualifier wrapping a pointer
+// ('const' applies to the pointer itself). We must recurse /through/ the
+// qualifier to discover 'struct struct16' behind the indirection; because it is
+// no longer direct and clashes with the typedef name, the tag is suffixed.
+struct struct16 {};
+typedef struct struct16 *const struct16;
+
+// Use sites for the qualified examples.
+struct use_sites_qual {
+  // struct15 is squashed, so only the typedef name survives
+  struct15 useTypedef_struct15;
+
+  // for struct16 both types continue to exist (the tag is suffixed)
+  struct struct16 useStruct_struct16;
+  struct16 useTypedef_struct16;
+};

--- a/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_block.h
+++ b/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_block.h
@@ -1,0 +1,18 @@
+
+/** @file
+ * Block-typedef cases for typedef name-clash analysis
+ *
+ * Kept separate from typedef_analysis.h because this header requires -fblocks.
+ *
+ * The two cases mirror examples 13 and 14 from typedef_analysis.h: a tagged
+ * type reached through a block type (rather than a function-pointer type) and
+ * sharing its name with the surrounding typedef should be suffixed.
+ */
+
+// Block returning the eponymous struct: 'struct blk' is suffixed.
+struct blk { int x; };
+typedef struct blk (^blk)(void);
+
+// Block taking the eponymous struct as an argument: 'struct blkarg' suffixed.
+struct blkarg { int y; };
+typedef int (^blkarg)(struct blkarg arg);

--- a/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_name_clash.h
+++ b/hs-bindgen/test-artefacts/headers/golden/program-analysis/typedef_name_clash.h
@@ -1,0 +1,47 @@
+/** @file
+ * Fixtures for typedef-vs-tag name clashes that hs-bindgen deliberately does
+ * NOT resolve locally; they are reported as 'MangleNamesCollision' failures.
+ *
+ * The typedef analysis resolves clashes only when the typedef's own type
+ * /syntactically references/ the eponymous tagged type (see typedef_analysis.h
+ * for those cases).  Clashes that are not locally visible fall through to the
+ * name-mangler's collision check, which deselects all involved declarations.
+ *
+ *   Case  Description                                    Collision
+ *   ------------------------------------------------------------------
+ *   a     Typedef type unrelated to eponymous tag         a_unrelated (struct) vs a_unrelated (typedef)
+ *   a'    Function-pointer typedef, no eponymous ref      a_fun (struct) vs a_fun (typedef)
+ *   b     Typedef aliases a different tag; squashing      b_clash (struct) vs b_other (struct renamed B_clash)
+ *         renames that tag to the colliding name
+ *
+ * Note on case (c): a typedef chain such as
+ *
+ *   struct c_chain { int x; };
+ *   typedef struct c_chain c_chain_t;
+ *   typedef c_chain_t c_chain;
+ *
+ * does not produce a collision in practice: because c_chain_t is the sole
+ * direct typedef of struct c_chain, squashing renames the struct to C_chain_t,
+ * leaving C_chain free for the outer typedef.  It is therefore omitted here.
+ */
+
+// (a) Unrelated typedef sharing a tag's name: the typedef's type ('int') does
+// not reference 'struct a_unrelated' at all.  Both declarations mangle to
+// 'A_unrelated' and are deselected.
+struct a_unrelated { int x; };
+typedef int a_unrelated;
+
+// (a') Function-pointer typedef not referencing the eponymous tag: the
+// function type contains no reference to 'struct a_fun'.  Both declarations
+// mangle to 'A_fun' and are deselected.
+struct a_fun { int x; };
+typedef void (*a_fun)(void);
+
+// (b) Typedef aliasing a different tag ('struct b_other'), whose name collides
+// with 'struct b_clash'.  The typedef analysis squashes b_clash → struct
+// b_other (sole direct typedef, sole use), renaming b_other to 'B_clash'.
+// This clashes with the independently existing 'struct b_clash'.  Both structs
+// and the typedef are deselected.
+struct b_clash { int x; };
+struct b_other { int y; };
+typedef struct b_other b_clash;

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
@@ -3,7 +3,7 @@ module Test.HsBindgen.Golden.Declarations (testCases) where
 
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Naming
-import HsBindgen.Frontend.Pass.MangleNames.Error (MangleNamesError (MangleNamesCollision))
+import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
@@ -27,8 +27,10 @@ testCases = [
       -- Bespoke tests
     , test_declarations_declaration_unselected_b
     , test_declarations_definitions
+    , test_declarations_duplicate_field_name_omit
     , test_declarations_failing_tentative_definitions_linkage
     , test_declarations_name_collision
+    , test_declarations_name_collision_aux
     , test_declarations_redeclaration
     , test_declarations_redeclaration_different
     , test_declarations_redeclaration_identical
@@ -62,6 +64,22 @@ test_declarations_definitions =
     declsWithMsgs :: [CDeclName]
     declsWithMsgs = ["foo", "n"]
 
+test_declarations_duplicate_field_name_omit :: TestCase
+test_declarations_duplicate_field_name_omit =
+    defaultTest "declarations/duplicate_field_name_omit"
+      & #onFrontend      .~ (\cfg -> cfg
+            & #fieldNamingStrategy .~ OmitFieldPrefixes
+          )
+      & #tracePredicate  .~ multiTracePredicate declsWithMsgs (\case
+            MatchSelect name (SelectMangleNamesFailure MangleNamesDuplicateFieldName{}) ->
+              Just $ Expected name
+            _otherwise ->
+              Nothing
+          )
+  where
+    declsWithMsgs :: [CDeclName]
+    declsWithMsgs = ["struct S"]
+
 test_declarations_failing_tentative_definitions_linkage :: TestCase
 test_declarations_failing_tentative_definitions_linkage =
     failingTestLibclangMulti "declarations/failing/tentative_definitions_linkage" [(), ()] $ \case
@@ -73,6 +91,10 @@ test_declarations_failing_tentative_definitions_linkage =
         Nothing
 
 -- This tests https://github.com/well-typed/hs-bindgen/issues/1373.
+--
+-- It covers both a cross-declaration collision (@union y@ vs @union Y@) and an
+-- intra-declaration collision (@enum Color { Color }@, whose tag and enumerator
+-- both produce the Haskell name @Color@).
 test_declarations_name_collision :: TestCase
 test_declarations_name_collision =
     testTraceMulti "declarations/name_collision" declsWithMsgs $ \case
@@ -82,7 +104,25 @@ test_declarations_name_collision =
         Nothing
   where
     declsWithMsgs :: [CDeclName]
-    declsWithMsgs = ["union y", "union Y"]
+    declsWithMsgs = ["union y", "union Y", "enum Color", "struct S", "S_x"]
+
+-- This tests sweep-2 collision detection for names derived in pass 2:
+--
+-- * A struct with a flexible array member generates @Foo_Aux@ (the FLAM
+--   auxiliary type), which clashes with a top-level @foo_Aux@ declaration.
+--
+-- * A function-pointer typedef generates @Bar_Aux@ (the function-pointer
+--   auxiliary type), which clashes with a top-level @bar_Aux@ declaration.
+test_declarations_name_collision_aux :: TestCase
+test_declarations_name_collision_aux =
+    testTraceMulti "declarations/name_collision_aux" declsWithMsgs $ \case
+      MatchSelect name (SelectMangleNamesFailure MangleNamesCollision{}) ->
+        Just $ Expected name
+      _otherwise ->
+        Nothing
+  where
+    declsWithMsgs :: [CDeclName]
+    declsWithMsgs = ["struct foo", "foo_Aux", "bar", "bar_Aux"]
 
 test_declarations_redeclaration :: TestCase
 test_declarations_redeclaration =

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
@@ -2,6 +2,7 @@
 module Test.HsBindgen.Golden.ProgramAnalysis (testCases) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.MangleNames.Error
@@ -48,6 +49,8 @@ testCases = [
     , test_programAnalysis_selection_squash
       -- * Typedef analysis
     , test_programAnalysis_typedef_analysis
+    , test_programAnalysis_typedef_block
+    , test_programAnalysis_typedef_name_clash
     ]
 
 {-------------------------------------------------------------------------------
@@ -468,6 +471,11 @@ test_programAnalysis_selection_squash =
   Typedef analysis
 -------------------------------------------------------------------------------}
 
+-- | Locally resolvable typedef/tag clashes: squashing and suffixing.
+--
+-- See also 'test_programAnalysis_typedef_block' (the @-fblocks@ path) and
+-- 'test_programAnalysis_typedef_name_clash' (clashes that are /not/ locally
+-- resolvable and are reported as failures).
 test_programAnalysis_typedef_analysis :: TestCase
 test_programAnalysis_typedef_analysis =
     testTraceMulti "program-analysis/typedef_analysis" declsWithMsgs $ \case
@@ -488,7 +496,8 @@ test_programAnalysis_typedef_analysis =
         , ("struct3_t"       , Nothing)
         , ("struct struct4"  , Just "Struct4_t")
         , ("struct4_t"       , Nothing)
-        , ("struct struct6"  , Just "Struct6_Aux")
+        , ("struct struct6a" , Just "Struct6a_struct")
+        , ("struct struct6b" , Just "Struct6b_struct")
         , ("struct8"         , Nothing)
         , ("struct9"         , Nothing)
         , ("struct struct10" , Just "Struct10_t")
@@ -497,4 +506,62 @@ test_programAnalysis_typedef_analysis =
         , ("struct11_t"      , Nothing)
         , ("struct struct12" , Just "Struct12_t")
         , ("struct12_t"      , Nothing)
+          -- Tagged types referenced (and clashing by name) inside a
+          -- function-pointer typedef: suffixed via the return type ('foo') and
+          -- via an argument type ('bar').
+        , ("struct foo"      , Just "Foo_struct")
+        , ("struct bar"      , Just "Bar_struct")
+          -- A 'const' qualifier is transparent: the tagged type underneath
+          -- keeps its directness. Example 15 is a same-name direct alias and is
+          -- squashed (like example 8); in example 16 the qualifier wraps a
+          -- pointer, so the eponymous tag is reached through indirection and
+          -- suffixed (like example 6a).
+        , ("struct15"        , Nothing)
+        , ("struct struct16" , Just "Struct16_struct")
+        ]
+
+-- | Exercise the 'C.TypeBlock' path in 'taggedPayloads'.
+--
+-- Kept separate from 'test_programAnalysis_typedef_analysis' because this
+-- header requires @-fblocks@.
+test_programAnalysis_typedef_block :: TestCase
+test_programAnalysis_typedef_block =
+    testTraceMulti "program-analysis/typedef_block" declsWithMsgs (\case
+          MatchMangle name (MangleNamesAssignedName new) ->
+            Just $ Expected (name, new.text)
+          _otherwise ->
+            Nothing
+        )
+      & #onBoot .~ ( #clangArgs % #enableBlocks .~ True )
+  where
+    declsWithMsgs :: [(CDeclName, Text)]
+    declsWithMsgs = [
+          ("struct blk"    , "Blk_struct")
+        , ("struct blkarg" , "Blkarg_struct")
+        ]
+
+-- | Clash cases that the typedef analysis deliberately does NOT resolve
+-- locally; both colliding declarations are deselected via 'MangleNamesCollision'.
+--
+-- Complements 'test_programAnalysis_typedef_analysis', which covers the cases
+-- that /are/ locally resolvable.
+test_programAnalysis_typedef_name_clash :: TestCase
+test_programAnalysis_typedef_name_clash =
+    testTraceMulti "program-analysis/typedef_name_clash" declsWithMsgs $ \case
+      MatchSelect name (SelectMangleNamesFailure MangleNamesCollision{}) ->
+        Just $ Expected (name, "collision")
+      MatchSelect name (TransitiveDependenciesMissing{}) ->
+        Just $ Expected (name, "transitivity")
+      _otherwise ->
+        Nothing
+  where
+    declsWithMsgs :: [(CDeclName, String)]
+    declsWithMsgs = [
+          ("struct a_unrelated" , "collision")
+        , ("a_unrelated"        , "collision")
+        , ("struct a_fun"       , "collision")
+        , ("a_fun"              , "collision")
+        , ("struct b_clash"     , "collision")
+        , ("struct b_other"     , "collision")
+        , ("b_clash"            , "transitivity")
         ]


### PR DESCRIPTION
The `MangleNames` pass now consistently checks for name duplicates in both of its passes. In Pass 2, we distinguish between top-level names that can collide, and other names that do not lead to collisions. An example of the second kind are record field names when `OmitFieldPrefixes` and `DuplicateRecordFields` are enabled.

Closes #1734 #1432 #1445

Related issue: #1520 

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
