### PR TITLE
Store the original source location of externalized declarations

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -189,7 +189,6 @@ library internal
     HsBindgen.Frontend.Pass.AssignAnonIds.ChooseNames
     HsBindgen.Frontend.Pass.AssignAnonIds.IsPass
     HsBindgen.Frontend.Pass.ConstructTranslationUnit
-    HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict
     HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
     HsBindgen.Frontend.Pass.EnrichComments
     HsBindgen.Frontend.Pass.EnrichComments.IsPass
@@ -257,6 +256,7 @@ library internal
     HsBindgen.Imports
     HsBindgen.Instances
     HsBindgen.IR.C
+    HsBindgen.IR.C.Conflict
     HsBindgen.IR.C.Decl
     HsBindgen.IR.C.HashIncludeArg
     HsBindgen.IR.C.LocationInfo

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -105,6 +105,9 @@ data ResolvedExtBinding = ResolvedExtBinding{
       -- | C declaration for which we are using this binding
       cName :: C.DeclId
 
+      -- | Source location(s) of C declaration for which we are using this binding
+    , locs :: C.DeclLocs
+
       -- | The Haskell type which will be used
     , hsName :: Hs.ExtRef
 
@@ -114,7 +117,7 @@ data ResolvedExtBinding = ResolvedExtBinding{
       -- | Additional information about the Haskell type
     , hsSpec :: BindingSpec.HsTypeSpec
     }
-  deriving stock (Eq, Generic, Ord, Show)
+  deriving stock (Eq, Ord, Generic, Show)
 
 {-------------------------------------------------------------------------------
   Public API: Configuration

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -11,7 +11,6 @@ module HsBindgen.BindingSpec.Gen (
 import Data.ByteString (ByteString)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe qualified as Maybe
 import Data.Ord qualified as Ord
 import Data.Set qualified as Set
 
@@ -68,13 +67,18 @@ genBindingSpec
 
     aux :: C.DeclId -> (Int, Int, Int, Text)
     aux cDeclId =
-      case Maybe.listToMaybe (DeclIndex.lookupLoc cDeclId declIndex) of
-        Just sloc ->
-          ( fromMaybe maxBound (Map.lookup sloc.singleLocPath orderMap)
-          , sloc.singleLocLine
-          , sloc.singleLocColumn
-          , C.renderDeclId cDeclId
-          )
+      case DeclIndex.lookupLoc cDeclId declIndex of
+        Just locs ->
+          -- NOTE: At the moment, we attempt to get the “minimum” location and
+          -- discard other conflicting locations (e.g., the ones of other
+          -- colliding definitions). This is OK, since we only use the location
+          -- to sort the binding specifications before generating them.
+          let loc = C.declLocsMin locs
+          in  ( fromMaybe maxBound (Map.lookup loc.singleLocPath orderMap)
+              , loc.singleLocLine
+              , loc.singleLocColumn
+              , C.renderDeclId cDeclId
+              )
         Nothing -> (maxBound, maxBound, maxBound, C.renderDeclId cDeclId)
 
     orderMap :: Map SourcePath Int

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -27,7 +27,7 @@ module HsBindgen.Frontend.Analysis.DeclIndex (
   , lookupEntry
   , toList
   , lookupLoc
-  , lookupUnusableLoc
+  , unusableToLoc
   , keysSet
   , getOmitted
   , getSquashed
@@ -52,7 +52,6 @@ import Prelude hiding (filter, lookup)
 import Control.Monad.State
 import Data.Foldable qualified as Foldable
 import Data.Map.Strict qualified as Map
-import Data.Maybe (maybeToList)
 import Data.Set qualified as Set
 import Optics.Core (traverseOf)
 
@@ -161,21 +160,18 @@ data DeclIndex l = DeclIndex {
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
 data Usable l =
-      UsableSuccess (Success l Out)
-      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1577>
-      -- This should have a SingleLoc.
-    | UsableExternal
-      -- Squashed declarations are always "usable" because we only squash
-      -- declaration in the list of declarations attached to the declaration
-      -- unit.
-    | UsableSquashed Squashed
-    deriving stock (Show, Generic)
+    UsableSuccess (Success l Out)
+  | UsableExternal C.DeclLocs
+    -- Squashed declarations are always "usable" because we only squash
+    -- declaration in the list of declarations attached to the declaration unit.
+  | UsableSquashed Squashed
+  deriving stock (Show, Generic)
 
-usableToLoc :: Usable l -> Maybe SingleLoc
+usableToLoc :: Usable l -> C.DeclLocs
 usableToLoc = \case
-    UsableSuccess  x -> Just x.decl.info.loc
-    UsableExternal   -> Nothing
-    UsableSquashed x -> Just x.typedefLoc
+    UsableSuccess  x    -> C.DeclLoc x.decl.info.loc
+    UsableExternal locs -> locs
+    UsableSquashed x    -> C.DeclLoc x.typedefLoc
 
 -- | Unusable declaration
 --
@@ -186,16 +182,16 @@ usableToLoc = \case
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
 data Unusable =
-      UnusableParseUnavailable       SingleLoc
-    | UnusableParseFailure           SingleLoc DelayedParseMsg
-    | UnusableConflict               Conflict
-    | UnusableMangleNamesFailure     SingleLoc MangleNamesError
-    | UnusableTypecheckMacrosError   SingleLoc MacroTypecheckError
-    | UnusableMacroResolutionFailure SingleLoc MacroResolutionError
+    UnusableParseUnavailable       SingleLoc
+  | UnusableParseFailure           SingleLoc DelayedParseMsg
+  | UnusableConflict               Conflict
+  | UnusableMangleNamesFailure     SingleLoc MangleNamesError
+  | UnusableTypecheckMacrosError   SingleLoc MacroTypecheckError
+  | UnusableMacroResolutionFailure SingleLoc MacroResolutionError
 
-      -- | Omitted by prescriptive binding specifications
-    | UnusableOmitted            SingleLoc
-    deriving stock (Show, Generic)
+    -- | Omitted by prescriptive binding specifications
+  | UnusableOmitted              SingleLoc
+  deriving stock (Show, Generic)
 
 instance PrettyForTrace Unusable where
   prettyForTrace = \case
@@ -214,15 +210,15 @@ instance PrettyForTrace Unusable where
     UnusableOmitted{} ->
       "Omitted by prescriptive binding specification"
 
-unusableToLoc :: Unusable -> [SingleLoc]
+unusableToLoc :: Unusable -> C.DeclLocs
 unusableToLoc = \case
-    UnusableParseUnavailable loc         -> [loc]
-    UnusableParseFailure loc _           -> [loc]
-    UnusableConflict conflict            -> Conflict.toList conflict
-    UnusableMangleNamesFailure loc _     -> [loc]
-    UnusableTypecheckMacrosError loc _   -> [loc]
-    UnusableMacroResolutionFailure loc _ -> [loc]
-    UnusableOmitted loc                  -> [loc]
+    UnusableParseUnavailable loc         -> C.DeclLoc loc
+    UnusableParseFailure loc _           -> C.DeclLoc loc
+    UnusableConflict conflict            -> C.DeclLocsConflict (Conflict.toList conflict)
+    UnusableMangleNamesFailure loc _     -> C.DeclLoc loc
+    UnusableTypecheckMacrosError loc _   -> C.DeclLoc loc
+    UnusableMacroResolutionFailure loc _ -> C.DeclLoc loc
+    UnusableOmitted loc                  -> C.DeclLoc loc
 
 data Success l p = Success {
     decl                              :: C.Decl l p
@@ -250,18 +246,16 @@ data Entry l =
   | UnusableE Unusable
   deriving stock (Show, Generic)
 
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1577>
--- This should return NonEmpty
-entryToLoc :: Entry l -> [SingleLoc]
+entryToLoc :: Entry l -> C.DeclLocs
 entryToLoc = \case
   (UnusableE e) -> unusableToLoc e
-  (UsableE   e) -> maybeToList $ usableToLoc e
+  (UsableE   e) -> usableToLoc e
 
 entryToAvailability :: Entry l -> C.Availability
 entryToAvailability = \case
     UsableE e   -> case e of
       UsableSuccess success -> success.decl.info.availability
-      UsableExternal        -> C.Available
+      UsableExternal{}      -> C.Available
       UsableSquashed{}      -> C.Available
     UnusableE{} -> C.Available
 
@@ -475,7 +469,8 @@ checkIsConflict new (oldId, old) = case new of
             UnusableE (UnusableConflict c) ->
               Conflict.insert c newLoc
             _otherwise ->
-              Conflict.fromList $ newLoc : entryToLoc old
+              Conflict.fromList $
+                newLoc : C.declLocsToList (entryToLoc old)
       in SingleConflict (Set.fromList [resolvedResultId new, oldId]) conflict
 
 {-------------------------------------------------------------------------------
@@ -526,16 +521,10 @@ toList :: DeclIndex l -> [(C.DeclId, Entry l)]
 toList index = Map.toList index.map
 
 -- | Get the source locations of a declaration.
-lookupLoc :: C.DeclId -> DeclIndex l -> [SingleLoc]
-lookupLoc d i = case lookupEntry d i of
-  Nothing -> []
-  Just e  -> entryToLoc e
-
--- | Get the source locations of an unusable declaration.
-lookupUnusableLoc :: C.DeclId -> DeclIndex l -> [SingleLoc]
-lookupUnusableLoc d i = case lookupEntry d i of
-  Just (UnusableE  e) -> unusableToLoc e
-  _otherwise          -> []
+--
+-- 'Nothing' indicates the declaration was /not found/.
+lookupLoc :: C.DeclId -> DeclIndex l -> Maybe C.DeclLocs
+lookupLoc d i = entryToLoc <$> lookupEntry d i
 
 -- | Get the identifiers of all declarations in the index.
 keysSet :: DeclIndex l -> Set C.DeclId
@@ -671,12 +660,15 @@ registerOmittedDeclarations ::
 registerOmittedDeclarations xs index = DeclIndex $
     Map.union (UnusableE . UnusableOmitted <$> xs) index.map
 
-registerExternalDeclarations :: Set C.DeclId -> DeclIndex l -> DeclIndex l
+registerExternalDeclarations ::
+     [(C.DeclId, C.DeclLocs)]
+  -> DeclIndex l
+  -> DeclIndex l
 registerExternalDeclarations xs index = Foldable.foldl' insert index xs
   where
-    insert :: DeclIndex l -> C.DeclId -> DeclIndex l
-    insert (DeclIndex i) x =
-      DeclIndex $ Map.insert x (UsableE UsableExternal) i
+    insert :: DeclIndex l -> (C.DeclId, C.DeclLocs) -> DeclIndex l
+    insert (DeclIndex i) (declId, locs) =
+      DeclIndex $ Map.insert declId (UsableE $ UsableExternal locs) i
 
 {-------------------------------------------------------------------------------
   Support for mangle names

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -60,8 +60,6 @@ import Clang.Paths
 
 import HsBindgen.Errors
 import HsBindgen.Frontend.Analysis.DeclIndex.ResolveMacro
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (Conflict)
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.EnrichComments.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.Error
@@ -184,7 +182,7 @@ usableToLoc = \case
 data Unusable =
     UnusableParseUnavailable       SingleLoc
   | UnusableParseFailure           SingleLoc DelayedParseMsg
-  | UnusableConflict               Conflict
+  | UnusableConflict               C.Conflict
   | UnusableMangleNamesFailure     SingleLoc MangleNamesError
   | UnusableTypecheckMacrosError   SingleLoc MacroTypecheckError
   | UnusableMacroResolutionFailure SingleLoc MacroResolutionError
@@ -214,7 +212,7 @@ unusableToLoc :: Unusable -> C.DeclLocs
 unusableToLoc = \case
     UnusableParseUnavailable loc         -> C.DeclLoc loc
     UnusableParseFailure loc _           -> C.DeclLoc loc
-    UnusableConflict conflict            -> C.DeclLocsConflict (Conflict.toList conflict)
+    UnusableConflict conflict            -> C.DeclLocsConflict conflict
     UnusableMangleNamesFailure loc _     -> C.DeclLoc loc
     UnusableTypecheckMacrosError loc _   -> C.DeclLoc loc
     UnusableMacroResolutionFailure loc _ -> C.DeclLoc loc
@@ -433,7 +431,7 @@ buildIndex results = flip execState empty $ mapM_ aux results
 
 data IsConflict l =
     Redefinition (Success l ConstructTranslationUnit)
-  | SingleConflict (Set C.DeclId) Conflict
+  | SingleConflict (Set C.DeclId) C.Conflict
 
 checkIsConflict ::
      Macro.HasTypes l
@@ -464,12 +462,12 @@ checkIsConflict new (oldId, old) = case new of
   where
     singleConflict =
       let newLoc = resolvedResultLoc new
-          conflict :: Conflict
+          conflict :: C.Conflict
           conflict = case old of
             UnusableE (UnusableConflict c) ->
-              Conflict.insert c newLoc
+              C.conflictInsert c newLoc
             _otherwise ->
-              Conflict.fromList $
+              C.conflictFromList $
                 newLoc : C.declLocsToList (entryToLoc old)
       in SingleConflict (Set.fromList [resolvedResultId new, oldId]) conflict
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/Conflict.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/Conflict.hs
@@ -5,7 +5,7 @@
 -- > import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (Conflict)
 -- > import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
 module HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (
-    Conflict(..)
+    Conflict
     -- * Construction
   , between
   , insert
@@ -15,6 +15,7 @@ module HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (
   , getMinimumLoc
   ) where
 
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Set qualified as Set
 import Text.SimplePrettyPrint qualified as PP
 
@@ -74,11 +75,17 @@ fromList ls = Conflict $ Set.fromList ls
   Query
 -------------------------------------------------------------------------------}
 
-toList :: Conflict -> [SingleLoc]
-toList conflict = Set.toList conflict.locs
+toList :: Conflict -> NonEmpty SingleLoc
+ -- 'NonEmpty.fromList' safe due to invariant.
+toList conflict = NonEmpty.fromList $ Set.toList conflict.locs
 
+-- | Attempts to get the “minimum” location.
+--
+-- This is only meaningful if the locations share the same source path.
+-- Comparisons across source paths happen in lexicographical order.
 getMinimumLoc :: Conflict -> SingleLoc
-getMinimumLoc conflict = minimum conflict.locs -- safe due to invariant
+ -- 'minimum' safe due to invariant.
+getMinimumLoc conflict = minimum conflict.locs
 
 {-------------------------------------------------------------------------------
   Tracing

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -17,6 +17,7 @@ import Clang.Paths
 
 import HsBindgen.BindingSpec (MergedBindingSpecs, PrescriptiveBindingSpec)
 import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Errors
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph)
@@ -81,12 +82,12 @@ resolveBindingSpecs hsModuleName extSpecs pSpec unit =
       -> MState
       -> C.TranslationUnit l ResolveBindingSpecs
     reconstruct decls' declUseGraph state =
-      let externalIds :: Set C.DeclId
-          externalIds = Map.keysSet state.extTypes
+      let externals :: [(C.DeclId, C.DeclLocs)]
+          externals = map (second (.locs)) $ Map.toList state.extTypes
 
           index' :: DeclIndex l
           index' =
-                DeclIndex.registerExternalDeclarations externalIds
+                DeclIndex.registerExternalDeclarations externals
               . DeclIndex.registerOmittedDeclarations state.omitTypes
               $ unit.meta.declIndex
 
@@ -222,7 +223,11 @@ resolveTop decl = Reader.ask >>= \env -> do
     let sourcePath = singleLocPath decl.info.loc
         declPaths  = IncludeGraph.reaches env.includeGraph sourcePath
         mMsg       = Just $ withCallStack $ ResolveBindingSpecsOmittedType decl.info.id
-    isExt <- isJust <$> resolveExtBinding decl.info.id declPaths mMsg
+    isExt <- isJust <$>
+      resolveExtBinding
+        decl.info.id
+        (C.DeclLoc decl.info.loc)
+        declPaths mMsg
     if isExt
       then do
         State.modify' $ insertTrace (withCallStack $ ResolveBindingSpecsExtDecl decl.info.id)
@@ -577,7 +582,7 @@ instance Resolve (TypecheckedMacroType l) l where
         -> M l (MacroTypeBodyVar ResolveBindingSpecs)
       resolveVar (MacroTypeExtBinding   x) = absurd x
       resolveVar (MacroTypeBodyVar declId) = do
-          mExt <- auxExt ctx declId
+          mExt <- resolveUseSite ctx declId
           pure $ case mExt of
             Just ext -> MacroTypeExtBinding ext
             Nothing  -> MacroTypeBodyVar declId
@@ -630,7 +635,7 @@ instance Resolve C.Type l where
            HasCallStack
         => C.DeclId
         -> M l (Maybe (C.Type ResolveBindingSpecs -> C.Type ResolveBindingSpecs))
-      aux cDeclId = fmap reconstruct <$> auxExt ctx cDeclId
+      aux cDeclId = fmap reconstruct <$> resolveUseSite ctx cDeclId
         where
           reconstruct ty uTy = C.TypeExtBinding $ C.Ref ty uTy
 
@@ -642,32 +647,50 @@ instance Resolve C.TypeFunArg l where
         , ann = arg.ann
         }
 
-auxExt ::
+resolveUseSite ::
      HasCallStack
   => C.DeclId
+     -- ^ The declaration in which we resolve the use site; used for trace
+     -- messages only
   -> C.DeclId
+     -- ^ Use site itself
   -> M l (Maybe BindingSpec.ResolvedExtBinding)
-auxExt ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
+resolveUseSite ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
     case Map.lookup cDeclId state.extTypes of
+      -- 1. Search cache: We expect all usable declarations with external
+      -- bindings to be in the cache.
       Just ty -> do
         State.modify' $ insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
         pure (Just ty)
+      -- 2. No cache hit: The declaration is either usable and has no external
+      -- binding, or it is unusable.
       Nothing ->
-        case DeclIndex.lookupUnusableLoc cDeclId env.declIndex of
-          []   -> pure Nothing
-          locs -> do
-            let declPaths =
-                  foldMap
-                    (IncludeGraph.reaches env.includeGraph . singleLocPath)
-                    locs
-            mTy <- resolveExtBinding cDeclId declPaths Nothing
-            case mTy of
-              Just ty -> do
-                State.modify' $
-                    insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
-                  . insertExtType cDeclId ty
-                pure (Just ty)
-              Nothing -> pure Nothing
+        case DeclIndex.lookupEntry cDeclId env.declIndex of
+          Nothing ->
+            panicPure $
+              "resolveUseSite: declaration ID "
+              <> show cDeclId
+              <> " not in declaration index"
+          -- Interesting case, an unusable declaration may have an external
+          -- binding specification.
+          Just (DeclIndex.UnusableE x) -> do
+              let locs :: C.DeclLocs
+                  locs = DeclIndex.unusableToLoc x
+                  declPaths =
+                    foldMap
+                      (IncludeGraph.reaches env.includeGraph . singleLocPath)
+                      (C.declLocsToList locs)
+              mTy <- resolveExtBinding cDeclId locs declPaths Nothing
+              case mTy of
+                Just ty -> do
+                  State.modify' $
+                      insertTrace (withCallStack $ ResolveBindingSpecsExtType ctx cDeclId)
+                    . insertExtType cDeclId ty
+                  pure (Just ty)
+                Nothing -> pure Nothing
+          -- Cannot have an external binding specification.
+          Just DeclIndex.UsableE{} ->
+            pure Nothing
 
 {-------------------------------------------------------------------------------
   Internal: auxiliary functions
@@ -677,11 +700,12 @@ auxExt ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
 resolveExtBinding ::
      HasCallStack
   => C.DeclId
+  -> C.DeclLocs
   -> Set SourcePath
      -- | Message to emit for omitted types.
   -> Maybe (AnnMsg ResolveBindingSpecs)
   -> M l (Maybe BindingSpec.ResolvedExtBinding)
-resolveExtBinding cDeclId declPaths mMsg = do
+resolveExtBinding cDeclId locs declPaths mMsg = do
     env <- Reader.ask
     case BindingSpec.lookupMergedBindingSpecs cDeclId declPaths env.extSpecs of
       Just (hsModuleName, BindingSpec.Require cTypeSpec, mHsTypeSpec) ->
@@ -689,6 +713,7 @@ resolveExtBinding cDeclId declPaths mMsg = do
           (Just hsName, Just hsTypeSpec) -> do
             let resolved = BindingSpec.ResolvedExtBinding {
                     cName  = cDeclId
+                  , locs   = locs
                   , hsName = Hs.ExtRef hsModuleName hsName
                   , cSpec  = cTypeSpec
                   , hsSpec = hsTypeSpec

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -28,7 +28,6 @@ import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
-import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
@@ -453,7 +452,7 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
             }
         UnusableConflict x ->
           List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId $ NonEmpty.toList $ Conflict.toList x
+              loc = C.declIdLocationInfo declId $ NonEmpty.toList $ C.conflictToList x
             , msg = SelectConflict
             }
         UnusableMangleNamesFailure loc x ->

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -2,8 +2,10 @@ module HsBindgen.Frontend.Pass.Select (
     selectDecls
   ) where
 
+import Data.Foldable qualified as Foldable
 import Data.List (sortBy)
 import Data.List qualified as List
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Data.Ord (comparing)
@@ -216,7 +218,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
               selectMsgs
             , getDelayedMsgsSelectionRoots selectionRootsIndex
             , getDelayedMsgsAdditionalSelectedTransDeps additionalSelectedTransDepsIndex
-            , getDelayedMsgsNotSelected notSelectedIndex
+            , getBugMsgsNotSelected notSelectedIndex
             , noDeclarationsMatchedMsg
             ]
 
@@ -355,19 +357,19 @@ getSelectMsgsDeclId
         , [ withLoc $ SelectDeprecated selectReason | isDeprecated ]
         ]
 
-    loc :: [SingleLoc]
-    loc = DeclIndex.entryToLoc entry
-
     withLoc :: HasCallStack => a -> WithCallStack (C.WithLocationInfo a)
     withLoc x = withCallStack C.WithLocationInfo{
-                  loc = C.declIdLocationInfo declId loc
+                  loc = C.declIdLocationInfo declId $
+                          C.declLocsToList $
+                            DeclIndex.entryToLoc entry
                 , msg = x
                 }
 
     getUnavailMsg ::
          HasCallStack
       => SelectReason
-      -> Map C.DeclId Unselectable -> Maybe (AnnMsg Select)
+      -> Map C.DeclId Unselectable
+      -> Maybe (AnnMsg Select)
     getUnavailMsg selectReason unavailReasons =
         if null msgs then
           Nothing
@@ -377,15 +379,13 @@ getSelectMsgsDeclId
         msgs = [
                case r of
                  Unselectable u ->
-                   TransitiveDependencyUnusable
-                     i
-                     u
-                     (DeclIndex.lookupLoc i declIndex)
+                   TransitiveDependencyUnusable i u
                  UnselectableNotSelected ->
-                   TransitiveDependencyNotSelected
-                     i
-                     (DeclIndex.lookupLoc i declIndex)
+                   TransitiveDependencyNotSelected i locs
              | (i, r) <- Map.toList unavailReasons
+             , let locs = case DeclIndex.lookupLoc i declIndex of
+                     Nothing -> []
+                     Just xs -> C.declLocsToList xs
              ]
 
     isDeprecated :: Bool
@@ -430,8 +430,9 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
       -> [AnnMsg Select]
     aux declId = \case
       UsableE e -> case e of
-        UsableSuccess success -> mkSuccessMessages declId success
-        UsableExternal   -> []
+        UsableSuccess success ->
+          mkSuccessMessages declId success
+        UsableExternal{} -> []
         -- Parse messages are unavailable for squashed entries. We are OK with
         -- this; instead we have issued a notice that the @typedef@ was squashed.
         UsableSquashed x ->
@@ -452,7 +453,7 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
             }
         UnusableConflict x ->
           List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId (Conflict.toList x)
+              loc = C.declIdLocationInfo declId $ NonEmpty.toList $ Conflict.toList x
             , msg = SelectConflict
             }
         UnusableMangleNamesFailure loc x ->
@@ -486,8 +487,9 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
       -> [AnnMsg Select]
     aux declId = \case
       UsableE e -> case e of
-        UsableSuccess success -> mkSuccessMessages declId success
-        UsableExternal   -> []
+        UsableSuccess success ->
+          mkSuccessMessages declId success
+        UsableExternal{} -> []
         -- Parse messages are unavailable for squashed entries. We are OK with
         -- this; instead we have issued a notice that the @typedef@ was squashed.
         UsableSquashed x ->
@@ -503,8 +505,8 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
 -- NOTE: We emit delayed BUG-level parse messages even for declarations that are
 -- not selected. We do not have a test for this; please ensure delayed BUG-level
 -- parse messages are emitted for all declarations also in the future.
-getDelayedMsgsNotSelected :: HasCallStack => DeclIndex l -> [AnnMsg Select]
-getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
+getBugMsgsNotSelected :: HasCallStack => DeclIndex l -> [AnnMsg Select]
+getBugMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
   where
     aux ::
          HasCallStack
@@ -516,7 +518,7 @@ getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
         UsableSuccess success ->
           let isBugLevel x = getDefaultLogLevel x == Bug
           in  filter isBugLevel $ mkSuccessMessages declId success
-        UsableExternal -> []
+        UsableExternal{} -> []
         UsableSquashed{} -> []
       UnusableE e -> case e of
         UnusableParseUnavailable{} -> []
@@ -594,7 +596,7 @@ type Match = C.DeclName -> SingleLoc -> C.Availability -> Bool
 -- | Limit the declaration index to those entries that match the select
 --   predicate. Do not include anything external nor omitted.
 selectDeclIndex :: DeclUseGraph -> Match -> DeclIndex l -> DeclIndex l
-selectDeclIndex declUseGraph p declIndex =
+selectDeclIndex declUseGraph predicate declIndex =
     DeclIndex.filter matchEntry declIndex
   where
     matchEntry :: C.DeclId -> Entry l -> Bool
@@ -607,7 +609,9 @@ selectDeclIndex declUseGraph p declIndex =
           Just (locs, availability) ->
             if declId.isAnon
               then matchAnon declId
-              else or [p declId.name loc availability| loc <- locs]
+              else Foldable.any
+                     (\loc -> predicate declId.name loc availability)
+                     (C.declLocsToList locs)
 
     matchDeclId :: C.DeclId -> Bool
     matchDeclId declId =
@@ -620,31 +624,14 @@ selectDeclIndex declUseGraph p declIndex =
     -- Returns 'Nothing' for external or omitted declarations.
     -- Returns 'Just _' for squashed declarations. Those can still be selected.
     -- Returns multiple locations only for conflicts.
-    entryInfo :: Entry l -> Maybe ([SingleLoc], C.Availability)
-    entryInfo = \case
-        UsableE e -> case e of
-          UsableSuccess success ->
-            let info = success.decl.info
-            in Just ([info.loc], info.availability)
-          UsableExternal ->
-            Nothing
-          UsableSquashed x ->
-            Just ([x.typedefLoc], C.Available)
-        UnusableE e -> case e of
-          UnusableParseUnavailable loc ->
-            Just ([loc], C.Available)
-          UnusableParseFailure loc _ ->
-            Just ([loc], C.Available)
-          UnusableConflict conflict ->
-            Just (Conflict.toList conflict, C.Available)
-          UnusableMangleNamesFailure loc _ ->
-            Just ([loc], C.Available)
-          UnusableTypecheckMacrosError loc _ ->
-            Just ([loc], C.Available)
-          UnusableMacroResolutionFailure loc _ ->
-            Just ([loc], C.Available)
-          UnusableOmitted{} ->
-            Nothing
+    entryInfo :: Entry l -> Maybe (C.DeclLocs, C.Availability)
+    entryInfo entry = case entry of
+        UsableE UsableExternal{} ->
+          Nothing
+        UnusableE UnusableOmitted{} ->
+          Nothing
+        _otherwise ->
+          Just (DeclIndex.entryToLoc entry, DeclIndex.entryToAvailability entry)
 
     -- We match anonymous declarations based on their use sites.
     --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -17,7 +17,9 @@ import Text.SimplePrettyPrint qualified as PP
 import Clang.HighLevel.Types
 
 import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.Frontend.Analysis.DeclIndex (Squashed (..), Unusable (..))
+import HsBindgen.Frontend.Analysis.DeclIndex (Entry (..), Squashed (..),
+                                              Unusable (..))
+import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
@@ -131,17 +133,19 @@ data SelectStatus =
 
 data TransitiveDependencyMissing =
     -- | Transitive dependency is 'Unusable'.
-    TransitiveDependencyUnusable C.DeclId Unusable [SingleLoc]
+    TransitiveDependencyUnusable C.DeclId Unusable
     -- | Transitive dependency is not selected.
   | TransitiveDependencyNotSelected C.DeclId [SingleLoc]
   deriving stock (Show)
 
 instance PrettyForTrace TransitiveDependencyMissing where
   prettyForTrace = \case
-      TransitiveDependencyUnusable i r ls ->
+      TransitiveDependencyUnusable i r ->
         let intro = "Transitive dependency unusable:"
         in  PP.hang intro 2 $ prettyForTrace $ C.WithLocationInfo{
-                loc = C.declIdLocationInfo i ls
+                loc = C.declIdLocationInfo i $
+                        C.declLocsToList $
+                          DeclIndex.entryToLoc (UnusableE r)
               , msg = r
               }
       TransitiveDependencyNotSelected i ls ->

--- a/hs-bindgen/src-internal/HsBindgen/IR/C.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C.hs
@@ -8,7 +8,8 @@
 --
 -- > import HsBindgen.IR.C qualified as C
 module HsBindgen.IR.C (
-    module HsBindgen.IR.C.Decl
+    module HsBindgen.IR.C.Conflict
+  , module HsBindgen.IR.C.Decl
   , module HsBindgen.IR.C.HashIncludeArg
   , module HsBindgen.IR.C.LocationInfo
   , module HsBindgen.IR.C.Naming
@@ -16,6 +17,7 @@ module HsBindgen.IR.C (
   , module HsBindgen.IR.C.Type
   ) where
 
+import HsBindgen.IR.C.Conflict
 import HsBindgen.IR.C.Decl
 import HsBindgen.IR.C.HashIncludeArg
 import HsBindgen.IR.C.LocationInfo

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Conflict.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Conflict.hs
@@ -1,18 +1,21 @@
--- | Conflicting declarations
+-- | Conflicting C declarations
 --
--- Intended for qualified import.
+-- This module should only be used within the @HsBindgen.IR@ hierarchy.  From
+-- outside the @HsBindgen.IR@ hierarchy, "HsBindgen.IR.C" should be used.
 --
--- > import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (Conflict)
--- > import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
-module HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (
+-- Within @HsBindgen.IR@, all modules aside from "HsBindgen.IR.C" should import
+-- this module qualified for consistency.
+--
+-- > import HsBindgen.IR.C.Conflict qualified as C
+module HsBindgen.IR.C.Conflict (
     Conflict
     -- * Construction
-  , between
-  , insert
-  , fromList
+  , conflictBetween
+  , conflictInsert
+  , conflictFromList
     -- * Query
-  , toList
-  , getMinimumLoc
+  , conflictToList
+  , conflictGetMinimumLoc
   ) where
 
 import Data.List.NonEmpty qualified as NonEmpty
@@ -21,7 +24,7 @@ import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
 
-import HsBindgen.Imports hiding (toList)
+import HsBindgen.Imports
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -53,39 +56,39 @@ import HsBindgen.Util.Tracer
 data Conflict = Conflict {
       locs :: Set SingleLoc
     }
-  deriving stock (Eq, Show)
+  deriving stock (Eq, Ord, Show)
 
 {-------------------------------------------------------------------------------
   Construction
 -------------------------------------------------------------------------------}
 
-between :: SingleLoc -> SingleLoc -> Conflict
-between l1 l2 = Conflict $ Set.fromList [l1, l2]
+conflictBetween :: SingleLoc -> SingleLoc -> Conflict
+conflictBetween l1 l2 = Conflict $ Set.fromList [l1, l2]
 
-insert :: Conflict -> SingleLoc -> Conflict
-insert (Conflict xs) x = Conflict $ Set.insert x xs
+conflictInsert :: Conflict -> SingleLoc -> Conflict
+conflictInsert (Conflict xs) x = Conflict $ Set.insert x xs
 
 -- | Precondition: The length of the list must be 2 or longer.
 --
 -- TODO <https://github.com/well-typed/hs-bindgen/issues/1577>
-fromList :: [SingleLoc] -> Conflict
-fromList ls = Conflict $ Set.fromList ls
+conflictFromList :: [SingleLoc] -> Conflict
+conflictFromList ls = Conflict $ Set.fromList ls
 
 {-------------------------------------------------------------------------------
   Query
 -------------------------------------------------------------------------------}
 
-toList :: Conflict -> NonEmpty SingleLoc
+conflictToList :: Conflict -> NonEmpty SingleLoc
  -- 'NonEmpty.fromList' safe due to invariant.
-toList conflict = NonEmpty.fromList $ Set.toList conflict.locs
+conflictToList conflict = NonEmpty.fromList $ Set.toList conflict.locs
 
 -- | Attempts to get the “minimum” location.
 --
 -- This is only meaningful if the locations share the same source path.
 -- Comparisons across source paths happen in lexicographical order.
-getMinimumLoc :: Conflict -> SingleLoc
+conflictGetMinimumLoc :: Conflict -> SingleLoc
  -- 'minimum' safe due to invariant.
-getMinimumLoc conflict = minimum conflict.locs
+conflictGetMinimumLoc conflict = minimum conflict.locs
 
 {-------------------------------------------------------------------------------
   Tracing

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
@@ -17,9 +17,15 @@ module HsBindgen.IR.C.LocationInfo (
     -- ** Query
   , locationInfoName
   , locationInfoLocs
+    -- * Declaration locations
+  , DeclLocs(..)
+  , declLocsMin
+  , declLocsToList
   ) where
 
-import Text.SimplePrettyPrint ((><))
+import Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty qualified as NonEmpty
+import Text.SimplePrettyPrint (CtxDoc, (><))
 import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
@@ -66,6 +72,9 @@ data LocationInfo =
     -- | Message about an anonymous declaration
     --
     -- We record the /assigned/ name, /if/ it is available.
+    --
+    -- Usually we expect the list of locations to be a singleton: the location
+    -- of the declaration.
   | LocationDeclAnon (Maybe C.DeclName) [SingleLoc]
 
     -- | No location information
@@ -74,32 +83,29 @@ data LocationInfo =
 
 instance PrettyForTrace LocationInfo where
   prettyForTrace = \case
-      LocationDeclNamed name [] -> PP.hsep [
-          prettyForTrace name
-        , "(location unavailable)"
-        ]
-      LocationDeclNamed name [loc] -> PP.hsep [
-          prettyForTrace name
-        , "at"
-        , PP.show loc
-        ]
       LocationDeclNamed name locs -> PP.hsep [
           prettyForTrace name
         , "at"
-        , PP.hlist "(" ")" (map PP.show locs)
+        , prettyLocs locs
         ]
-      LocationDeclAnon (Just name) loc -> PP.hsep [
+      LocationDeclAnon (Just name) locs -> PP.hsep [
           "anonymous declaration"
         , prettyForTrace name
         , "at"
-        , PP.show loc
+        , prettyLocs locs
         ]
-      LocationDeclAnon Nothing loc -> PP.hsep [
+      LocationDeclAnon Nothing locs -> PP.hsep [
           "anonymous declaration at"
-        , PP.show loc
+        , prettyLocs locs
         ]
       LocationUnavailable ->
         "location unavailable"
+    where
+      prettyLocs :: Show a => [a] -> CtxDoc
+      prettyLocs = \case
+        []    -> "(source location unavailable)"
+        [loc] -> PP.show loc
+        locs  -> PP.hlist "(" ")" (map PP.show locs)
 
 {-------------------------------------------------------------------------------
   Construction
@@ -132,3 +138,33 @@ locationInfoLocs = \case
     LocationDeclNamed _ locs -> locs
     LocationDeclAnon _ locs  -> locs
     LocationUnavailable      -> []
+
+{-------------------------------------------------------------------------------
+  Declaration locations
+-------------------------------------------------------------------------------}
+
+-- | Source location(s) of a declaration.
+--
+-- Most declarations have a single source location; only conflicting
+-- declarations carry more than one.
+data DeclLocs =
+    -- | The declaration has a single source location.
+    DeclLoc SingleLoc
+    -- | Conflicting declarations, each with its own source location.
+  | DeclLocsConflict (NonEmpty SingleLoc)
+  deriving stock (Eq, Ord, Show)
+
+-- | Attempts to get the “minimum” location.
+--
+-- This is only meaningful if the locations share the same source path.
+-- Comparisons across source paths happen in lexicographical order.
+declLocsMin :: DeclLocs -> SingleLoc
+declLocsMin = \case
+  DeclLoc x           -> x
+  DeclLocsConflict xs -> minimum xs
+
+-- | All source locations, discarding the single\/conflict distinction.
+declLocsToList :: DeclLocs -> [SingleLoc]
+declLocsToList = \case
+    DeclLoc          loc  -> [loc]
+    DeclLocsConflict locs -> NonEmpty.toList locs

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
@@ -23,13 +23,13 @@ module HsBindgen.IR.C.LocationInfo (
   , declLocsToList
   ) where
 
-import Data.List.NonEmpty (NonEmpty)
 import Data.List.NonEmpty qualified as NonEmpty
 import Text.SimplePrettyPrint (CtxDoc, (><))
 import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
 
+import HsBindgen.IR.C.Conflict qualified as C
 import HsBindgen.IR.C.Naming qualified as C
 import HsBindgen.Util.Tracer
 
@@ -151,7 +151,7 @@ data DeclLocs =
     -- | The declaration has a single source location.
     DeclLoc SingleLoc
     -- | Conflicting declarations, each with its own source location.
-  | DeclLocsConflict (NonEmpty SingleLoc)
+  | DeclLocsConflict C.Conflict
   deriving stock (Eq, Ord, Show)
 
 -- | Attempts to get the “minimum” location.
@@ -160,11 +160,11 @@ data DeclLocs =
 -- Comparisons across source paths happen in lexicographical order.
 declLocsMin :: DeclLocs -> SingleLoc
 declLocsMin = \case
-  DeclLoc x           -> x
-  DeclLocsConflict xs -> minimum xs
+  DeclLoc x                 -> x
+  DeclLocsConflict conflict -> C.conflictGetMinimumLoc conflict
 
--- | All source locations, discarding the single\/conflict distinction.
+-- | All source locations, discarding the single vs conflict distinction.
 declLocsToList :: DeclLocs -> [SingleLoc]
 declLocsToList = \case
-    DeclLoc          loc  -> [loc]
-    DeclLocsConflict locs -> NonEmpty.toList locs
+    DeclLoc          loc      -> [loc]
+    DeclLocsConflict conflict -> NonEmpty.toList $ C.conflictToList conflict

--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
@@ -179,7 +179,7 @@ pattern MatchTransNotSelected <- TransitiveDependencyNotSelected _ _
 
 -- | A single transitive dependency of a declaration is unusable
 pattern MatchTransUnusable :: Unusable -> TransitiveDependencyMissing
-pattern MatchTransUnusable x <- TransitiveDependencyUnusable _ x _
+pattern MatchTransUnusable x <- TransitiveDependencyUnusable _ x
 
 {-------------------------------------------------------------------------------
   MangleNames


### PR DESCRIPTION
Introduces a new ADT `DeclLocs` which reflects that a declaration has either one source location or is a conflict, in which case it has many.

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

