### PR TITLE
Document the macro language parameter `l`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/AST/TranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/AST/TranslationUnit.hs
@@ -16,6 +16,14 @@ import HsBindgen.Frontend.Pass
 import HsBindgen.Imports
 import HsBindgen.Macro.Type
 
+-- | Information we collect from a C translation unit.
+--
+-- The macro language parameter @l@ describes how C macros are parsed,
+-- typechecked, and translated (see "HsBindgen.Macro.Type" and
+-- "HsBindgen.Macro.Interface").
+--
+-- The pass parameter @p@ describes how the data types evolve along passes in
+-- the frontend in a "trees that grow" (TTG) style.
 data TranslationUnit l p = TranslationUnit{
       -- | Declarations in the unit
       --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass.hs
@@ -40,6 +40,10 @@ class    (Show (MacroBody p l), Eq (MacroBody p l)) => ValidMacroBody p l
 instance (Show (MacroBody p l), Eq (MacroBody p l)) => ValidMacroBody p l
 
 -- | Pass definition
+--
+-- The macro language parameter @l@ describes how C macros are parsed,
+-- typechecked, and translated (see "HsBindgen.Macro.Type" and
+-- "HsBindgen.Macro.Interface").
 class (
         -- 'Show' constraints for debugging
 


### PR DESCRIPTION
This is a minor change of documentation that I am going to merge soon.
