### PR TITLE
Organization

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -243,6 +243,7 @@ library internal
     HsBindgen.Frontend.Pass.Zip.IsPass
     HsBindgen.Frontend.Pass.Zip.Zip
     HsBindgen.Frontend.Predicate
+    HsBindgen.Frontend.PrettyC
     HsBindgen.Frontend.ProcessIncludes
     HsBindgen.Frontend.RootHeader
     HsBindgen.Guasi
@@ -254,7 +255,6 @@ library internal
     HsBindgen.Macro.Type
     HsBindgen.NameHint
     HsBindgen.Orphans
-    HsBindgen.PrettyC
     HsBindgen.Resolve
     HsBindgen.Test
     HsBindgen.Test.C

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -46,6 +46,7 @@ import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.IsPass qualified as MangleNames
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
+import HsBindgen.Frontend.PrettyC qualified as PC
 import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
 import HsBindgen.Language.C qualified as C
@@ -53,7 +54,6 @@ import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Macro.Interface
 import HsBindgen.Macro.Type
 import HsBindgen.NameHint
-import HsBindgen.PrettyC qualified as PC
 
 import Doxygen.Parser.Types qualified as Doxy
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -34,12 +34,12 @@ import HsBindgen.Frontend.Naming
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass (AdjustedFrom (..))
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
+import HsBindgen.Frontend.PrettyC qualified as PC
 import HsBindgen.Frontend.RootHeader
 import HsBindgen.Imports hiding (def)
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.NameHint (NameHint (..))
-import HsBindgen.PrettyC qualified as PC
 
 -- | Bind to a C function
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -15,7 +15,6 @@ import Clang.Enum.Bitfield
 import Clang.LowLevel.Core
 import Clang.Paths
 
-import HsBindgen.Backend.Category
 import HsBindgen.Boot
 import HsBindgen.Cache
 import HsBindgen.Clang
@@ -62,6 +61,7 @@ import HsBindgen.Frontend.ProcessIncludes
 import HsBindgen.Frontend.RootHeader (RootHeader)
 import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Macro.Type
 import HsBindgen.Util.Tracer
 
@@ -379,12 +379,9 @@ runFrontend tracer config boot = do
       afterZip <- zipPass
       extSpecs <- boot.externalBindingSpecs
       pSpec    <- boot.prescriptiveBindingSpec
-      let (afterResolveBindingSpecs, msgsResolveBindingSpecs) =
-            resolveBindingSpecs
-              (fromBaseModuleName boot.baseModule (Just CType))
-              extSpecs
-              pSpec
-              afterZip
+      let moduleName = Hs.ModuleName boot.baseModule.text -- do not import Backend
+          (afterResolveBindingSpecs, msgsResolveBindingSpecs) =
+            resolveBindingSpecs moduleName extSpecs pSpec afterZip
       forM_ msgsResolveBindingSpecs $ traceWith (contramap FrontendResolveBindingSpecs tracer)
       pure afterResolveBindingSpecs
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/PrettyC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/PrettyC.hs
@@ -2,7 +2,7 @@
 --
 -- Used for generating C wrappers in userland-capi approach.
 -- It's cleaner to generate AST than glueing string-of-code together.
-module HsBindgen.PrettyC (
+module HsBindgen.Frontend.PrettyC (
     FunDefn (..),
     Args,
     withArgs,


### PR DESCRIPTION
We are running into some situations where our organization makes it challenging to develop/refactor without causing import cycles.  As we work around such issues by partitioning modules, we increase structural debt.  @dschrempf and I discussed yesterday.

So far, this PR makes two trivial changes to simplify the module import graph:

* We should avoid importing from `Backend` modules in `Frontend` modules.  We have mostly maintained this, but we now import `Backend.Category` to determine the module that is passed to `ResolveBindingSpecs`.  We *could* move `Category` and `Level` into `Frontend`, but the simplest fix is to just use the base module; we do not need to call `fromBaseModuleName` at all because it just returns the base module in this case.

* The `PrettyC` module is moved into `Frontend` because it makes use of many `Frontend` modules.

These small changes do not help with the import cycle issue, but they are a step in the direction of better organization.

Another thing that we discussed is general and `Util` modules.  In this context, a *general module* is one that is not specific to `hs-bindgen` and could conceptually be in a separate package.  We have two:

* `Data.Digraph` implements a graph data structure.  It contains some functions that are implemented for specific `hs-bindgen` needs, but the implementation is general, with no mention of `hs-bindgen` at all.
* `Text.SimplePrettyPrint` implements a wrapper around the `pretty` library that make it easier for `hs-bindgen` to pretty-print generated code.  It is general, with no mention of `hs-bindgen`.

A `Util` module contains shared auxiliary code for a project.  Such modules contain general functions, and such functions may be adapted for the project (using project types/monads).  We have five:

* `Monad` implements `mapMaybeM`, a basic function that is unfortunately missing from `base`, used in multiple modules.
* `Process` implements auxiliary functions for executing processes and reading output.  It uses `Tracer`.
* `Rational` implements `canBeRepresentedAsRational`, used in multiple modules.
* `TH` is a compatibility module that re-exports `getPackageRoot` from different packages/modules depending on how `hs-bindgen` is being built.
* `Tracer` implements a somewhat general tracer, but documentation is specific to `hs-bindgen` and `HsBindgen.Errors` is used.

@dschrempf suggested moving the `Util` modules outside of the `HsBindgen` hierarchy, but I think that the first four are in the right place.  For example, `*.Util.Monad` is *the* expected place to put monad auxiliary functions in Haskell projects, and `HsBindgen.Util.Process` should be in the `HsBindgen` hierarchy because it uses `Tracer`.

IMHO `HsBindgen.Util.Tracer` should be moved to `HsBindgen.Tracer`, because it implements infrastructure, not auxiliary code.  Thoughts?

At any rate, moving around general and `Util` modules does not help with the import cycle issue either.

Indeed, just moving/renaming modules cannot help with such issues.  Relations can only be changed be changing the strategy for organizing code into modules.  We discussed the possibility of introducing a `HsBindgen.Types` hierarchy, which would simplify the module import graph and help with the import cycle issue.  Details:

* In this context, I use the term *component* to refer to a subtree of modules.  For example, `Frontend` is a component of `HsBindgen` containing all `HsBindgen.Frontend**` modules, and `SHs` is a component within the `Backend` component.
* Only types that are used across multiple components (such as `Frontend` and `Backend`) would go there.  Types that are local to a specific component can still be implemented within that component without causing issues.  In our case, use of TTG would pull many types into the `Types` hierarchy.
* Modules in the `Type` hierarchy may import other modules in the `Type` hierarchy as well as "top-level" modules, but they must not import from any components/modules that import from the `Type` hierarchy.  For example, a `Type` module should never (transitively) import from `Frontend` or `Backend`.
* Each module in the type hierarchy can implement the core API for that type, as long as it follows the rules.  It is not limited to just the data type and instances.
* While partitioning modules into submodules can also help with the import cycle issue, doing so complicates the module import graph instead of simplifies it.  (In the macro case, we even have to partition types!)  A `Type` hierarchy simplifies it; the unfortunate cost is that related code is not always implemented in a single place.  With good organization, however, it is often *easier* to find things without having to use an IDE (HLS) or search.  (As somebody who avoids HLS, I frequently search to find where things are defined in the current codebase.)
* A different name could be used, but IMHO `Type` is best because it is an established pattern in Haskell projects (like `Util`).  Other names that have been suggested include `Interface` and `Definition`.

While I am happy to implement this, I am hesitant to push for it too hard because some may not like it.  It is also a large refactoring that would touch a lot of code.

We also discussed organization of the frontend in to groups, as I wrote about [here](https://github.com/well-typed/hs-bindgen/issues/1604#issuecomment-4608498385).  Using compiler lingo, a *frontend* translates the input (source code) into an intermediate representation, while a *backend* translates from an (perhaps transformed) intermediate into output (machine code, bytecode, etc.).  FWIW, I see `libclang` as our frontend, our `Frontend` passes iteratively transform our intermediate representation, and we (will) have multiple backends that generate output from the intermediate representation, as shown [here](https://github.com/well-typed/hs-bindgen/issues/1604#issuecomment-4608445923).

Terminology aside, we would like our `Frontend` to handle anything that could cause an error.  If we keep the `Select` pass last, all errors are taken into account when we do program slicing.  Our `Backend`(s) should never result in errors caused by input (source code, binding specifications, configuration, etc.).

Regarding the WIP `TranslateTypes` pass ([#1599](https://github.com/well-typed/hs-bindgen/issues/1599)) I do not think that there is a clean solution for such an intermediate step that just translates types in `Frontend` but still translates declarations in `Backend`.  My current strategy is to simply import the needed modules from `Backend`, and we can move such modules into `Frontend` when we translate declarations there.  While (temporarily) making the tangle of imports even worse, this avoids import cycles and minimizes the amount of refactoring needed.