### PR TITLE
`HasField`: why we can't get rid of `(~)`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -115,7 +115,8 @@ typeClassExtensions = \case
     Inst.HasField     -> Set.singleton TH.UndecidableInstances
     Inst.HasFFIType   -> Set.singleton TH.UndecidableInstances
     Inst.Prim         -> Set.fromList [TH.MagicHash, TH.UnboxedTuples]
-    _ -> mempty
+    Inst.IsArray      -> Set.singleton TH.FlexibleContexts
+    _                 -> Set.empty
 
 exprExtensions :: SExpr ctx -> Set TH.Extension
 exprExtensions = \case

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -578,7 +578,7 @@ translateHasFieldInstance inst mbComment = Instance{
     , args    = [fieldLit, parentPtr, tyPtr]
     , types   = []
     , comment = mbComment
-    , super   = [ TApp (TApp TEq tyTypeVar) field ]
+    , super   = [ ]
     , decs    = [ ( bindgenGlobalTerm HasField_getField
                   , eBindgenGlobal ptrToFieldGlobal `EApp`
                       (eBindgenGlobal Proxy_constructor `ETypeApp` fieldLit)
@@ -590,21 +590,17 @@ translateHasFieldInstance inst mbComment = Instance{
       case inst.deriveVia of
         Hs.ViaHasCField -> (
             HasCField_fromPtr
-          , tBindgenGlobal Foreign_Ptr_type `TApp` tyTypeVar
+          , tBindgenGlobal Foreign_Ptr_type `TApp` field
           )
         Hs.ViaHasCBitfield -> (
             HasCBitfield_toPtr
-          , tBindgenGlobal HasCBitfield_BitfieldPtr_type `TApp` tyTypeVar
+          , tBindgenGlobal HasCBitfield_BitfieldPtr_type `TApp` field
           )
 
     parent    = translateType inst.parentType
     parentPtr = tBindgenGlobal Foreign_Ptr_type `TApp` parent
     field     = translateType inst.fieldType
     fieldLit  = translateType $ HsStrLit $ Hs.nameToStr inst.fieldName
-
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1287>
-    -- This is not actually a free type variable.
-    tyTypeVar = TFree $ Hs.UnsafeName "ty"
 
 {-------------------------------------------------------------------------------
   Unions

--- a/hs-bindgen/test-artefacts/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/array/Example.hs
@@ -10,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -48,8 +47,7 @@ newtype Triplet = Triplet
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTriplet")
@@ -73,8 +71,7 @@ newtype List = List
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.HasField "unwrapList" (RIP.Ptr List) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapList" (RIP.Ptr List) (RIP.Ptr (IA.IncompleteArray RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapList")
@@ -104,8 +101,7 @@ newtype Matrix = Matrix
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr (CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMatrix")
@@ -129,8 +125,7 @@ newtype Tripletlist = Tripletlist
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "unwrapTripletlist" (RIP.Ptr Tripletlist) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTripletlist" (RIP.Ptr Tripletlist) (RIP.Ptr (IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTripletlist")
@@ -199,8 +194,7 @@ instance HasCField.HasCField Example "example_triple" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "example_triple" (RIP.Ptr Example) (RIP.Ptr ty) where
+instance RIP.HasField "example_triple" (RIP.Ptr Example) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_triple")
@@ -212,8 +206,7 @@ instance HasCField.HasCField Example "example_sudoku" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "example_sudoku" (RIP.Ptr Example) (RIP.Ptr ty) where
+instance RIP.HasField "example_sudoku" (RIP.Ptr Example) (RIP.Ptr (CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_sudoku")
@@ -238,8 +231,7 @@ newtype Sudoku = Sudoku
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 Triplet
-         ) => RIP.HasField "unwrapSudoku" (RIP.Ptr Sudoku) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSudoku" (RIP.Ptr Sudoku) (RIP.Ptr (CA.ConstantArray 3 Triplet)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSudoku")

--- a/hs-bindgen/test-artefacts/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/array/th.txt
@@ -679,8 +679,9 @@ newtype Triplet
     = Triplet {unwrapTriplet :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
@@ -696,8 +697,9 @@ newtype List
     = List {unwrapList :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapList" (Ptr List) (Ptr ty)
+instance HasField "unwrapList"
+                  (Ptr List)
+                  (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt
@@ -712,8 +714,9 @@ newtype Matrix
     = Matrix {unwrapMatrix :: (ConstantArray 4 (ConstantArray 3 CInt))}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -730,8 +733,9 @@ newtype Tripletlist
                                                                         CInt))}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
-         HasField "unwrapTripletlist" (Ptr Tripletlist) (Ptr ty)
+instance HasField "unwrapTripletlist"
+                  (Ptr Tripletlist)
+                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapTripletlist")
 instance HasCField Tripletlist "unwrapTripletlist"
     where type CFieldType Tripletlist
@@ -773,15 +777,17 @@ instance HasCField Example "example_triple"
     where type CFieldType Example "example_triple" = ConstantArray 3
                                                                    CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "example_triple" (Ptr Example) (Ptr ty)
+instance HasField "example_triple"
+                  (Ptr Example)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"example_triple")
 instance HasCField Example "example_sudoku"
     where type CFieldType Example "example_sudoku" = ConstantArray 3
                                                                    (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 12
-instance (~) ty (ConstantArray 3 (ConstantArray 3 CInt)) =>
-         HasField "example_sudoku" (Ptr Example) (Ptr ty)
+instance HasField "example_sudoku"
+                  (Ptr Example)
+                  (Ptr (ConstantArray 3 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"example_sudoku")
 {-| Typedef-in-typedef.
 
@@ -795,8 +801,9 @@ newtype Sudoku
     = Sudoku {unwrapSudoku :: (ConstantArray 3 Triplet)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 Triplet) =>
-         HasField "unwrapSudoku" (Ptr Sudoku) (Ptr ty)
+instance HasField "unwrapSudoku"
+                  (Ptr Sudoku)
+                  (Ptr (ConstantArray 3 Triplet))
     where getField = fromPtr (Proxy @"unwrapSudoku")
 instance HasCField Sudoku "unwrapSudoku"
     where type CFieldType Sudoku "unwrapSudoku" = ConstantArray 3

--- a/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -40,8 +39,7 @@ newtype S = S
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr (IA.IncompleteArray RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS")
 
@@ -64,8 +62,7 @@ newtype T = T
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr (IA.IncompleteArray RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 
@@ -94,8 +91,7 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
 
@@ -124,8 +120,7 @@ newtype V = V
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapV" (RIP.Ptr V) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapV" (RIP.Ptr V) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapV")
 
@@ -154,8 +149,7 @@ newtype W = W
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapW" (RIP.Ptr W) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapW" (RIP.Ptr W) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapW")
 
@@ -184,8 +178,7 @@ newtype X = X
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapX" (RIP.Ptr X) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapX" (RIP.Ptr X) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapX")
 

--- a/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/th.txt
@@ -250,8 +250,7 @@ newtype S
     = S {unwrapS :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapS" (Ptr S) (Ptr ty)
+instance HasField "unwrapS" (Ptr S) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = IncompleteArray CInt
@@ -266,8 +265,7 @@ newtype T
     = T {unwrapT :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = IncompleteArray CInt
@@ -282,8 +280,7 @@ newtype U
     = U {unwrapU :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = ConstantArray 3 CInt
@@ -298,8 +295,7 @@ newtype V
     = V {unwrapV :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapV" (Ptr V) (Ptr ty)
+instance HasField "unwrapV" (Ptr V) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapV")
 instance HasCField V "unwrapV"
     where type CFieldType V "unwrapV" = ConstantArray 3 CInt
@@ -314,8 +310,7 @@ newtype W
     = W {unwrapW :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapW" (Ptr W) (Ptr ty)
+instance HasField "unwrapW" (Ptr W) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapW")
 instance HasCField W "unwrapW"
     where type CFieldType W "unwrapW" = ConstantArray 3 CInt
@@ -330,8 +325,7 @@ newtype X
     = X {unwrapX :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapX" (Ptr X) (Ptr ty)
+instance HasField "unwrapX" (Ptr X) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapX")
 instance HasCField X "unwrapX"
     where type CFieldType X "unwrapX" = ConstantArray 3 CInt

--- a/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -42,8 +41,7 @@ newtype Matrix = Matrix
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr (CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMatrix")
@@ -67,8 +65,7 @@ newtype Triplets = Triplets
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "unwrapTriplets" (RIP.Ptr Triplets) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTriplets" (RIP.Ptr Triplets) (RIP.Ptr (IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTriplets")

--- a/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/th.txt
@@ -170,8 +170,9 @@ newtype Matrix
     = Matrix {unwrapMatrix :: (ConstantArray 4 (ConstantArray 3 CInt))}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
-         HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
+instance HasField "unwrapMatrix"
+                  (Ptr Matrix)
+                  (Ptr (ConstantArray 4 (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
@@ -188,8 +189,9 @@ newtype Triplets
                                                                   CInt))}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
-         HasField "unwrapTriplets" (Ptr Triplets) (Ptr ty)
+instance HasField "unwrapTriplets"
+                  (Ptr Triplets)
+                  (Ptr (IncompleteArray (ConstantArray 3 CInt)))
     where getField = fromPtr (Proxy @"unwrapTriplets")
 instance HasCField Triplets "unwrapTriplets"
     where type CFieldType Triplets

--- a/hs-bindgen/test-artefacts/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/attributes/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -81,8 +79,7 @@ instance HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
 
@@ -92,8 +89,7 @@ instance HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
 
@@ -153,8 +149,7 @@ instance HasCField.HasCField Bar "bar_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "bar_c" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_c" (RIP.Ptr Bar) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_c")
 
@@ -164,8 +159,7 @@ instance HasCField.HasCField Bar "bar_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_i" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_i" (RIP.Ptr Bar) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_i")
 
@@ -225,8 +219,7 @@ instance HasCField.HasCField Baz "baz_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "baz_c" (RIP.Ptr Baz) (RIP.Ptr ty) where
+instance RIP.HasField "baz_c" (RIP.Ptr Baz) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"baz_c")
 
@@ -236,8 +229,7 @@ instance HasCField.HasCField Baz "baz_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_i" (RIP.Ptr Baz) (RIP.Ptr ty) where
+instance RIP.HasField "baz_i" (RIP.Ptr Baz) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"baz_i")
 
@@ -297,8 +289,7 @@ instance HasCField.HasCField Qux "qux_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "qux_c" (RIP.Ptr Qux) (RIP.Ptr ty) where
+instance RIP.HasField "qux_c" (RIP.Ptr Qux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"qux_c")
 
@@ -308,8 +299,7 @@ instance HasCField.HasCField Qux "qux_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "qux_i" (RIP.Ptr Qux) (RIP.Ptr ty) where
+instance RIP.HasField "qux_i" (RIP.Ptr Qux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"qux_i")
 
@@ -378,8 +368,7 @@ instance HasCField.HasCField FILE "fILE__r" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "fILE__r" (RIP.Ptr FILE) (RIP.Ptr ty) where
+instance RIP.HasField "fILE__r" (RIP.Ptr FILE) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"fILE__r")
 
@@ -389,8 +378,7 @@ instance HasCField.HasCField FILE "fILE__w" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "fILE__w" (RIP.Ptr FILE) (RIP.Ptr ty) where
+instance RIP.HasField "fILE__w" (RIP.Ptr FILE) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"fILE__w")
 
@@ -401,8 +389,7 @@ instance HasCField.HasCField FILE "fILE__close" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.HasField "fILE__close" (RIP.Ptr FILE) (RIP.Ptr ty) where
+instance RIP.HasField "fILE__close" (RIP.Ptr FILE) (RIP.Ptr (RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"fILE__close")

--- a/hs-bindgen/test-artefacts/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/attributes/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
+instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
     where getField = fromPtr (Proxy @"foo_c")
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
+instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_i")
 {-| __C declaration:__ @struct bar@
 
@@ -76,12 +76,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_c"
     where type CFieldType Bar "bar_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "bar_c" (Ptr Bar) (Ptr ty)
+instance HasField "bar_c" (Ptr Bar) (Ptr CChar)
     where getField = fromPtr (Proxy @"bar_c")
 instance HasCField Bar "bar_i"
     where type CFieldType Bar "bar_i" = CInt
           offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "bar_i" (Ptr Bar) (Ptr ty)
+instance HasField "bar_i" (Ptr Bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"bar_i")
 {-| __C declaration:__ @struct baz@
 
@@ -118,12 +118,12 @@ deriving via (EquivStorable Baz) instance Storable Baz
 instance HasCField Baz "baz_c"
     where type CFieldType Baz "baz_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "baz_c" (Ptr Baz) (Ptr ty)
+instance HasField "baz_c" (Ptr Baz) (Ptr CChar)
     where getField = fromPtr (Proxy @"baz_c")
 instance HasCField Baz "baz_i"
     where type CFieldType Baz "baz_i" = CInt
           offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "baz_i" (Ptr Baz) (Ptr ty)
+instance HasField "baz_i" (Ptr Baz) (Ptr CInt)
     where getField = fromPtr (Proxy @"baz_i")
 {-| __C declaration:__ @struct qux@
 
@@ -160,12 +160,12 @@ deriving via (EquivStorable Qux) instance Storable Qux
 instance HasCField Qux "qux_c"
     where type CFieldType Qux "qux_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "qux_c" (Ptr Qux) (Ptr ty)
+instance HasField "qux_c" (Ptr Qux) (Ptr CChar)
     where getField = fromPtr (Proxy @"qux_c")
 instance HasCField Qux "qux_i"
     where type CFieldType Qux "qux_i" = CInt
           offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "qux_i" (Ptr Qux) (Ptr ty)
+instance HasField "qux_i" (Ptr Qux) (Ptr CInt)
     where getField = fromPtr (Proxy @"qux_i")
 {-| __C declaration:__ @struct __sFILE@
 
@@ -210,17 +210,18 @@ deriving via (EquivStorable FILE) instance Storable FILE
 instance HasCField FILE "fILE__r"
     where type CFieldType FILE "fILE__r" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "fILE__r" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__r" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"fILE__r")
 instance HasCField FILE "fILE__w"
     where type CFieldType FILE "fILE__w" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "fILE__w" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__w" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"fILE__w")
 instance HasCField FILE "fILE__close"
     where type CFieldType FILE "fILE__close" = FunPtr (Ptr Void ->
                                                        IO CInt)
           offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Void -> IO CInt)) =>
-         HasField "fILE__close" (Ptr FILE) (Ptr ty)
+instance HasField "fILE__close"
+                  (Ptr FILE)
+                  (Ptr (FunPtr (Ptr Void -> IO CInt)))
     where getField = fromPtr (Proxy @"fILE__close")

--- a/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -85,8 +83,7 @@ instance HasCField.HasCField S "s_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CShort
-         ) => RIP.HasField "s_f" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_f" (RIP.Ptr S) (RIP.Ptr (CA.ConstantArray 3 RIP.CShort)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_f")
 
@@ -118,8 +115,7 @@ newtype More_aligned_int = More_aligned_int
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMore_aligned_int" (RIP.Ptr More_aligned_int) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMore_aligned_int" (RIP.Ptr More_aligned_int) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMore_aligned_int")
@@ -179,8 +175,7 @@ instance HasCField.HasCField S2 "s2_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CShort
-         ) => RIP.HasField "s2_f" (RIP.Ptr S2) (RIP.Ptr ty) where
+instance RIP.HasField "s2_f" (RIP.Ptr S2) (RIP.Ptr (CA.ConstantArray 3 RIP.CShort)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_f")
 
@@ -241,8 +236,7 @@ instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "my_unpacked_struct_c" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
+instance RIP.HasField "my_unpacked_struct_c" (RIP.Ptr My_unpacked_struct) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_c")
@@ -254,8 +248,7 @@ instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_i" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "my_unpacked_struct_i" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
+instance RIP.HasField "my_unpacked_struct_i" (RIP.Ptr My_unpacked_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_i")
@@ -326,8 +319,7 @@ instance HasCField.HasCField My_packed_struct "my_packed_struct_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "my_packed_struct_c" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+instance RIP.HasField "my_packed_struct_c" (RIP.Ptr My_packed_struct) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"my_packed_struct_c")
@@ -339,8 +331,7 @@ instance HasCField.HasCField My_packed_struct "my_packed_struct_i" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "my_packed_struct_i" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+instance RIP.HasField "my_packed_struct_i" (RIP.Ptr My_packed_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"my_packed_struct_i")
@@ -352,8 +343,7 @@ instance HasCField.HasCField My_packed_struct "my_packed_struct_s" where
 
   offset# = \_ -> \_ -> 5
 
-instance ( ty ~ My_unpacked_struct
-         ) => RIP.HasField "my_packed_struct_s" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+instance RIP.HasField "my_packed_struct_s" (RIP.Ptr My_packed_struct) (RIP.Ptr My_unpacked_struct) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"my_packed_struct_s")
@@ -434,8 +424,7 @@ instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___ip" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "wait_status_ptr_t___ip" (RIP.Ptr Wait_status_ptr_t) (RIP.Ptr ty) where
+instance RIP.HasField "wait_status_ptr_t___ip" (RIP.Ptr Wait_status_ptr_t) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"wait_status_ptr_t___ip")
@@ -447,8 +436,7 @@ instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___up" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr Wait
-         ) => RIP.HasField "wait_status_ptr_t___up" (RIP.Ptr Wait_status_ptr_t) (RIP.Ptr ty) where
+instance RIP.HasField "wait_status_ptr_t___up" (RIP.Ptr Wait_status_ptr_t) (RIP.Ptr (RIP.Ptr Wait)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"wait_status_ptr_t___up")
@@ -489,8 +477,7 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT1")
 
@@ -528,8 +515,7 @@ newtype Short_a = Short_a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapShort_a" (RIP.Ptr Short_a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapShort_a" (RIP.Ptr Short_a) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapShort_a")

--- a/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_f"
     where type CFieldType S "s_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CShort) =>
-         HasField "s_f" (Ptr S) (Ptr ty)
+instance HasField "s_f" (Ptr S) (Ptr (ConstantArray 3 CShort))
     where getField = fromPtr (Proxy @"s_f")
 {-| __C declaration:__ @more_aligned_int@
 
@@ -53,8 +52,9 @@ newtype More_aligned_int
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapMore_aligned_int" (Ptr More_aligned_int) (Ptr ty)
+instance HasField "unwrapMore_aligned_int"
+                  (Ptr More_aligned_int)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMore_aligned_int")
 instance HasCField More_aligned_int "unwrapMore_aligned_int"
     where type CFieldType More_aligned_int
@@ -87,8 +87,7 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_f"
     where type CFieldType S2 "s2_f" = ConstantArray 3 CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CShort) =>
-         HasField "s2_f" (Ptr S2) (Ptr ty)
+instance HasField "s2_f" (Ptr S2) (Ptr (ConstantArray 3 CShort))
     where getField = fromPtr (Proxy @"s2_f")
 {-| __C declaration:__ @struct my_unpacked_struct@
 
@@ -126,15 +125,17 @@ instance HasCField My_unpacked_struct "my_unpacked_struct_c"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "my_unpacked_struct_c" (Ptr My_unpacked_struct) (Ptr ty)
+instance HasField "my_unpacked_struct_c"
+                  (Ptr My_unpacked_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"my_unpacked_struct_c")
 instance HasCField My_unpacked_struct "my_unpacked_struct_i"
     where type CFieldType My_unpacked_struct
                           "my_unpacked_struct_i" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "my_unpacked_struct_i" (Ptr My_unpacked_struct) (Ptr ty)
+instance HasField "my_unpacked_struct_i"
+                  (Ptr My_unpacked_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"my_unpacked_struct_i")
 {-| __C declaration:__ @struct my_packed_struct@
 
@@ -179,21 +180,24 @@ deriving via (EquivStorable My_packed_struct) instance Storable My_packed_struct
 instance HasCField My_packed_struct "my_packed_struct_c"
     where type CFieldType My_packed_struct "my_packed_struct_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "my_packed_struct_c" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_c"
+                  (Ptr My_packed_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"my_packed_struct_c")
 instance HasCField My_packed_struct "my_packed_struct_i"
     where type CFieldType My_packed_struct "my_packed_struct_i" = CInt
           offset# = \_ -> \_ -> 1
-instance (~) ty CInt =>
-         HasField "my_packed_struct_i" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_i"
+                  (Ptr My_packed_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"my_packed_struct_i")
 instance HasCField My_packed_struct "my_packed_struct_s"
     where type CFieldType My_packed_struct
                           "my_packed_struct_s" = My_unpacked_struct
           offset# = \_ -> \_ -> 5
-instance (~) ty My_unpacked_struct =>
-         HasField "my_packed_struct_s" (Ptr My_packed_struct) (Ptr ty)
+instance HasField "my_packed_struct_s"
+                  (Ptr My_packed_struct)
+                  (Ptr My_unpacked_struct)
     where getField = fromPtr (Proxy @"my_packed_struct_s")
 {-| __C declaration:__ @union wait_status_ptr_t@
 
@@ -283,15 +287,17 @@ instance HasCField Wait_status_ptr_t "wait_status_ptr_t___ip"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___ip" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "wait_status_ptr_t___ip" (Ptr Wait_status_ptr_t) (Ptr ty)
+instance HasField "wait_status_ptr_t___ip"
+                  (Ptr Wait_status_ptr_t)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"wait_status_ptr_t___ip")
 instance HasCField Wait_status_ptr_t "wait_status_ptr_t___up"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___up" = Ptr Wait
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Wait) =>
-         HasField "wait_status_ptr_t___up" (Ptr Wait_status_ptr_t) (Ptr ty)
+instance HasField "wait_status_ptr_t___up"
+                  (Ptr Wait_status_ptr_t)
+                  (Ptr (Ptr Wait))
     where getField = fromPtr (Proxy @"wait_status_ptr_t___up")
 {-| __C declaration:__ @union wait@
 
@@ -324,7 +330,7 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -353,8 +359,7 @@ newtype Short_a
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort =>
-         HasField "unwrapShort_a" (Ptr Short_a) (Ptr ty)
+instance HasField "unwrapShort_a" (Ptr Short_a) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapShort_a")
 instance HasCField Short_a "unwrapShort_a"
     where type CFieldType Short_a "unwrapShort_a" = CShort

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -74,7 +72,7 @@ instance HasCField.HasCField U "u_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u_x")
 
@@ -125,6 +123,6 @@ instance HasCField.HasCField S "s_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ U) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr U) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/th.txt
@@ -47,7 +47,7 @@ set_u_x = setUnionPayload
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
+instance HasField "u_x" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @struct S@
 
@@ -76,5 +76,5 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_y"
     where type CFieldType S "s_y" = U
           offset# = \_ -> \_ -> 0
-instance (~) ty U => HasField "s_y" (Ptr S) (Ptr ty)
+instance HasField "s_y" (Ptr S) (Ptr U)
     where getField = fromPtr (Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -217,7 +215,7 @@ instance HasCField.HasCField S5 "s5_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_x" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "s5_x" (RIP.Ptr S5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s5_x")
 
@@ -268,7 +266,7 @@ instance HasCField.HasCField S6 "s6_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_x" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "s6_x" (RIP.Ptr S6) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s6_x")
 
@@ -319,7 +317,7 @@ instance HasCField.HasCField S7 "s7_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s7_x" (RIP.Ptr S7) (RIP.Ptr ty) where
+instance RIP.HasField "s7_x" (RIP.Ptr S7) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7_x")
 
@@ -370,7 +368,7 @@ instance HasCField.HasCField S8 "s8_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s8_x" (RIP.Ptr S8) (RIP.Ptr ty) where
+instance RIP.HasField "s8_x" (RIP.Ptr S8) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s8_x")
 
@@ -421,7 +419,7 @@ instance HasCField.HasCField S9 "s9_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s9_x" (RIP.Ptr S9) (RIP.Ptr ty) where
+instance RIP.HasField "s9_x" (RIP.Ptr S9) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s9_x")
 
@@ -472,8 +470,7 @@ instance HasCField.HasCField S10 "s10_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s10_x" (RIP.Ptr S10) (RIP.Ptr ty) where
+instance RIP.HasField "s10_x" (RIP.Ptr S10) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s10_x")
 
@@ -524,8 +521,7 @@ instance HasCField.HasCField S11 "s11_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s11_x" (RIP.Ptr S11) (RIP.Ptr ty) where
+instance RIP.HasField "s11_x" (RIP.Ptr S11) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s11_x")
 
@@ -576,8 +572,7 @@ instance HasCField.HasCField S12 "s12_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s12_x" (RIP.Ptr S12) (RIP.Ptr ty) where
+instance RIP.HasField "s12_x" (RIP.Ptr S12) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s12_x")
 
@@ -628,8 +623,7 @@ instance HasCField.HasCField S13 "s13_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s13_x" (RIP.Ptr S13) (RIP.Ptr ty) where
+instance RIP.HasField "s13_x" (RIP.Ptr S13) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s13_x")
 
@@ -680,8 +674,7 @@ instance HasCField.HasCField S14 "s14_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s14_x" (RIP.Ptr S14) (RIP.Ptr ty) where
+instance RIP.HasField "s14_x" (RIP.Ptr S14) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s14_x")
 
@@ -732,8 +725,7 @@ instance HasCField.HasCField S15 "s15_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s15_x" (RIP.Ptr S15) (RIP.Ptr ty) where
+instance RIP.HasField "s15_x" (RIP.Ptr S15) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s15_x")
 
@@ -784,8 +776,7 @@ instance HasCField.HasCField S16 "s16_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s16_x" (RIP.Ptr S16) (RIP.Ptr ty) where
+instance RIP.HasField "s16_x" (RIP.Ptr S16) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s16_x")
 
@@ -836,8 +827,7 @@ instance HasCField.HasCField S17 "s17_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s17_x" (RIP.Ptr S17) (RIP.Ptr ty) where
+instance RIP.HasField "s17_x" (RIP.Ptr S17) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s17_x")
 
@@ -888,8 +878,7 @@ instance HasCField.HasCField S18 "s18_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s18_x" (RIP.Ptr S18) (RIP.Ptr ty) where
+instance RIP.HasField "s18_x" (RIP.Ptr S18) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s18_x")
 
@@ -940,8 +929,7 @@ instance HasCField.HasCField S19 "s19_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s19_x" (RIP.Ptr S19) (RIP.Ptr ty) where
+instance RIP.HasField "s19_x" (RIP.Ptr S19) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s19_x")
 
@@ -1035,7 +1023,7 @@ instance HasCField.HasCField U5 "u5_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u5_x" (RIP.Ptr U5) (RIP.Ptr ty) where
+instance RIP.HasField "u5_x" (RIP.Ptr U5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u5_x")
 
@@ -1089,7 +1077,7 @@ instance HasCField.HasCField U6 "u6_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u6_x" (RIP.Ptr U6) (RIP.Ptr ty) where
+instance RIP.HasField "u6_x" (RIP.Ptr U6) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u6_x")
 
@@ -1143,7 +1131,7 @@ instance HasCField.HasCField U7 "u7_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u7_x" (RIP.Ptr U7) (RIP.Ptr ty) where
+instance RIP.HasField "u7_x" (RIP.Ptr U7) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u7_x")
 
@@ -1197,7 +1185,7 @@ instance HasCField.HasCField U8 "u8_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u8_x" (RIP.Ptr U8) (RIP.Ptr ty) where
+instance RIP.HasField "u8_x" (RIP.Ptr U8) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u8_x")
 
@@ -1251,7 +1239,7 @@ instance HasCField.HasCField U9 "u9_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u9_x" (RIP.Ptr U9) (RIP.Ptr ty) where
+instance RIP.HasField "u9_x" (RIP.Ptr U9) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u9_x")
 
@@ -1305,8 +1293,7 @@ instance HasCField.HasCField U10 "u10_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u10_x" (RIP.Ptr U10) (RIP.Ptr ty) where
+instance RIP.HasField "u10_x" (RIP.Ptr U10) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u10_x")
 
@@ -1360,8 +1347,7 @@ instance HasCField.HasCField U11 "u11_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u11_x" (RIP.Ptr U11) (RIP.Ptr ty) where
+instance RIP.HasField "u11_x" (RIP.Ptr U11) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u11_x")
 
@@ -1415,8 +1401,7 @@ instance HasCField.HasCField U12 "u12_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u12_x" (RIP.Ptr U12) (RIP.Ptr ty) where
+instance RIP.HasField "u12_x" (RIP.Ptr U12) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u12_x")
 
@@ -1470,8 +1455,7 @@ instance HasCField.HasCField U13 "u13_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u13_x" (RIP.Ptr U13) (RIP.Ptr ty) where
+instance RIP.HasField "u13_x" (RIP.Ptr U13) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u13_x")
 
@@ -1525,8 +1509,7 @@ instance HasCField.HasCField U14 "u14_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u14_x" (RIP.Ptr U14) (RIP.Ptr ty) where
+instance RIP.HasField "u14_x" (RIP.Ptr U14) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u14_x")
 
@@ -1580,8 +1563,7 @@ instance HasCField.HasCField U15 "u15_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u15_x" (RIP.Ptr U15) (RIP.Ptr ty) where
+instance RIP.HasField "u15_x" (RIP.Ptr U15) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u15_x")
 
@@ -1635,8 +1617,7 @@ instance HasCField.HasCField U16 "u16_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u16_x" (RIP.Ptr U16) (RIP.Ptr ty) where
+instance RIP.HasField "u16_x" (RIP.Ptr U16) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u16_x")
 
@@ -1690,8 +1671,7 @@ instance HasCField.HasCField U17 "u17_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u17_x" (RIP.Ptr U17) (RIP.Ptr ty) where
+instance RIP.HasField "u17_x" (RIP.Ptr U17) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u17_x")
 
@@ -1745,8 +1725,7 @@ instance HasCField.HasCField U18 "u18_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u18_x" (RIP.Ptr U18) (RIP.Ptr ty) where
+instance RIP.HasField "u18_x" (RIP.Ptr U18) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u18_x")
 
@@ -1800,8 +1779,7 @@ instance HasCField.HasCField U19 "u19_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u19_x" (RIP.Ptr U19) (RIP.Ptr ty) where
+instance RIP.HasField "u19_x" (RIP.Ptr U19) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u19_x")
 
@@ -1922,8 +1900,7 @@ instance Read E5 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE5" (RIP.Ptr E5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE5" (RIP.Ptr E5) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE5")
 
@@ -2019,8 +1996,7 @@ instance Read E6 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE6" (RIP.Ptr E6) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE6" (RIP.Ptr E6) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE6")
 
@@ -2116,8 +2092,7 @@ instance Read E7 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE7" (RIP.Ptr E7) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE7" (RIP.Ptr E7) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE7")
 
@@ -2213,8 +2188,7 @@ instance Read E8 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE8" (RIP.Ptr E8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE8" (RIP.Ptr E8) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE8")
 
@@ -2310,8 +2284,7 @@ instance Read E9 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE9" (RIP.Ptr E9) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE9" (RIP.Ptr E9) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE9")
 
@@ -2407,8 +2380,7 @@ instance Read E10 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE10" (RIP.Ptr E10) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE10" (RIP.Ptr E10) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE10")
 
@@ -2504,8 +2476,7 @@ instance Read E11 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE11" (RIP.Ptr E11) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE11" (RIP.Ptr E11) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE11")
 
@@ -2601,8 +2572,7 @@ instance Read E12 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE12" (RIP.Ptr E12) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE12" (RIP.Ptr E12) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE12")
 
@@ -2698,8 +2668,7 @@ instance Read E13 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE13" (RIP.Ptr E13) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE13" (RIP.Ptr E13) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE13")
 
@@ -2795,8 +2764,7 @@ instance Read E14 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE14" (RIP.Ptr E14) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE14" (RIP.Ptr E14) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE14")
 
@@ -2892,8 +2860,7 @@ instance Read E15 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE15" (RIP.Ptr E15) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE15" (RIP.Ptr E15) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE15")
 
@@ -2989,8 +2956,7 @@ instance Read E16 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE16" (RIP.Ptr E16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE16" (RIP.Ptr E16) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE16")
 
@@ -3086,8 +3052,7 @@ instance Read E17 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE17" (RIP.Ptr E17) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE17" (RIP.Ptr E17) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE17")
 
@@ -3183,8 +3148,7 @@ instance Read E18 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE18" (RIP.Ptr E18) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE18" (RIP.Ptr E18) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE18")
 
@@ -3280,8 +3244,7 @@ instance Read E19 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE19" (RIP.Ptr E19) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE19" (RIP.Ptr E19) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE19")
 

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/th.txt
@@ -61,7 +61,7 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "s5_x"
     where type CFieldType S5 "s5_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s5_x" (Ptr S5) (Ptr ty)
+instance HasField "s5_x" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"s5_x")
 {-| __C declaration:__ @struct S6@
 
@@ -90,7 +90,7 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "s6_x"
     where type CFieldType S6 "s6_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s6_x" (Ptr S6) (Ptr ty)
+instance HasField "s6_x" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"s6_x")
 {-| __C declaration:__ @struct S7@
 
@@ -119,7 +119,7 @@ deriving via (EquivStorable S7) instance Storable S7
 instance HasCField S7 "s7_x"
     where type CFieldType S7 "s7_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s7_x" (Ptr S7) (Ptr ty)
+instance HasField "s7_x" (Ptr S7) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7_x")
 {-| __C declaration:__ @struct S8@
 
@@ -148,7 +148,7 @@ deriving via (EquivStorable S8) instance Storable S8
 instance HasCField S8 "s8_x"
     where type CFieldType S8 "s8_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s8_x" (Ptr S8) (Ptr ty)
+instance HasField "s8_x" (Ptr S8) (Ptr CInt)
     where getField = fromPtr (Proxy @"s8_x")
 {-| __C declaration:__ @struct S9@
 
@@ -177,7 +177,7 @@ deriving via (EquivStorable S9) instance Storable S9
 instance HasCField S9 "s9_x"
     where type CFieldType S9 "s9_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s9_x" (Ptr S9) (Ptr ty)
+instance HasField "s9_x" (Ptr S9) (Ptr CInt)
     where getField = fromPtr (Proxy @"s9_x")
 {-| __C declaration:__ @struct S10@
 
@@ -206,7 +206,7 @@ deriving via (EquivStorable S10) instance Storable S10
 instance HasCField S10 "s10_x"
     where type CFieldType S10 "s10_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s10_x" (Ptr S10) (Ptr ty)
+instance HasField "s10_x" (Ptr S10) (Ptr CInt)
     where getField = fromPtr (Proxy @"s10_x")
 {-| __C declaration:__ @struct S11@
 
@@ -235,7 +235,7 @@ deriving via (EquivStorable S11) instance Storable S11
 instance HasCField S11 "s11_x"
     where type CFieldType S11 "s11_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s11_x" (Ptr S11) (Ptr ty)
+instance HasField "s11_x" (Ptr S11) (Ptr CInt)
     where getField = fromPtr (Proxy @"s11_x")
 {-| __C declaration:__ @struct S12@
 
@@ -264,7 +264,7 @@ deriving via (EquivStorable S12) instance Storable S12
 instance HasCField S12 "s12_x"
     where type CFieldType S12 "s12_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s12_x" (Ptr S12) (Ptr ty)
+instance HasField "s12_x" (Ptr S12) (Ptr CInt)
     where getField = fromPtr (Proxy @"s12_x")
 {-| __C declaration:__ @struct S13@
 
@@ -293,7 +293,7 @@ deriving via (EquivStorable S13) instance Storable S13
 instance HasCField S13 "s13_x"
     where type CFieldType S13 "s13_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s13_x" (Ptr S13) (Ptr ty)
+instance HasField "s13_x" (Ptr S13) (Ptr CInt)
     where getField = fromPtr (Proxy @"s13_x")
 {-| __C declaration:__ @struct S14@
 
@@ -322,7 +322,7 @@ deriving via (EquivStorable S14) instance Storable S14
 instance HasCField S14 "s14_x"
     where type CFieldType S14 "s14_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s14_x" (Ptr S14) (Ptr ty)
+instance HasField "s14_x" (Ptr S14) (Ptr CInt)
     where getField = fromPtr (Proxy @"s14_x")
 {-| __C declaration:__ @struct S15@
 
@@ -351,7 +351,7 @@ deriving via (EquivStorable S15) instance Storable S15
 instance HasCField S15 "s15_x"
     where type CFieldType S15 "s15_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s15_x" (Ptr S15) (Ptr ty)
+instance HasField "s15_x" (Ptr S15) (Ptr CInt)
     where getField = fromPtr (Proxy @"s15_x")
 {-| __C declaration:__ @struct S16@
 
@@ -380,7 +380,7 @@ deriving via (EquivStorable S16) instance Storable S16
 instance HasCField S16 "s16_x"
     where type CFieldType S16 "s16_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s16_x" (Ptr S16) (Ptr ty)
+instance HasField "s16_x" (Ptr S16) (Ptr CInt)
     where getField = fromPtr (Proxy @"s16_x")
 {-| __C declaration:__ @struct S17@
 
@@ -409,7 +409,7 @@ deriving via (EquivStorable S17) instance Storable S17
 instance HasCField S17 "s17_x"
     where type CFieldType S17 "s17_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s17_x" (Ptr S17) (Ptr ty)
+instance HasField "s17_x" (Ptr S17) (Ptr CInt)
     where getField = fromPtr (Proxy @"s17_x")
 {-| __C declaration:__ @struct S18@
 
@@ -438,7 +438,7 @@ deriving via (EquivStorable S18) instance Storable S18
 instance HasCField S18 "s18_x"
     where type CFieldType S18 "s18_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s18_x" (Ptr S18) (Ptr ty)
+instance HasField "s18_x" (Ptr S18) (Ptr CInt)
     where getField = fromPtr (Proxy @"s18_x")
 {-| __C declaration:__ @struct S19@
 
@@ -467,7 +467,7 @@ deriving via (EquivStorable S19) instance Storable S19
 instance HasCField S19 "s19_x"
     where type CFieldType S19 "s19_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s19_x" (Ptr S19) (Ptr ty)
+instance HasField "s19_x" (Ptr S19) (Ptr CInt)
     where getField = fromPtr (Proxy @"s19_x")
 {-| __C declaration:__ @union U0@
 
@@ -552,7 +552,7 @@ set_u5_x = setUnionPayload
 instance HasCField U5 "u5_x"
     where type CFieldType U5 "u5_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u5_x" (Ptr U5) (Ptr ty)
+instance HasField "u5_x" (Ptr U5) (Ptr CInt)
     where getField = fromPtr (Proxy @"u5_x")
 {-| __C declaration:__ @union U6@
 
@@ -602,7 +602,7 @@ set_u6_x = setUnionPayload
 instance HasCField U6 "u6_x"
     where type CFieldType U6 "u6_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u6_x" (Ptr U6) (Ptr ty)
+instance HasField "u6_x" (Ptr U6) (Ptr CInt)
     where getField = fromPtr (Proxy @"u6_x")
 {-| __C declaration:__ @union U7@
 
@@ -652,7 +652,7 @@ set_u7_x = setUnionPayload
 instance HasCField U7 "u7_x"
     where type CFieldType U7 "u7_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u7_x" (Ptr U7) (Ptr ty)
+instance HasField "u7_x" (Ptr U7) (Ptr CInt)
     where getField = fromPtr (Proxy @"u7_x")
 {-| __C declaration:__ @union U8@
 
@@ -702,7 +702,7 @@ set_u8_x = setUnionPayload
 instance HasCField U8 "u8_x"
     where type CFieldType U8 "u8_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u8_x" (Ptr U8) (Ptr ty)
+instance HasField "u8_x" (Ptr U8) (Ptr CInt)
     where getField = fromPtr (Proxy @"u8_x")
 {-| __C declaration:__ @union U9@
 
@@ -752,7 +752,7 @@ set_u9_x = setUnionPayload
 instance HasCField U9 "u9_x"
     where type CFieldType U9 "u9_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u9_x" (Ptr U9) (Ptr ty)
+instance HasField "u9_x" (Ptr U9) (Ptr CInt)
     where getField = fromPtr (Proxy @"u9_x")
 {-| __C declaration:__ @union U10@
 
@@ -802,7 +802,7 @@ set_u10_x = setUnionPayload
 instance HasCField U10 "u10_x"
     where type CFieldType U10 "u10_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u10_x" (Ptr U10) (Ptr ty)
+instance HasField "u10_x" (Ptr U10) (Ptr CInt)
     where getField = fromPtr (Proxy @"u10_x")
 {-| __C declaration:__ @union U11@
 
@@ -852,7 +852,7 @@ set_u11_x = setUnionPayload
 instance HasCField U11 "u11_x"
     where type CFieldType U11 "u11_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u11_x" (Ptr U11) (Ptr ty)
+instance HasField "u11_x" (Ptr U11) (Ptr CInt)
     where getField = fromPtr (Proxy @"u11_x")
 {-| __C declaration:__ @union U12@
 
@@ -902,7 +902,7 @@ set_u12_x = setUnionPayload
 instance HasCField U12 "u12_x"
     where type CFieldType U12 "u12_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u12_x" (Ptr U12) (Ptr ty)
+instance HasField "u12_x" (Ptr U12) (Ptr CInt)
     where getField = fromPtr (Proxy @"u12_x")
 {-| __C declaration:__ @union U13@
 
@@ -952,7 +952,7 @@ set_u13_x = setUnionPayload
 instance HasCField U13 "u13_x"
     where type CFieldType U13 "u13_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u13_x" (Ptr U13) (Ptr ty)
+instance HasField "u13_x" (Ptr U13) (Ptr CInt)
     where getField = fromPtr (Proxy @"u13_x")
 {-| __C declaration:__ @union U14@
 
@@ -1002,7 +1002,7 @@ set_u14_x = setUnionPayload
 instance HasCField U14 "u14_x"
     where type CFieldType U14 "u14_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u14_x" (Ptr U14) (Ptr ty)
+instance HasField "u14_x" (Ptr U14) (Ptr CInt)
     where getField = fromPtr (Proxy @"u14_x")
 {-| __C declaration:__ @union U15@
 
@@ -1052,7 +1052,7 @@ set_u15_x = setUnionPayload
 instance HasCField U15 "u15_x"
     where type CFieldType U15 "u15_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u15_x" (Ptr U15) (Ptr ty)
+instance HasField "u15_x" (Ptr U15) (Ptr CInt)
     where getField = fromPtr (Proxy @"u15_x")
 {-| __C declaration:__ @union U16@
 
@@ -1102,7 +1102,7 @@ set_u16_x = setUnionPayload
 instance HasCField U16 "u16_x"
     where type CFieldType U16 "u16_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u16_x" (Ptr U16) (Ptr ty)
+instance HasField "u16_x" (Ptr U16) (Ptr CInt)
     where getField = fromPtr (Proxy @"u16_x")
 {-| __C declaration:__ @union U17@
 
@@ -1152,7 +1152,7 @@ set_u17_x = setUnionPayload
 instance HasCField U17 "u17_x"
     where type CFieldType U17 "u17_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u17_x" (Ptr U17) (Ptr ty)
+instance HasField "u17_x" (Ptr U17) (Ptr CInt)
     where getField = fromPtr (Proxy @"u17_x")
 {-| __C declaration:__ @union U18@
 
@@ -1202,7 +1202,7 @@ set_u18_x = setUnionPayload
 instance HasCField U18 "u18_x"
     where type CFieldType U18 "u18_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u18_x" (Ptr U18) (Ptr ty)
+instance HasField "u18_x" (Ptr U18) (Ptr CInt)
     where getField = fromPtr (Proxy @"u18_x")
 {-| __C declaration:__ @union U19@
 
@@ -1252,7 +1252,7 @@ set_u19_x = setUnionPayload
 instance HasCField U19 "u19_x"
     where type CFieldType U19 "u19_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u19_x" (Ptr U19) (Ptr ty)
+instance HasField "u19_x" (Ptr U19) (Ptr CInt)
     where getField = fromPtr (Proxy @"u19_x")
 {-| __C declaration:__ @enum E0@
 
@@ -1327,7 +1327,7 @@ instance Read E5
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE5" (Ptr E5) (Ptr ty)
+instance HasField "unwrapE5" (Ptr E5) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE5")
 instance HasCField E5 "unwrapE5"
     where type CFieldType E5 "unwrapE5" = CUInt
@@ -1378,7 +1378,7 @@ instance Read E6
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE6" (Ptr E6) (Ptr ty)
+instance HasField "unwrapE6" (Ptr E6) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE6")
 instance HasCField E6 "unwrapE6"
     where type CFieldType E6 "unwrapE6" = CUInt
@@ -1429,7 +1429,7 @@ instance Read E7
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE7" (Ptr E7) (Ptr ty)
+instance HasField "unwrapE7" (Ptr E7) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE7")
 instance HasCField E7 "unwrapE7"
     where type CFieldType E7 "unwrapE7" = CUInt
@@ -1480,7 +1480,7 @@ instance Read E8
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE8" (Ptr E8) (Ptr ty)
+instance HasField "unwrapE8" (Ptr E8) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE8")
 instance HasCField E8 "unwrapE8"
     where type CFieldType E8 "unwrapE8" = CUInt
@@ -1531,7 +1531,7 @@ instance Read E9
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE9" (Ptr E9) (Ptr ty)
+instance HasField "unwrapE9" (Ptr E9) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE9")
 instance HasCField E9 "unwrapE9"
     where type CFieldType E9 "unwrapE9" = CUInt
@@ -1583,7 +1583,7 @@ instance Read E10
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE10" (Ptr E10) (Ptr ty)
+instance HasField "unwrapE10" (Ptr E10) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE10")
 instance HasCField E10 "unwrapE10"
     where type CFieldType E10 "unwrapE10" = CUInt
@@ -1635,7 +1635,7 @@ instance Read E11
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE11" (Ptr E11) (Ptr ty)
+instance HasField "unwrapE11" (Ptr E11) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE11")
 instance HasCField E11 "unwrapE11"
     where type CFieldType E11 "unwrapE11" = CUInt
@@ -1687,7 +1687,7 @@ instance Read E12
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE12" (Ptr E12) (Ptr ty)
+instance HasField "unwrapE12" (Ptr E12) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE12")
 instance HasCField E12 "unwrapE12"
     where type CFieldType E12 "unwrapE12" = CUInt
@@ -1739,7 +1739,7 @@ instance Read E13
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE13" (Ptr E13) (Ptr ty)
+instance HasField "unwrapE13" (Ptr E13) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE13")
 instance HasCField E13 "unwrapE13"
     where type CFieldType E13 "unwrapE13" = CUInt
@@ -1791,7 +1791,7 @@ instance Read E14
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE14" (Ptr E14) (Ptr ty)
+instance HasField "unwrapE14" (Ptr E14) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE14")
 instance HasCField E14 "unwrapE14"
     where type CFieldType E14 "unwrapE14" = CUInt
@@ -1843,7 +1843,7 @@ instance Read E15
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE15" (Ptr E15) (Ptr ty)
+instance HasField "unwrapE15" (Ptr E15) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE15")
 instance HasCField E15 "unwrapE15"
     where type CFieldType E15 "unwrapE15" = CUInt
@@ -1895,7 +1895,7 @@ instance Read E16
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE16" (Ptr E16) (Ptr ty)
+instance HasField "unwrapE16" (Ptr E16) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE16")
 instance HasCField E16 "unwrapE16"
     where type CFieldType E16 "unwrapE16" = CUInt
@@ -1947,7 +1947,7 @@ instance Read E17
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE17" (Ptr E17) (Ptr ty)
+instance HasField "unwrapE17" (Ptr E17) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE17")
 instance HasCField E17 "unwrapE17"
     where type CFieldType E17 "unwrapE17" = CUInt
@@ -1999,7 +1999,7 @@ instance Read E18
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE18" (Ptr E18) (Ptr ty)
+instance HasField "unwrapE18" (Ptr E18) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE18")
 instance HasCField E18 "unwrapE18"
     where type CFieldType E18 "unwrapE18" = CUInt
@@ -2051,7 +2051,7 @@ instance Read E19
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE19" (Ptr E19) (Ptr ty)
+instance HasField "unwrapE19" (Ptr E19) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE19")
 instance HasCField E19 "unwrapE19"
     where type CFieldType E19 "unwrapE19" = CUInt

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -37,8 +36,7 @@ newtype MyArray = MyArray
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr (IA.IncompleteArray RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyArray")
@@ -62,7 +60,7 @@ newtype A = A
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance (ty ~ MyArray) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyArray) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -84,7 +82,7 @@ newtype B = B
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -105,7 +103,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -130,8 +130,9 @@ newtype MyArray
     = MyArray {unwrapMyArray :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
+instance HasField "unwrapMyArray"
+                  (Ptr MyArray)
+                  (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray
@@ -147,7 +148,7 @@ newtype A
     = A {unwrapA :: MyArray}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -162,7 +163,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -174,7 +175,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -44,8 +43,7 @@ newtype MyArray = MyArray
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyArray")
@@ -75,7 +73,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MyArray) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyArray) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -103,7 +101,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -124,7 +122,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -130,8 +130,9 @@ newtype MyArray
     = MyArray {unwrapMyArray :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
+instance HasField "unwrapMyArray"
+                  (Ptr MyArray)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray "unwrapMyArray" = ConstantArray 3
@@ -147,7 +148,7 @@ newtype A
     = A {unwrapA :: MyArray}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyArray)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
@@ -162,7 +163,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -174,7 +175,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -108,8 +106,7 @@ instance Read MyEnum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyEnum")
@@ -148,7 +145,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MyEnum) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyEnum) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -177,7 +174,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -198,7 +195,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -158,8 +158,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -187,7 +186,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -207,7 +206,7 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -219,7 +218,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance RIP.FromFunPtr MyFunction where
 
   fromFunPtr = hs_bindgen_bb71f7e730356103
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapMyFunction" (RIP.Ptr MyFunction) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyFunction" (RIP.Ptr MyFunction) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyFunction")
@@ -94,8 +91,7 @@ newtype A = A
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance ( ty ~ MyFunction
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyFunction) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -117,7 +113,7 @@ newtype B = B
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -138,7 +134,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/th.txt
@@ -277,8 +277,9 @@ instance ToFunPtr MyFunction
     where toFunPtr = hs_bindgen_4e8a459829b269e0
 instance FromFunPtr MyFunction
     where fromFunPtr = hs_bindgen_bb71f7e730356103
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapMyFunction" (Ptr MyFunction) (Ptr ty)
+instance HasField "unwrapMyFunction"
+                  (Ptr MyFunction)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapMyFunction")
 instance HasCField MyFunction "unwrapMyFunction"
     where type CFieldType MyFunction "unwrapMyFunction" = CInt ->
@@ -294,7 +295,7 @@ newtype A
     = A {unwrapA :: MyFunction}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty MyFunction => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyFunction)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunction
@@ -309,7 +310,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -321,7 +322,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/function.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,8 +71,7 @@ instance RIP.FromFunPtr MyFunctionPointer_Aux where
 
   fromFunPtr = hs_bindgen_5738272f94a589e2
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapMyFunctionPointer_Aux" (RIP.Ptr MyFunctionPointer_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyFunctionPointer_Aux" (RIP.Ptr MyFunctionPointer_Aux) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyFunctionPointer_Aux")
@@ -104,8 +101,7 @@ newtype MyFunctionPointer = MyFunctionPointer
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr MyFunctionPointer_Aux
-         ) => RIP.HasField "unwrapMyFunctionPointer" (RIP.Ptr MyFunctionPointer) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyFunctionPointer" (RIP.Ptr MyFunctionPointer) (RIP.Ptr (RIP.FunPtr MyFunctionPointer_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyFunctionPointer")
@@ -135,8 +131,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ MyFunctionPointer
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyFunctionPointer) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -164,7 +159,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -185,7 +180,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -156,10 +156,9 @@ instance ToFunPtr MyFunctionPointer_Aux
     where toFunPtr = hs_bindgen_47dfd04698dd2e6f
 instance FromFunPtr MyFunctionPointer_Aux
     where fromFunPtr = hs_bindgen_5738272f94a589e2
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapMyFunctionPointer_Aux"
+instance HasField "unwrapMyFunctionPointer_Aux"
                   (Ptr MyFunctionPointer_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer_Aux")
 instance HasCField MyFunctionPointer_Aux
                    "unwrapMyFunctionPointer_Aux"
@@ -180,8 +179,9 @@ newtype MyFunctionPointer
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr MyFunctionPointer_Aux) =>
-         HasField "unwrapMyFunctionPointer" (Ptr MyFunctionPointer) (Ptr ty)
+instance HasField "unwrapMyFunctionPointer"
+                  (Ptr MyFunctionPointer)
+                  (Ptr (FunPtr MyFunctionPointer_Aux))
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer")
 instance HasCField MyFunctionPointer "unwrapMyFunctionPointer"
     where type CFieldType MyFunctionPointer
@@ -201,8 +201,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty MyFunctionPointer =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyFunctionPointer)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunctionPointer
@@ -221,7 +220,7 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -233,7 +232,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,8 +71,7 @@ instance HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
+instance RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"myStruct_x")
@@ -96,8 +93,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ MyStruct
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyStruct) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -124,7 +120,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -145,7 +141,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -147,8 +147,7 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @macro A@
 
@@ -160,7 +159,7 @@ newtype A
     = A {unwrapA :: MyStruct}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -175,7 +174,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -187,7 +186,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -78,8 +76,7 @@ instance HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
+instance RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
 
@@ -100,7 +97,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MyUnion) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyUnion) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -127,7 +124,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -148,7 +145,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/th.txt
@@ -170,7 +170,7 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @macro A@
 
@@ -182,7 +182,7 @@ newtype A
     = A {unwrapA :: MyUnion}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -197,7 +197,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -209,7 +209,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/macro\/union.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -36,8 +35,7 @@ newtype A = A
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr (IA.IncompleteArray RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -60,7 +58,7 @@ newtype B = B
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -81,7 +79,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -130,8 +130,7 @@ newtype A
     = A {unwrapA :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (IncompleteArray CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = IncompleteArray CInt
@@ -146,7 +145,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -158,7 +157,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -43,8 +42,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -73,7 +71,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -94,7 +92,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -130,8 +130,7 @@ newtype A
     = A {unwrapA :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = ConstantArray 3 CInt
@@ -146,7 +145,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -158,7 +157,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -108,8 +106,7 @@ instance Read MyEnum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyEnum")
@@ -148,7 +145,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MyEnum) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyEnum) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -177,7 +174,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -199,7 +196,7 @@ newtype E = E
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -158,8 +158,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
@@ -187,7 +186,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyEnum)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
@@ -207,7 +206,7 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -222,7 +221,7 @@ newtype E
     = E {unwrapE :: M.C}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,8 +66,7 @@ instance RIP.FromFunPtr A where
 
   fromFunPtr = hs_bindgen_0cf9a6d50f563441
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -91,7 +88,7 @@ newtype B = B
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -112,7 +109,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/th.txt
@@ -283,8 +283,7 @@ instance ToFunPtr A
     where toFunPtr = hs_bindgen_0c7d4776a632d026
 instance FromFunPtr A
     where fromFunPtr = hs_bindgen_0cf9a6d50f563441
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt -> IO CInt
@@ -299,7 +298,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -311,7 +310,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -72,8 +70,7 @@ instance RIP.FromFunPtr A_Aux where
 
   fromFunPtr = hs_bindgen_cdb12400c6863f15
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapA_Aux" (RIP.Ptr A_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA_Aux" (RIP.Ptr A_Aux) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapA_Aux")
@@ -103,8 +100,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr A_Aux
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr (RIP.FunPtr A_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -132,7 +128,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -154,7 +150,7 @@ newtype E = E
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -159,8 +159,7 @@ instance ToFunPtr A_Aux
     where toFunPtr = hs_bindgen_1cabb32c661d9a0e
 instance FromFunPtr A_Aux
     where fromFunPtr = hs_bindgen_cdb12400c6863f15
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr ty)
+instance HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapA_Aux")
 instance HasCField A_Aux "unwrapA_Aux"
     where type CFieldType A_Aux "unwrapA_Aux" = CInt -> IO CInt
@@ -179,8 +178,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr A_Aux) =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr (FunPtr A_Aux))
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = FunPtr A_Aux
@@ -199,7 +197,7 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -214,7 +212,7 @@ newtype E
     = E {unwrapE :: M.C}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,8 +71,7 @@ instance HasCField.HasCField MyStruct "myStruct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
+instance RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"myStruct_x")
@@ -96,8 +93,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ MyStruct
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyStruct) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -124,7 +120,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -145,7 +141,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -147,8 +147,7 @@ deriving via (EquivStorable MyStruct) instance Storable MyStruct
 instance HasCField MyStruct "myStruct_x"
     where type CFieldType MyStruct "myStruct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
     where getField = fromPtr (Proxy @"myStruct_x")
 {-| __C declaration:__ @A@
 
@@ -160,7 +159,7 @@ newtype A
     = A {unwrapA :: MyStruct}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyStruct)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
@@ -175,7 +174,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -187,7 +186,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -78,8 +76,7 @@ instance HasCField.HasCField MyUnion "myUnion_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
+instance RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
 
@@ -100,7 +97,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MyUnion) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr MyUnion) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -127,7 +124,7 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
-instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 
@@ -148,7 +145,7 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr M.C) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/th.txt
@@ -170,7 +170,7 @@ set_myUnion_x = setUnionPayload
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+instance HasField "myUnion_x" (Ptr MyUnion) (Ptr CInt)
     where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
@@ -182,7 +182,7 @@ newtype A
     = A {unwrapA :: MyUnion}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr MyUnion)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
@@ -197,7 +197,7 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
@@ -209,7 +209,7 @@ instance HasCField B "unwrapB"
     __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
-instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr M.C)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -77,8 +75,7 @@ instance HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+instance RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
 
@@ -88,7 +85,6 @@ instance HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+instance RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/th.txt
@@ -34,10 +34,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -77,8 +75,7 @@ instance HasCField.HasCField Hoge "hoge_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+instance RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
 
@@ -88,7 +85,6 @@ instance HasCField.HasCField Hoge "hoge_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+instance RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/th.txt
@@ -34,10 +34,10 @@ deriving via (EquivStorable Hoge) instance Storable Hoge
 instance HasCField Hoge "hoge_x"
     where type CFieldType Hoge "hoge_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_x" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_x")
 instance HasCField Hoge "hoge_y"
     where type CFieldType Hoge "hoge_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+instance HasField "hoge_y" (Ptr Hoge) (Ptr CInt)
     where getField = fromPtr (Proxy @"hoge_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -77,8 +75,7 @@ instance HasCField.HasCField Piyo "piyo_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "piyo_x" (RIP.Ptr Piyo) (RIP.Ptr ty) where
+instance RIP.HasField "piyo_x" (RIP.Ptr Piyo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"piyo_x")
 
@@ -88,7 +85,6 @@ instance HasCField.HasCField Piyo "piyo_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "piyo_y" (RIP.Ptr Piyo) (RIP.Ptr ty) where
+instance RIP.HasField "piyo_y" (RIP.Ptr Piyo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"piyo_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -34,10 +34,10 @@ deriving via (EquivStorable Piyo) instance Storable Piyo
 instance HasCField Piyo "piyo_x"
     where type CFieldType Piyo "piyo_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "piyo_x" (Ptr Piyo) (Ptr ty)
+instance HasField "piyo_x" (Ptr Piyo) (Ptr CInt)
     where getField = fromPtr (Proxy @"piyo_x")
 instance HasCField Piyo "piyo_y"
     where type CFieldType Piyo "piyo_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "piyo_y" (Ptr Piyo) (Ptr ty)
+instance HasField "piyo_y" (Ptr Piyo) (Ptr CInt)
     where getField = fromPtr (Proxy @"piyo_y")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype MySym = MySym
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapMySym" (RIP.Ptr MySym) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMySym" (RIP.Ptr MySym) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMySym")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/th.txt
@@ -23,8 +23,7 @@ newtype MySym
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar =>
-         HasField "unwrapMySym" (Ptr MySym) (Ptr ty)
+instance HasField "unwrapMySym" (Ptr MySym) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapMySym")
 instance HasCField MySym "unwrapMySym"
     where type CFieldType MySym "unwrapMySym" = CChar

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype Sym = Sym
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapSym" (RIP.Ptr Sym) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSym" (RIP.Ptr Sym) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapSym")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/th.txt
@@ -23,7 +23,7 @@ newtype Sym
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapSym" (Ptr Sym) (Ptr ty)
+instance HasField "unwrapSym" (Ptr Sym) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapSym")
 instance HasCField Sym "unwrapSym"
     where type CFieldType Sym "unwrapSym" = CChar

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/opaque/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -78,7 +76,6 @@ instance HasCField.HasCField Bar "bar_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr Foo
-         ) => RIP.HasField "bar_a" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_a" (RIP.Ptr Bar) (RIP.Ptr (RIP.Ptr Foo)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_a")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/opaque/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/opaque/th.txt
@@ -33,5 +33,5 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_a"
     where type CFieldType Bar "bar_a" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Foo) => HasField "bar_a" (Ptr Bar) (Ptr ty)
+instance HasField "bar_a" (Ptr Bar) (Ptr (Ptr Foo))
     where getField = fromPtr (Proxy @"bar_a")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/struct/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -106,8 +104,7 @@ instance HasCField.HasCField Named "named_e" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_e" (RIP.Ptr Named) (RIP.Ptr ty) where
+instance RIP.HasField "named_e" (RIP.Ptr Named) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"named_e")
 
@@ -117,8 +114,7 @@ instance HasCField.HasCField Named "named_f" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_f" (RIP.Ptr Named) (RIP.Ptr ty) where
+instance RIP.HasField "named_f" (RIP.Ptr Named) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"named_f")
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/struct/th.txt
@@ -56,12 +56,12 @@ deriving via (EquivStorable Named) instance Storable Named
 instance HasCField Named "named_e"
     where type CFieldType Named "named_e" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "named_e" (Ptr Named) (Ptr ty)
+instance HasField "named_e" (Ptr Named) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_e")
 instance HasCField Named "named_f"
     where type CFieldType Named "named_f" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "named_f" (Ptr Named) (Ptr ty)
+instance HasField "named_f" (Ptr Named) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_f")
 {-| __C declaration:__ @struct oan@
 

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype Stdlib_CBool = Stdlib_CBool
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CBool")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/th.txt
@@ -23,8 +23,9 @@ newtype Stdlib_CBool
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
+instance HasField "unwrapStdlib_CBool"
+                  (Ptr Stdlib_CBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -80,8 +78,7 @@ newtype Stdlib_CBool = Stdlib_CBool
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CBool")
@@ -121,8 +118,7 @@ newtype Stdlib_Int8 = Stdlib_Int8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int8")
@@ -162,8 +158,7 @@ newtype Stdlib_Int16 = Stdlib_Int16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int16")
@@ -203,8 +198,7 @@ newtype Stdlib_Int32 = Stdlib_Int32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int32")
@@ -244,8 +238,7 @@ newtype Stdlib_Int64 = Stdlib_Int64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int64")
@@ -285,8 +278,7 @@ newtype Stdlib_Word8 = Stdlib_Word8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word8")
@@ -326,8 +318,7 @@ newtype Stdlib_Word16 = Stdlib_Word16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word16")
@@ -367,8 +358,7 @@ newtype Stdlib_Word32 = Stdlib_Word32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word32")
@@ -408,8 +398,7 @@ newtype Stdlib_Word64 = Stdlib_Word64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word64")
@@ -449,8 +438,7 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
-         ) => RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr HsBindgen.Runtime.LibC.CIntMax) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CIntMax")
@@ -490,8 +478,7 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
-         ) => RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr HsBindgen.Runtime.LibC.CUIntMax) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CUIntMax")
@@ -531,8 +518,7 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
-         ) => RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr HsBindgen.Runtime.LibC.CIntPtr) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CIntPtr")
@@ -572,8 +558,7 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
-         ) => RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr HsBindgen.Runtime.LibC.CUIntPtr) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CUIntPtr")
@@ -596,8 +581,7 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
-         ) => RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr HsBindgen.Runtime.LibC.CFenvT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFenvT")
@@ -620,8 +604,7 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
-         ) => RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr HsBindgen.Runtime.LibC.CFexceptT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFexceptT")
@@ -661,8 +644,7 @@ newtype Stdlib_CSize = Stdlib_CSize
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CSize")
@@ -702,8 +684,7 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CPtrdiff")
@@ -726,8 +707,7 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
-         ) => RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr HsBindgen.Runtime.LibC.CJmpBuf) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CJmpBuf")
@@ -767,8 +747,7 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
-         ) => RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr HsBindgen.Runtime.LibC.CWchar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWchar")
@@ -808,8 +787,7 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
-         ) => RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr HsBindgen.Runtime.LibC.CWintT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWintT")
@@ -832,8 +810,7 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
-         ) => RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr HsBindgen.Runtime.LibC.CMbstateT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CMbstateT")
@@ -864,8 +841,7 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
-         ) => RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr HsBindgen.Runtime.LibC.CWctransT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWctransT")
@@ -896,8 +872,7 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
-         ) => RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr HsBindgen.Runtime.LibC.CWctypeT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWctypeT")
@@ -937,8 +912,7 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
-         ) => RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr HsBindgen.Runtime.LibC.CChar16T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CChar16T")
@@ -978,8 +952,7 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
-         ) => RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr HsBindgen.Runtime.LibC.CChar32T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CChar32T")
@@ -1012,8 +985,7 @@ newtype Stdlib_CTime = Stdlib_CTime
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTime
-         ) => RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr HsBindgen.Runtime.LibC.CTime) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CTime")
@@ -1046,8 +1018,7 @@ newtype Stdlib_CClock = Stdlib_CClock
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CClock
-         ) => RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr HsBindgen.Runtime.LibC.CClock) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CClock")
@@ -1071,8 +1042,7 @@ newtype Stdlib_CTm = Stdlib_CTm
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (Marshal.ReadRaw, Marshal.StaticSize)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTm
-         ) => RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr HsBindgen.Runtime.LibC.CTm) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CTm")
@@ -1095,8 +1065,7 @@ newtype Stdlib_CFile = Stdlib_CFile
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFile
-         ) => RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr HsBindgen.Runtime.LibC.CFile) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFile")
@@ -1119,8 +1088,7 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
-         ) => RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr HsBindgen.Runtime.LibC.CFpos) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFpos")
@@ -1160,8 +1128,7 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
-         ) => RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr HsBindgen.Runtime.LibC.CSigAtomic) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CSigAtomic")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/th.txt
@@ -40,8 +40,9 @@ newtype Stdlib_CBool
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
+instance HasField "unwrapStdlib_CBool"
+                  (Ptr Stdlib_CBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
@@ -70,8 +71,9 @@ newtype Stdlib_Int8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
+instance HasField "unwrapStdlib_Int8"
+                  (Ptr Stdlib_Int8)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
@@ -101,8 +103,9 @@ newtype Stdlib_Int16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
+instance HasField "unwrapStdlib_Int16"
+                  (Ptr Stdlib_Int16)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
@@ -132,8 +135,9 @@ newtype Stdlib_Int32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
+instance HasField "unwrapStdlib_Int32"
+                  (Ptr Stdlib_Int32)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
@@ -163,8 +167,9 @@ newtype Stdlib_Int64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
+instance HasField "unwrapStdlib_Int64"
+                  (Ptr Stdlib_Int64)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
@@ -194,8 +199,9 @@ newtype Stdlib_Word8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
+instance HasField "unwrapStdlib_Word8"
+                  (Ptr Stdlib_Word8)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
@@ -225,8 +231,9 @@ newtype Stdlib_Word16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
+instance HasField "unwrapStdlib_Word16"
+                  (Ptr Stdlib_Word16)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
@@ -256,8 +263,9 @@ newtype Stdlib_Word32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
+instance HasField "unwrapStdlib_Word32"
+                  (Ptr Stdlib_Word32)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
@@ -287,8 +295,9 @@ newtype Stdlib_Word64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
+instance HasField "unwrapStdlib_Word64"
+                  (Ptr Stdlib_Word64)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
@@ -318,8 +327,9 @@ newtype Stdlib_CIntMax
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
-         HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CIntMax"
+                  (Ptr Stdlib_CIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
@@ -349,8 +359,9 @@ newtype Stdlib_CUIntMax
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
-         HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntMax"
+                  (Ptr Stdlib_CUIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
@@ -380,8 +391,9 @@ newtype Stdlib_CIntPtr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
-         HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CIntPtr"
+                  (Ptr Stdlib_CIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
@@ -411,8 +423,9 @@ newtype Stdlib_CUIntPtr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
-         HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntPtr"
+                  (Ptr Stdlib_CUIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
@@ -427,8 +440,9 @@ instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
 newtype Stdlib_CFenvT
     = Stdlib_CFenvT {unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
-         HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
+instance HasField "unwrapStdlib_CFenvT"
+                  (Ptr Stdlib_CFenvT)
+                  (Ptr HsBindgen.Runtime.LibC.CFenvT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
@@ -443,8 +457,9 @@ instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
 newtype Stdlib_CFexceptT
     = Stdlib_CFexceptT {unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
-         HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
+instance HasField "unwrapStdlib_CFexceptT"
+                  (Ptr Stdlib_CFexceptT)
+                  (Ptr HsBindgen.Runtime.LibC.CFexceptT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
@@ -474,8 +489,9 @@ newtype Stdlib_CSize
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
+instance HasField "unwrapStdlib_CSize"
+                  (Ptr Stdlib_CSize)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
@@ -505,8 +521,9 @@ newtype Stdlib_CPtrdiff
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
+instance HasField "unwrapStdlib_CPtrdiff"
+                  (Ptr Stdlib_CPtrdiff)
+                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
@@ -521,8 +538,9 @@ instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
 newtype Stdlib_CJmpBuf
     = Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf :: HsBindgen.Runtime.LibC.CJmpBuf}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
-         HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
+instance HasField "unwrapStdlib_CJmpBuf"
+                  (Ptr Stdlib_CJmpBuf)
+                  (Ptr HsBindgen.Runtime.LibC.CJmpBuf)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
@@ -552,8 +570,9 @@ newtype Stdlib_CWchar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
-         HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
+instance HasField "unwrapStdlib_CWchar"
+                  (Ptr Stdlib_CWchar)
+                  (Ptr HsBindgen.Runtime.LibC.CWchar)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
@@ -583,8 +602,9 @@ newtype Stdlib_CWintT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
-         HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
+instance HasField "unwrapStdlib_CWintT"
+                  (Ptr Stdlib_CWintT)
+                  (Ptr HsBindgen.Runtime.LibC.CWintT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
@@ -599,8 +619,9 @@ instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
 newtype Stdlib_CMbstateT
     = Stdlib_CMbstateT {unwrapStdlib_CMbstateT :: HsBindgen.Runtime.LibC.CMbstateT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
-         HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
+instance HasField "unwrapStdlib_CMbstateT"
+                  (Ptr Stdlib_CMbstateT)
+                  (Ptr HsBindgen.Runtime.LibC.CMbstateT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
@@ -621,8 +642,9 @@ newtype Stdlib_CWctransT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
-         HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctransT"
+                  (Ptr Stdlib_CWctransT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctransT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
@@ -643,8 +665,9 @@ newtype Stdlib_CWctypeT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
-         HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctypeT"
+                  (Ptr Stdlib_CWctypeT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctypeT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
@@ -674,8 +697,9 @@ newtype Stdlib_CChar16T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
-         HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar16T"
+                  (Ptr Stdlib_CChar16T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar16T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
@@ -705,8 +729,9 @@ newtype Stdlib_CChar32T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
-         HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar32T"
+                  (Ptr Stdlib_CChar32T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar32T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
@@ -729,8 +754,9 @@ newtype Stdlib_CTime
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CTime =>
-         HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
+instance HasField "unwrapStdlib_CTime"
+                  (Ptr Stdlib_CTime)
+                  (Ptr HsBindgen.Runtime.LibC.CTime)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
@@ -753,8 +779,9 @@ newtype Stdlib_CClock
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CClock =>
-         HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
+instance HasField "unwrapStdlib_CClock"
+                  (Ptr Stdlib_CClock)
+                  (Ptr HsBindgen.Runtime.LibC.CClock)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
@@ -770,8 +797,9 @@ newtype Stdlib_CTm
     = Stdlib_CTm {unwrapStdlib_CTm :: HsBindgen.Runtime.LibC.CTm}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize)
-instance (~) ty HsBindgen.Runtime.LibC.CTm =>
-         HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
+instance HasField "unwrapStdlib_CTm"
+                  (Ptr Stdlib_CTm)
+                  (Ptr HsBindgen.Runtime.LibC.CTm)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
@@ -786,8 +814,9 @@ instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
 newtype Stdlib_CFile
     = Stdlib_CFile {unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFile =>
-         HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
+instance HasField "unwrapStdlib_CFile"
+                  (Ptr Stdlib_CFile)
+                  (Ptr HsBindgen.Runtime.LibC.CFile)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
@@ -802,8 +831,9 @@ instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
 newtype Stdlib_CFpos
     = Stdlib_CFpos {unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
-         HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
+instance HasField "unwrapStdlib_CFpos"
+                  (Ptr Stdlib_CFpos)
+                  (Ptr HsBindgen.Runtime.LibC.CFpos)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
@@ -833,8 +863,9 @@ newtype Stdlib_CSigAtomic
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
-         HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
+instance HasField "unwrapStdlib_CSigAtomic"
+                  (Ptr Stdlib_CSigAtomic)
+                  (Ptr HsBindgen.Runtime.LibC.CSigAtomic)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -80,8 +78,7 @@ newtype Stdlib_CBool = Stdlib_CBool
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CBool")
@@ -121,8 +118,7 @@ newtype Stdlib_Int8 = Stdlib_Int8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int8")
@@ -162,8 +158,7 @@ newtype Stdlib_Int16 = Stdlib_Int16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int16")
@@ -203,8 +198,7 @@ newtype Stdlib_Int32 = Stdlib_Int32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int32")
@@ -244,8 +238,7 @@ newtype Stdlib_Int64 = Stdlib_Int64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Int64")
@@ -285,8 +278,7 @@ newtype Stdlib_Word8 = Stdlib_Word8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word8")
@@ -326,8 +318,7 @@ newtype Stdlib_Word16 = Stdlib_Word16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word16")
@@ -367,8 +358,7 @@ newtype Stdlib_Word32 = Stdlib_Word32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word32")
@@ -408,8 +398,7 @@ newtype Stdlib_Word64 = Stdlib_Word64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_Word64")
@@ -449,8 +438,7 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
-         ) => RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr HsBindgen.Runtime.LibC.CIntMax) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CIntMax")
@@ -490,8 +478,7 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
-         ) => RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr HsBindgen.Runtime.LibC.CUIntMax) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CUIntMax")
@@ -531,8 +518,7 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
-         ) => RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr HsBindgen.Runtime.LibC.CIntPtr) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CIntPtr")
@@ -572,8 +558,7 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
-         ) => RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr HsBindgen.Runtime.LibC.CUIntPtr) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CUIntPtr")
@@ -596,8 +581,7 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
-         ) => RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr HsBindgen.Runtime.LibC.CFenvT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFenvT")
@@ -620,8 +604,7 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
-         ) => RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr HsBindgen.Runtime.LibC.CFexceptT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFexceptT")
@@ -661,8 +644,7 @@ newtype Stdlib_CSize = Stdlib_CSize
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CSize")
@@ -702,8 +684,7 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CPtrdiff")
@@ -726,8 +707,7 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
-         ) => RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr HsBindgen.Runtime.LibC.CJmpBuf) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CJmpBuf")
@@ -767,8 +747,7 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
-         ) => RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr HsBindgen.Runtime.LibC.CWchar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWchar")
@@ -808,8 +787,7 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
-         ) => RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr HsBindgen.Runtime.LibC.CWintT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWintT")
@@ -832,8 +810,7 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
-         ) => RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr HsBindgen.Runtime.LibC.CMbstateT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CMbstateT")
@@ -864,8 +841,7 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
-         ) => RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr HsBindgen.Runtime.LibC.CWctransT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWctransT")
@@ -896,8 +872,7 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
-         ) => RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr HsBindgen.Runtime.LibC.CWctypeT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CWctypeT")
@@ -937,8 +912,7 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
-         ) => RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr HsBindgen.Runtime.LibC.CChar16T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CChar16T")
@@ -978,8 +952,7 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
-         ) => RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr HsBindgen.Runtime.LibC.CChar32T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CChar32T")
@@ -1012,8 +985,7 @@ newtype Stdlib_CTime = Stdlib_CTime
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTime
-         ) => RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr HsBindgen.Runtime.LibC.CTime) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CTime")
@@ -1046,8 +1018,7 @@ newtype Stdlib_CClock = Stdlib_CClock
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CClock
-         ) => RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr HsBindgen.Runtime.LibC.CClock) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CClock")
@@ -1071,8 +1042,7 @@ newtype Stdlib_CTm = Stdlib_CTm
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (Marshal.ReadRaw, Marshal.StaticSize)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTm
-         ) => RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr HsBindgen.Runtime.LibC.CTm) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CTm")
@@ -1095,8 +1065,7 @@ newtype Stdlib_CFile = Stdlib_CFile
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFile
-         ) => RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr HsBindgen.Runtime.LibC.CFile) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFile")
@@ -1119,8 +1088,7 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
-         ) => RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr HsBindgen.Runtime.LibC.CFpos) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CFpos")
@@ -1160,8 +1128,7 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
-         ) => RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr HsBindgen.Runtime.LibC.CSigAtomic) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStdlib_CSigAtomic")

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/th.txt
@@ -40,8 +40,9 @@ newtype Stdlib_CBool
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
+instance HasField "unwrapStdlib_CBool"
+                  (Ptr Stdlib_CBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
@@ -70,8 +71,9 @@ newtype Stdlib_Int8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
+instance HasField "unwrapStdlib_Int8"
+                  (Ptr Stdlib_Int8)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
@@ -101,8 +103,9 @@ newtype Stdlib_Int16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
+instance HasField "unwrapStdlib_Int16"
+                  (Ptr Stdlib_Int16)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
@@ -132,8 +135,9 @@ newtype Stdlib_Int32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
+instance HasField "unwrapStdlib_Int32"
+                  (Ptr Stdlib_Int32)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
@@ -163,8 +167,9 @@ newtype Stdlib_Int64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
+instance HasField "unwrapStdlib_Int64"
+                  (Ptr Stdlib_Int64)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
@@ -194,8 +199,9 @@ newtype Stdlib_Word8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
+instance HasField "unwrapStdlib_Word8"
+                  (Ptr Stdlib_Word8)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
@@ -225,8 +231,9 @@ newtype Stdlib_Word16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
+instance HasField "unwrapStdlib_Word16"
+                  (Ptr Stdlib_Word16)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
@@ -256,8 +263,9 @@ newtype Stdlib_Word32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
+instance HasField "unwrapStdlib_Word32"
+                  (Ptr Stdlib_Word32)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
@@ -287,8 +295,9 @@ newtype Stdlib_Word64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
+instance HasField "unwrapStdlib_Word64"
+                  (Ptr Stdlib_Word64)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
@@ -318,8 +327,9 @@ newtype Stdlib_CIntMax
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
-         HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CIntMax"
+                  (Ptr Stdlib_CIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
@@ -349,8 +359,9 @@ newtype Stdlib_CUIntMax
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
-         HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntMax"
+                  (Ptr Stdlib_CUIntMax)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntMax)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
@@ -380,8 +391,9 @@ newtype Stdlib_CIntPtr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
-         HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CIntPtr"
+                  (Ptr Stdlib_CIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
@@ -411,8 +423,9 @@ newtype Stdlib_CUIntPtr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
-         HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
+instance HasField "unwrapStdlib_CUIntPtr"
+                  (Ptr Stdlib_CUIntPtr)
+                  (Ptr HsBindgen.Runtime.LibC.CUIntPtr)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
@@ -427,8 +440,9 @@ instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
 newtype Stdlib_CFenvT
     = Stdlib_CFenvT {unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
-         HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
+instance HasField "unwrapStdlib_CFenvT"
+                  (Ptr Stdlib_CFenvT)
+                  (Ptr HsBindgen.Runtime.LibC.CFenvT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
@@ -443,8 +457,9 @@ instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
 newtype Stdlib_CFexceptT
     = Stdlib_CFexceptT {unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
-         HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
+instance HasField "unwrapStdlib_CFexceptT"
+                  (Ptr Stdlib_CFexceptT)
+                  (Ptr HsBindgen.Runtime.LibC.CFexceptT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
@@ -474,8 +489,9 @@ newtype Stdlib_CSize
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
+instance HasField "unwrapStdlib_CSize"
+                  (Ptr Stdlib_CSize)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
@@ -505,8 +521,9 @@ newtype Stdlib_CPtrdiff
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
+instance HasField "unwrapStdlib_CPtrdiff"
+                  (Ptr Stdlib_CPtrdiff)
+                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
@@ -521,8 +538,9 @@ instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
 newtype Stdlib_CJmpBuf
     = Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf :: HsBindgen.Runtime.LibC.CJmpBuf}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
-         HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
+instance HasField "unwrapStdlib_CJmpBuf"
+                  (Ptr Stdlib_CJmpBuf)
+                  (Ptr HsBindgen.Runtime.LibC.CJmpBuf)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
@@ -552,8 +570,9 @@ newtype Stdlib_CWchar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
-         HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
+instance HasField "unwrapStdlib_CWchar"
+                  (Ptr Stdlib_CWchar)
+                  (Ptr HsBindgen.Runtime.LibC.CWchar)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
@@ -583,8 +602,9 @@ newtype Stdlib_CWintT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
-         HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
+instance HasField "unwrapStdlib_CWintT"
+                  (Ptr Stdlib_CWintT)
+                  (Ptr HsBindgen.Runtime.LibC.CWintT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
@@ -599,8 +619,9 @@ instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
 newtype Stdlib_CMbstateT
     = Stdlib_CMbstateT {unwrapStdlib_CMbstateT :: HsBindgen.Runtime.LibC.CMbstateT}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
-         HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
+instance HasField "unwrapStdlib_CMbstateT"
+                  (Ptr Stdlib_CMbstateT)
+                  (Ptr HsBindgen.Runtime.LibC.CMbstateT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
@@ -621,8 +642,9 @@ newtype Stdlib_CWctransT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
-         HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctransT"
+                  (Ptr Stdlib_CWctransT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctransT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
@@ -643,8 +665,9 @@ newtype Stdlib_CWctypeT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
-         HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
+instance HasField "unwrapStdlib_CWctypeT"
+                  (Ptr Stdlib_CWctypeT)
+                  (Ptr HsBindgen.Runtime.LibC.CWctypeT)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
@@ -674,8 +697,9 @@ newtype Stdlib_CChar16T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
-         HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar16T"
+                  (Ptr Stdlib_CChar16T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar16T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
@@ -705,8 +729,9 @@ newtype Stdlib_CChar32T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
-         HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
+instance HasField "unwrapStdlib_CChar32T"
+                  (Ptr Stdlib_CChar32T)
+                  (Ptr HsBindgen.Runtime.LibC.CChar32T)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
@@ -729,8 +754,9 @@ newtype Stdlib_CTime
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CTime =>
-         HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
+instance HasField "unwrapStdlib_CTime"
+                  (Ptr Stdlib_CTime)
+                  (Ptr HsBindgen.Runtime.LibC.CTime)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
@@ -753,8 +779,9 @@ newtype Stdlib_CClock
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CClock =>
-         HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
+instance HasField "unwrapStdlib_CClock"
+                  (Ptr Stdlib_CClock)
+                  (Ptr HsBindgen.Runtime.LibC.CClock)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
@@ -770,8 +797,9 @@ newtype Stdlib_CTm
     = Stdlib_CTm {unwrapStdlib_CTm :: HsBindgen.Runtime.LibC.CTm}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize)
-instance (~) ty HsBindgen.Runtime.LibC.CTm =>
-         HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
+instance HasField "unwrapStdlib_CTm"
+                  (Ptr Stdlib_CTm)
+                  (Ptr HsBindgen.Runtime.LibC.CTm)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
@@ -786,8 +814,9 @@ instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
 newtype Stdlib_CFile
     = Stdlib_CFile {unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFile =>
-         HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
+instance HasField "unwrapStdlib_CFile"
+                  (Ptr Stdlib_CFile)
+                  (Ptr HsBindgen.Runtime.LibC.CFile)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
@@ -802,8 +831,9 @@ instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
 newtype Stdlib_CFpos
     = Stdlib_CFpos {unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos}
     deriving stock Generic
-instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
-         HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
+instance HasField "unwrapStdlib_CFpos"
+                  (Ptr Stdlib_CFpos)
+                  (Ptr HsBindgen.Runtime.LibC.CFpos)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
@@ -833,8 +863,9 @@ newtype Stdlib_CSigAtomic
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
-         HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
+instance HasField "unwrapStdlib_CSigAtomic"
+                  (Ptr Stdlib_CSigAtomic)
+                  (Ptr HsBindgen.Runtime.LibC.CSigAtomic)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/Example.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -150,8 +149,7 @@ newtype An_pchar = An_pchar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.CChar
-         ) => RIP.HasField "unwrap" (RIP.Ptr An_pchar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr An_pchar) (RIP.Ptr (PtrConst.PtrConst RIP.CChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -210,8 +208,7 @@ instance HasCField.HasCField MyCoolStruct "listOfNames" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
-         ) => RIP.HasField "listOfNames" (RIP.Ptr MyCoolStruct) (RIP.Ptr ty) where
+instance RIP.HasField "listOfNames" (RIP.Ptr MyCoolStruct) (RIP.Ptr (CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"listOfNames")
@@ -264,8 +261,7 @@ instance RIP.FromFunPtr Foo_Aux where
 
   fromFunPtr = hs_bindgen_223d08172bb37c01
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrap" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Foo_Aux) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -294,8 +290,7 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Foo_Aux
-         ) => RIP.HasField "unwrap" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Foo) (RIP.Ptr (RIP.FunPtr Foo_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -353,8 +348,7 @@ instance HasCField.HasCField Foo_t "foo_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "foo_member" (RIP.Ptr Foo_t) (RIP.Ptr ty) where
+instance RIP.HasField "foo_member" (RIP.Ptr Foo_t) (RIP.Ptr (RIP.FunPtr (RIP.CInt -> IO RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"foo_member")
@@ -445,8 +439,7 @@ instance Read Bar_10 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Bar_10) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Bar_10) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -511,7 +504,7 @@ instance HasCField.HasCField St "i" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "i" (RIP.Ptr St) (RIP.Ptr ty) where
+instance RIP.HasField "i" (RIP.Ptr St) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"i")
 
@@ -592,8 +585,7 @@ instance Read E where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr E) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -662,7 +654,7 @@ instance HasCField.HasCField U "c" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "c" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "c" (RIP.Ptr U) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c")
 
@@ -692,8 +684,7 @@ newtype MyType = MyType
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr MyTypeImpl
-         ) => RIP.HasField "unwrap" (RIP.Ptr MyType) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr MyType) (RIP.Ptr (RIP.Ptr MyTypeImpl)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -750,8 +741,7 @@ instance HasCField.HasCField MyStructType "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "x" (RIP.Ptr MyStructType) (RIP.Ptr ty) where
+instance RIP.HasField "x" (RIP.Ptr MyStructType) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x")
 
@@ -813,8 +803,7 @@ instance HasCField.HasCField Ordinary_float_struct "ordinary_float_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "ordinary_float_member" (RIP.Ptr Ordinary_float_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_float_member" (RIP.Ptr Ordinary_float_struct) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_float_member")
@@ -867,8 +856,7 @@ instance HasCField.HasCField Ordinary_double_struct "ordinary_double_member" whe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "ordinary_double_member" (RIP.Ptr Ordinary_double_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_double_member" (RIP.Ptr Ordinary_double_struct) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_double_member")
@@ -921,8 +909,7 @@ instance HasCField.HasCField Ordinary_signed_char_struct "ordinary_signed_char_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_member" (RIP.Ptr Ordinary_signed_char_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_char_member" (RIP.Ptr Ordinary_signed_char_struct) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_member")
@@ -975,8 +962,7 @@ instance HasCField.HasCField Explicit_signed_char_struct "explicit_signed_char_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_member" (RIP.Ptr Explicit_signed_char_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_char_member" (RIP.Ptr Explicit_signed_char_struct) (RIP.Ptr RIP.CSChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_member")
@@ -1029,8 +1015,7 @@ instance HasCField.HasCField Unsigned_char_struct "unsigned_char_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unsigned_char_member" (RIP.Ptr Unsigned_char_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_char_member" (RIP.Ptr Unsigned_char_struct) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_char_member")
@@ -1083,8 +1068,7 @@ instance HasCField.HasCField Ordinary_signed_short_struct "ordinary_signed_short
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_member" (RIP.Ptr Ordinary_signed_short_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_short_member" (RIP.Ptr Ordinary_signed_short_struct) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_member")
@@ -1137,8 +1121,7 @@ instance HasCField.HasCField Explicit_signed_short_struct "explicit_signed_short
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_member" (RIP.Ptr Explicit_signed_short_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_short_member" (RIP.Ptr Explicit_signed_short_struct) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_member")
@@ -1191,8 +1174,7 @@ instance HasCField.HasCField Unsigned_short_struct "unsigned_short_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "unsigned_short_member" (RIP.Ptr Unsigned_short_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_short_member" (RIP.Ptr Unsigned_short_struct) (RIP.Ptr RIP.CUShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_short_member")
@@ -1245,8 +1227,7 @@ instance HasCField.HasCField Ordinary_signed_int_struct "ordinary_signed_int_mem
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_member" (RIP.Ptr Ordinary_signed_int_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_int_member" (RIP.Ptr Ordinary_signed_int_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_member")
@@ -1299,8 +1280,7 @@ instance HasCField.HasCField Explicit_signed_int_struct "explicit_signed_int_mem
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_member" (RIP.Ptr Explicit_signed_int_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_int_member" (RIP.Ptr Explicit_signed_int_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_member")
@@ -1353,8 +1333,7 @@ instance HasCField.HasCField Unsigned_int_struct "unsigned_int_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unsigned_int_member" (RIP.Ptr Unsigned_int_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_int_member" (RIP.Ptr Unsigned_int_struct) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_int_member")
@@ -1407,8 +1386,7 @@ instance HasCField.HasCField Ordinary_signed_long_struct "ordinary_signed_long_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_member" (RIP.Ptr Ordinary_signed_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_member" (RIP.Ptr Ordinary_signed_long_struct) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_member")
@@ -1461,8 +1439,7 @@ instance HasCField.HasCField Explicit_signed_long_struct "explicit_signed_long_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_member" (RIP.Ptr Explicit_signed_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_member" (RIP.Ptr Explicit_signed_long_struct) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_member")
@@ -1515,8 +1492,7 @@ instance HasCField.HasCField Unsigned_long_struct "unsigned_long_member" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "unsigned_long_member" (RIP.Ptr Unsigned_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_member" (RIP.Ptr Unsigned_long_struct) (RIP.Ptr RIP.CULong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_member")
@@ -1569,8 +1545,7 @@ instance HasCField.HasCField Ordinary_signed_long_long_struct "ordinary_signed_l
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_member" (RIP.Ptr Ordinary_signed_long_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_long_member" (RIP.Ptr Ordinary_signed_long_long_struct) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_member")
@@ -1623,8 +1598,7 @@ instance HasCField.HasCField Explicit_signed_long_long_struct "explicit_signed_l
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_member" (RIP.Ptr Explicit_signed_long_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_long_member" (RIP.Ptr Explicit_signed_long_long_struct) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_member")
@@ -1677,8 +1651,7 @@ instance HasCField.HasCField Unsigned_long_long_struct "unsigned_long_long_membe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_member" (RIP.Ptr Unsigned_long_long_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_long_member" (RIP.Ptr Unsigned_long_long_struct) (RIP.Ptr RIP.CULLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_member")
@@ -1735,8 +1708,7 @@ instance HasCField.HasCField Ordinary_void_pointer_struct "ordinary_void_pointer
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "ordinary_void_pointer_member" (RIP.Ptr Ordinary_void_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_void_pointer_member" (RIP.Ptr Ordinary_void_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_member")
@@ -1789,8 +1761,7 @@ instance HasCField.HasCField Ordinary_float_pointer_struct "ordinary_float_point
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CFloat
-         ) => RIP.HasField "ordinary_float_pointer_member" (RIP.Ptr Ordinary_float_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_float_pointer_member" (RIP.Ptr Ordinary_float_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CFloat)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_member")
@@ -1843,8 +1814,7 @@ instance HasCField.HasCField Ordinary_double_pointer_struct "ordinary_double_poi
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CDouble
-         ) => RIP.HasField "ordinary_double_pointer_member" (RIP.Ptr Ordinary_double_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_double_pointer_member" (RIP.Ptr Ordinary_double_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CDouble)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_member")
@@ -1897,8 +1867,7 @@ instance HasCField.HasCField Ordinary_signed_char_pointer_struct "ordinary_signe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_pointer_member" (RIP.Ptr Ordinary_signed_char_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_char_pointer_member" (RIP.Ptr Ordinary_signed_char_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_member")
@@ -1951,8 +1920,7 @@ instance HasCField.HasCField Explicit_signed_char_pointer_struct "explicit_signe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_pointer_member" (RIP.Ptr Explicit_signed_char_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_char_pointer_member" (RIP.Ptr Explicit_signed_char_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CSChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_member")
@@ -2005,8 +1973,7 @@ instance HasCField.HasCField Unsigned_char_pointer_struct "unsigned_char_pointer
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CUChar
-         ) => RIP.HasField "unsigned_char_pointer_member" (RIP.Ptr Unsigned_char_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_char_pointer_member" (RIP.Ptr Unsigned_char_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CUChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_member")
@@ -2059,8 +2026,7 @@ instance HasCField.HasCField Ordinary_signed_short_pointer_struct "ordinary_sign
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_pointer_member" (RIP.Ptr Ordinary_signed_short_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_short_pointer_member" (RIP.Ptr Ordinary_signed_short_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_member")
@@ -2113,8 +2079,7 @@ instance HasCField.HasCField Explicit_signed_short_pointer_struct "explicit_sign
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_pointer_member" (RIP.Ptr Explicit_signed_short_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_short_pointer_member" (RIP.Ptr Explicit_signed_short_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_member")
@@ -2167,8 +2132,7 @@ instance HasCField.HasCField Unsigned_short_pointer_struct "unsigned_short_point
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CUShort
-         ) => RIP.HasField "unsigned_short_pointer_member" (RIP.Ptr Unsigned_short_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_short_pointer_member" (RIP.Ptr Unsigned_short_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CUShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_member")
@@ -2221,8 +2185,7 @@ instance HasCField.HasCField Ordinary_signed_int_pointer_struct "ordinary_signed
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_pointer_member" (RIP.Ptr Ordinary_signed_int_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_int_pointer_member" (RIP.Ptr Ordinary_signed_int_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_member")
@@ -2275,8 +2238,7 @@ instance HasCField.HasCField Explicit_signed_int_pointer_struct "explicit_signed
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_pointer_member" (RIP.Ptr Explicit_signed_int_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_int_pointer_member" (RIP.Ptr Explicit_signed_int_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_member")
@@ -2329,8 +2291,7 @@ instance HasCField.HasCField Unsigned_int_pointer_struct "unsigned_int_pointer_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CUInt
-         ) => RIP.HasField "unsigned_int_pointer_member" (RIP.Ptr Unsigned_int_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_int_pointer_member" (RIP.Ptr Unsigned_int_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CUInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_member")
@@ -2383,8 +2344,7 @@ instance HasCField.HasCField Ordinary_signed_long_pointer_struct "ordinary_signe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_pointer_member" (RIP.Ptr Ordinary_signed_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_pointer_member" (RIP.Ptr Ordinary_signed_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_member")
@@ -2437,8 +2397,7 @@ instance HasCField.HasCField Explicit_signed_long_pointer_struct "explicit_signe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_pointer_member" (RIP.Ptr Explicit_signed_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_pointer_member" (RIP.Ptr Explicit_signed_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_member")
@@ -2491,8 +2450,7 @@ instance HasCField.HasCField Unsigned_long_pointer_struct "unsigned_long_pointer
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CULong
-         ) => RIP.HasField "unsigned_long_pointer_member" (RIP.Ptr Unsigned_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_pointer_member" (RIP.Ptr Unsigned_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CULong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_member")
@@ -2546,8 +2504,7 @@ instance HasCField.HasCField Ordinary_signed_long_long_pointer_struct "ordinary_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_pointer_member" (RIP.Ptr Ordinary_signed_long_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_long_pointer_member" (RIP.Ptr Ordinary_signed_long_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CLLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_member")
@@ -2601,8 +2558,7 @@ instance HasCField.HasCField Explicit_signed_long_long_pointer_struct "explicit_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_pointer_member" (RIP.Ptr Explicit_signed_long_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_long_pointer_member" (RIP.Ptr Explicit_signed_long_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CLLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_member")
@@ -2655,8 +2611,7 @@ instance HasCField.HasCField Unsigned_long_long_pointer_struct "unsigned_long_lo
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_pointer_member" (RIP.Ptr Unsigned_long_long_pointer_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_long_pointer_member" (RIP.Ptr Unsigned_long_long_pointer_struct) (RIP.Ptr (RIP.Ptr RIP.CULLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_member")
@@ -2711,8 +2666,7 @@ instance HasCField.HasCField Ordinary_float_array_struct "ordinary_float_array_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CFloat
-         ) => RIP.HasField "ordinary_float_array_member" (RIP.Ptr Ordinary_float_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_float_array_member" (RIP.Ptr Ordinary_float_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CFloat)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_float_array_member")
@@ -2765,8 +2719,7 @@ instance HasCField.HasCField Ordinary_double_array_struct "ordinary_double_array
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CDouble
-         ) => RIP.HasField "ordinary_double_array_member" (RIP.Ptr Ordinary_double_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_double_array_member" (RIP.Ptr Ordinary_double_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CDouble)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_double_array_member")
@@ -2819,8 +2772,7 @@ instance HasCField.HasCField Ordinary_signed_char_array_struct "ordinary_signed_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_array_member" (RIP.Ptr Ordinary_signed_char_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_char_array_member" (RIP.Ptr Ordinary_signed_char_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_array_member")
@@ -2873,8 +2825,7 @@ instance HasCField.HasCField Explicit_signed_char_array_struct "explicit_signed_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_array_member" (RIP.Ptr Explicit_signed_char_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_char_array_member" (RIP.Ptr Explicit_signed_char_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CSChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_array_member")
@@ -2927,8 +2878,7 @@ instance HasCField.HasCField Unsigned_char_array_struct "unsigned_char_array_mem
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CUChar
-         ) => RIP.HasField "unsigned_char_array_member" (RIP.Ptr Unsigned_char_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_char_array_member" (RIP.Ptr Unsigned_char_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CUChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_char_array_member")
@@ -2981,8 +2931,7 @@ instance HasCField.HasCField Ordinary_signed_short_array_struct "ordinary_signed
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_array_member" (RIP.Ptr Ordinary_signed_short_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_short_array_member" (RIP.Ptr Ordinary_signed_short_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_array_member")
@@ -3035,8 +2984,7 @@ instance HasCField.HasCField Explicit_signed_short_array_struct "explicit_signed
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_array_member" (RIP.Ptr Explicit_signed_short_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_short_array_member" (RIP.Ptr Explicit_signed_short_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_array_member")
@@ -3089,8 +3037,7 @@ instance HasCField.HasCField Unsigned_short_array_struct "unsigned_short_array_m
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CUShort
-         ) => RIP.HasField "unsigned_short_array_member" (RIP.Ptr Unsigned_short_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_short_array_member" (RIP.Ptr Unsigned_short_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CUShort)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_short_array_member")
@@ -3143,8 +3090,7 @@ instance HasCField.HasCField Ordinary_signed_int_array_struct "ordinary_signed_i
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_array_member" (RIP.Ptr Ordinary_signed_int_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_int_array_member" (RIP.Ptr Ordinary_signed_int_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_array_member")
@@ -3197,8 +3143,7 @@ instance HasCField.HasCField Explicit_signed_int_array_struct "explicit_signed_i
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_array_member" (RIP.Ptr Explicit_signed_int_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_int_array_member" (RIP.Ptr Explicit_signed_int_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_array_member")
@@ -3251,8 +3196,7 @@ instance HasCField.HasCField Unsigned_int_array_struct "unsigned_int_array_membe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CUInt
-         ) => RIP.HasField "unsigned_int_array_member" (RIP.Ptr Unsigned_int_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_int_array_member" (RIP.Ptr Unsigned_int_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CUInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_int_array_member")
@@ -3305,8 +3249,7 @@ instance HasCField.HasCField Ordinary_signed_long_array_struct "ordinary_signed_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_array_member" (RIP.Ptr Ordinary_signed_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_array_member" (RIP.Ptr Ordinary_signed_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_array_member")
@@ -3359,8 +3302,7 @@ instance HasCField.HasCField Explicit_signed_long_array_struct "explicit_signed_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_array_member" (RIP.Ptr Explicit_signed_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_array_member" (RIP.Ptr Explicit_signed_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_array_member")
@@ -3413,8 +3355,7 @@ instance HasCField.HasCField Unsigned_long_array_struct "unsigned_long_array_mem
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CULong
-         ) => RIP.HasField "unsigned_long_array_member" (RIP.Ptr Unsigned_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_array_member" (RIP.Ptr Unsigned_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CULong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_array_member")
@@ -3468,8 +3409,7 @@ instance HasCField.HasCField Ordinary_signed_long_long_array_struct "ordinary_si
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_array_member" (RIP.Ptr Ordinary_signed_long_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_long_array_member" (RIP.Ptr Ordinary_signed_long_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CLLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_array_member")
@@ -3523,8 +3463,7 @@ instance HasCField.HasCField Explicit_signed_long_long_array_struct "explicit_si
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_array_member" (RIP.Ptr Explicit_signed_long_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_long_array_member" (RIP.Ptr Explicit_signed_long_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CLLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_array_member")
@@ -3577,8 +3516,7 @@ instance HasCField.HasCField Unsigned_long_long_array_struct "unsigned_long_long
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_array_member" (RIP.Ptr Unsigned_long_long_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_long_array_member" (RIP.Ptr Unsigned_long_long_array_struct) (RIP.Ptr (CA.ConstantArray 10 RIP.CULLong)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_array_member")
@@ -3635,8 +3573,7 @@ instance HasCField.HasCField Ordinary_void_pointer_array_struct "ordinary_void_p
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.Void)
-         ) => RIP.HasField "ordinary_void_pointer_array_member" (RIP.Ptr Ordinary_void_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_void_pointer_array_member" (RIP.Ptr Ordinary_void_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.Void))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_array_member")
@@ -3689,8 +3626,7 @@ instance HasCField.HasCField Ordinary_float_pointer_array_struct "ordinary_float
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
-         ) => RIP.HasField "ordinary_float_pointer_array_member" (RIP.Ptr Ordinary_float_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_float_pointer_array_member" (RIP.Ptr Ordinary_float_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CFloat))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_array_member")
@@ -3743,8 +3679,7 @@ instance HasCField.HasCField Ordinary_double_pointer_array_struct "ordinary_doub
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
-         ) => RIP.HasField "ordinary_double_pointer_array_member" (RIP.Ptr Ordinary_double_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_double_pointer_array_member" (RIP.Ptr Ordinary_double_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CDouble))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_array_member")
@@ -3798,8 +3733,7 @@ instance HasCField.HasCField Ordinary_signed_char_pointer_array_struct "ordinary
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
-         ) => RIP.HasField "ordinary_signed_char_pointer_array_member" (RIP.Ptr Ordinary_signed_char_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_char_pointer_array_member" (RIP.Ptr Ordinary_signed_char_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CChar))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_array_member")
@@ -3853,8 +3787,7 @@ instance HasCField.HasCField Explicit_signed_char_pointer_array_struct "explicit
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
-         ) => RIP.HasField "explicit_signed_char_pointer_array_member" (RIP.Ptr Explicit_signed_char_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_char_pointer_array_member" (RIP.Ptr Explicit_signed_char_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CSChar))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_array_member")
@@ -3907,8 +3840,7 @@ instance HasCField.HasCField Unsigned_char_pointer_array_struct "unsigned_char_p
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
-         ) => RIP.HasField "unsigned_char_pointer_array_member" (RIP.Ptr Unsigned_char_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_char_pointer_array_member" (RIP.Ptr Unsigned_char_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CUChar))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_array_member")
@@ -3962,8 +3894,7 @@ instance HasCField.HasCField Ordinary_signed_short_pointer_array_struct "ordinar
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-         ) => RIP.HasField "ordinary_signed_short_pointer_array_member" (RIP.Ptr Ordinary_signed_short_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_short_pointer_array_member" (RIP.Ptr Ordinary_signed_short_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CShort))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_array_member")
@@ -4017,8 +3948,7 @@ instance HasCField.HasCField Explicit_signed_short_pointer_array_struct "explici
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-         ) => RIP.HasField "explicit_signed_short_pointer_array_member" (RIP.Ptr Explicit_signed_short_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_short_pointer_array_member" (RIP.Ptr Explicit_signed_short_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CShort))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_array_member")
@@ -4071,8 +4001,7 @@ instance HasCField.HasCField Unsigned_short_pointer_array_struct "unsigned_short
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
-         ) => RIP.HasField "unsigned_short_pointer_array_member" (RIP.Ptr Unsigned_short_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_short_pointer_array_member" (RIP.Ptr Unsigned_short_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CUShort))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_array_member")
@@ -4126,8 +4055,7 @@ instance HasCField.HasCField Ordinary_signed_int_pointer_array_struct "ordinary_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-         ) => RIP.HasField "ordinary_signed_int_pointer_array_member" (RIP.Ptr Ordinary_signed_int_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_int_pointer_array_member" (RIP.Ptr Ordinary_signed_int_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_array_member")
@@ -4181,8 +4109,7 @@ instance HasCField.HasCField Explicit_signed_int_pointer_array_struct "explicit_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-         ) => RIP.HasField "explicit_signed_int_pointer_array_member" (RIP.Ptr Explicit_signed_int_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_int_pointer_array_member" (RIP.Ptr Explicit_signed_int_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_array_member")
@@ -4235,8 +4162,7 @@ instance HasCField.HasCField Unsigned_int_pointer_array_struct "unsigned_int_poi
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
-         ) => RIP.HasField "unsigned_int_pointer_array_member" (RIP.Ptr Unsigned_int_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_int_pointer_array_member" (RIP.Ptr Unsigned_int_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CUInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_array_member")
@@ -4290,8 +4216,7 @@ instance HasCField.HasCField Ordinary_signed_long_pointer_array_struct "ordinary
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-         ) => RIP.HasField "ordinary_signed_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CLong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_array_member")
@@ -4345,8 +4270,7 @@ instance HasCField.HasCField Explicit_signed_long_pointer_array_struct "explicit
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-         ) => RIP.HasField "explicit_signed_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CLong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_array_member")
@@ -4399,8 +4323,7 @@ instance HasCField.HasCField Unsigned_long_pointer_array_struct "unsigned_long_p
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
-         ) => RIP.HasField "unsigned_long_pointer_array_member" (RIP.Ptr Unsigned_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_pointer_array_member" (RIP.Ptr Unsigned_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CULong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_array_member")
@@ -4454,8 +4377,7 @@ instance HasCField.HasCField Ordinary_signed_long_long_pointer_array_struct "ord
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-         ) => RIP.HasField "ordinary_signed_long_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ordinary_signed_long_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CLLong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_array_member")
@@ -4509,8 +4431,7 @@ instance HasCField.HasCField Explicit_signed_long_long_pointer_array_struct "exp
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-         ) => RIP.HasField "explicit_signed_long_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "explicit_signed_long_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CLLong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_array_member")
@@ -4564,8 +4485,7 @@ instance HasCField.HasCField Unsigned_long_long_pointer_array_struct "unsigned_l
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
-         ) => RIP.HasField "unsigned_long_long_pointer_array_member" (RIP.Ptr Unsigned_long_long_pointer_array_struct) (RIP.Ptr ty) where
+instance RIP.HasField "unsigned_long_long_pointer_array_member" (RIP.Ptr Unsigned_long_long_pointer_array_struct) (RIP.Ptr (CA.ConstantArray 10 (RIP.Ptr RIP.CULLong))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_array_member")
@@ -4602,8 +4522,7 @@ newtype An_int = An_int
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr An_int) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr An_int) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -4669,8 +4588,7 @@ instance HasCField.HasCField Cal_table_table "raw" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "raw" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
+instance RIP.HasField "raw" (RIP.Ptr Cal_table_table) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"raw")
 
@@ -4680,8 +4598,7 @@ instance HasCField.HasCField Cal_table_table "val" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "val" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
+instance RIP.HasField "val" (RIP.Ptr Cal_table_table) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"val")
 
@@ -4745,8 +4662,7 @@ instance HasCField.HasCField Cal_table "size" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "size" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
+instance RIP.HasField "size" (RIP.Ptr Cal_table) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"size")
 
@@ -4757,8 +4673,7 @@ instance HasCField.HasCField Cal_table "table" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ CA.ConstantArray 32 Cal_table_table
-         ) => RIP.HasField "table" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
+instance RIP.HasField "table" (RIP.Ptr Cal_table) (RIP.Ptr (CA.ConstantArray 32 Cal_table_table)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"table")
 
@@ -4842,8 +4757,7 @@ instance HasCField.HasCField Elf32_External_Dyn_d_un "d_val" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_val" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
+instance RIP.HasField "d_val" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr (CA.ConstantArray 4 RIP.CUChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"d_val")
 
@@ -4854,8 +4768,7 @@ instance HasCField.HasCField Elf32_External_Dyn_d_un "d_ptr" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_ptr" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
+instance RIP.HasField "d_ptr" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr (CA.ConstantArray 4 RIP.CUChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"d_ptr")
 
@@ -4916,8 +4829,7 @@ instance HasCField.HasCField Elf32_External_Dyn "d_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_tag" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
+instance RIP.HasField "d_tag" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr (CA.ConstantArray 4 RIP.CUChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"d_tag")
 
@@ -4928,8 +4840,7 @@ instance HasCField.HasCField Elf32_External_Dyn "d_un" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Elf32_External_Dyn_d_un
-         ) => RIP.HasField "d_un" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
+instance RIP.HasField "d_un" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr Elf32_External_Dyn_d_un) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"d_un")
 
@@ -4951,8 +4862,7 @@ newtype Bug_24 = Bug_24
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Bug_24) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Bug_24) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -4980,8 +4890,7 @@ newtype Bug_24_2 = Bug_24_2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Bug_24_2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Bug_24_2) (RIP.Ptr (PtrConst.PtrConst RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -5010,8 +4919,7 @@ newtype MyArray_27 = MyArray_27
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 20 RIP.CInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr MyArray_27) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr MyArray_27) (RIP.Ptr (CA.ConstantArray 20 RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -5069,7 +4977,6 @@ instance HasCField.HasCField MyStruct_27 "x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ MyArray_27
-         ) => RIP.HasField "x" (RIP.Ptr MyStruct_27) (RIP.Ptr ty) where
+instance RIP.HasField "x" (RIP.Ptr MyStruct_27) (RIP.Ptr MyArray_27) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x")

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/th.txt
@@ -530,8 +530,7 @@ newtype An_pchar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst CChar) =>
-         HasField "unwrap" (Ptr An_pchar) (Ptr ty)
+instance HasField "unwrap" (Ptr An_pchar) (Ptr (PtrConst CChar))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField An_pchar "unwrap"
     where type CFieldType An_pchar "unwrap" = PtrConst CChar
@@ -565,8 +564,9 @@ instance HasCField MyCoolStruct "listOfNames"
     where type CFieldType MyCoolStruct "listOfNames" = ConstantArray 8
                                                                      (ConstantArray 255 CChar)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 8 (ConstantArray 255 CChar)) =>
-         HasField "listOfNames" (Ptr MyCoolStruct) (Ptr ty)
+instance HasField "listOfNames"
+                  (Ptr MyCoolStruct)
+                  (Ptr (ConstantArray 8 (ConstantArray 255 CChar)))
     where getField = fromPtr (Proxy @"listOfNames")
 {-| Auxiliary type used by 'Foo'
 
@@ -601,8 +601,7 @@ instance ToFunPtr Foo_Aux
     where toFunPtr = hs_bindgen_b5a7b5e83ffee6b4
 instance FromFunPtr Foo_Aux
     where fromFunPtr = hs_bindgen_223d08172bb37c01
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrap" (Ptr Foo_Aux) (Ptr ty)
+instance HasField "unwrap" (Ptr Foo_Aux) (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Foo_Aux "unwrap"
     where type CFieldType Foo_Aux "unwrap" = CInt -> IO CInt
@@ -621,8 +620,7 @@ newtype Foo
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Foo_Aux) =>
-         HasField "unwrap" (Ptr Foo) (Ptr ty)
+instance HasField "unwrap" (Ptr Foo) (Ptr (FunPtr Foo_Aux))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Foo "unwrap"
     where type CFieldType Foo "unwrap" = FunPtr Foo_Aux
@@ -654,8 +652,9 @@ deriving via (EquivStorable Foo_t) instance Storable Foo_t
 instance HasCField Foo_t "foo_member"
     where type CFieldType Foo_t "foo_member" = FunPtr (CInt -> IO CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (CInt -> IO CInt)) =>
-         HasField "foo_member" (Ptr Foo_t) (Ptr ty)
+instance HasField "foo_member"
+                  (Ptr Foo_t)
+                  (Ptr (FunPtr (CInt -> IO CInt)))
     where getField = fromPtr (Proxy @"foo_member")
 {-| __C declaration:__ @struct Foo_10_@
 
@@ -703,7 +702,7 @@ instance Read Bar_10
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrap" (Ptr Bar_10) (Ptr ty)
+instance HasField "unwrap" (Ptr Bar_10) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bar_10 "unwrap"
     where type CFieldType Bar_10 "unwrap" = CUInt
@@ -743,7 +742,7 @@ deriving via (EquivStorable St) instance Storable St
 instance HasCField St "i"
     where type CFieldType St "i" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "i" (Ptr St) (Ptr ty)
+instance HasField "i" (Ptr St) (Ptr CInt)
     where getField = fromPtr (Proxy @"i")
 {-| __C declaration:__ @enum e@
 
@@ -784,7 +783,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrap" (Ptr E) (Ptr ty)
+instance HasField "unwrap" (Ptr E) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField E "unwrap"
     where type CFieldType E "unwrap" = CUInt
@@ -845,7 +844,7 @@ set_u_c = setUnionPayload
 instance HasCField U "c"
     where type CFieldType U "c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "c" (Ptr U) (Ptr ty)
+instance HasField "c" (Ptr U) (Ptr CChar)
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct MyTypeImpl@
 
@@ -868,8 +867,7 @@ newtype MyType
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr MyTypeImpl) =>
-         HasField "unwrap" (Ptr MyType) (Ptr ty)
+instance HasField "unwrap" (Ptr MyType) (Ptr (Ptr MyTypeImpl))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField MyType "unwrap"
     where type CFieldType MyType "unwrap" = Ptr MyTypeImpl
@@ -901,7 +899,7 @@ deriving via (EquivStorable MyStructType) instance Storable MyStructType
 instance HasCField MyStructType "x"
     where type CFieldType MyStructType "x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x" (Ptr MyStructType) (Ptr ty)
+instance HasField "x" (Ptr MyStructType) (Ptr CInt)
     where getField = fromPtr (Proxy @"x")
 {-| __C declaration:__ @struct MyStructEmpty@
 
@@ -940,10 +938,9 @@ instance HasCField Ordinary_float_struct "ordinary_float_member"
     where type CFieldType Ordinary_float_struct
                           "ordinary_float_member" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "ordinary_float_member"
+instance HasField "ordinary_float_member"
                   (Ptr Ordinary_float_struct)
-                  (Ptr ty)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"ordinary_float_member")
 {-| __C declaration:__ @struct ordinary_double_struct@
 
@@ -973,10 +970,9 @@ instance HasCField Ordinary_double_struct "ordinary_double_member"
     where type CFieldType Ordinary_double_struct
                           "ordinary_double_member" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "ordinary_double_member"
+instance HasField "ordinary_double_member"
                   (Ptr Ordinary_double_struct)
-                  (Ptr ty)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"ordinary_double_member")
 {-| __C declaration:__ @struct ordinary_signed_char_struct@
 
@@ -1007,10 +1003,9 @@ instance HasCField Ordinary_signed_char_struct
     where type CFieldType Ordinary_signed_char_struct
                           "ordinary_signed_char_member" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "ordinary_signed_char_member"
+instance HasField "ordinary_signed_char_member"
                   (Ptr Ordinary_signed_char_struct)
-                  (Ptr ty)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"ordinary_signed_char_member")
 {-| __C declaration:__ @struct explicit_signed_char_struct@
 
@@ -1041,10 +1036,9 @@ instance HasCField Explicit_signed_char_struct
     where type CFieldType Explicit_signed_char_struct
                           "explicit_signed_char_member" = CSChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CSChar =>
-         HasField "explicit_signed_char_member"
+instance HasField "explicit_signed_char_member"
                   (Ptr Explicit_signed_char_struct)
-                  (Ptr ty)
+                  (Ptr CSChar)
     where getField = fromPtr (Proxy @"explicit_signed_char_member")
 {-| __C declaration:__ @struct unsigned_char_struct@
 
@@ -1074,8 +1068,9 @@ instance HasCField Unsigned_char_struct "unsigned_char_member"
     where type CFieldType Unsigned_char_struct
                           "unsigned_char_member" = CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CUChar =>
-         HasField "unsigned_char_member" (Ptr Unsigned_char_struct) (Ptr ty)
+instance HasField "unsigned_char_member"
+                  (Ptr Unsigned_char_struct)
+                  (Ptr CUChar)
     where getField = fromPtr (Proxy @"unsigned_char_member")
 {-| __C declaration:__ @struct ordinary_signed_short_struct@
 
@@ -1106,10 +1101,9 @@ instance HasCField Ordinary_signed_short_struct
     where type CFieldType Ordinary_signed_short_struct
                           "ordinary_signed_short_member" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "ordinary_signed_short_member"
+instance HasField "ordinary_signed_short_member"
                   (Ptr Ordinary_signed_short_struct)
-                  (Ptr ty)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"ordinary_signed_short_member")
 {-| __C declaration:__ @struct explicit_signed_short_struct@
 
@@ -1140,10 +1134,9 @@ instance HasCField Explicit_signed_short_struct
     where type CFieldType Explicit_signed_short_struct
                           "explicit_signed_short_member" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "explicit_signed_short_member"
+instance HasField "explicit_signed_short_member"
                   (Ptr Explicit_signed_short_struct)
-                  (Ptr ty)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"explicit_signed_short_member")
 {-| __C declaration:__ @struct unsigned_short_struct@
 
@@ -1173,10 +1166,9 @@ instance HasCField Unsigned_short_struct "unsigned_short_member"
     where type CFieldType Unsigned_short_struct
                           "unsigned_short_member" = CUShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CUShort =>
-         HasField "unsigned_short_member"
+instance HasField "unsigned_short_member"
                   (Ptr Unsigned_short_struct)
-                  (Ptr ty)
+                  (Ptr CUShort)
     where getField = fromPtr (Proxy @"unsigned_short_member")
 {-| __C declaration:__ @struct ordinary_signed_int_struct@
 
@@ -1207,10 +1199,9 @@ instance HasCField Ordinary_signed_int_struct
     where type CFieldType Ordinary_signed_int_struct
                           "ordinary_signed_int_member" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "ordinary_signed_int_member"
+instance HasField "ordinary_signed_int_member"
                   (Ptr Ordinary_signed_int_struct)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"ordinary_signed_int_member")
 {-| __C declaration:__ @struct explicit_signed_int_struct@
 
@@ -1241,10 +1232,9 @@ instance HasCField Explicit_signed_int_struct
     where type CFieldType Explicit_signed_int_struct
                           "explicit_signed_int_member" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "explicit_signed_int_member"
+instance HasField "explicit_signed_int_member"
                   (Ptr Explicit_signed_int_struct)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"explicit_signed_int_member")
 {-| __C declaration:__ @struct unsigned_int_struct@
 
@@ -1274,8 +1264,9 @@ instance HasCField Unsigned_int_struct "unsigned_int_member"
     where type CFieldType Unsigned_int_struct
                           "unsigned_int_member" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unsigned_int_member" (Ptr Unsigned_int_struct) (Ptr ty)
+instance HasField "unsigned_int_member"
+                  (Ptr Unsigned_int_struct)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unsigned_int_member")
 {-| __C declaration:__ @struct ordinary_signed_long_struct@
 
@@ -1306,10 +1297,9 @@ instance HasCField Ordinary_signed_long_struct
     where type CFieldType Ordinary_signed_long_struct
                           "ordinary_signed_long_member" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "ordinary_signed_long_member"
+instance HasField "ordinary_signed_long_member"
                   (Ptr Ordinary_signed_long_struct)
-                  (Ptr ty)
+                  (Ptr CLong)
     where getField = fromPtr (Proxy @"ordinary_signed_long_member")
 {-| __C declaration:__ @struct explicit_signed_long_struct@
 
@@ -1340,10 +1330,9 @@ instance HasCField Explicit_signed_long_struct
     where type CFieldType Explicit_signed_long_struct
                           "explicit_signed_long_member" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "explicit_signed_long_member"
+instance HasField "explicit_signed_long_member"
                   (Ptr Explicit_signed_long_struct)
-                  (Ptr ty)
+                  (Ptr CLong)
     where getField = fromPtr (Proxy @"explicit_signed_long_member")
 {-| __C declaration:__ @struct unsigned_long_struct@
 
@@ -1373,8 +1362,9 @@ instance HasCField Unsigned_long_struct "unsigned_long_member"
     where type CFieldType Unsigned_long_struct
                           "unsigned_long_member" = CULong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULong =>
-         HasField "unsigned_long_member" (Ptr Unsigned_long_struct) (Ptr ty)
+instance HasField "unsigned_long_member"
+                  (Ptr Unsigned_long_struct)
+                  (Ptr CULong)
     where getField = fromPtr (Proxy @"unsigned_long_member")
 {-| __C declaration:__ @struct ordinary_signed_long_long_struct@
 
@@ -1405,10 +1395,9 @@ instance HasCField Ordinary_signed_long_long_struct
     where type CFieldType Ordinary_signed_long_long_struct
                           "ordinary_signed_long_long_member" = CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLLong =>
-         HasField "ordinary_signed_long_long_member"
+instance HasField "ordinary_signed_long_long_member"
                   (Ptr Ordinary_signed_long_long_struct)
-                  (Ptr ty)
+                  (Ptr CLLong)
     where getField = fromPtr (Proxy @"ordinary_signed_long_long_member")
 {-| __C declaration:__ @struct explicit_signed_long_long_struct@
 
@@ -1439,10 +1428,9 @@ instance HasCField Explicit_signed_long_long_struct
     where type CFieldType Explicit_signed_long_long_struct
                           "explicit_signed_long_long_member" = CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLLong =>
-         HasField "explicit_signed_long_long_member"
+instance HasField "explicit_signed_long_long_member"
                   (Ptr Explicit_signed_long_long_struct)
-                  (Ptr ty)
+                  (Ptr CLLong)
     where getField = fromPtr (Proxy @"explicit_signed_long_long_member")
 {-| __C declaration:__ @struct unsigned_long_long_struct@
 
@@ -1473,10 +1461,9 @@ instance HasCField Unsigned_long_long_struct
     where type CFieldType Unsigned_long_long_struct
                           "unsigned_long_long_member" = CULLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULLong =>
-         HasField "unsigned_long_long_member"
+instance HasField "unsigned_long_long_member"
                   (Ptr Unsigned_long_long_struct)
-                  (Ptr ty)
+                  (Ptr CULLong)
     where getField = fromPtr (Proxy @"unsigned_long_long_member")
 {-| Structs: pointers
 
@@ -1511,10 +1498,9 @@ instance HasCField Ordinary_void_pointer_struct
     where type CFieldType Ordinary_void_pointer_struct
                           "ordinary_void_pointer_member" = Ptr Void
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Void) =>
-         HasField "ordinary_void_pointer_member"
+instance HasField "ordinary_void_pointer_member"
                   (Ptr Ordinary_void_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"ordinary_void_pointer_member")
 {-| __C declaration:__ @struct ordinary_float_pointer_struct@
 
@@ -1545,10 +1531,9 @@ instance HasCField Ordinary_float_pointer_struct
     where type CFieldType Ordinary_float_pointer_struct
                           "ordinary_float_pointer_member" = Ptr CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CFloat) =>
-         HasField "ordinary_float_pointer_member"
+instance HasField "ordinary_float_pointer_member"
                   (Ptr Ordinary_float_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CFloat))
     where getField = fromPtr (Proxy @"ordinary_float_pointer_member")
 {-| __C declaration:__ @struct ordinary_double_pointer_struct@
 
@@ -1579,10 +1564,9 @@ instance HasCField Ordinary_double_pointer_struct
     where type CFieldType Ordinary_double_pointer_struct
                           "ordinary_double_pointer_member" = Ptr CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CDouble) =>
-         HasField "ordinary_double_pointer_member"
+instance HasField "ordinary_double_pointer_member"
                   (Ptr Ordinary_double_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CDouble))
     where getField = fromPtr (Proxy @"ordinary_double_pointer_member")
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_struct@
 
@@ -1613,10 +1597,9 @@ instance HasCField Ordinary_signed_char_pointer_struct
     where type CFieldType Ordinary_signed_char_pointer_struct
                           "ordinary_signed_char_pointer_member" = Ptr CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CChar) =>
-         HasField "ordinary_signed_char_pointer_member"
+instance HasField "ordinary_signed_char_pointer_member"
                   (Ptr Ordinary_signed_char_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CChar))
     where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_member")
 {-| __C declaration:__ @struct explicit_signed_char_pointer_struct@
 
@@ -1647,10 +1630,9 @@ instance HasCField Explicit_signed_char_pointer_struct
     where type CFieldType Explicit_signed_char_pointer_struct
                           "explicit_signed_char_pointer_member" = Ptr CSChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CSChar) =>
-         HasField "explicit_signed_char_pointer_member"
+instance HasField "explicit_signed_char_pointer_member"
                   (Ptr Explicit_signed_char_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CSChar))
     where getField = fromPtr (Proxy @"explicit_signed_char_pointer_member")
 {-| __C declaration:__ @struct unsigned_char_pointer_struct@
 
@@ -1681,10 +1663,9 @@ instance HasCField Unsigned_char_pointer_struct
     where type CFieldType Unsigned_char_pointer_struct
                           "unsigned_char_pointer_member" = Ptr CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUChar) =>
-         HasField "unsigned_char_pointer_member"
+instance HasField "unsigned_char_pointer_member"
                   (Ptr Unsigned_char_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CUChar))
     where getField = fromPtr (Proxy @"unsigned_char_pointer_member")
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_struct@
 
@@ -1715,10 +1696,9 @@ instance HasCField Ordinary_signed_short_pointer_struct
     where type CFieldType Ordinary_signed_short_pointer_struct
                           "ordinary_signed_short_pointer_member" = Ptr CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CShort) =>
-         HasField "ordinary_signed_short_pointer_member"
+instance HasField "ordinary_signed_short_pointer_member"
                   (Ptr Ordinary_signed_short_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CShort))
     where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_member")
 {-| __C declaration:__ @struct explicit_signed_short_pointer_struct@
 
@@ -1749,10 +1729,9 @@ instance HasCField Explicit_signed_short_pointer_struct
     where type CFieldType Explicit_signed_short_pointer_struct
                           "explicit_signed_short_pointer_member" = Ptr CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CShort) =>
-         HasField "explicit_signed_short_pointer_member"
+instance HasField "explicit_signed_short_pointer_member"
                   (Ptr Explicit_signed_short_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CShort))
     where getField = fromPtr (Proxy @"explicit_signed_short_pointer_member")
 {-| __C declaration:__ @struct unsigned_short_pointer_struct@
 
@@ -1783,10 +1762,9 @@ instance HasCField Unsigned_short_pointer_struct
     where type CFieldType Unsigned_short_pointer_struct
                           "unsigned_short_pointer_member" = Ptr CUShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUShort) =>
-         HasField "unsigned_short_pointer_member"
+instance HasField "unsigned_short_pointer_member"
                   (Ptr Unsigned_short_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CUShort))
     where getField = fromPtr (Proxy @"unsigned_short_pointer_member")
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_struct@
 
@@ -1817,10 +1795,9 @@ instance HasCField Ordinary_signed_int_pointer_struct
     where type CFieldType Ordinary_signed_int_pointer_struct
                           "ordinary_signed_int_pointer_member" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "ordinary_signed_int_pointer_member"
+instance HasField "ordinary_signed_int_pointer_member"
                   (Ptr Ordinary_signed_int_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_member")
 {-| __C declaration:__ @struct explicit_signed_int_pointer_struct@
 
@@ -1851,10 +1828,9 @@ instance HasCField Explicit_signed_int_pointer_struct
     where type CFieldType Explicit_signed_int_pointer_struct
                           "explicit_signed_int_pointer_member" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "explicit_signed_int_pointer_member"
+instance HasField "explicit_signed_int_pointer_member"
                   (Ptr Explicit_signed_int_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"explicit_signed_int_pointer_member")
 {-| __C declaration:__ @struct unsigned_int_pointer_struct@
 
@@ -1885,10 +1861,9 @@ instance HasCField Unsigned_int_pointer_struct
     where type CFieldType Unsigned_int_pointer_struct
                           "unsigned_int_pointer_member" = Ptr CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUInt) =>
-         HasField "unsigned_int_pointer_member"
+instance HasField "unsigned_int_pointer_member"
                   (Ptr Unsigned_int_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CUInt))
     where getField = fromPtr (Proxy @"unsigned_int_pointer_member")
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_struct@
 
@@ -1919,10 +1894,9 @@ instance HasCField Ordinary_signed_long_pointer_struct
     where type CFieldType Ordinary_signed_long_pointer_struct
                           "ordinary_signed_long_pointer_member" = Ptr CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLong) =>
-         HasField "ordinary_signed_long_pointer_member"
+instance HasField "ordinary_signed_long_pointer_member"
                   (Ptr Ordinary_signed_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CLong))
     where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_member")
 {-| __C declaration:__ @struct explicit_signed_long_pointer_struct@
 
@@ -1953,10 +1927,9 @@ instance HasCField Explicit_signed_long_pointer_struct
     where type CFieldType Explicit_signed_long_pointer_struct
                           "explicit_signed_long_pointer_member" = Ptr CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLong) =>
-         HasField "explicit_signed_long_pointer_member"
+instance HasField "explicit_signed_long_pointer_member"
                   (Ptr Explicit_signed_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CLong))
     where getField = fromPtr (Proxy @"explicit_signed_long_pointer_member")
 {-| __C declaration:__ @struct unsigned_long_pointer_struct@
 
@@ -1987,10 +1960,9 @@ instance HasCField Unsigned_long_pointer_struct
     where type CFieldType Unsigned_long_pointer_struct
                           "unsigned_long_pointer_member" = Ptr CULong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CULong) =>
-         HasField "unsigned_long_pointer_member"
+instance HasField "unsigned_long_pointer_member"
                   (Ptr Unsigned_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CULong))
     where getField = fromPtr (Proxy @"unsigned_long_pointer_member")
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_struct@
 
@@ -2021,10 +1993,9 @@ instance HasCField Ordinary_signed_long_long_pointer_struct
     where type CFieldType Ordinary_signed_long_long_pointer_struct
                           "ordinary_signed_long_long_pointer_member" = Ptr CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLLong) =>
-         HasField "ordinary_signed_long_long_pointer_member"
+instance HasField "ordinary_signed_long_long_pointer_member"
                   (Ptr Ordinary_signed_long_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CLLong))
     where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_member")
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_struct@
 
@@ -2055,10 +2026,9 @@ instance HasCField Explicit_signed_long_long_pointer_struct
     where type CFieldType Explicit_signed_long_long_pointer_struct
                           "explicit_signed_long_long_pointer_member" = Ptr CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLLong) =>
-         HasField "explicit_signed_long_long_pointer_member"
+instance HasField "explicit_signed_long_long_pointer_member"
                   (Ptr Explicit_signed_long_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CLLong))
     where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_member")
 {-| __C declaration:__ @struct unsigned_long_long_pointer_struct@
 
@@ -2089,10 +2059,9 @@ instance HasCField Unsigned_long_long_pointer_struct
     where type CFieldType Unsigned_long_long_pointer_struct
                           "unsigned_long_long_pointer_member" = Ptr CULLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CULLong) =>
-         HasField "unsigned_long_long_pointer_member"
+instance HasField "unsigned_long_long_pointer_member"
                   (Ptr Unsigned_long_long_pointer_struct)
-                  (Ptr ty)
+                  (Ptr (Ptr CULLong))
     where getField = fromPtr (Proxy @"unsigned_long_long_pointer_member")
 {-| Structs: arrays
 
@@ -2126,10 +2095,9 @@ instance HasCField Ordinary_float_array_struct
     where type CFieldType Ordinary_float_array_struct
                           "ordinary_float_array_member" = ConstantArray 10 CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CFloat) =>
-         HasField "ordinary_float_array_member"
+instance HasField "ordinary_float_array_member"
                   (Ptr Ordinary_float_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CFloat))
     where getField = fromPtr (Proxy @"ordinary_float_array_member")
 {-| __C declaration:__ @struct ordinary_double_array_struct@
 
@@ -2161,10 +2129,9 @@ instance HasCField Ordinary_double_array_struct
     where type CFieldType Ordinary_double_array_struct
                           "ordinary_double_array_member" = ConstantArray 10 CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CDouble) =>
-         HasField "ordinary_double_array_member"
+instance HasField "ordinary_double_array_member"
                   (Ptr Ordinary_double_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CDouble))
     where getField = fromPtr (Proxy @"ordinary_double_array_member")
 {-| __C declaration:__ @struct ordinary_signed_char_array_struct@
 
@@ -2196,10 +2163,9 @@ instance HasCField Ordinary_signed_char_array_struct
     where type CFieldType Ordinary_signed_char_array_struct
                           "ordinary_signed_char_array_member" = ConstantArray 10 CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CChar) =>
-         HasField "ordinary_signed_char_array_member"
+instance HasField "ordinary_signed_char_array_member"
                   (Ptr Ordinary_signed_char_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CChar))
     where getField = fromPtr (Proxy @"ordinary_signed_char_array_member")
 {-| __C declaration:__ @struct explicit_signed_char_array_struct@
 
@@ -2231,10 +2197,9 @@ instance HasCField Explicit_signed_char_array_struct
     where type CFieldType Explicit_signed_char_array_struct
                           "explicit_signed_char_array_member" = ConstantArray 10 CSChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CSChar) =>
-         HasField "explicit_signed_char_array_member"
+instance HasField "explicit_signed_char_array_member"
                   (Ptr Explicit_signed_char_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CSChar))
     where getField = fromPtr (Proxy @"explicit_signed_char_array_member")
 {-| __C declaration:__ @struct unsigned_char_array_struct@
 
@@ -2266,10 +2231,9 @@ instance HasCField Unsigned_char_array_struct
     where type CFieldType Unsigned_char_array_struct
                           "unsigned_char_array_member" = ConstantArray 10 CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CUChar) =>
-         HasField "unsigned_char_array_member"
+instance HasField "unsigned_char_array_member"
                   (Ptr Unsigned_char_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CUChar))
     where getField = fromPtr (Proxy @"unsigned_char_array_member")
 {-| __C declaration:__ @struct ordinary_signed_short_array_struct@
 
@@ -2301,10 +2265,9 @@ instance HasCField Ordinary_signed_short_array_struct
     where type CFieldType Ordinary_signed_short_array_struct
                           "ordinary_signed_short_array_member" = ConstantArray 10 CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CShort) =>
-         HasField "ordinary_signed_short_array_member"
+instance HasField "ordinary_signed_short_array_member"
                   (Ptr Ordinary_signed_short_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CShort))
     where getField = fromPtr (Proxy @"ordinary_signed_short_array_member")
 {-| __C declaration:__ @struct explicit_signed_short_array_struct@
 
@@ -2336,10 +2299,9 @@ instance HasCField Explicit_signed_short_array_struct
     where type CFieldType Explicit_signed_short_array_struct
                           "explicit_signed_short_array_member" = ConstantArray 10 CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CShort) =>
-         HasField "explicit_signed_short_array_member"
+instance HasField "explicit_signed_short_array_member"
                   (Ptr Explicit_signed_short_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CShort))
     where getField = fromPtr (Proxy @"explicit_signed_short_array_member")
 {-| __C declaration:__ @struct unsigned_short_array_struct@
 
@@ -2371,10 +2333,9 @@ instance HasCField Unsigned_short_array_struct
     where type CFieldType Unsigned_short_array_struct
                           "unsigned_short_array_member" = ConstantArray 10 CUShort
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CUShort) =>
-         HasField "unsigned_short_array_member"
+instance HasField "unsigned_short_array_member"
                   (Ptr Unsigned_short_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CUShort))
     where getField = fromPtr (Proxy @"unsigned_short_array_member")
 {-| __C declaration:__ @struct ordinary_signed_int_array_struct@
 
@@ -2406,10 +2367,9 @@ instance HasCField Ordinary_signed_int_array_struct
     where type CFieldType Ordinary_signed_int_array_struct
                           "ordinary_signed_int_array_member" = ConstantArray 10 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CInt) =>
-         HasField "ordinary_signed_int_array_member"
+instance HasField "ordinary_signed_int_array_member"
                   (Ptr Ordinary_signed_int_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CInt))
     where getField = fromPtr (Proxy @"ordinary_signed_int_array_member")
 {-| __C declaration:__ @struct explicit_signed_int_array_struct@
 
@@ -2441,10 +2401,9 @@ instance HasCField Explicit_signed_int_array_struct
     where type CFieldType Explicit_signed_int_array_struct
                           "explicit_signed_int_array_member" = ConstantArray 10 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CInt) =>
-         HasField "explicit_signed_int_array_member"
+instance HasField "explicit_signed_int_array_member"
                   (Ptr Explicit_signed_int_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CInt))
     where getField = fromPtr (Proxy @"explicit_signed_int_array_member")
 {-| __C declaration:__ @struct unsigned_int_array_struct@
 
@@ -2476,10 +2435,9 @@ instance HasCField Unsigned_int_array_struct
     where type CFieldType Unsigned_int_array_struct
                           "unsigned_int_array_member" = ConstantArray 10 CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CUInt) =>
-         HasField "unsigned_int_array_member"
+instance HasField "unsigned_int_array_member"
                   (Ptr Unsigned_int_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CUInt))
     where getField = fromPtr (Proxy @"unsigned_int_array_member")
 {-| __C declaration:__ @struct ordinary_signed_long_array_struct@
 
@@ -2511,10 +2469,9 @@ instance HasCField Ordinary_signed_long_array_struct
     where type CFieldType Ordinary_signed_long_array_struct
                           "ordinary_signed_long_array_member" = ConstantArray 10 CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLong) =>
-         HasField "ordinary_signed_long_array_member"
+instance HasField "ordinary_signed_long_array_member"
                   (Ptr Ordinary_signed_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CLong))
     where getField = fromPtr (Proxy @"ordinary_signed_long_array_member")
 {-| __C declaration:__ @struct explicit_signed_long_array_struct@
 
@@ -2546,10 +2503,9 @@ instance HasCField Explicit_signed_long_array_struct
     where type CFieldType Explicit_signed_long_array_struct
                           "explicit_signed_long_array_member" = ConstantArray 10 CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLong) =>
-         HasField "explicit_signed_long_array_member"
+instance HasField "explicit_signed_long_array_member"
                   (Ptr Explicit_signed_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CLong))
     where getField = fromPtr (Proxy @"explicit_signed_long_array_member")
 {-| __C declaration:__ @struct unsigned_long_array_struct@
 
@@ -2581,10 +2537,9 @@ instance HasCField Unsigned_long_array_struct
     where type CFieldType Unsigned_long_array_struct
                           "unsigned_long_array_member" = ConstantArray 10 CULong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CULong) =>
-         HasField "unsigned_long_array_member"
+instance HasField "unsigned_long_array_member"
                   (Ptr Unsigned_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CULong))
     where getField = fromPtr (Proxy @"unsigned_long_array_member")
 {-| __C declaration:__ @struct ordinary_signed_long_long_array_struct@
 
@@ -2616,10 +2571,9 @@ instance HasCField Ordinary_signed_long_long_array_struct
     where type CFieldType Ordinary_signed_long_long_array_struct
                           "ordinary_signed_long_long_array_member" = ConstantArray 10 CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLLong) =>
-         HasField "ordinary_signed_long_long_array_member"
+instance HasField "ordinary_signed_long_long_array_member"
                   (Ptr Ordinary_signed_long_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CLLong))
     where getField = fromPtr (Proxy @"ordinary_signed_long_long_array_member")
 {-| __C declaration:__ @struct explicit_signed_long_long_array_struct@
 
@@ -2651,10 +2605,9 @@ instance HasCField Explicit_signed_long_long_array_struct
     where type CFieldType Explicit_signed_long_long_array_struct
                           "explicit_signed_long_long_array_member" = ConstantArray 10 CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLLong) =>
-         HasField "explicit_signed_long_long_array_member"
+instance HasField "explicit_signed_long_long_array_member"
                   (Ptr Explicit_signed_long_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CLLong))
     where getField = fromPtr (Proxy @"explicit_signed_long_long_array_member")
 {-| __C declaration:__ @struct unsigned_long_long_array_struct@
 
@@ -2686,10 +2639,9 @@ instance HasCField Unsigned_long_long_array_struct
     where type CFieldType Unsigned_long_long_array_struct
                           "unsigned_long_long_array_member" = ConstantArray 10 CULLong
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CULLong) =>
-         HasField "unsigned_long_long_array_member"
+instance HasField "unsigned_long_long_array_member"
                   (Ptr Unsigned_long_long_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 CULLong))
     where getField = fromPtr (Proxy @"unsigned_long_long_array_member")
 {-| Structs: arrays of pointers
 
@@ -2725,10 +2677,9 @@ instance HasCField Ordinary_void_pointer_array_struct
     where type CFieldType Ordinary_void_pointer_array_struct
                           "ordinary_void_pointer_array_member" = ConstantArray 10 (Ptr Void)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr Void)) =>
-         HasField "ordinary_void_pointer_array_member"
+instance HasField "ordinary_void_pointer_array_member"
                   (Ptr Ordinary_void_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr Void)))
     where getField = fromPtr (Proxy @"ordinary_void_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_float_pointer_array_struct@
 
@@ -2761,10 +2712,9 @@ instance HasCField Ordinary_float_pointer_array_struct
                           "ordinary_float_pointer_array_member" = ConstantArray 10
                                                                                 (Ptr CFloat)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CFloat)) =>
-         HasField "ordinary_float_pointer_array_member"
+instance HasField "ordinary_float_pointer_array_member"
                   (Ptr Ordinary_float_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CFloat)))
     where getField = fromPtr (Proxy @"ordinary_float_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_double_pointer_array_struct@
 
@@ -2797,10 +2747,9 @@ instance HasCField Ordinary_double_pointer_array_struct
                           "ordinary_double_pointer_array_member" = ConstantArray 10
                                                                                  (Ptr CDouble)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CDouble)) =>
-         HasField "ordinary_double_pointer_array_member"
+instance HasField "ordinary_double_pointer_array_member"
                   (Ptr Ordinary_double_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CDouble)))
     where getField = fromPtr (Proxy @"ordinary_double_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_array_struct@
 
@@ -2833,10 +2782,9 @@ instance HasCField Ordinary_signed_char_pointer_array_struct
                           "ordinary_signed_char_pointer_array_member" = ConstantArray 10
                                                                                       (Ptr CChar)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CChar)) =>
-         HasField "ordinary_signed_char_pointer_array_member"
+instance HasField "ordinary_signed_char_pointer_array_member"
                   (Ptr Ordinary_signed_char_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CChar)))
     where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_array_member")
 {-| __C declaration:__ @struct explicit_signed_char_pointer_array_struct@
 
@@ -2869,10 +2817,9 @@ instance HasCField Explicit_signed_char_pointer_array_struct
                           "explicit_signed_char_pointer_array_member" = ConstantArray 10
                                                                                       (Ptr CSChar)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CSChar)) =>
-         HasField "explicit_signed_char_pointer_array_member"
+instance HasField "explicit_signed_char_pointer_array_member"
                   (Ptr Explicit_signed_char_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CSChar)))
     where getField = fromPtr (Proxy @"explicit_signed_char_pointer_array_member")
 {-| __C declaration:__ @struct unsigned_char_pointer_array_struct@
 
@@ -2905,10 +2852,9 @@ instance HasCField Unsigned_char_pointer_array_struct
                           "unsigned_char_pointer_array_member" = ConstantArray 10
                                                                                (Ptr CUChar)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUChar)) =>
-         HasField "unsigned_char_pointer_array_member"
+instance HasField "unsigned_char_pointer_array_member"
                   (Ptr Unsigned_char_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CUChar)))
     where getField = fromPtr (Proxy @"unsigned_char_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_array_struct@
 
@@ -2941,10 +2887,9 @@ instance HasCField Ordinary_signed_short_pointer_array_struct
                           "ordinary_signed_short_pointer_array_member" = ConstantArray 10
                                                                                        (Ptr CShort)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
-         HasField "ordinary_signed_short_pointer_array_member"
+instance HasField "ordinary_signed_short_pointer_array_member"
                   (Ptr Ordinary_signed_short_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CShort)))
     where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_array_member")
 {-| __C declaration:__ @struct explicit_signed_short_pointer_array_struct@
 
@@ -2977,10 +2922,9 @@ instance HasCField Explicit_signed_short_pointer_array_struct
                           "explicit_signed_short_pointer_array_member" = ConstantArray 10
                                                                                        (Ptr CShort)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
-         HasField "explicit_signed_short_pointer_array_member"
+instance HasField "explicit_signed_short_pointer_array_member"
                   (Ptr Explicit_signed_short_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CShort)))
     where getField = fromPtr (Proxy @"explicit_signed_short_pointer_array_member")
 {-| __C declaration:__ @struct unsigned_short_pointer_array_struct@
 
@@ -3013,10 +2957,9 @@ instance HasCField Unsigned_short_pointer_array_struct
                           "unsigned_short_pointer_array_member" = ConstantArray 10
                                                                                 (Ptr CUShort)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUShort)) =>
-         HasField "unsigned_short_pointer_array_member"
+instance HasField "unsigned_short_pointer_array_member"
                   (Ptr Unsigned_short_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CUShort)))
     where getField = fromPtr (Proxy @"unsigned_short_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_array_struct@
 
@@ -3049,10 +2992,9 @@ instance HasCField Ordinary_signed_int_pointer_array_struct
                           "ordinary_signed_int_pointer_array_member" = ConstantArray 10
                                                                                      (Ptr CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
-         HasField "ordinary_signed_int_pointer_array_member"
+instance HasField "ordinary_signed_int_pointer_array_member"
                   (Ptr Ordinary_signed_int_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CInt)))
     where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_array_member")
 {-| __C declaration:__ @struct explicit_signed_int_pointer_array_struct@
 
@@ -3085,10 +3027,9 @@ instance HasCField Explicit_signed_int_pointer_array_struct
                           "explicit_signed_int_pointer_array_member" = ConstantArray 10
                                                                                      (Ptr CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
-         HasField "explicit_signed_int_pointer_array_member"
+instance HasField "explicit_signed_int_pointer_array_member"
                   (Ptr Explicit_signed_int_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CInt)))
     where getField = fromPtr (Proxy @"explicit_signed_int_pointer_array_member")
 {-| __C declaration:__ @struct unsigned_int_pointer_array_struct@
 
@@ -3120,10 +3061,9 @@ instance HasCField Unsigned_int_pointer_array_struct
     where type CFieldType Unsigned_int_pointer_array_struct
                           "unsigned_int_pointer_array_member" = ConstantArray 10 (Ptr CUInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUInt)) =>
-         HasField "unsigned_int_pointer_array_member"
+instance HasField "unsigned_int_pointer_array_member"
                   (Ptr Unsigned_int_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CUInt)))
     where getField = fromPtr (Proxy @"unsigned_int_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_array_struct@
 
@@ -3156,10 +3096,9 @@ instance HasCField Ordinary_signed_long_pointer_array_struct
                           "ordinary_signed_long_pointer_array_member" = ConstantArray 10
                                                                                       (Ptr CLong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
-         HasField "ordinary_signed_long_pointer_array_member"
+instance HasField "ordinary_signed_long_pointer_array_member"
                   (Ptr Ordinary_signed_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CLong)))
     where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_array_member")
 {-| __C declaration:__ @struct explicit_signed_long_pointer_array_struct@
 
@@ -3192,10 +3131,9 @@ instance HasCField Explicit_signed_long_pointer_array_struct
                           "explicit_signed_long_pointer_array_member" = ConstantArray 10
                                                                                       (Ptr CLong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
-         HasField "explicit_signed_long_pointer_array_member"
+instance HasField "explicit_signed_long_pointer_array_member"
                   (Ptr Explicit_signed_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CLong)))
     where getField = fromPtr (Proxy @"explicit_signed_long_pointer_array_member")
 {-| __C declaration:__ @struct unsigned_long_pointer_array_struct@
 
@@ -3228,10 +3166,9 @@ instance HasCField Unsigned_long_pointer_array_struct
                           "unsigned_long_pointer_array_member" = ConstantArray 10
                                                                                (Ptr CULong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CULong)) =>
-         HasField "unsigned_long_pointer_array_member"
+instance HasField "unsigned_long_pointer_array_member"
                   (Ptr Unsigned_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CULong)))
     where getField = fromPtr (Proxy @"unsigned_long_pointer_array_member")
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_array_struct@
 
@@ -3264,10 +3201,9 @@ instance HasCField Ordinary_signed_long_long_pointer_array_struct
                           "ordinary_signed_long_long_pointer_array_member" = ConstantArray 10
                                                                                            (Ptr CLLong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
-         HasField "ordinary_signed_long_long_pointer_array_member"
+instance HasField "ordinary_signed_long_long_pointer_array_member"
                   (Ptr Ordinary_signed_long_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CLLong)))
     where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_array_member")
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_array_struct@
 
@@ -3300,10 +3236,9 @@ instance HasCField Explicit_signed_long_long_pointer_array_struct
                           "explicit_signed_long_long_pointer_array_member" = ConstantArray 10
                                                                                            (Ptr CLLong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
-         HasField "explicit_signed_long_long_pointer_array_member"
+instance HasField "explicit_signed_long_long_pointer_array_member"
                   (Ptr Explicit_signed_long_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CLLong)))
     where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_array_member")
 {-| __C declaration:__ @struct unsigned_long_long_pointer_array_struct@
 
@@ -3336,10 +3271,9 @@ instance HasCField Unsigned_long_long_pointer_array_struct
                           "unsigned_long_long_pointer_array_member" = ConstantArray 10
                                                                                     (Ptr CULLong)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CULLong)) =>
-         HasField "unsigned_long_long_pointer_array_member"
+instance HasField "unsigned_long_long_pointer_array_member"
                   (Ptr Unsigned_long_long_pointer_array_struct)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 10 (Ptr CULLong)))
     where getField = fromPtr (Proxy @"unsigned_long_long_pointer_array_member")
 {-| Sanity checks
 
@@ -3369,7 +3303,7 @@ newtype An_int
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrap" (Ptr An_int) (Ptr ty)
+instance HasField "unwrap" (Ptr An_int) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField An_int "unwrap"
     where type CFieldType An_int "unwrap" = CInt
@@ -3409,14 +3343,12 @@ deriving via (EquivStorable Cal_table_table) instance Storable Cal_table_table
 instance HasCField Cal_table_table "raw"
     where type CFieldType Cal_table_table "raw" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "raw" (Ptr Cal_table_table) (Ptr ty)
+instance HasField "raw" (Ptr Cal_table_table) (Ptr CInt)
     where getField = fromPtr (Proxy @"raw")
 instance HasCField Cal_table_table "val"
     where type CFieldType Cal_table_table "val" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "val" (Ptr Cal_table_table) (Ptr ty)
+instance HasField "val" (Ptr Cal_table_table) (Ptr CInt)
     where getField = fromPtr (Proxy @"val")
 {-| Issues without test cases in the original test suite
 
@@ -3457,14 +3389,15 @@ deriving via (EquivStorable Cal_table) instance Storable Cal_table
 instance HasCField Cal_table "size"
     where type CFieldType Cal_table "size" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "size" (Ptr Cal_table) (Ptr ty)
+instance HasField "size" (Ptr Cal_table) (Ptr CInt)
     where getField = fromPtr (Proxy @"size")
 instance HasCField Cal_table "table"
     where type CFieldType Cal_table "table" = ConstantArray 32
                                                             Cal_table_table
           offset# = \_ -> \_ -> 4
-instance (~) ty (ConstantArray 32 Cal_table_table) =>
-         HasField "table" (Ptr Cal_table) (Ptr ty)
+instance HasField "table"
+                  (Ptr Cal_table)
+                  (Ptr (ConstantArray 32 Cal_table_table))
     where getField = fromPtr (Proxy @"table")
 {-| __C declaration:__ @union \@Elf32_External_Dyn_d_un@
 
@@ -3558,15 +3491,17 @@ instance HasCField Elf32_External_Dyn_d_un "d_val"
     where type CFieldType Elf32_External_Dyn_d_un
                           "d_val" = ConstantArray 4 CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_val" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
+instance HasField "d_val"
+                  (Ptr Elf32_External_Dyn_d_un)
+                  (Ptr (ConstantArray 4 CUChar))
     where getField = fromPtr (Proxy @"d_val")
 instance HasCField Elf32_External_Dyn_d_un "d_ptr"
     where type CFieldType Elf32_External_Dyn_d_un
                           "d_ptr" = ConstantArray 4 CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_ptr" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
+instance HasField "d_ptr"
+                  (Ptr Elf32_External_Dyn_d_un)
+                  (Ptr (ConstantArray 4 CUChar))
     where getField = fromPtr (Proxy @"d_ptr")
 {-| __C declaration:__ @struct Elf32_External_Dyn@
 
@@ -3604,15 +3539,17 @@ instance HasCField Elf32_External_Dyn "d_tag"
     where type CFieldType Elf32_External_Dyn "d_tag" = ConstantArray 4
                                                                      CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_tag" (Ptr Elf32_External_Dyn) (Ptr ty)
+instance HasField "d_tag"
+                  (Ptr Elf32_External_Dyn)
+                  (Ptr (ConstantArray 4 CUChar))
     where getField = fromPtr (Proxy @"d_tag")
 instance HasCField Elf32_External_Dyn "d_un"
     where type CFieldType Elf32_External_Dyn
                           "d_un" = Elf32_External_Dyn_d_un
           offset# = \_ -> \_ -> 4
-instance (~) ty Elf32_External_Dyn_d_un =>
-         HasField "d_un" (Ptr Elf32_External_Dyn) (Ptr ty)
+instance HasField "d_un"
+                  (Ptr Elf32_External_Dyn)
+                  (Ptr Elf32_External_Dyn_d_un)
     where getField = fromPtr (Proxy @"d_un")
 {-| __C declaration:__ @bug_24@
 
@@ -3628,8 +3565,7 @@ newtype Bug_24
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrap" (Ptr Bug_24) (Ptr ty)
+instance HasField "unwrap" (Ptr Bug_24) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bug_24 "unwrap"
     where type CFieldType Bug_24 "unwrap" = Ptr CInt
@@ -3648,8 +3584,7 @@ newtype Bug_24_2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrap" (Ptr Bug_24_2) (Ptr ty)
+instance HasField "unwrap" (Ptr Bug_24_2) (Ptr (PtrConst CInt))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bug_24_2 "unwrap"
     where type CFieldType Bug_24_2 "unwrap" = PtrConst CInt
@@ -3664,8 +3599,9 @@ newtype MyArray_27
     = MyArray_27 {unwrap :: (ConstantArray 20 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 20 CInt) =>
-         HasField "unwrap" (Ptr MyArray_27) (Ptr ty)
+instance HasField "unwrap"
+                  (Ptr MyArray_27)
+                  (Ptr (ConstantArray 20 CInt))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField MyArray_27 "unwrap"
     where type CFieldType MyArray_27 "unwrap" = ConstantArray 20 CInt
@@ -3697,8 +3633,7 @@ deriving via (EquivStorable MyStruct_27) instance Storable MyStruct_27
 instance HasCField MyStruct_27 "x"
     where type CFieldType MyStruct_27 "x" = MyArray_27
           offset# = \_ -> \_ -> 0
-instance (~) ty MyArray_27 =>
-         HasField "x" (Ptr MyStruct_27) (Ptr ty)
+instance HasField "x" (Ptr MyStruct_27) (Ptr MyArray_27)
     where getField = fromPtr (Proxy @"x")
 -- __unique:__ @test_comprehensivec2hsc_Example_Safe_foo_function@
 foreign import ccall safe "hs_bindgen_3fd2a5c6e681c44b" hs_bindgen_3fd2a5c6e681c44b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -66,8 +64,7 @@ newtype Uint = Uint
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Uint) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Uint) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -105,8 +102,7 @@ newtype Size_t = Size_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "unwrap" (RIP.Ptr Size_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Size_t) (RIP.Ptr RIP.CULong) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -253,8 +249,7 @@ instance HasCField.HasCField Bar1_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "a" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.Ptr RIP.Void)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -264,7 +259,7 @@ instance HasCField.HasCField Bar1_t "b" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr Bar1_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -274,8 +269,7 @@ instance HasCField.HasCField Bar1_t "c" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "c" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "c" (RIP.Ptr Bar1_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c")
 
@@ -285,8 +279,7 @@ instance HasCField.HasCField Bar1_t "d" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "d" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "d" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.Ptr RIP.CChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"d")
 
@@ -297,8 +290,7 @@ instance HasCField.HasCField Bar1_t "e" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
-         ) => RIP.HasField "e" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "e" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.FunPtr (IO (RIP.Ptr RIP.CChar)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"e")
 
@@ -309,8 +301,7 @@ instance HasCField.HasCField Bar1_t "f" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
-         ) => RIP.HasField "f" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "f" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.FunPtr (RIP.Ptr RIP.Void -> IO ()))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"f")
 
@@ -321,8 +312,7 @@ instance HasCField.HasCField Bar1_t "g" where
 
   offset# = \_ -> \_ -> 40
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
-         ) => RIP.HasField "g" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "g" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g")
 
@@ -333,8 +323,7 @@ instance HasCField.HasCField Bar1_t "h" where
 
   offset# = \_ -> \_ -> 48
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
-         ) => RIP.HasField "h" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "h" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt))))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"h")
 
@@ -345,8 +334,7 @@ instance HasCField.HasCField Bar1_t "i" where
 
   offset# = \_ -> \_ -> 56
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
-         ) => RIP.HasField "i" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "i" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt)))))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"i")
 
@@ -357,8 +345,7 @@ instance HasCField.HasCField Bar1_t "j" where
 
   offset# = \_ -> \_ -> 64
 
-instance ( ty ~ CA.ConstantArray 2 RIP.CChar
-         ) => RIP.HasField "j" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "j" (RIP.Ptr Bar1_t) (RIP.Ptr (CA.ConstantArray 2 RIP.CChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"j")
 
@@ -368,8 +355,7 @@ instance HasCField.HasCField Bar1_t "k" where
 
   offset# = \_ -> \_ -> 72
 
-instance ( ty ~ RIP.Ptr Bar1_t
-         ) => RIP.HasField "k" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+instance RIP.HasField "k" (RIP.Ptr Bar1_t) (RIP.Ptr (RIP.Ptr Bar1_t)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"k")
 
@@ -420,7 +406,7 @@ instance HasCField.HasCField Bar2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr Bar2_t) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr Bar2_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -471,7 +457,7 @@ instance HasCField.HasCField Bar3_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr Bar3_t) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr Bar3_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -562,8 +548,7 @@ instance Read Baz2_t where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Baz2_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Baz2_t) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -660,8 +645,7 @@ instance Read Baz3_t where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Baz3_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Baz3_t) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -758,8 +742,7 @@ instance Read Baz4_t where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrap" (RIP.Ptr Baz4_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr Baz4_t) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/th.txt
@@ -658,7 +658,7 @@ newtype Uint
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUInt => HasField "unwrap" (Ptr Uint) (Ptr ty)
+instance HasField "unwrap" (Ptr Uint) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Uint "unwrap"
     where type CFieldType Uint "unwrap" = CUInt
@@ -687,7 +687,7 @@ newtype Size_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CULong => HasField "unwrap" (Ptr Size_t) (Ptr ty)
+instance HasField "unwrap" (Ptr Size_t) (Ptr CULong)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Size_t "unwrap"
     where type CFieldType Size_t "unwrap" = CULong
@@ -799,66 +799,68 @@ deriving via (EquivStorable Bar1_t) instance Storable Bar1_t
 instance HasCField Bar1_t "a"
     where type CFieldType Bar1_t "a" = Ptr Void
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Void) => HasField "a" (Ptr Bar1_t) (Ptr ty)
+instance HasField "a" (Ptr Bar1_t) (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"a")
 instance HasCField Bar1_t "b"
     where type CFieldType Bar1_t "b" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "b" (Ptr Bar1_t) (Ptr ty)
+instance HasField "b" (Ptr Bar1_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 instance HasCField Bar1_t "c"
     where type CFieldType Bar1_t "c" = CChar
           offset# = \_ -> \_ -> 12
-instance (~) ty CChar => HasField "c" (Ptr Bar1_t) (Ptr ty)
+instance HasField "c" (Ptr Bar1_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"c")
 instance HasCField Bar1_t "d"
     where type CFieldType Bar1_t "d" = Ptr CChar
           offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr CChar) => HasField "d" (Ptr Bar1_t) (Ptr ty)
+instance HasField "d" (Ptr Bar1_t) (Ptr (Ptr CChar))
     where getField = fromPtr (Proxy @"d")
 instance HasCField Bar1_t "e"
     where type CFieldType Bar1_t "e" = FunPtr (IO (Ptr CChar))
           offset# = \_ -> \_ -> 24
-instance (~) ty (FunPtr (IO (Ptr CChar))) =>
-         HasField "e" (Ptr Bar1_t) (Ptr ty)
+instance HasField "e" (Ptr Bar1_t) (Ptr (FunPtr (IO (Ptr CChar))))
     where getField = fromPtr (Proxy @"e")
 instance HasCField Bar1_t "f"
     where type CFieldType Bar1_t "f" = FunPtr (Ptr Void -> IO ())
           offset# = \_ -> \_ -> 32
-instance (~) ty (FunPtr (Ptr Void -> IO ())) =>
-         HasField "f" (Ptr Bar1_t) (Ptr ty)
+instance HasField "f"
+                  (Ptr Bar1_t)
+                  (Ptr (FunPtr (Ptr Void -> IO ())))
     where getField = fromPtr (Proxy @"f")
 instance HasCField Bar1_t "g"
     where type CFieldType Bar1_t "g" = FunPtr (Ptr Void ->
                                                IO (Ptr CInt))
           offset# = \_ -> \_ -> 40
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr CInt))) =>
-         HasField "g" (Ptr Bar1_t) (Ptr ty)
+instance HasField "g"
+                  (Ptr Bar1_t)
+                  (Ptr (FunPtr (Ptr Void -> IO (Ptr CInt))))
     where getField = fromPtr (Proxy @"g")
 instance HasCField Bar1_t "h"
     where type CFieldType Bar1_t "h" = FunPtr (Ptr Void ->
                                                IO (Ptr (Ptr CInt)))
           offset# = \_ -> \_ -> 48
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))) =>
-         HasField "h" (Ptr Bar1_t) (Ptr ty)
+instance HasField "h"
+                  (Ptr Bar1_t)
+                  (Ptr (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))))
     where getField = fromPtr (Proxy @"h")
 instance HasCField Bar1_t "i"
     where type CFieldType Bar1_t "i" = FunPtr (Ptr Void ->
                                                IO (Ptr (Ptr (Ptr CInt))))
           offset# = \_ -> \_ -> 56
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))) =>
-         HasField "i" (Ptr Bar1_t) (Ptr ty)
+instance HasField "i"
+                  (Ptr Bar1_t)
+                  (Ptr (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))))
     where getField = fromPtr (Proxy @"i")
 instance HasCField Bar1_t "j"
     where type CFieldType Bar1_t "j" = ConstantArray 2 CChar
           offset# = \_ -> \_ -> 64
-instance (~) ty (ConstantArray 2 CChar) =>
-         HasField "j" (Ptr Bar1_t) (Ptr ty)
+instance HasField "j" (Ptr Bar1_t) (Ptr (ConstantArray 2 CChar))
     where getField = fromPtr (Proxy @"j")
 instance HasCField Bar1_t "k"
     where type CFieldType Bar1_t "k" = Ptr Bar1_t
           offset# = \_ -> \_ -> 72
-instance (~) ty (Ptr Bar1_t) => HasField "k" (Ptr Bar1_t) (Ptr ty)
+instance HasField "k" (Ptr Bar1_t) (Ptr (Ptr Bar1_t))
     where getField = fromPtr (Proxy @"k")
 {-| __C declaration:__ @struct bar2_t@
 
@@ -887,7 +889,7 @@ deriving via (EquivStorable Bar2_t) instance Storable Bar2_t
 instance HasCField Bar2_t "a"
     where type CFieldType Bar2_t "a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr Bar2_t) (Ptr ty)
+instance HasField "a" (Ptr Bar2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 {-| __C declaration:__ @struct bar3_t@
 
@@ -916,7 +918,7 @@ deriving via (EquivStorable Bar3_t) instance Storable Bar3_t
 instance HasCField Bar3_t "a"
     where type CFieldType Bar3_t "a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr Bar3_t) (Ptr ty)
+instance HasField "a" (Ptr Bar3_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 {-| __C declaration:__ @BAZ1@
 
@@ -965,7 +967,7 @@ instance Read Baz2_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrap" (Ptr Baz2_t) (Ptr ty)
+instance HasField "unwrap" (Ptr Baz2_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz2_t "unwrap"
     where type CFieldType Baz2_t "unwrap" = CUInt
@@ -1017,7 +1019,7 @@ instance Read Baz3_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrap" (Ptr Baz3_t) (Ptr ty)
+instance HasField "unwrap" (Ptr Baz3_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz3_t "unwrap"
     where type CFieldType Baz3_t "unwrap" = CUInt
@@ -1069,7 +1071,7 @@ instance Read Baz4_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrap" (Ptr Baz4_t) (Ptr ty)
+instance HasField "unwrap" (Ptr Baz4_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz4_t "unwrap"
     where type CFieldType Baz4_t "unwrap" = CUInt

--- a/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 

--- a/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -46,8 +46,9 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA"
+                  (Ptr A)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = HsBindgen.Runtime.LibC.CSize

--- a/hs-bindgen/test-artefacts/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/definitions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,7 +71,7 @@ instance HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr ty) where
+instance RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x_n")
 
@@ -152,7 +150,7 @@ instance HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"y_m")
 
@@ -162,6 +160,6 @@ instance HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"y_o")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/definitions/th.txt
@@ -53,7 +53,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
+instance HasField "x_n" (Ptr X) (Ptr CInt)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -137,12 +137,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
+instance HasField "y_m" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
+instance HasField "y_o" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsdefinitions_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_9cdc88a6d09442d6" hs_bindgen_9cdc88a6d09442d6_base ::

--- a/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance HasCField.HasCField S1_t "s1_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_t_a" (RIP.Ptr S1_t) (RIP.Ptr ty) where
+instance RIP.HasField "s1_t_a" (RIP.Ptr S1_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_t_a")
 
@@ -121,6 +118,6 @@ instance HasCField.HasCField S2 "s2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s2_a" (RIP.Ptr S2) (RIP.Ptr ty) where
+instance RIP.HasField "s2_a" (RIP.Ptr S2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_a")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable S1_t) instance Storable S1_t
 instance HasCField S1_t "s1_t_a"
     where type CFieldType S1_t "s1_t_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_t_a" (Ptr S1_t) (Ptr ty)
+instance HasField "s1_t_a" (Ptr S1_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_t_a")
 {-| __C declaration:__ @struct S2@
 
@@ -55,5 +55,5 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_a"
     where type CFieldType S2 "s2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s2_a" (Ptr S2) (Ptr ty)
+instance HasField "s2_a" (Ptr S2) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_a")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -90,8 +88,7 @@ instance HasCField.HasCField Bar "bar_ptrA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr Foo
-         ) => RIP.HasField "bar_ptrA" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_ptrA" (RIP.Ptr Bar) (RIP.Ptr (RIP.Ptr Foo)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrA")
 
@@ -101,8 +98,7 @@ instance HasCField.HasCField Bar "bar_ptrB" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Bar
-         ) => RIP.HasField "bar_ptrB" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_ptrB" (RIP.Ptr Bar) (RIP.Ptr (RIP.Ptr Bar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrB")
 

--- a/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/th.txt
@@ -41,12 +41,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_ptrA"
     where type CFieldType Bar "bar_ptrA" = Ptr Foo
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Foo) => HasField "bar_ptrA" (Ptr Bar) (Ptr ty)
+instance HasField "bar_ptrA" (Ptr Bar) (Ptr (Ptr Foo))
     where getField = fromPtr (Proxy @"bar_ptrA")
 instance HasCField Bar "bar_ptrB"
     where type CFieldType Bar "bar_ptrB" = Ptr Bar
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Bar) => HasField "bar_ptrB" (Ptr Bar) (Ptr ty)
+instance HasField "bar_ptrB" (Ptr Bar) (Ptr (Ptr Bar))
     where getField = fromPtr (Proxy @"bar_ptrB")
 {-| __C declaration:__ @struct baz@
 

--- a/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -57,8 +55,7 @@ newtype Int_t = Int_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapInt_t" (RIP.Ptr Int_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_t" (RIP.Ptr Int_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_t")
@@ -116,7 +113,7 @@ instance HasCField.HasCField X "x_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr ty) where
+instance RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x_n")
 
@@ -195,7 +192,7 @@ instance HasCField.HasCField Y "y_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"y_m")
 
@@ -205,6 +202,6 @@ instance HasCField.HasCField Y "y_o" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"y_o")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/th.txt
@@ -36,7 +36,7 @@ newtype Int_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapInt_t" (Ptr Int_t) (Ptr ty)
+instance HasField "unwrapInt_t" (Ptr Int_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapInt_t")
 instance HasCField Int_t "unwrapInt_t"
     where type CFieldType Int_t "unwrapInt_t" = CInt
@@ -68,7 +68,7 @@ deriving via (EquivStorable X) instance Storable X
 instance HasCField X "x_n"
     where type CFieldType X "x_n" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
+instance HasField "x_n" (Ptr X) (Ptr CInt)
     where getField = fromPtr (Proxy @"x_n")
 {-| __C declaration:__ @union Y@
 
@@ -152,12 +152,12 @@ set_y_o = setUnionPayload
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
+instance HasField "y_m" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
+instance HasField "y_o" (Ptr Y) (Ptr CInt)
     where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsredeclaration_Example_get_x@
 foreign import ccall unsafe "hs_bindgen_6f47e5cbb92690b9" hs_bindgen_6f47e5cbb92690b9_base ::

--- a/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype ParsedAndSelected1 = ParsedAndSelected1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapParsedAndSelected1" (RIP.Ptr ParsedAndSelected1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapParsedAndSelected1" (RIP.Ptr ParsedAndSelected1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapParsedAndSelected1")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/th.txt
@@ -24,10 +24,9 @@ newtype ParsedAndSelected1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapParsedAndSelected1"
+instance HasField "unwrapParsedAndSelected1"
                   (Ptr ParsedAndSelected1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapParsedAndSelected1")
 instance HasCField ParsedAndSelected1 "unwrapParsedAndSelected1"
     where type CFieldType ParsedAndSelected1

--- a/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/Example.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -40,8 +39,7 @@ newtype Triplet = Triplet
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr (CA.ConstantArray 3 RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTriplet")

--- a/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/th.txt
@@ -9,8 +9,9 @@ newtype Triplet
     = Triplet {unwrapTriplet :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
+instance HasField "unwrapTriplet"
+                  (Ptr Triplet)
+                  (Ptr (ConstantArray 3 CInt))
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/Example.hs
@@ -13,7 +13,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -123,8 +122,7 @@ newtype Size_type = Size_type
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "unwrapSize_type" (RIP.Ptr Size_type) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSize_type" (RIP.Ptr Size_type) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSize_type")
@@ -235,8 +233,7 @@ instance Read Color_enum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapColor_enum" (RIP.Ptr Color_enum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapColor_enum" (RIP.Ptr Color_enum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapColor_enum")
@@ -329,8 +326,7 @@ instance RIP.FromFunPtr Event_callback_t_Aux where
 
   fromFunPtr = hs_bindgen_9e9d478c2d75628c
 
-instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapEvent_callback_t_Aux" (RIP.Ptr Event_callback_t_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEvent_callback_t_Aux" (RIP.Ptr Event_callback_t_Aux) (RIP.Ptr (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEvent_callback_t_Aux")
@@ -368,8 +364,7 @@ newtype Event_callback_t = Event_callback_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Event_callback_t_Aux
-         ) => RIP.HasField "unwrapEvent_callback_t" (RIP.Ptr Event_callback_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEvent_callback_t" (RIP.Ptr Event_callback_t) (RIP.Ptr (RIP.FunPtr Event_callback_t_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEvent_callback_t")
@@ -486,8 +481,7 @@ instance HasCField.HasCField Config_t "config_t_id" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "config_t_id" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance RIP.HasField "config_t_id" (RIP.Ptr Config_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"config_t_id")
@@ -499,8 +493,7 @@ instance HasCField.HasCField Config_t "config_t_name" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ CA.ConstantArray 64 RIP.CChar
-         ) => RIP.HasField "config_t_name" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance RIP.HasField "config_t_name" (RIP.Ptr Config_t) (RIP.Ptr (CA.ConstantArray 64 RIP.CChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"config_t_name")
@@ -512,8 +505,7 @@ instance HasCField.HasCField Config_t "config_t_flags" where
 
   offset# = \_ -> \_ -> 68
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "config_t_flags" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance RIP.HasField "config_t_flags" (RIP.Ptr Config_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"config_t_flags")
@@ -525,8 +517,7 @@ instance HasCField.HasCField Config_t "config_t_callback" where
 
   offset# = \_ -> \_ -> 72
 
-instance ( ty ~ Event_callback_t
-         ) => RIP.HasField "config_t_callback" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance RIP.HasField "config_t_callback" (RIP.Ptr Config_t) (RIP.Ptr Event_callback_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"config_t_callback")
@@ -538,8 +529,7 @@ instance HasCField.HasCField Config_t "config_t_user_data" where
 
   offset# = \_ -> \_ -> 80
 
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "config_t_user_data" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance RIP.HasField "config_t_user_data" (RIP.Ptr Config_t) (RIP.Ptr (RIP.Ptr RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"config_t_user_data")
@@ -621,8 +611,7 @@ instance Read Status_code_t where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapStatus_code_t" (RIP.Ptr Status_code_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStatus_code_t" (RIP.Ptr Status_code_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStatus_code_t")
@@ -750,8 +739,7 @@ instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_low" w
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "data_union_t_as_parts_low" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_parts_low" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_low")
@@ -763,8 +751,7 @@ instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_high" 
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "data_union_t_as_parts_high" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_parts_high" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_high")
@@ -901,8 +888,7 @@ instance HasCField.HasCField Data_union_t "data_union_t_as_int" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "data_union_t_as_int" (RIP.Ptr Data_union_t) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_int" (RIP.Ptr Data_union_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_int")
@@ -914,8 +900,7 @@ instance HasCField.HasCField Data_union_t "data_union_t_as_float" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "data_union_t_as_float" (RIP.Ptr Data_union_t) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_float" (RIP.Ptr Data_union_t) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_float")
@@ -927,8 +912,7 @@ instance HasCField.HasCField Data_union_t "data_union_t_as_bytes" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ CA.ConstantArray 4 HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "data_union_t_as_bytes" (RIP.Ptr Data_union_t) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_bytes" (RIP.Ptr Data_union_t) (RIP.Ptr (CA.ConstantArray 4 HsBindgen.Runtime.LibC.Word8)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_bytes")
@@ -940,8 +924,7 @@ instance HasCField.HasCField Data_union_t "data_union_t_as_parts" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Data_union_t_as_parts
-         ) => RIP.HasField "data_union_t_as_parts" (RIP.Ptr Data_union_t) (RIP.Ptr ty) where
+instance RIP.HasField "data_union_t_as_parts" (RIP.Ptr Data_union_t) (RIP.Ptr Data_union_t_as_parts) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts")
@@ -1039,8 +1022,7 @@ instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag1" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_flag1" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bitfield_t_flag1" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr RIP.CUInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag1")
@@ -1054,8 +1036,7 @@ instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag2" where
 
   bitfieldWidth# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_flag2" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bitfield_t_flag2" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr RIP.CUInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag2")
@@ -1069,8 +1050,7 @@ instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_counter" where
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_counter" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bitfield_t_counter" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr RIP.CUInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_counter")
@@ -1084,8 +1064,7 @@ instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_reserved" where
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_reserved" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bitfield_t_reserved" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr RIP.CUInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_reserved")
@@ -1138,8 +1117,7 @@ instance RIP.FromFunPtr Processor_fn_t_Aux where
 
   fromFunPtr = hs_bindgen_0d4b3d0461629423
 
-instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapProcessor_fn_t_Aux" (RIP.Ptr Processor_fn_t_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapProcessor_fn_t_Aux" (RIP.Ptr Processor_fn_t_Aux) (RIP.Ptr (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapProcessor_fn_t_Aux")
@@ -1177,8 +1155,7 @@ newtype Processor_fn_t = Processor_fn_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Processor_fn_t_Aux
-         ) => RIP.HasField "unwrapProcessor_fn_t" (RIP.Ptr Processor_fn_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapProcessor_fn_t" (RIP.Ptr Processor_fn_t) (RIP.Ptr (RIP.FunPtr Processor_fn_t_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapProcessor_fn_t")
@@ -1210,8 +1187,7 @@ newtype Filename_t = Filename_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 256 RIP.CChar
-         ) => RIP.HasField "unwrapFilename_t" (RIP.Ptr Filename_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFilename_t" (RIP.Ptr Filename_t) (RIP.Ptr (CA.ConstantArray 256 RIP.CChar)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFilename_t")
@@ -1277,8 +1253,7 @@ instance HasCField.HasCField Flexible_array_Aux "flexible_array_count" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "flexible_array_count" (RIP.Ptr Flexible_array_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "flexible_array_count" (RIP.Ptr Flexible_array_Aux) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"flexible_array_count")
@@ -1376,8 +1351,7 @@ instance HasCField.HasCField Dyn_array_t "dyn_array_t_data" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "dyn_array_t_data" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+instance RIP.HasField "dyn_array_t_data" (RIP.Ptr Dyn_array_t) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dyn_array_t_data")
@@ -1389,8 +1363,7 @@ instance HasCField.HasCField Dyn_array_t "dyn_array_t_size" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "dyn_array_t_size" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+instance RIP.HasField "dyn_array_t_size" (RIP.Ptr Dyn_array_t) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dyn_array_t_size")
@@ -1402,8 +1375,7 @@ instance HasCField.HasCField Dyn_array_t "dyn_array_t_capacity" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "dyn_array_t_capacity" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+instance RIP.HasField "dyn_array_t_capacity" (RIP.Ptr Dyn_array_t) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dyn_array_t_capacity")
@@ -1469,8 +1441,7 @@ instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_pos_x" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_pos_x" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_x")
@@ -1482,8 +1453,7 @@ instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_pos_y" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_pos_y" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_y")
@@ -1549,8 +1519,7 @@ instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_w" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_dim_w" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_dim_w" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_w")
@@ -1562,8 +1531,7 @@ instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_h" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_dim_h" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_dim_h" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_h")
@@ -1637,8 +1605,7 @@ instance HasCField.HasCField Multi_anon_t "multi_anon_t_pos" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Multi_anon_t_pos
-         ) => RIP.HasField "multi_anon_t_pos" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_pos" (RIP.Ptr Multi_anon_t) (RIP.Ptr Multi_anon_t_pos) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos")
@@ -1650,8 +1617,7 @@ instance HasCField.HasCField Multi_anon_t "multi_anon_t_dim" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ Multi_anon_t_dim
-         ) => RIP.HasField "multi_anon_t_dim" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
+instance RIP.HasField "multi_anon_t_dim" (RIP.Ptr Multi_anon_t) (RIP.Ptr Multi_anon_t_dim) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim")
@@ -1719,8 +1685,7 @@ instance HasCField.HasCField Named_inner "named_inner_nx" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_inner_nx" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
+instance RIP.HasField "named_inner_nx" (RIP.Ptr Named_inner) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"named_inner_nx")
@@ -1732,8 +1697,7 @@ instance HasCField.HasCField Named_inner "named_inner_ny" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_inner_ny" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
+instance RIP.HasField "named_inner_ny" (RIP.Ptr Named_inner) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"named_inner_ny")
@@ -1801,8 +1765,7 @@ instance HasCField.HasCField Named_outer "named_outer_inner_field" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Named_inner
-         ) => RIP.HasField "named_outer_inner_field" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
+instance RIP.HasField "named_outer_inner_field" (RIP.Ptr Named_outer) (RIP.Ptr Named_inner) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"named_outer_inner_field")
@@ -1814,8 +1777,7 @@ instance HasCField.HasCField Named_outer "named_outer_nz" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_outer_nz" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
+instance RIP.HasField "named_outer_nz" (RIP.Ptr Named_outer) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"named_outer_nz")
@@ -1870,8 +1832,7 @@ instance HasCField.HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a" wh
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_mid_anon_field_deep_a" (RIP.Ptr Deep_mid_anon_field) (RIP.Ptr ty) where
+instance RIP.HasField "deep_mid_anon_field_deep_a" (RIP.Ptr Deep_mid_anon_field) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field_deep_a")
@@ -1938,8 +1899,7 @@ instance HasCField.HasCField Deep_mid "deep_mid_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_mid_m" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
+instance RIP.HasField "deep_mid_m" (RIP.Ptr Deep_mid) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"deep_mid_m")
@@ -1951,8 +1911,7 @@ instance HasCField.HasCField Deep_mid "deep_mid_anon_field" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Deep_mid_anon_field
-         ) => RIP.HasField "deep_mid_anon_field" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
+instance RIP.HasField "deep_mid_anon_field" (RIP.Ptr Deep_mid) (RIP.Ptr Deep_mid_anon_field) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field")
@@ -2020,8 +1979,7 @@ instance HasCField.HasCField Deep_outer "deep_outer_mid_field" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Deep_mid
-         ) => RIP.HasField "deep_outer_mid_field" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
+instance RIP.HasField "deep_outer_mid_field" (RIP.Ptr Deep_outer) (RIP.Ptr Deep_mid) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"deep_outer_mid_field")
@@ -2032,8 +1990,7 @@ instance HasCField.HasCField Deep_outer "deep_outer_o" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_outer_o" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
+instance RIP.HasField "deep_outer_o" (RIP.Ptr Deep_outer) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"deep_outer_o")
@@ -2099,8 +2056,7 @@ instance HasCField.HasCField Unnamed_field_t_ua "unnamed_field_t_ua_ua" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_ua_ua" (RIP.Ptr Unnamed_field_t_ua) (RIP.Ptr ty) where
+instance RIP.HasField "unnamed_field_t_ua_ua" (RIP.Ptr Unnamed_field_t_ua) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_ua_ua")
@@ -2112,8 +2068,7 @@ instance HasCField.HasCField Unnamed_field_t_ua "unnamed_field_t_ua_ub" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_ua_ub" (RIP.Ptr Unnamed_field_t_ua) (RIP.Ptr ty) where
+instance RIP.HasField "unnamed_field_t_ua_ub" (RIP.Ptr Unnamed_field_t_ua) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_ua_ub")
@@ -2197,8 +2152,7 @@ instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_before" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_before" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+instance RIP.HasField "unnamed_field_t_before" (RIP.Ptr Unnamed_field_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_before")
@@ -2210,8 +2164,7 @@ instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_ua" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Unnamed_field_t_ua
-         ) => RIP.HasField "unnamed_field_t_ua" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+instance RIP.HasField "unnamed_field_t_ua" (RIP.Ptr Unnamed_field_t) (RIP.Ptr Unnamed_field_t_ua) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_ua")
@@ -2223,8 +2176,7 @@ instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_after" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_after" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+instance RIP.HasField "unnamed_field_t_after" (RIP.Ptr Unnamed_field_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_after")
@@ -2259,8 +2211,7 @@ newtype Api_version_t = Api_version_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapApi_version_t" (RIP.Ptr Api_version_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapApi_version_t" (RIP.Ptr Api_version_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapApi_version_t")

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/th.txt
@@ -588,8 +588,9 @@ newtype Size_type
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapSize_type" (Ptr Size_type) (Ptr ty)
+instance HasField "unwrapSize_type"
+                  (Ptr Size_type)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"unwrapSize_type")
 instance HasCField Size_type "unwrapSize_type"
     where type CFieldType Size_type
@@ -652,8 +653,7 @@ instance Read Color_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr ty)
+instance HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapColor_enum")
 instance HasCField Color_enum "unwrapColor_enum"
     where type CFieldType Color_enum "unwrapColor_enum" = CUInt
@@ -725,10 +725,9 @@ instance ToFunPtr Event_callback_t_Aux
     where toFunPtr = hs_bindgen_111918b0aee2a7fb
 instance FromFunPtr Event_callback_t_Aux
     where fromFunPtr = hs_bindgen_9e9d478c2d75628c
-instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
-         HasField "unwrapEvent_callback_t_Aux"
+instance HasField "unwrapEvent_callback_t_Aux"
                   (Ptr Event_callback_t_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> Ptr Void -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t_Aux")
 instance HasCField Event_callback_t_Aux
                    "unwrapEvent_callback_t_Aux"
@@ -757,8 +756,9 @@ newtype Event_callback_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Event_callback_t_Aux) =>
-         HasField "unwrapEvent_callback_t" (Ptr Event_callback_t) (Ptr ty)
+instance HasField "unwrapEvent_callback_t"
+                  (Ptr Event_callback_t)
+                  (Ptr (FunPtr Event_callback_t_Aux))
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t")
 instance HasCField Event_callback_t "unwrapEvent_callback_t"
     where type CFieldType Event_callback_t
@@ -840,35 +840,40 @@ instance HasCField Config_t "config_t_id"
     where type CFieldType Config_t
                           "config_t_id" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "config_t_id" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_id"
+                  (Ptr Config_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"config_t_id")
 instance HasCField Config_t "config_t_name"
     where type CFieldType Config_t "config_t_name" = ConstantArray 64
                                                                    CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty (ConstantArray 64 CChar) =>
-         HasField "config_t_name" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_name"
+                  (Ptr Config_t)
+                  (Ptr (ConstantArray 64 CChar))
     where getField = fromPtr (Proxy @"config_t_name")
 instance HasCField Config_t "config_t_flags"
     where type CFieldType Config_t
                           "config_t_flags" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 68
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "config_t_flags" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_flags"
+                  (Ptr Config_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"config_t_flags")
 instance HasCField Config_t "config_t_callback"
     where type CFieldType Config_t
                           "config_t_callback" = Event_callback_t
           offset# = \_ -> \_ -> 72
-instance (~) ty Event_callback_t =>
-         HasField "config_t_callback" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_callback"
+                  (Ptr Config_t)
+                  (Ptr Event_callback_t)
     where getField = fromPtr (Proxy @"config_t_callback")
 instance HasCField Config_t "config_t_user_data"
     where type CFieldType Config_t "config_t_user_data" = Ptr Void
           offset# = \_ -> \_ -> 80
-instance (~) ty (Ptr Void) =>
-         HasField "config_t_user_data" (Ptr Config_t) (Ptr ty)
+instance HasField "config_t_user_data"
+                  (Ptr Config_t)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"config_t_user_data")
 {-| Enumeration with documented values.
 
@@ -912,8 +917,9 @@ instance Read Status_code_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CInt =>
-         HasField "unwrapStatus_code_t" (Ptr Status_code_t) (Ptr ty)
+instance HasField "unwrapStatus_code_t"
+                  (Ptr Status_code_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapStatus_code_t")
 instance HasCField Status_code_t "unwrapStatus_code_t"
     where type CFieldType Status_code_t "unwrapStatus_code_t" = CInt
@@ -1009,20 +1015,18 @@ instance HasCField Data_union_t_as_parts
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_low" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "data_union_t_as_parts_low"
+instance HasField "data_union_t_as_parts_low"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_low")
 instance HasCField Data_union_t_as_parts
                    "data_union_t_as_parts_high"
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_high" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "data_union_t_as_parts_high"
+instance HasField "data_union_t_as_parts_high"
                   (Ptr Data_union_t_as_parts)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_high")
 {-| Union with documented fields.
 
@@ -1190,29 +1194,33 @@ instance HasCField Data_union_t "data_union_t_as_int"
     where type CFieldType Data_union_t
                           "data_union_t_as_int" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "data_union_t_as_int" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_int"
+                  (Ptr Data_union_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"data_union_t_as_int")
 instance HasCField Data_union_t "data_union_t_as_float"
     where type CFieldType Data_union_t "data_union_t_as_float" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "data_union_t_as_float" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_float"
+                  (Ptr Data_union_t)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"data_union_t_as_float")
 instance HasCField Data_union_t "data_union_t_as_bytes"
     where type CFieldType Data_union_t
                           "data_union_t_as_bytes" = ConstantArray 4
                                                                   HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 HsBindgen.Runtime.LibC.Word8) =>
-         HasField "data_union_t_as_bytes" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_bytes"
+                  (Ptr Data_union_t)
+                  (Ptr (ConstantArray 4 HsBindgen.Runtime.LibC.Word8))
     where getField = fromPtr (Proxy @"data_union_t_as_bytes")
 instance HasCField Data_union_t "data_union_t_as_parts"
     where type CFieldType Data_union_t
                           "data_union_t_as_parts" = Data_union_t_as_parts
           offset# = \_ -> \_ -> 0
-instance (~) ty Data_union_t_as_parts =>
-         HasField "data_union_t_as_parts" (Ptr Data_union_t) (Ptr ty)
+instance HasField "data_union_t_as_parts"
+                  (Ptr Data_union_t)
+                  (Ptr Data_union_t_as_parts)
     where getField = fromPtr (Proxy @"data_union_t_as_parts")
 {-| Bit field structure.
 
@@ -1278,29 +1286,33 @@ instance HasCBitfield Bitfield_t "bitfield_t_flag1"
     where type CBitfieldType Bitfield_t "bitfield_t_flag1" = CUInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 1
-instance (~) ty CUInt =>
-         HasField "bitfield_t_flag1" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_flag1"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_flag1")
 instance HasCBitfield Bitfield_t "bitfield_t_flag2"
     where type CBitfieldType Bitfield_t "bitfield_t_flag2" = CUInt
           bitfieldOffset# = \_ -> \_ -> 1
           bitfieldWidth# = \_ -> \_ -> 1
-instance (~) ty CUInt =>
-         HasField "bitfield_t_flag2" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_flag2"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_flag2")
 instance HasCBitfield Bitfield_t "bitfield_t_counter"
     where type CBitfieldType Bitfield_t "bitfield_t_counter" = CUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CUInt =>
-         HasField "bitfield_t_counter" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_counter"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_counter")
 instance HasCBitfield Bitfield_t "bitfield_t_reserved"
     where type CBitfieldType Bitfield_t "bitfield_t_reserved" = CUInt
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CUInt =>
-         HasField "bitfield_t_reserved" (Ptr Bitfield_t) (BitfieldPtr ty)
+instance HasField "bitfield_t_reserved"
+                  (Ptr Bitfield_t)
+                  (BitfieldPtr CUInt)
     where getField = toPtr (Proxy @"bitfield_t_reserved")
 {-| Auxiliary type used by 'Processor_fn_t'
 
@@ -1339,10 +1351,9 @@ instance ToFunPtr Processor_fn_t_Aux
     where toFunPtr = hs_bindgen_d4e16471c82d5df0
 instance FromFunPtr Processor_fn_t_Aux
     where fromFunPtr = hs_bindgen_0d4b3d0461629423
-instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
-         HasField "unwrapProcessor_fn_t_Aux"
+instance HasField "unwrapProcessor_fn_t_Aux"
                   (Ptr Processor_fn_t_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> Ptr Void -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t_Aux")
 instance HasCField Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux"
     where type CFieldType Processor_fn_t_Aux
@@ -1370,8 +1381,9 @@ newtype Processor_fn_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Processor_fn_t_Aux) =>
-         HasField "unwrapProcessor_fn_t" (Ptr Processor_fn_t) (Ptr ty)
+instance HasField "unwrapProcessor_fn_t"
+                  (Ptr Processor_fn_t)
+                  (Ptr (FunPtr Processor_fn_t_Aux))
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t")
 instance HasCField Processor_fn_t "unwrapProcessor_fn_t"
     where type CFieldType Processor_fn_t
@@ -1389,8 +1401,9 @@ newtype Filename_t
     = Filename_t {unwrapFilename_t :: (ConstantArray 256 CChar)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 256 CChar) =>
-         HasField "unwrapFilename_t" (Ptr Filename_t) (Ptr ty)
+instance HasField "unwrapFilename_t"
+                  (Ptr Filename_t)
+                  (Ptr (ConstantArray 256 CChar))
     where getField = fromPtr (Proxy @"unwrapFilename_t")
 instance HasCField Filename_t "unwrapFilename_t"
     where type CFieldType Filename_t
@@ -1430,8 +1443,9 @@ instance HasCField Flexible_array_Aux "flexible_array_count"
     where type CFieldType Flexible_array_Aux
                           "flexible_array_count" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
+instance HasField "flexible_array_count"
+                  (Ptr Flexible_array_Aux)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"flexible_array_count")
 instance Offset CInt Flexible_array_Aux
     where offset = \_proxy_0 -> 8
@@ -1489,22 +1503,25 @@ deriving via (EquivStorable Dyn_array_t) instance Storable Dyn_array_t
 instance HasCField Dyn_array_t "dyn_array_t_data"
     where type CFieldType Dyn_array_t "dyn_array_t_data" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "dyn_array_t_data" (Ptr Dyn_array_t) (Ptr ty)
+instance HasField "dyn_array_t_data"
+                  (Ptr Dyn_array_t)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"dyn_array_t_data")
 instance HasCField Dyn_array_t "dyn_array_t_size"
     where type CFieldType Dyn_array_t
                           "dyn_array_t_size" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "dyn_array_t_size" (Ptr Dyn_array_t) (Ptr ty)
+instance HasField "dyn_array_t_size"
+                  (Ptr Dyn_array_t)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"dyn_array_t_size")
 instance HasCField Dyn_array_t "dyn_array_t_capacity"
     where type CFieldType Dyn_array_t
                           "dyn_array_t_capacity" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 16
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "dyn_array_t_capacity" (Ptr Dyn_array_t) (Ptr ty)
+instance HasField "dyn_array_t_capacity"
+                  (Ptr Dyn_array_t)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"dyn_array_t_capacity")
 {-| __C declaration:__ @struct \@multi_anon_t_pos@
 
@@ -1546,15 +1563,17 @@ instance HasCField Multi_anon_t_pos "multi_anon_t_pos_x"
     where type CFieldType Multi_anon_t_pos
                           "multi_anon_t_pos_x" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_pos_x" (Ptr Multi_anon_t_pos) (Ptr ty)
+instance HasField "multi_anon_t_pos_x"
+                  (Ptr Multi_anon_t_pos)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"multi_anon_t_pos_x")
 instance HasCField Multi_anon_t_pos "multi_anon_t_pos_y"
     where type CFieldType Multi_anon_t_pos
                           "multi_anon_t_pos_y" = CFloat
           offset# = \_ -> \_ -> 4
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_pos_y" (Ptr Multi_anon_t_pos) (Ptr ty)
+instance HasField "multi_anon_t_pos_y"
+                  (Ptr Multi_anon_t_pos)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"multi_anon_t_pos_y")
 {-| __C declaration:__ @struct \@multi_anon_t_dim@
 
@@ -1596,15 +1615,17 @@ instance HasCField Multi_anon_t_dim "multi_anon_t_dim_w"
     where type CFieldType Multi_anon_t_dim
                           "multi_anon_t_dim_w" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_dim_w" (Ptr Multi_anon_t_dim) (Ptr ty)
+instance HasField "multi_anon_t_dim_w"
+                  (Ptr Multi_anon_t_dim)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"multi_anon_t_dim_w")
 instance HasCField Multi_anon_t_dim "multi_anon_t_dim_h"
     where type CFieldType Multi_anon_t_dim
                           "multi_anon_t_dim_h" = CFloat
           offset# = \_ -> \_ -> 4
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_dim_h" (Ptr Multi_anon_t_dim) (Ptr ty)
+instance HasField "multi_anon_t_dim_h"
+                  (Ptr Multi_anon_t_dim)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"multi_anon_t_dim_h")
 {-| Struct with multiple anonymous inner structs.
 
@@ -1654,15 +1675,17 @@ instance HasCField Multi_anon_t "multi_anon_t_pos"
     where type CFieldType Multi_anon_t
                           "multi_anon_t_pos" = Multi_anon_t_pos
           offset# = \_ -> \_ -> 0
-instance (~) ty Multi_anon_t_pos =>
-         HasField "multi_anon_t_pos" (Ptr Multi_anon_t) (Ptr ty)
+instance HasField "multi_anon_t_pos"
+                  (Ptr Multi_anon_t)
+                  (Ptr Multi_anon_t_pos)
     where getField = fromPtr (Proxy @"multi_anon_t_pos")
 instance HasCField Multi_anon_t "multi_anon_t_dim"
     where type CFieldType Multi_anon_t
                           "multi_anon_t_dim" = Multi_anon_t_dim
           offset# = \_ -> \_ -> 8
-instance (~) ty Multi_anon_t_dim =>
-         HasField "multi_anon_t_dim" (Ptr Multi_anon_t) (Ptr ty)
+instance HasField "multi_anon_t_dim"
+                  (Ptr Multi_anon_t)
+                  (Ptr Multi_anon_t_dim)
     where getField = fromPtr (Proxy @"multi_anon_t_dim")
 {-| Named inner struct
 
@@ -1705,14 +1728,12 @@ deriving via (EquivStorable Named_inner) instance Storable Named_inner
 instance HasCField Named_inner "named_inner_nx"
     where type CFieldType Named_inner "named_inner_nx" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "named_inner_nx" (Ptr Named_inner) (Ptr ty)
+instance HasField "named_inner_nx" (Ptr Named_inner) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_inner_nx")
 instance HasCField Named_inner "named_inner_ny"
     where type CFieldType Named_inner "named_inner_ny" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "named_inner_ny" (Ptr Named_inner) (Ptr ty)
+instance HasField "named_inner_ny" (Ptr Named_inner) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_inner_ny")
 {-| Struct with a named inner struct.
 
@@ -1756,14 +1777,14 @@ instance HasCField Named_outer "named_outer_inner_field"
     where type CFieldType Named_outer
                           "named_outer_inner_field" = Named_inner
           offset# = \_ -> \_ -> 0
-instance (~) ty Named_inner =>
-         HasField "named_outer_inner_field" (Ptr Named_outer) (Ptr ty)
+instance HasField "named_outer_inner_field"
+                  (Ptr Named_outer)
+                  (Ptr Named_inner)
     where getField = fromPtr (Proxy @"named_outer_inner_field")
 instance HasCField Named_outer "named_outer_nz"
     where type CFieldType Named_outer "named_outer_nz" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "named_outer_nz" (Ptr Named_outer) (Ptr ty)
+instance HasField "named_outer_nz" (Ptr Named_outer) (Ptr CInt)
     where getField = fromPtr (Proxy @"named_outer_nz")
 {-| __C declaration:__ @struct \@deep_mid_anon_field@
 
@@ -1795,10 +1816,9 @@ instance HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a"
     where type CFieldType Deep_mid_anon_field
                           "deep_mid_anon_field_deep_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "deep_mid_anon_field_deep_a"
+instance HasField "deep_mid_anon_field_deep_a"
                   (Ptr Deep_mid_anon_field)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"deep_mid_anon_field_deep_a")
 {-| The named mid-level struct
 
@@ -1841,15 +1861,15 @@ deriving via (EquivStorable Deep_mid) instance Storable Deep_mid
 instance HasCField Deep_mid "deep_mid_m"
     where type CFieldType Deep_mid "deep_mid_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "deep_mid_m" (Ptr Deep_mid) (Ptr ty)
+instance HasField "deep_mid_m" (Ptr Deep_mid) (Ptr CInt)
     where getField = fromPtr (Proxy @"deep_mid_m")
 instance HasCField Deep_mid "deep_mid_anon_field"
     where type CFieldType Deep_mid
                           "deep_mid_anon_field" = Deep_mid_anon_field
           offset# = \_ -> \_ -> 4
-instance (~) ty Deep_mid_anon_field =>
-         HasField "deep_mid_anon_field" (Ptr Deep_mid) (Ptr ty)
+instance HasField "deep_mid_anon_field"
+                  (Ptr Deep_mid)
+                  (Ptr Deep_mid_anon_field)
     where getField = fromPtr (Proxy @"deep_mid_anon_field")
 {-| Deeply nested mix of named and anonymous structs.
 
@@ -1892,14 +1912,14 @@ deriving via (EquivStorable Deep_outer) instance Storable Deep_outer
 instance HasCField Deep_outer "deep_outer_mid_field"
     where type CFieldType Deep_outer "deep_outer_mid_field" = Deep_mid
           offset# = \_ -> \_ -> 0
-instance (~) ty Deep_mid =>
-         HasField "deep_outer_mid_field" (Ptr Deep_outer) (Ptr ty)
+instance HasField "deep_outer_mid_field"
+                  (Ptr Deep_outer)
+                  (Ptr Deep_mid)
     where getField = fromPtr (Proxy @"deep_outer_mid_field")
 instance HasCField Deep_outer "deep_outer_o"
     where type CFieldType Deep_outer "deep_outer_o" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "deep_outer_o" (Ptr Deep_outer) (Ptr ty)
+instance HasField "deep_outer_o" (Ptr Deep_outer) (Ptr CInt)
     where getField = fromPtr (Proxy @"deep_outer_o")
 {-| __C declaration:__ @struct \@unnamed_field_t_ua@
 
@@ -1941,15 +1961,17 @@ instance HasCField Unnamed_field_t_ua "unnamed_field_t_ua_ua"
     where type CFieldType Unnamed_field_t_ua
                           "unnamed_field_t_ua_ua" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_ua_ua" (Ptr Unnamed_field_t_ua) (Ptr ty)
+instance HasField "unnamed_field_t_ua_ua"
+                  (Ptr Unnamed_field_t_ua)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unnamed_field_t_ua_ua")
 instance HasCField Unnamed_field_t_ua "unnamed_field_t_ua_ub"
     where type CFieldType Unnamed_field_t_ua
                           "unnamed_field_t_ua_ub" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_ua_ub" (Ptr Unnamed_field_t_ua) (Ptr ty)
+instance HasField "unnamed_field_t_ua_ub"
+                  (Ptr Unnamed_field_t_ua)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unnamed_field_t_ua_ub")
 {-| Struct with unnamed anonymous field.
 
@@ -2005,22 +2027,25 @@ instance HasCField Unnamed_field_t "unnamed_field_t_before"
     where type CFieldType Unnamed_field_t
                           "unnamed_field_t_before" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_before" (Ptr Unnamed_field_t) (Ptr ty)
+instance HasField "unnamed_field_t_before"
+                  (Ptr Unnamed_field_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unnamed_field_t_before")
 instance HasCField Unnamed_field_t "unnamed_field_t_ua"
     where type CFieldType Unnamed_field_t
                           "unnamed_field_t_ua" = Unnamed_field_t_ua
           offset# = \_ -> \_ -> 4
-instance (~) ty Unnamed_field_t_ua =>
-         HasField "unnamed_field_t_ua" (Ptr Unnamed_field_t) (Ptr ty)
+instance HasField "unnamed_field_t_ua"
+                  (Ptr Unnamed_field_t)
+                  (Ptr Unnamed_field_t_ua)
     where getField = fromPtr (Proxy @"unnamed_field_t_ua")
 instance HasCField Unnamed_field_t "unnamed_field_t_after"
     where type CFieldType Unnamed_field_t
                           "unnamed_field_t_after" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_after" (Ptr Unnamed_field_t) (Ptr ty)
+instance HasField "unnamed_field_t_after"
+                  (Ptr Unnamed_field_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unnamed_field_t_after")
 {-| API version number (not in any group).
 
@@ -2048,8 +2073,9 @@ newtype Api_version_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapApi_version_t" (Ptr Api_version_t) (Ptr ty)
+instance HasField "unwrapApi_version_t"
+                  (Ptr Api_version_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapApi_version_t")
 instance HasCField Api_version_t "unwrapApi_version_t"
     where type CFieldType Api_version_t "unwrapApi_version_t" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -84,8 +82,7 @@ instance HasCField.HasCField Banner_point "banner_point_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "banner_point_x" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
+instance RIP.HasField "banner_point_x" (RIP.Ptr Banner_point) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"banner_point_x")
@@ -97,8 +94,7 @@ instance HasCField.HasCField Banner_point "banner_point_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "banner_point_y" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
+instance RIP.HasField "banner_point_y" (RIP.Ptr Banner_point) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"banner_point_y")

--- a/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/th.txt
@@ -61,14 +61,12 @@ deriving via (EquivStorable Banner_point) instance Storable Banner_point
 instance HasCField Banner_point "banner_point_x"
     where type CFieldType Banner_point "banner_point_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "banner_point_x" (Ptr Banner_point) (Ptr ty)
+instance HasField "banner_point_x" (Ptr Banner_point) (Ptr CInt)
     where getField = fromPtr (Proxy @"banner_point_x")
 instance HasCField Banner_point "banner_point_y"
     where type CFieldType Banner_point "banner_point_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "banner_point_y" (Ptr Banner_point) (Ptr ty)
+instance HasField "banner_point_y" (Ptr Banner_point) (Ptr CInt)
     where getField = fromPtr (Proxy @"banner_point_y")
 -- __unique:__ @test_documentationjavadoc_banner_Example_Safe_banner_double@
 foreign import ccall safe "hs_bindgen_7d3fd818d0780e11" hs_bindgen_7d3fd818d0780e11_base ::

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype Adio'0301s = Adio'0301s
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapAdio'0301s" (RIP.Ptr Adio'0301s) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapAdio'0301s" (RIP.Ptr Adio'0301s) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapAdio'0301s")
@@ -91,8 +88,7 @@ newtype C数字 = C数字
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapC\25968\23383" (RIP.Ptr C数字) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapC\25968\23383" (RIP.Ptr C数字) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapC\25968\23383")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/th.txt
@@ -92,8 +92,7 @@ newtype Adio'0301s
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr ty)
+instance HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapAdio'0301s")
 instance HasCField Adio'0301s "unwrapAdio'0301s"
     where type CFieldType Adio'0301s "unwrapAdio'0301s" = CInt
@@ -122,8 +121,7 @@ newtype C数字
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr ty)
+instance HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapC\25968\23383")
 instance HasCField C数字 "unwrapC\25968\23383"
     where type CFieldType C数字 "unwrapC\25968\23383" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -79,8 +77,7 @@ instance HasCField.HasCField Some_struct_field1 "some_struct_field1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "some_struct_field1_x" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
+instance RIP.HasField "some_struct_field1_x" (RIP.Ptr Some_struct_field1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"some_struct_field1_x")
@@ -92,8 +89,7 @@ instance HasCField.HasCField Some_struct_field1 "some_struct_field1_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "some_struct_field1_y" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
+instance RIP.HasField "some_struct_field1_y" (RIP.Ptr Some_struct_field1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"some_struct_field1_y")
@@ -164,8 +160,7 @@ instance HasCField.HasCField Some_struct "some_struct_field1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field1" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+instance RIP.HasField "some_struct_field1" (RIP.Ptr Some_struct) (RIP.Ptr Some_struct_field1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"some_struct_field1")
@@ -177,8 +172,7 @@ instance HasCField.HasCField Some_struct "some_struct_field2" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field2" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+instance RIP.HasField "some_struct_field2" (RIP.Ptr Some_struct) (RIP.Ptr Some_struct_field1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"some_struct_field2")
@@ -190,8 +184,7 @@ instance HasCField.HasCField Some_struct "some_struct_field3" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field3" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+instance RIP.HasField "some_struct_field3" (RIP.Ptr Some_struct) (RIP.Ptr Some_struct_field1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"some_struct_field3")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -35,15 +35,17 @@ instance HasCField Some_struct_field1 "some_struct_field1_x"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "some_struct_field1_x" (Ptr Some_struct_field1) (Ptr ty)
+instance HasField "some_struct_field1_x"
+                  (Ptr Some_struct_field1)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"some_struct_field1_x")
 instance HasCField Some_struct_field1 "some_struct_field1_y"
     where type CFieldType Some_struct_field1
                           "some_struct_field1_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "some_struct_field1_y" (Ptr Some_struct_field1) (Ptr ty)
+instance HasField "some_struct_field1_y"
+                  (Ptr Some_struct_field1)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"some_struct_field1_y")
 {-| __C declaration:__ @struct some_struct@
 
@@ -89,20 +91,23 @@ instance HasCField Some_struct "some_struct_field1"
     where type CFieldType Some_struct
                           "some_struct_field1" = Some_struct_field1
           offset# = \_ -> \_ -> 0
-instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field1" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field1"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field1")
 instance HasCField Some_struct "some_struct_field2"
     where type CFieldType Some_struct
                           "some_struct_field2" = Some_struct_field1
           offset# = \_ -> \_ -> 8
-instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field2" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field2"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field2")
 instance HasCField Some_struct "some_struct_field3"
     where type CFieldType Some_struct
                           "some_struct_field3" = Some_struct_field1
           offset# = \_ -> \_ -> 16
-instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field3" (Ptr Some_struct) (Ptr ty)
+instance HasField "some_struct_field3"
+                  (Ptr Some_struct)
+                  (Ptr Some_struct_field1)
     where getField = fromPtr (Proxy @"some_struct_field3")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -84,8 +82,7 @@ instance HasCField.HasCField Point1a "point1a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point1a_x" (RIP.Ptr Point1a) (RIP.Ptr ty) where
+instance RIP.HasField "point1a_x" (RIP.Ptr Point1a) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"point1a_x")
 
@@ -95,8 +92,7 @@ instance HasCField.HasCField Point1a "point1a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point1a_y" (RIP.Ptr Point1a) (RIP.Ptr ty) where
+instance RIP.HasField "point1a_y" (RIP.Ptr Point1a) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"point1a_y")
 
@@ -117,8 +113,7 @@ newtype Point1b = Point1b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Point1a
-         ) => RIP.HasField "unwrapPoint1b" (RIP.Ptr Point1b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPoint1b" (RIP.Ptr Point1b) (RIP.Ptr Point1a) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPoint1b")
@@ -185,8 +180,7 @@ instance HasCField.HasCField Point2a "point2a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point2a_x" (RIP.Ptr Point2a) (RIP.Ptr ty) where
+instance RIP.HasField "point2a_x" (RIP.Ptr Point2a) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"point2a_x")
 
@@ -196,8 +190,7 @@ instance HasCField.HasCField Point2a "point2a_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point2a_y" (RIP.Ptr Point2a) (RIP.Ptr ty) where
+instance RIP.HasField "point2a_y" (RIP.Ptr Point2a) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"point2a_y")
 
@@ -219,8 +212,7 @@ newtype Point2b = Point2b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Point2a
-         ) => RIP.HasField "unwrapPoint2b" (RIP.Ptr Point2b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPoint2b" (RIP.Ptr Point2b) (RIP.Ptr (RIP.Ptr Point2a)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPoint2b")
@@ -289,8 +281,7 @@ instance HasCField.HasCField Point3a_Aux "point3a_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point3a_Aux_x" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "point3a_Aux_x" (RIP.Ptr Point3a_Aux) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"point3a_Aux_x")
@@ -302,8 +293,7 @@ instance HasCField.HasCField Point3a_Aux "point3a_Aux_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point3a_Aux_y" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "point3a_Aux_y" (RIP.Ptr Point3a_Aux) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"point3a_Aux_y")
@@ -326,8 +316,7 @@ newtype Point3a = Point3a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Point3a_Aux
-         ) => RIP.HasField "unwrapPoint3a" (RIP.Ptr Point3a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPoint3a" (RIP.Ptr Point3a) (RIP.Ptr (RIP.Ptr Point3a_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPoint3a")
@@ -357,8 +346,7 @@ newtype Point3b = Point3b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Point3a_Aux
-         ) => RIP.HasField "unwrapPoint3b" (RIP.Ptr Point3b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPoint3b" (RIP.Ptr Point3b) (RIP.Ptr (RIP.Ptr Point3a_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPoint3b")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -58,12 +58,12 @@ deriving via (EquivStorable Point1a) instance Storable Point1a
 instance HasCField Point1a "point1a_x"
     where type CFieldType Point1a "point1a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "point1a_x" (Ptr Point1a) (Ptr ty)
+instance HasField "point1a_x" (Ptr Point1a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point1a_x")
 instance HasCField Point1a "point1a_y"
     where type CFieldType Point1a "point1a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "point1a_y" (Ptr Point1a) (Ptr ty)
+instance HasField "point1a_y" (Ptr Point1a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point1a_y")
 {-| __C declaration:__ @point1b@
 
@@ -75,8 +75,7 @@ newtype Point1b
     = Point1b {unwrapPoint1b :: Point1a}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Point1a =>
-         HasField "unwrapPoint1b" (Ptr Point1b) (Ptr ty)
+instance HasField "unwrapPoint1b" (Ptr Point1b) (Ptr Point1a)
     where getField = fromPtr (Proxy @"unwrapPoint1b")
 instance HasCField Point1b "unwrapPoint1b"
     where type CFieldType Point1b "unwrapPoint1b" = Point1a
@@ -116,12 +115,12 @@ deriving via (EquivStorable Point2a) instance Storable Point2a
 instance HasCField Point2a "point2a_x"
     where type CFieldType Point2a "point2a_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "point2a_x" (Ptr Point2a) (Ptr ty)
+instance HasField "point2a_x" (Ptr Point2a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point2a_x")
 instance HasCField Point2a "point2a_y"
     where type CFieldType Point2a "point2a_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "point2a_y" (Ptr Point2a) (Ptr ty)
+instance HasField "point2a_y" (Ptr Point2a) (Ptr CInt)
     where getField = fromPtr (Proxy @"point2a_y")
 {-| __C declaration:__ @point2b@
 
@@ -137,8 +136,7 @@ newtype Point2b
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Point2a) =>
-         HasField "unwrapPoint2b" (Ptr Point2b) (Ptr ty)
+instance HasField "unwrapPoint2b" (Ptr Point2b) (Ptr (Ptr Point2a))
     where getField = fromPtr (Proxy @"unwrapPoint2b")
 instance HasCField Point2b "unwrapPoint2b"
     where type CFieldType Point2b "unwrapPoint2b" = Ptr Point2a
@@ -178,14 +176,12 @@ deriving via (EquivStorable Point3a_Aux) instance Storable Point3a_Aux
 instance HasCField Point3a_Aux "point3a_Aux_x"
     where type CFieldType Point3a_Aux "point3a_Aux_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr ty)
+instance HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"point3a_Aux_x")
 instance HasCField Point3a_Aux "point3a_Aux_y"
     where type CFieldType Point3a_Aux "point3a_Aux_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr ty)
+instance HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"point3a_Aux_y")
 {-| __C declaration:__ @point3a@
 
@@ -201,8 +197,9 @@ newtype Point3a
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Point3a_Aux) =>
-         HasField "unwrapPoint3a" (Ptr Point3a) (Ptr ty)
+instance HasField "unwrapPoint3a"
+                  (Ptr Point3a)
+                  (Ptr (Ptr Point3a_Aux))
     where getField = fromPtr (Proxy @"unwrapPoint3a")
 instance HasCField Point3a "unwrapPoint3a"
     where type CFieldType Point3a "unwrapPoint3a" = Ptr Point3a_Aux
@@ -221,8 +218,9 @@ newtype Point3b
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Point3a_Aux) =>
-         HasField "unwrapPoint3b" (Ptr Point3b) (Ptr ty)
+instance HasField "unwrapPoint3b"
+                  (Ptr Point3b)
+                  (Ptr (Ptr Point3a_Aux))
     where getField = fromPtr (Proxy @"unwrapPoint3b")
 instance HasCField Point3b "unwrapPoint3b"
     where type CFieldType Point3b "unwrapPoint3b" = Ptr Point3a_Aux

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -37,8 +35,7 @@ newtype FunPtr_Aux = FunPtr_Aux
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ (Foo -> IO ())
-         ) => RIP.HasField "unwrapFunPtr_Aux" (RIP.Ptr FunPtr_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunPtr_Aux" (RIP.Ptr FunPtr_Aux) (RIP.Ptr (Foo -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunPtr_Aux")
@@ -68,8 +65,7 @@ newtype FunPtr = FunPtr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr FunPtr_Aux
-         ) => RIP.HasField "unwrapFunPtr" (RIP.Ptr FunPtr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunPtr" (RIP.Ptr FunPtr) (RIP.Ptr (RIP.FunPtr FunPtr_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunPtr")
@@ -137,8 +133,7 @@ instance HasCField.HasCField Foo "foo_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_x" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_x" (RIP.Ptr Foo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_x")
 
@@ -148,7 +143,6 @@ instance HasCField.HasCField Foo "foo_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_y" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_y" (RIP.Ptr Foo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_y")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/th.txt
@@ -10,8 +10,9 @@
 newtype FunPtr_Aux
     = FunPtr_Aux {unwrapFunPtr_Aux :: (Foo -> IO ())}
     deriving stock Generic
-instance (~) ty (Foo -> IO ()) =>
-         HasField "unwrapFunPtr_Aux" (Ptr FunPtr_Aux) (Ptr ty)
+instance HasField "unwrapFunPtr_Aux"
+                  (Ptr FunPtr_Aux)
+                  (Ptr (Foo -> IO ()))
     where getField = fromPtr (Proxy @"unwrapFunPtr_Aux")
 instance HasCField FunPtr_Aux "unwrapFunPtr_Aux"
     where type CFieldType FunPtr_Aux "unwrapFunPtr_Aux" = Foo -> IO ()
@@ -30,8 +31,9 @@ newtype FunPtr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr FunPtr_Aux) =>
-         HasField "unwrapFunPtr" (Ptr FunPtr) (Ptr ty)
+instance HasField "unwrapFunPtr"
+                  (Ptr FunPtr)
+                  (Ptr (FunPtr FunPtr_Aux))
     where getField = fromPtr (Proxy @"unwrapFunPtr")
 instance HasCField FunPtr "unwrapFunPtr"
     where type CFieldType FunPtr "unwrapFunPtr" = FunPtr FunPtr_Aux
@@ -71,10 +73,10 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_x"
     where type CFieldType Foo "foo_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_x" (Ptr Foo) (Ptr ty)
+instance HasField "foo_x" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_x")
 instance HasCField Foo "foo_y"
     where type CFieldType Foo "foo_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "foo_y" (Ptr Foo) (Ptr ty)
+instance HasField "foo_y" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_y")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -12,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -107,8 +105,7 @@ instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "another_typedef_struct_t_foo" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "another_typedef_struct_t_foo" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_foo")
@@ -120,8 +117,7 @@ instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "another_typedef_struct_t_bar" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "another_typedef_struct_t_bar" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_bar")
@@ -205,8 +201,7 @@ instance Read Another_typedef_enum_e where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapAnother_typedef_enum_e" (RIP.Ptr Another_typedef_enum_e) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapAnother_typedef_enum_e" (RIP.Ptr Another_typedef_enum_e) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapAnother_typedef_enum_e")
@@ -291,8 +286,7 @@ newtype A_type_t = A_type_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA_type_t" (RIP.Ptr A_type_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA_type_t" (RIP.Ptr A_type_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapA_type_t")
@@ -331,8 +325,7 @@ newtype Var_t = Var_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapVar_t" (RIP.Ptr Var_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapVar_t" (RIP.Ptr Var_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapVar_t")
@@ -492,8 +485,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_0" whe
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "a_typedef_struct_t_field_0" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_0" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_0")
@@ -505,8 +497,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_1" whe
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "a_typedef_struct_t_field_1" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_1" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_1")
@@ -518,8 +509,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_2" whe
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "a_typedef_struct_t_field_2" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_2" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_2")
@@ -531,8 +521,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_3" whe
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "a_typedef_struct_t_field_3" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_3" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_3")
@@ -544,8 +533,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_4" whe
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ Another_typedef_struct_t
-         ) => RIP.HasField "a_typedef_struct_t_field_4" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_4" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr Another_typedef_struct_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_4")
@@ -557,8 +545,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_5" whe
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.Ptr Another_typedef_struct_t
-         ) => RIP.HasField "a_typedef_struct_t_field_5" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_5" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr (RIP.Ptr Another_typedef_struct_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_5")
@@ -570,8 +557,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_6" whe
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "a_typedef_struct_t_field_6" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_6" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr (RIP.Ptr RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_6")
@@ -583,8 +569,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_7" whe
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "a_typedef_struct_t_field_7" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_7" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr (CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_7")
@@ -596,8 +581,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_8" whe
 
   offset# = \_ -> \_ -> 60
 
-instance ( ty ~ Another_typedef_enum_e
-         ) => RIP.HasField "a_typedef_struct_t_field_8" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_8" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr Another_typedef_enum_e) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_8")
@@ -609,8 +593,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_9" whe
 
   offset# = \_ -> \_ -> 64
 
-instance ( ty ~ CA.ConstantArray 4 Another_typedef_enum_e
-         ) => RIP.HasField "a_typedef_struct_t_field_9" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_9" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr (CA.ConstantArray 4 Another_typedef_enum_e)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_9")
@@ -622,8 +605,7 @@ instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_10" wh
 
   offset# = \_ -> \_ -> 80
 
-instance ( ty ~ CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
-         ) => RIP.HasField "a_typedef_struct_t_field_10" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance RIP.HasField "a_typedef_struct_t_field_10" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr (CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_10")
@@ -746,8 +728,7 @@ instance Read A_typedef_enum_e where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unwrapA_typedef_enum_e" (RIP.Ptr A_typedef_enum_e) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA_typedef_enum_e" (RIP.Ptr A_typedef_enum_e) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapA_typedef_enum_e")
@@ -843,8 +824,7 @@ instance RIP.FromFunPtr Callback_t_Aux where
 
   fromFunPtr = hs_bindgen_d6debb4b8d5bb869
 
-instance ( ty ~ (RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)
-         ) => RIP.HasField "unwrapCallback_t_Aux" (RIP.Ptr Callback_t_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapCallback_t_Aux" (RIP.Ptr Callback_t_Aux) (RIP.Ptr (RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapCallback_t_Aux")
@@ -874,8 +854,7 @@ newtype Callback_t = Callback_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Callback_t_Aux
-         ) => RIP.HasField "unwrapCallback_t" (RIP.Ptr Callback_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapCallback_t" (RIP.Ptr Callback_t) (RIP.Ptr (RIP.FunPtr Callback_t_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapCallback_t")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -73,20 +73,18 @@ instance HasCField Another_typedef_struct_t
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_foo" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "another_typedef_struct_t_foo"
+instance HasField "another_typedef_struct_t_foo"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_foo")
 instance HasCField Another_typedef_struct_t
                    "another_typedef_struct_t_bar"
     where type CFieldType Another_typedef_struct_t
                           "another_typedef_struct_t_bar" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar =>
-         HasField "another_typedef_struct_t_bar"
+instance HasField "another_typedef_struct_t_bar"
                   (Ptr Another_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"another_typedef_struct_t_bar")
 {-| __C declaration:__ @enum another_typedef_enum_e@
 
@@ -128,10 +126,9 @@ instance Read Another_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapAnother_typedef_enum_e"
+instance HasField "unwrapAnother_typedef_enum_e"
                   (Ptr Another_typedef_enum_e)
-                  (Ptr ty)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapAnother_typedef_enum_e")
 instance HasCField Another_typedef_enum_e
                    "unwrapAnother_typedef_enum_e"
@@ -220,8 +217,7 @@ newtype A_type_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr ty)
+instance HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA_type_t")
 instance HasCField A_type_t "unwrapA_type_t"
     where type CFieldType A_type_t "unwrapA_type_t" = CInt
@@ -250,7 +246,7 @@ newtype Var_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapVar_t" (Ptr Var_t) (Ptr ty)
+instance HasField "unwrapVar_t" (Ptr Var_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapVar_t")
 instance HasCField Var_t "unwrapVar_t"
     where type CFieldType Var_t "unwrapVar_t" = CInt
@@ -367,93 +363,83 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_0"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_0" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "a_typedef_struct_t_field_0"
+instance HasField "a_typedef_struct_t_field_0"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_0")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_1"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_1" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 1
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "a_typedef_struct_t_field_1"
+instance HasField "a_typedef_struct_t_field_1"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_1")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_2"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_2" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "a_typedef_struct_t_field_2"
+instance HasField "a_typedef_struct_t_field_2"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_2")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_3"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_3" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 4
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "a_typedef_struct_t_field_3"
+instance HasField "a_typedef_struct_t_field_3"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_3")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_4"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_4" = Another_typedef_struct_t
           offset# = \_ -> \_ -> 8
-instance (~) ty Another_typedef_struct_t =>
-         HasField "a_typedef_struct_t_field_4"
+instance HasField "a_typedef_struct_t_field_4"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr Another_typedef_struct_t)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_4")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_5"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_5" = Ptr Another_typedef_struct_t
           offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr Another_typedef_struct_t) =>
-         HasField "a_typedef_struct_t_field_5"
+instance HasField "a_typedef_struct_t_field_5"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (Ptr Another_typedef_struct_t))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_5")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_6"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_6" = Ptr Void
           offset# = \_ -> \_ -> 24
-instance (~) ty (Ptr Void) =>
-         HasField "a_typedef_struct_t_field_6"
+instance HasField "a_typedef_struct_t_field_6"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_6")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_7"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_7" = ConstantArray 7
                                                                        HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 32
-instance (~) ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
-         HasField "a_typedef_struct_t_field_7"
+instance HasField "a_typedef_struct_t_field_7"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 7 HsBindgen.Runtime.LibC.Word32))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_7")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_8"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_8" = Another_typedef_enum_e
           offset# = \_ -> \_ -> 60
-instance (~) ty Another_typedef_enum_e =>
-         HasField "a_typedef_struct_t_field_8"
+instance HasField "a_typedef_struct_t_field_8"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr Another_typedef_enum_e)
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_8")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_9"
     where type CFieldType A_typedef_struct_t
                           "a_typedef_struct_t_field_9" = ConstantArray 4
                                                                        Another_typedef_enum_e
           offset# = \_ -> \_ -> 64
-instance (~) ty (ConstantArray 4 Another_typedef_enum_e) =>
-         HasField "a_typedef_struct_t_field_9"
+instance HasField "a_typedef_struct_t_field_9"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 4 Another_typedef_enum_e))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_9")
 instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
     where type CFieldType A_typedef_struct_t
@@ -461,11 +447,9 @@ instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
                                                                         (ConstantArray 3
                                                                                        Another_typedef_enum_e)
           offset# = \_ -> \_ -> 80
-instance (~) ty
-             (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)) =>
-         HasField "a_typedef_struct_t_field_10"
+instance HasField "a_typedef_struct_t_field_10"
                   (Ptr A_typedef_struct_t)
-                  (Ptr ty)
+                  (Ptr (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)))
     where getField = fromPtr (Proxy @"a_typedef_struct_t_field_10")
 {-| __C declaration:__ @macro A_DEFINE_0@
 
@@ -565,8 +549,9 @@ instance Read A_typedef_enum_e
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUChar =>
-         HasField "unwrapA_typedef_enum_e" (Ptr A_typedef_enum_e) (Ptr ty)
+instance HasField "unwrapA_typedef_enum_e"
+                  (Ptr A_typedef_enum_e)
+                  (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapA_typedef_enum_e")
 instance HasCField A_typedef_enum_e "unwrapA_typedef_enum_e"
     where type CFieldType A_typedef_enum_e
@@ -642,11 +627,10 @@ instance ToFunPtr Callback_t_Aux
     where toFunPtr = hs_bindgen_b6b6922e35047658
 instance FromFunPtr Callback_t_Aux
     where fromFunPtr = hs_bindgen_d6debb4b8d5bb869
-instance (~) ty
-             (Ptr Void ->
-              HsBindgen.Runtime.LibC.Word32 ->
-              IO HsBindgen.Runtime.LibC.Word32) =>
-         HasField "unwrapCallback_t_Aux" (Ptr Callback_t_Aux) (Ptr ty)
+instance HasField "unwrapCallback_t_Aux"
+                  (Ptr Callback_t_Aux)
+                  (Ptr (Ptr Void ->
+                        HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32))
     where getField = fromPtr (Proxy @"unwrapCallback_t_Aux")
 instance HasCField Callback_t_Aux "unwrapCallback_t_Aux"
     where type CFieldType Callback_t_Aux
@@ -668,8 +652,9 @@ newtype Callback_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Callback_t_Aux) =>
-         HasField "unwrapCallback_t" (Ptr Callback_t) (Ptr ty)
+instance HasField "unwrapCallback_t"
+                  (Ptr Callback_t)
+                  (Ptr (FunPtr Callback_t_Aux))
     where getField = fromPtr (Proxy @"unwrapCallback_t")
 instance HasCField Callback_t "unwrapCallback_t"
     where type CFieldType Callback_t

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,7 +68,7 @@ instance HasCField.HasCField A "dup" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "dup" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "dup" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dup")
 
@@ -121,6 +119,6 @@ instance HasCField.HasCField B "dup" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "dup" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "dup" (RIP.Ptr B) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dup")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "dup"
     where type CFieldType A "dup" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dup" (Ptr A) (Ptr ty)
+instance HasField "dup" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"dup")
 {-| __C declaration:__ @struct B@
 
@@ -55,5 +55,5 @@ deriving via (EquivStorable B) instance Storable B
 instance HasCField B "dup"
     where type CFieldType B "dup" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dup" (Ptr B) (Ptr ty)
+instance HasField "dup" (Ptr B) (Ptr CInt)
     where getField = fromPtr (Proxy @"dup")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -104,8 +102,7 @@ instance Read Test where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapTest" (RIP.Ptr Test) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTest" (RIP.Ptr Test) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTest")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -46,7 +46,7 @@ instance Read Test
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapTest" (Ptr Test) (Ptr ty)
+instance HasField "unwrapTest" (Ptr Test) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapTest")
 instance HasCField Test "unwrapTest"
     where type CFieldType Test "unwrapTest" = CUInt

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -78,8 +76,7 @@ instance HasCField.HasCField Pascal_Aux "pascal_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "pascal_len" (RIP.Ptr Pascal_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "pascal_len" (RIP.Ptr Pascal_Aux) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"pascal_len")
@@ -152,8 +149,7 @@ instance HasCField.HasCField Foo_bar "foo_bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_bar_x" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
+instance RIP.HasField "foo_bar_x" (RIP.Ptr Foo_bar) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_x")
 
@@ -163,8 +159,7 @@ instance HasCField.HasCField Foo_bar "foo_bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_bar_y" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
+instance RIP.HasField "foo_bar_y" (RIP.Ptr Foo_bar) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_y")
 
@@ -215,8 +210,7 @@ instance HasCField.HasCField Foo_Aux "foo_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_len" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "foo_len" (RIP.Ptr Foo_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_len")
 
@@ -288,8 +282,7 @@ instance HasCField.HasCField Diff_Aux "diff_first" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "diff_first" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "diff_first" (RIP.Ptr Diff_Aux) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"diff_first")
@@ -300,8 +293,7 @@ instance HasCField.HasCField Diff_Aux "diff_second" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "diff_second" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "diff_second" (RIP.Ptr Diff_Aux) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"diff_second")
@@ -368,8 +360,7 @@ instance HasCField.HasCField Triplets_Aux "triplets_len" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "triplets_len" (RIP.Ptr Triplets_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "triplets_len" (RIP.Ptr Triplets_Aux) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"triplets_len")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable Pascal_Aux) instance Storable Pascal_Aux
 instance HasCField Pascal_Aux "pascal_len"
     where type CFieldType Pascal_Aux "pascal_len" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
+instance HasField "pascal_len" (Ptr Pascal_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"pascal_len")
 instance Offset CChar Pascal_Aux
     where offset = \_proxy_0 -> 4
@@ -67,12 +66,12 @@ deriving via (EquivStorable Foo_bar) instance Storable Foo_bar
 instance HasCField Foo_bar "foo_bar_x"
     where type CFieldType Foo_bar "foo_bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_bar_x" (Ptr Foo_bar) (Ptr ty)
+instance HasField "foo_bar_x" (Ptr Foo_bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_bar_x")
 instance HasCField Foo_bar "foo_bar_y"
     where type CFieldType Foo_bar "foo_bar_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "foo_bar_y" (Ptr Foo_bar) (Ptr ty)
+instance HasField "foo_bar_y" (Ptr Foo_bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_bar_y")
 {-| __C declaration:__ @struct foo@
 
@@ -101,7 +100,7 @@ deriving via (EquivStorable Foo_Aux) instance Storable Foo_Aux
 instance HasCField Foo_Aux "foo_len"
     where type CFieldType Foo_Aux "foo_len" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
+instance HasField "foo_len" (Ptr Foo_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_len")
 instance Offset Foo_bar Foo_Aux
     where offset = \_proxy_0 -> 4
@@ -141,14 +140,12 @@ deriving via (EquivStorable Diff_Aux) instance Storable Diff_Aux
 instance HasCField Diff_Aux "diff_first"
     where type CFieldType Diff_Aux "diff_first" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "diff_first" (Ptr Diff_Aux) (Ptr ty)
+instance HasField "diff_first" (Ptr Diff_Aux) (Ptr CLong)
     where getField = fromPtr (Proxy @"diff_first")
 instance HasCField Diff_Aux "diff_second"
     where type CFieldType Diff_Aux "diff_second" = CChar
           offset# = \_ -> \_ -> 8
-instance (~) ty CChar =>
-         HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
+instance HasField "diff_second" (Ptr Diff_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"diff_second")
 instance Offset CChar Diff_Aux
     where offset = \_proxy_0 -> 9
@@ -182,8 +179,7 @@ deriving via (EquivStorable Triplets_Aux) instance Storable Triplets_Aux
 instance HasCField Triplets_Aux "triplets_len"
     where type CFieldType Triplets_Aux "triplets_len" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
+instance HasField "triplets_len" (Ptr Triplets_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"triplets_len")
 instance Offset (ConstantArray 3 CInt) Triplets_Aux
     where offset = \_proxy_0 -> 4

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,8 +68,7 @@ instance HasCField.HasCField Vector_Aux "vector_length" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vector_length" (RIP.Ptr Vector_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "vector_length" (RIP.Ptr Vector_Aux) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vector_length")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/th.txt
@@ -87,8 +87,7 @@ deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
 instance HasCField Vector_Aux "vector_length"
     where type CFieldType Vector_Aux "vector_length" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
+instance HasField "vector_length" (Ptr Vector_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"vector_length")
 instance Offset CLong Vector_Aux
     where offset = \_proxy_0 -> 8

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -81,8 +79,7 @@ instance HasCField.HasCField Pt "pt_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "pt_x" (RIP.Ptr Pt) (RIP.Ptr ty) where
+instance RIP.HasField "pt_x" (RIP.Ptr Pt) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"pt_x")
 
@@ -92,8 +89,7 @@ instance HasCField.HasCField Pt "pt_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "pt_y" (RIP.Ptr Pt) (RIP.Ptr ty) where
+instance RIP.HasField "pt_y" (RIP.Ptr Pt) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"pt_y")
 
@@ -165,7 +161,7 @@ instance HasCField.HasCField Rect "rect_tl" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ Pt) => RIP.HasField "rect_tl" (RIP.Ptr Rect) (RIP.Ptr ty) where
+instance RIP.HasField "rect_tl" (RIP.Ptr Rect) (RIP.Ptr Pt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"rect_tl")
 
@@ -175,6 +171,6 @@ instance HasCField.HasCField Rect "rect_br" where
 
   offset# = \_ -> \_ -> 16
 
-instance (ty ~ Pt) => RIP.HasField "rect_br" (RIP.Ptr Rect) (RIP.Ptr ty) where
+instance RIP.HasField "rect_br" (RIP.Ptr Rect) (RIP.Ptr Pt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"rect_br")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/th.txt
@@ -35,12 +35,12 @@ deriving via (EquivStorable Pt) instance Storable Pt
 instance HasCField Pt "pt_x"
     where type CFieldType Pt "pt_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble => HasField "pt_x" (Ptr Pt) (Ptr ty)
+instance HasField "pt_x" (Ptr Pt) (Ptr CDouble)
     where getField = fromPtr (Proxy @"pt_x")
 instance HasCField Pt "pt_y"
     where type CFieldType Pt "pt_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty CDouble => HasField "pt_y" (Ptr Pt) (Ptr ty)
+instance HasField "pt_y" (Ptr Pt) (Ptr CDouble)
     where getField = fromPtr (Proxy @"pt_y")
 {-| __C declaration:__ @macro CHILD_HEADER@
 
@@ -115,10 +115,10 @@ deriving via (EquivStorable Rect) instance Storable Rect
 instance HasCField Rect "rect_tl"
     where type CFieldType Rect "rect_tl" = Pt
           offset# = \_ -> \_ -> 0
-instance (~) ty Pt => HasField "rect_tl" (Ptr Rect) (Ptr ty)
+instance HasField "rect_tl" (Ptr Rect) (Ptr Pt)
     where getField = fromPtr (Proxy @"rect_tl")
 instance HasCField Rect "rect_br"
     where type CFieldType Rect "rect_br" = Pt
           offset# = \_ -> \_ -> 16
-instance (~) ty Pt => HasField "rect_br" (Ptr Rect) (Ptr ty)
+instance HasField "rect_br" (Ptr Rect) (Ptr Pt)
     where getField = fromPtr (Proxy @"rect_br")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -34,8 +32,7 @@ newtype Toggle = Toggle
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance ( ty ~ Block.Block (IO RIP.CBool)
-         ) => RIP.HasField "unwrapToggle" (RIP.Ptr Toggle) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapToggle" (RIP.Ptr Toggle) (RIP.Ptr (Block.Block (IO RIP.CBool))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapToggle")
@@ -59,8 +56,7 @@ newtype Counter = Counter
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance ( ty ~ Block.Block (IO RIP.CInt)
-         ) => RIP.HasField "unwrapCounter" (RIP.Ptr Counter) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapCounter" (RIP.Ptr Counter) (RIP.Ptr (Block.Block (IO RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapCounter")
@@ -84,8 +80,7 @@ newtype VarCounter = VarCounter
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance ( ty ~ Block.Block (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapVarCounter" (RIP.Ptr VarCounter) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapVarCounter" (RIP.Ptr VarCounter) (RIP.Ptr (Block.Block (RIP.CInt -> IO RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapVarCounter")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/th.txt
@@ -196,8 +196,9 @@ newtype Toggle
     = Toggle {unwrapToggle :: (Block (IO CBool))}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty (Block (IO CBool)) =>
-         HasField "unwrapToggle" (Ptr Toggle) (Ptr ty)
+instance HasField "unwrapToggle"
+                  (Ptr Toggle)
+                  (Ptr (Block (IO CBool)))
     where getField = fromPtr (Proxy @"unwrapToggle")
 instance HasCField Toggle "unwrapToggle"
     where type CFieldType Toggle "unwrapToggle" = Block (IO CBool)
@@ -212,8 +213,9 @@ newtype Counter
     = Counter {unwrapCounter :: (Block (IO CInt))}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty (Block (IO CInt)) =>
-         HasField "unwrapCounter" (Ptr Counter) (Ptr ty)
+instance HasField "unwrapCounter"
+                  (Ptr Counter)
+                  (Ptr (Block (IO CInt)))
     where getField = fromPtr (Proxy @"unwrapCounter")
 instance HasCField Counter "unwrapCounter"
     where type CFieldType Counter "unwrapCounter" = Block (IO CInt)
@@ -228,8 +230,9 @@ newtype VarCounter
     = VarCounter {unwrapVarCounter :: (Block (CInt -> IO CInt))}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty (Block (CInt -> IO CInt)) =>
-         HasField "unwrapVarCounter" (Ptr VarCounter) (Ptr ty)
+instance HasField "unwrapVarCounter"
+                  (Ptr VarCounter)
+                  (Ptr (Block (CInt -> IO CInt)))
     where getField = fromPtr (Proxy @"unwrapVarCounter")
 instance HasCField VarCounter "unwrapVarCounter"
     where type CFieldType VarCounter

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,6 +66,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/th.txt
@@ -107,7 +107,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
 foreign import ccall safe "hs_bindgen_32fb10fccaa5c64b" hs_bindgen_32fb10fccaa5c64b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -59,8 +57,7 @@ newtype Int16_T = Int16_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapInt16_T" (RIP.Ptr Int16_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt16_T" (RIP.Ptr Int16_T) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt16_T")
@@ -99,8 +96,7 @@ newtype Int32_T = Int32_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapInt32_T" (RIP.Ptr Int32_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt32_T" (RIP.Ptr Int32_T) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt32_T")
@@ -139,8 +135,7 @@ newtype Int64_T = Int64_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "unwrapInt64_T" (RIP.Ptr Int64_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt64_T" (RIP.Ptr Int64_T) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt64_T")
@@ -207,8 +202,7 @@ instance HasCField.HasCField Cint16_T "cint16_T_re" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Int16_T
-         ) => RIP.HasField "cint16_T_re" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
+instance RIP.HasField "cint16_T_re" (RIP.Ptr Cint16_T) (RIP.Ptr Int16_T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"cint16_T_re")
@@ -219,8 +213,7 @@ instance HasCField.HasCField Cint16_T "cint16_T_im" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ Int16_T
-         ) => RIP.HasField "cint16_T_im" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
+instance RIP.HasField "cint16_T_im" (RIP.Ptr Cint16_T) (RIP.Ptr Int16_T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"cint16_T_im")
@@ -338,7 +331,7 @@ instance HasCField.HasCField A "a_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CDouble) => RIP.HasField "a_x" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_x" (RIP.Ptr A) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_x")
 
@@ -348,8 +341,7 @@ instance HasCField.HasCField A "a_label" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "a_label" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_label" (RIP.Ptr A) (RIP.Ptr (RIP.Ptr RIP.CChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_label")
 
@@ -360,8 +352,7 @@ instance HasCField.HasCField A "a_samples" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ CA.ConstantArray 128 RIP.CChar
-         ) => RIP.HasField "a_samples" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_samples" (RIP.Ptr A) (RIP.Ptr (CA.ConstantArray 128 RIP.CChar)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_samples")
 
@@ -371,7 +362,7 @@ instance HasCField.HasCField A "a_b" where
 
   offset# = \_ -> \_ -> 144
 
-instance (ty ~ B) => RIP.HasField "a_b" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_b" (RIP.Ptr A) (RIP.Ptr B) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_b")
 
@@ -381,7 +372,7 @@ instance HasCField.HasCField A "a_c" where
 
   offset# = \_ -> \_ -> 144
 
-instance (ty ~ RIP.Ptr C) => RIP.HasField "a_c" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_c" (RIP.Ptr A) (RIP.Ptr (RIP.Ptr C)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_c")
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/th.txt
@@ -56,8 +56,7 @@ newtype Int16_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort =>
-         HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr ty)
+instance HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapInt16_T")
 instance HasCField Int16_T "unwrapInt16_T"
     where type CFieldType Int16_T "unwrapInt16_T" = CShort
@@ -86,8 +85,7 @@ newtype Int32_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr ty)
+instance HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapInt32_T")
 instance HasCField Int32_T "unwrapInt32_T"
     where type CFieldType Int32_T "unwrapInt32_T" = CInt
@@ -116,8 +114,7 @@ newtype Int64_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CLLong =>
-         HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr ty)
+instance HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr CLLong)
     where getField = fromPtr (Proxy @"unwrapInt64_T")
 instance HasCField Int64_T "unwrapInt64_T"
     where type CFieldType Int64_T "unwrapInt64_T" = CLLong
@@ -157,14 +154,12 @@ deriving via (EquivStorable Cint16_T) instance Storable Cint16_T
 instance HasCField Cint16_T "cint16_T_re"
     where type CFieldType Cint16_T "cint16_T_re" = Int16_T
           offset# = \_ -> \_ -> 0
-instance (~) ty Int16_T =>
-         HasField "cint16_T_re" (Ptr Cint16_T) (Ptr ty)
+instance HasField "cint16_T_re" (Ptr Cint16_T) (Ptr Int16_T)
     where getField = fromPtr (Proxy @"cint16_T_re")
 instance HasCField Cint16_T "cint16_T_im"
     where type CFieldType Cint16_T "cint16_T_im" = Int16_T
           offset# = \_ -> \_ -> 2
-instance (~) ty Int16_T =>
-         HasField "cint16_T_im" (Ptr Cint16_T) (Ptr ty)
+instance HasField "cint16_T_im" (Ptr Cint16_T) (Ptr Int16_T)
     where getField = fromPtr (Proxy @"cint16_T_im")
 {-| __C declaration:__ @struct B@
 
@@ -241,28 +236,29 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_x"
     where type CFieldType A "a_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble => HasField "a_x" (Ptr A) (Ptr ty)
+instance HasField "a_x" (Ptr A) (Ptr CDouble)
     where getField = fromPtr (Proxy @"a_x")
 instance HasCField A "a_label"
     where type CFieldType A "a_label" = Ptr CChar
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CChar) => HasField "a_label" (Ptr A) (Ptr ty)
+instance HasField "a_label" (Ptr A) (Ptr (Ptr CChar))
     where getField = fromPtr (Proxy @"a_label")
 instance HasCField A "a_samples"
     where type CFieldType A "a_samples" = ConstantArray 128 CChar
           offset# = \_ -> \_ -> 16
-instance (~) ty (ConstantArray 128 CChar) =>
-         HasField "a_samples" (Ptr A) (Ptr ty)
+instance HasField "a_samples"
+                  (Ptr A)
+                  (Ptr (ConstantArray 128 CChar))
     where getField = fromPtr (Proxy @"a_samples")
 instance HasCField A "a_b"
     where type CFieldType A "a_b" = B
           offset# = \_ -> \_ -> 144
-instance (~) ty B => HasField "a_b" (Ptr A) (Ptr ty)
+instance HasField "a_b" (Ptr A) (Ptr B)
     where getField = fromPtr (Proxy @"a_b")
 instance HasCField A "a_c"
     where type CFieldType A "a_c" = Ptr C
           offset# = \_ -> \_ -> 144
-instance (~) ty (Ptr C) => HasField "a_c" (Ptr A) (Ptr ty)
+instance HasField "a_c" (Ptr A) (Ptr (Ptr C))
     where getField = fromPtr (Proxy @"a_c")
 {-| __C declaration:__ @struct C@
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -56,8 +54,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -96,8 +93,7 @@ newtype MyUInt = MyUInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapMyUInt" (RIP.Ptr MyUInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyUInt" (RIP.Ptr MyUInt) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyUInt")
@@ -136,8 +132,7 @@ newtype MyLong = MyLong
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "unwrapMyLong" (RIP.Ptr MyLong) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyLong" (RIP.Ptr MyLong) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyLong")
@@ -215,8 +210,7 @@ instance HasCBitfield.HasCBitfield MyStruct "myStruct_x" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( ty ~ MyInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr MyInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"myStruct_x")
@@ -229,8 +223,7 @@ instance HasCBitfield.HasCBitfield MyStruct "myStruct_y" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( ty ~ MyUInt
-         ) => RIP.HasField "myStruct_y" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "myStruct_y" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr MyUInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"myStruct_y")
@@ -243,8 +236,7 @@ instance HasCBitfield.HasCBitfield MyStruct "myStruct_z" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ MyLong
-         ) => RIP.HasField "myStruct_z" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "myStruct_z" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr MyLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"myStruct_z")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -23,7 +23,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -52,8 +52,7 @@ newtype MyUInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUInt =>
-         HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr ty)
+instance HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyUInt")
 instance HasCField MyUInt "unwrapMyUInt"
     where type CFieldType MyUInt "unwrapMyUInt" = CUInt
@@ -82,8 +81,7 @@ newtype MyLong
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CLong =>
-         HasField "unwrapMyLong" (Ptr MyLong) (Ptr ty)
+instance HasField "unwrapMyLong" (Ptr MyLong) (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapMyLong")
 instance HasCField MyLong "unwrapMyLong"
     where type CFieldType MyLong "unwrapMyLong" = CLong
@@ -132,20 +130,17 @@ instance HasCBitfield MyStruct "myStruct_x"
     where type CBitfieldType MyStruct "myStruct_x" = MyInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 2
-instance (~) ty MyInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr MyInt)
     where getField = toPtr (Proxy @"myStruct_x")
 instance HasCBitfield MyStruct "myStruct_y"
     where type CBitfieldType MyStruct "myStruct_y" = MyUInt
           bitfieldOffset# = \_ -> \_ -> 2
           bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty MyUInt =>
-         HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr MyUInt)
     where getField = toPtr (Proxy @"myStruct_y")
 instance HasCBitfield MyStruct "myStruct_z"
     where type CBitfieldType MyStruct "myStruct_z" = MyLong
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty MyLong =>
-         HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr ty)
+instance HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr MyLong)
     where getField = toPtr (Proxy @"myStruct_z")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -105,8 +103,7 @@ instance Read MyEnum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyEnum")

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/th.txt
@@ -39,8 +39,7 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
+instance HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -103,8 +101,7 @@ instance RIP.FromFunPtr FileOpenedNotification_Aux where
 
   fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 
-instance ( ty ~ IO ()
-         ) => RIP.HasField "unwrapFileOpenedNotification_Aux" (RIP.Ptr FileOpenedNotification_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFileOpenedNotification_Aux" (RIP.Ptr FileOpenedNotification_Aux) (RIP.Ptr (IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFileOpenedNotification_Aux")
@@ -134,8 +131,7 @@ newtype FileOpenedNotification = FileOpenedNotification
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr FileOpenedNotification_Aux
-         ) => RIP.HasField "unwrapFileOpenedNotification" (RIP.Ptr FileOpenedNotification) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFileOpenedNotification" (RIP.Ptr FileOpenedNotification) (RIP.Ptr (RIP.FunPtr FileOpenedNotification_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFileOpenedNotification")
@@ -195,8 +191,7 @@ instance RIP.FromFunPtr ProgressUpdate_Aux where
 
   fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.HasField "unwrapProgressUpdate_Aux" (RIP.Ptr ProgressUpdate_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapProgressUpdate_Aux" (RIP.Ptr ProgressUpdate_Aux) (RIP.Ptr (RIP.CInt -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapProgressUpdate_Aux")
@@ -226,8 +221,7 @@ newtype ProgressUpdate = ProgressUpdate
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr ProgressUpdate_Aux
-         ) => RIP.HasField "unwrapProgressUpdate" (RIP.Ptr ProgressUpdate) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapProgressUpdate" (RIP.Ptr ProgressUpdate) (RIP.Ptr (RIP.FunPtr ProgressUpdate_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapProgressUpdate")
@@ -287,8 +281,7 @@ instance RIP.FromFunPtr DataValidator_Aux where
 
   fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapDataValidator_Aux" (RIP.Ptr DataValidator_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapDataValidator_Aux" (RIP.Ptr DataValidator_Aux) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapDataValidator_Aux")
@@ -318,8 +311,7 @@ newtype DataValidator = DataValidator
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr DataValidator_Aux
-         ) => RIP.HasField "unwrapDataValidator" (RIP.Ptr DataValidator) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapDataValidator" (RIP.Ptr DataValidator) (RIP.Ptr (RIP.FunPtr DataValidator_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapDataValidator")
@@ -388,8 +380,7 @@ instance HasCField.HasCField Measurement "measurement_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "measurement_value" (RIP.Ptr Measurement) (RIP.Ptr ty) where
+instance RIP.HasField "measurement_value" (RIP.Ptr Measurement) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"measurement_value")
@@ -401,8 +392,7 @@ instance HasCField.HasCField Measurement "measurement_timestamp" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "measurement_timestamp" (RIP.Ptr Measurement) (RIP.Ptr ty) where
+instance RIP.HasField "measurement_timestamp" (RIP.Ptr Measurement) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"measurement_timestamp")
@@ -455,8 +445,7 @@ instance RIP.FromFunPtr MeasurementReceived_Aux where
 
   fromFunPtr = hs_bindgen_383c36bb22947621
 
-instance ( ty ~ (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "unwrapMeasurementReceived_Aux" (RIP.Ptr MeasurementReceived_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMeasurementReceived_Aux" (RIP.Ptr MeasurementReceived_Aux) (RIP.Ptr (RIP.Ptr Measurement -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMeasurementReceived_Aux")
@@ -486,8 +475,7 @@ newtype MeasurementReceived = MeasurementReceived
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr MeasurementReceived_Aux
-         ) => RIP.HasField "unwrapMeasurementReceived" (RIP.Ptr MeasurementReceived) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMeasurementReceived" (RIP.Ptr MeasurementReceived) (RIP.Ptr (RIP.FunPtr MeasurementReceived_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMeasurementReceived")
@@ -512,8 +500,7 @@ newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
   }
   deriving stock (RIP.Generic)
 
-instance ( ty ~ (Measurement -> IO ())
-         ) => RIP.HasField "unwrapMeasurementReceived2_Aux" (RIP.Ptr MeasurementReceived2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMeasurementReceived2_Aux" (RIP.Ptr MeasurementReceived2_Aux) (RIP.Ptr (Measurement -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMeasurementReceived2_Aux")
@@ -543,8 +530,7 @@ newtype MeasurementReceived2 = MeasurementReceived2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr MeasurementReceived2_Aux
-         ) => RIP.HasField "unwrapMeasurementReceived2" (RIP.Ptr MeasurementReceived2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMeasurementReceived2" (RIP.Ptr MeasurementReceived2) (RIP.Ptr (RIP.FunPtr MeasurementReceived2_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMeasurementReceived2")
@@ -604,8 +590,7 @@ instance RIP.FromFunPtr SampleBufferFull_Aux where
 
   fromFunPtr = hs_bindgen_2ab7ac6bb756ba7e
 
-instance ( ty ~ (RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ())
-         ) => RIP.HasField "unwrapSampleBufferFull_Aux" (RIP.Ptr SampleBufferFull_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSampleBufferFull_Aux" (RIP.Ptr SampleBufferFull_Aux) (RIP.Ptr (RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSampleBufferFull_Aux")
@@ -635,8 +620,7 @@ newtype SampleBufferFull = SampleBufferFull
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr SampleBufferFull_Aux
-         ) => RIP.HasField "unwrapSampleBufferFull" (RIP.Ptr SampleBufferFull) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSampleBufferFull" (RIP.Ptr SampleBufferFull) (RIP.Ptr (RIP.FunPtr SampleBufferFull_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSampleBufferFull")
@@ -717,8 +701,7 @@ instance HasCField.HasCField MeasurementHandler "measurementHandler_onReceived" 
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "measurementHandler_onReceived" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+instance RIP.HasField "measurementHandler_onReceived" (RIP.Ptr MeasurementHandler) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"measurementHandler_onReceived")
@@ -730,8 +713,7 @@ instance HasCField.HasCField MeasurementHandler "measurementHandler_validate" wh
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
-         ) => RIP.HasField "measurementHandler_validate" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+instance RIP.HasField "measurementHandler_validate" (RIP.Ptr MeasurementHandler) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"measurementHandler_validate")
@@ -743,8 +725,7 @@ instance HasCField.HasCField MeasurementHandler "measurementHandler_onError" whe
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
-         ) => RIP.HasField "measurementHandler_onError" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+instance RIP.HasField "measurementHandler_onError" (RIP.Ptr MeasurementHandler) (RIP.Ptr (RIP.FunPtr (RIP.CInt -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"measurementHandler_onError")
@@ -818,8 +799,7 @@ instance HasCField.HasCField DataPipeline "dataPipeline_preProcess" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
-         ) => RIP.HasField "dataPipeline_preProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+instance RIP.HasField "dataPipeline_preProcess" (RIP.Ptr DataPipeline) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dataPipeline_preProcess")
@@ -831,8 +811,7 @@ instance HasCField.HasCField DataPipeline "dataPipeline_process" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "dataPipeline_process" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+instance RIP.HasField "dataPipeline_process" (RIP.Ptr DataPipeline) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dataPipeline_process")
@@ -844,8 +823,7 @@ instance HasCField.HasCField DataPipeline "dataPipeline_postProcess" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
-         ) => RIP.HasField "dataPipeline_postProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+instance RIP.HasField "dataPipeline_postProcess" (RIP.Ptr DataPipeline) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dataPipeline_postProcess")
@@ -955,8 +933,7 @@ instance HasCField.HasCField ProcessorCallback "processorCallback_simple" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "processorCallback_simple" (RIP.Ptr ProcessorCallback) (RIP.Ptr ty) where
+instance RIP.HasField "processorCallback_simple" (RIP.Ptr ProcessorCallback) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_simple")
@@ -968,8 +945,7 @@ instance HasCField.HasCField ProcessorCallback "processorCallback_withValidator"
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
-         ) => RIP.HasField "processorCallback_withValidator" (RIP.Ptr ProcessorCallback) (RIP.Ptr ty) where
+instance RIP.HasField "processorCallback_withValidator" (RIP.Ptr ProcessorCallback) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_withValidator")
@@ -981,8 +957,7 @@ instance HasCField.HasCField ProcessorCallback "processorCallback_withProgress" 
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
-         ) => RIP.HasField "processorCallback_withProgress" (RIP.Ptr ProcessorCallback) (RIP.Ptr ty) where
+instance RIP.HasField "processorCallback_withProgress" (RIP.Ptr ProcessorCallback) (RIP.Ptr (RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_withProgress")
@@ -1068,8 +1043,7 @@ instance Read Processor_mode where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapProcessor_mode" (RIP.Ptr Processor_mode) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapProcessor_mode" (RIP.Ptr Processor_mode) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapProcessor_mode")
@@ -1165,8 +1139,7 @@ instance HasCField.HasCField Processor "processor_mode" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Processor_mode
-         ) => RIP.HasField "processor_mode" (RIP.Ptr Processor) (RIP.Ptr ty) where
+instance RIP.HasField "processor_mode" (RIP.Ptr Processor) (RIP.Ptr Processor_mode) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processor_mode")
@@ -1178,8 +1151,7 @@ instance HasCField.HasCField Processor "processor_callback" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ ProcessorCallback
-         ) => RIP.HasField "processor_callback" (RIP.Ptr Processor) (RIP.Ptr ty) where
+instance RIP.HasField "processor_callback" (RIP.Ptr Processor) (RIP.Ptr ProcessorCallback) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processor_callback")
@@ -1212,8 +1184,7 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
 
@@ -1251,8 +1222,7 @@ newtype Foo2 = Foo2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapFoo2" (RIP.Ptr Foo2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFoo2" (RIP.Ptr Foo2) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFoo2")

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/th.txt
@@ -456,10 +456,9 @@ instance ToFunPtr FileOpenedNotification_Aux
     where toFunPtr = hs_bindgen_b3b8b1fad168671a
 instance FromFunPtr FileOpenedNotification_Aux
     where fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
-instance (~) ty (IO ()) =>
-         HasField "unwrapFileOpenedNotification_Aux"
+instance HasField "unwrapFileOpenedNotification_Aux"
                   (Ptr FileOpenedNotification_Aux)
-                  (Ptr ty)
+                  (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification_Aux")
 instance HasCField FileOpenedNotification_Aux
                    "unwrapFileOpenedNotification_Aux"
@@ -480,10 +479,9 @@ newtype FileOpenedNotification
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr FileOpenedNotification_Aux) =>
-         HasField "unwrapFileOpenedNotification"
+instance HasField "unwrapFileOpenedNotification"
                   (Ptr FileOpenedNotification)
-                  (Ptr ty)
+                  (Ptr (FunPtr FileOpenedNotification_Aux))
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification")
 instance HasCField FileOpenedNotification
                    "unwrapFileOpenedNotification"
@@ -525,10 +523,9 @@ instance ToFunPtr ProgressUpdate_Aux
     where toFunPtr = hs_bindgen_d551f31556ffa727
 instance FromFunPtr ProgressUpdate_Aux
     where fromFunPtr = hs_bindgen_ccf7f4b62a839a04
-instance (~) ty (CInt -> IO ()) =>
-         HasField "unwrapProgressUpdate_Aux"
+instance HasField "unwrapProgressUpdate_Aux"
                   (Ptr ProgressUpdate_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO ()))
     where getField = fromPtr (Proxy @"unwrapProgressUpdate_Aux")
 instance HasCField ProgressUpdate_Aux "unwrapProgressUpdate_Aux"
     where type CFieldType ProgressUpdate_Aux
@@ -548,8 +545,9 @@ newtype ProgressUpdate
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr ProgressUpdate_Aux) =>
-         HasField "unwrapProgressUpdate" (Ptr ProgressUpdate) (Ptr ty)
+instance HasField "unwrapProgressUpdate"
+                  (Ptr ProgressUpdate)
+                  (Ptr (FunPtr ProgressUpdate_Aux))
     where getField = fromPtr (Proxy @"unwrapProgressUpdate")
 instance HasCField ProgressUpdate "unwrapProgressUpdate"
     where type CFieldType ProgressUpdate
@@ -590,8 +588,9 @@ instance ToFunPtr DataValidator_Aux
     where toFunPtr = hs_bindgen_c656ca21e63343d6
 instance FromFunPtr DataValidator_Aux
     where fromFunPtr = hs_bindgen_c1e79a4c11ca4033
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapDataValidator_Aux" (Ptr DataValidator_Aux) (Ptr ty)
+instance HasField "unwrapDataValidator_Aux"
+                  (Ptr DataValidator_Aux)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapDataValidator_Aux")
 instance HasCField DataValidator_Aux "unwrapDataValidator_Aux"
     where type CFieldType DataValidator_Aux
@@ -611,8 +610,9 @@ newtype DataValidator
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr DataValidator_Aux) =>
-         HasField "unwrapDataValidator" (Ptr DataValidator) (Ptr ty)
+instance HasField "unwrapDataValidator"
+                  (Ptr DataValidator)
+                  (Ptr (FunPtr DataValidator_Aux))
     where getField = fromPtr (Proxy @"unwrapDataValidator")
 instance HasCField DataValidator "unwrapDataValidator"
     where type CFieldType DataValidator
@@ -653,14 +653,16 @@ deriving via (EquivStorable Measurement) instance Storable Measurement
 instance HasCField Measurement "measurement_value"
     where type CFieldType Measurement "measurement_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "measurement_value" (Ptr Measurement) (Ptr ty)
+instance HasField "measurement_value"
+                  (Ptr Measurement)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"measurement_value")
 instance HasCField Measurement "measurement_timestamp"
     where type CFieldType Measurement "measurement_timestamp" = CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty CDouble =>
-         HasField "measurement_timestamp" (Ptr Measurement) (Ptr ty)
+instance HasField "measurement_timestamp"
+                  (Ptr Measurement)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"measurement_timestamp")
 {-| Auxiliary type used by 'MeasurementReceived'
 
@@ -698,10 +700,9 @@ instance ToFunPtr MeasurementReceived_Aux
     where toFunPtr = hs_bindgen_9259654df9d40f5b
 instance FromFunPtr MeasurementReceived_Aux
     where fromFunPtr = hs_bindgen_383c36bb22947621
-instance (~) ty (Ptr Measurement -> IO ()) =>
-         HasField "unwrapMeasurementReceived_Aux"
+instance HasField "unwrapMeasurementReceived_Aux"
                   (Ptr MeasurementReceived_Aux)
-                  (Ptr ty)
+                  (Ptr (Ptr Measurement -> IO ()))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived_Aux")
 instance HasCField MeasurementReceived_Aux
                    "unwrapMeasurementReceived_Aux"
@@ -722,10 +723,9 @@ newtype MeasurementReceived
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr MeasurementReceived_Aux) =>
-         HasField "unwrapMeasurementReceived"
+instance HasField "unwrapMeasurementReceived"
                   (Ptr MeasurementReceived)
-                  (Ptr ty)
+                  (Ptr (FunPtr MeasurementReceived_Aux))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived")
 instance HasCField MeasurementReceived "unwrapMeasurementReceived"
     where type CFieldType MeasurementReceived
@@ -743,10 +743,9 @@ newtype MeasurementReceived2_Aux
     = MeasurementReceived2_Aux {unwrapMeasurementReceived2_Aux :: (Measurement ->
                                                                    IO ())}
     deriving stock Generic
-instance (~) ty (Measurement -> IO ()) =>
-         HasField "unwrapMeasurementReceived2_Aux"
+instance HasField "unwrapMeasurementReceived2_Aux"
                   (Ptr MeasurementReceived2_Aux)
-                  (Ptr ty)
+                  (Ptr (Measurement -> IO ()))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2_Aux")
 instance HasCField MeasurementReceived2_Aux
                    "unwrapMeasurementReceived2_Aux"
@@ -767,10 +766,9 @@ newtype MeasurementReceived2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr MeasurementReceived2_Aux) =>
-         HasField "unwrapMeasurementReceived2"
+instance HasField "unwrapMeasurementReceived2"
                   (Ptr MeasurementReceived2)
-                  (Ptr ty)
+                  (Ptr (FunPtr MeasurementReceived2_Aux))
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2")
 instance HasCField MeasurementReceived2
                    "unwrapMeasurementReceived2"
@@ -814,10 +812,9 @@ instance ToFunPtr SampleBufferFull_Aux
     where toFunPtr = hs_bindgen_57d9e30494ae4453
 instance FromFunPtr SampleBufferFull_Aux
     where fromFunPtr = hs_bindgen_2ab7ac6bb756ba7e
-instance (~) ty (Ptr (Elem (ConstantArray 10 CInt)) -> IO ()) =>
-         HasField "unwrapSampleBufferFull_Aux"
+instance HasField "unwrapSampleBufferFull_Aux"
                   (Ptr SampleBufferFull_Aux)
-                  (Ptr ty)
+                  (Ptr (Ptr (Elem (ConstantArray 10 CInt)) -> IO ()))
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull_Aux")
 instance HasCField SampleBufferFull_Aux
                    "unwrapSampleBufferFull_Aux"
@@ -840,8 +837,9 @@ newtype SampleBufferFull
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr SampleBufferFull_Aux) =>
-         HasField "unwrapSampleBufferFull" (Ptr SampleBufferFull) (Ptr ty)
+instance HasField "unwrapSampleBufferFull"
+                  (Ptr SampleBufferFull)
+                  (Ptr (FunPtr SampleBufferFull_Aux))
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull")
 instance HasCField SampleBufferFull "unwrapSampleBufferFull"
     where type CFieldType SampleBufferFull
@@ -894,28 +892,25 @@ instance HasCField MeasurementHandler
     where type CFieldType MeasurementHandler
                           "measurementHandler_onReceived" = FunPtr (Ptr Measurement -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
-         HasField "measurementHandler_onReceived"
+instance HasField "measurementHandler_onReceived"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO ())))
     where getField = fromPtr (Proxy @"measurementHandler_onReceived")
 instance HasCField MeasurementHandler "measurementHandler_validate"
     where type CFieldType MeasurementHandler
                           "measurementHandler_validate" = FunPtr (Ptr Measurement -> IO CInt)
           offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Measurement -> IO CInt)) =>
-         HasField "measurementHandler_validate"
+instance HasField "measurementHandler_validate"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO CInt)))
     where getField = fromPtr (Proxy @"measurementHandler_validate")
 instance HasCField MeasurementHandler "measurementHandler_onError"
     where type CFieldType MeasurementHandler
                           "measurementHandler_onError" = FunPtr (CInt -> IO ())
           offset# = \_ -> \_ -> 16
-instance (~) ty (FunPtr (CInt -> IO ())) =>
-         HasField "measurementHandler_onError"
+instance HasField "measurementHandler_onError"
                   (Ptr MeasurementHandler)
-                  (Ptr ty)
+                  (Ptr (FunPtr (CInt -> IO ())))
     where getField = fromPtr (Proxy @"measurementHandler_onError")
 {-| __C declaration:__ @struct DataPipeline@
 
@@ -964,25 +959,26 @@ instance HasCField DataPipeline "dataPipeline_preProcess"
                           "dataPipeline_preProcess" = FunPtr (Ptr Measurement ->
                                                               DataValidator -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty
-             (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
-         HasField "dataPipeline_preProcess" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_preProcess"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO ())))
     where getField = fromPtr (Proxy @"dataPipeline_preProcess")
 instance HasCField DataPipeline "dataPipeline_process"
     where type CFieldType DataPipeline
                           "dataPipeline_process" = FunPtr (Ptr Measurement -> IO ())
           offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
-         HasField "dataPipeline_process" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_process"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> IO ())))
     where getField = fromPtr (Proxy @"dataPipeline_process")
 instance HasCField DataPipeline "dataPipeline_postProcess"
     where type CFieldType DataPipeline
                           "dataPipeline_postProcess" = FunPtr (Ptr Measurement ->
                                                                ProgressUpdate -> IO ())
           offset# = \_ -> \_ -> 16
-instance (~) ty
-             (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
-         HasField "dataPipeline_postProcess" (Ptr DataPipeline) (Ptr ty)
+instance HasField "dataPipeline_postProcess"
+                  (Ptr DataPipeline)
+                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())))
     where getField = fromPtr (Proxy @"dataPipeline_postProcess")
 {-| __C declaration:__ @union ProcessorCallback@
 
@@ -1115,10 +1111,9 @@ instance HasCField ProcessorCallback "processorCallback_simple"
     where type CFieldType ProcessorCallback
                           "processorCallback_simple" = FunPtr (Ptr Measurement -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
-         HasField "processorCallback_simple"
+instance HasField "processorCallback_simple"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> IO ())))
     where getField = fromPtr (Proxy @"processorCallback_simple")
 instance HasCField ProcessorCallback
                    "processorCallback_withValidator"
@@ -1126,11 +1121,9 @@ instance HasCField ProcessorCallback
                           "processorCallback_withValidator" = FunPtr (Ptr Measurement ->
                                                                       DataValidator -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty
-             (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
-         HasField "processorCallback_withValidator"
+instance HasField "processorCallback_withValidator"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> DataValidator -> IO ())))
     where getField = fromPtr (Proxy @"processorCallback_withValidator")
 instance HasCField ProcessorCallback
                    "processorCallback_withProgress"
@@ -1138,11 +1131,9 @@ instance HasCField ProcessorCallback
                           "processorCallback_withProgress" = FunPtr (Ptr Measurement ->
                                                                      ProgressUpdate -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty
-             (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
-         HasField "processorCallback_withProgress"
+instance HasField "processorCallback_withProgress"
                   (Ptr ProcessorCallback)
-                  (Ptr ty)
+                  (Ptr (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())))
     where getField = fromPtr (Proxy @"processorCallback_withProgress")
 {-| __C declaration:__ @enum \@Processor_mode@
 
@@ -1185,8 +1176,9 @@ instance Read Processor_mode
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapProcessor_mode" (Ptr Processor_mode) (Ptr ty)
+instance HasField "unwrapProcessor_mode"
+                  (Ptr Processor_mode)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapProcessor_mode")
 instance HasCField Processor_mode "unwrapProcessor_mode"
     where type CFieldType Processor_mode "unwrapProcessor_mode" = CUInt
@@ -1250,15 +1242,17 @@ deriving via (EquivStorable Processor) instance Storable Processor
 instance HasCField Processor "processor_mode"
     where type CFieldType Processor "processor_mode" = Processor_mode
           offset# = \_ -> \_ -> 0
-instance (~) ty Processor_mode =>
-         HasField "processor_mode" (Ptr Processor) (Ptr ty)
+instance HasField "processor_mode"
+                  (Ptr Processor)
+                  (Ptr Processor_mode)
     where getField = fromPtr (Proxy @"processor_mode")
 instance HasCField Processor "processor_callback"
     where type CFieldType Processor
                           "processor_callback" = ProcessorCallback
           offset# = \_ -> \_ -> 8
-instance (~) ty ProcessorCallback =>
-         HasField "processor_callback" (Ptr Processor) (Ptr ty)
+instance HasField "processor_callback"
+                  (Ptr Processor)
+                  (Ptr ProcessorCallback)
     where getField = fromPtr (Proxy @"processor_callback")
 {-| __C declaration:__ @foo@
 
@@ -1284,7 +1278,7 @@ newtype Foo
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+instance HasField "unwrapFoo" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = CInt
@@ -1313,7 +1307,7 @@ newtype Foo2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapFoo2" (Ptr Foo2) (Ptr ty)
+instance HasField "unwrapFoo2" (Ptr Foo2) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFoo2")
 instance HasCField Foo2 "unwrapFoo2"
     where type CFieldType Foo2 "unwrapFoo2" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -72,8 +70,7 @@ instance RIP.FromFunPtr Fun_ptr_Aux where
 
   fromFunPtr = hs_bindgen_f8391e85af67fcb6
 
-instance ( ty ~ (RIP.Ptr Forward_declaration -> IO ())
-         ) => RIP.HasField "unwrapFun_ptr_Aux" (RIP.Ptr Fun_ptr_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFun_ptr_Aux" (RIP.Ptr Fun_ptr_Aux) (RIP.Ptr (RIP.Ptr Forward_declaration -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFun_ptr_Aux")
@@ -103,8 +100,7 @@ newtype Fun_ptr = Fun_ptr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Fun_ptr_Aux
-         ) => RIP.HasField "unwrapFun_ptr" (RIP.Ptr Fun_ptr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFun_ptr" (RIP.Ptr Fun_ptr) (RIP.Ptr (RIP.FunPtr Fun_ptr_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFun_ptr")
@@ -164,8 +160,7 @@ instance HasCField.HasCField Forward_declaration "forward_declaration_f" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Fun_ptr
-         ) => RIP.HasField "forward_declaration_f" (RIP.Ptr Forward_declaration) (RIP.Ptr ty) where
+instance RIP.HasField "forward_declaration_f" (RIP.Ptr Forward_declaration) (RIP.Ptr Fun_ptr) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"forward_declaration_f")

--- a/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/th.txt
@@ -34,8 +34,9 @@ instance ToFunPtr Fun_ptr_Aux
     where toFunPtr = hs_bindgen_5964bbadb359ee4a
 instance FromFunPtr Fun_ptr_Aux
     where fromFunPtr = hs_bindgen_f8391e85af67fcb6
-instance (~) ty (Ptr Forward_declaration -> IO ()) =>
-         HasField "unwrapFun_ptr_Aux" (Ptr Fun_ptr_Aux) (Ptr ty)
+instance HasField "unwrapFun_ptr_Aux"
+                  (Ptr Fun_ptr_Aux)
+                  (Ptr (Ptr Forward_declaration -> IO ()))
     where getField = fromPtr (Proxy @"unwrapFun_ptr_Aux")
 instance HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux"
     where type CFieldType Fun_ptr_Aux
@@ -55,8 +56,9 @@ newtype Fun_ptr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Fun_ptr_Aux) =>
-         HasField "unwrapFun_ptr" (Ptr Fun_ptr) (Ptr ty)
+instance HasField "unwrapFun_ptr"
+                  (Ptr Fun_ptr)
+                  (Ptr (FunPtr Fun_ptr_Aux))
     where getField = fromPtr (Proxy @"unwrapFun_ptr")
 instance HasCField Fun_ptr "unwrapFun_ptr"
     where type CFieldType Fun_ptr "unwrapFun_ptr" = FunPtr Fun_ptr_Aux
@@ -89,6 +91,7 @@ instance HasCField Forward_declaration "forward_declaration_f"
     where type CFieldType Forward_declaration
                           "forward_declaration_f" = Fun_ptr
           offset# = \_ -> \_ -> 0
-instance (~) ty Fun_ptr =>
-         HasField "forward_declaration_f" (Ptr Forward_declaration) (Ptr ty)
+instance HasField "forward_declaration_f"
+                  (Ptr Forward_declaration)
+                  (Ptr Fun_ptr)
     where getField = fromPtr (Proxy @"forward_declaration_f")

--- a/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/Example.hs
@@ -3,14 +3,12 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -87,8 +85,7 @@ instance HasCField.HasCField Outside "outside_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outside_x" (RIP.Ptr Outside) (RIP.Ptr ty) where
+instance RIP.HasField "outside_x" (RIP.Ptr Outside) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"outside_x")
 
@@ -98,7 +95,6 @@ instance HasCField.HasCField Outside "outside_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outside_y" (RIP.Ptr Outside) (RIP.Ptr ty) where
+instance RIP.HasField "outside_y" (RIP.Ptr Outside) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"outside_y")

--- a/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/th.txt
@@ -68,12 +68,12 @@ deriving via (EquivStorable Outside) instance Storable Outside
 instance HasCField Outside "outside_x"
     where type CFieldType Outside "outside_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "outside_x" (Ptr Outside) (Ptr ty)
+instance HasField "outside_x" (Ptr Outside) (Ptr CInt)
     where getField = fromPtr (Proxy @"outside_x")
 instance HasCField Outside "outside_y"
     where type CFieldType Outside "outside_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "outside_y" (Ptr Outside) (Ptr ty)
+instance HasField "outside_y" (Ptr Outside) (Ptr CInt)
     where getField = fromPtr (Proxy @"outside_y")
 -- __unique:__ @test_functionsdecls_in_signature_Example_Safe_normal@
 foreign import ccall safe "hs_bindgen_920e5c20f770432b" hs_bindgen_920e5c20f770432b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -82,8 +80,7 @@ newtype Size_t = Size_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapSize_t" (RIP.Ptr Size_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSize_t" (RIP.Ptr Size_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSize_t")

--- a/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/th.txt
@@ -469,8 +469,7 @@ newtype Size_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapSize_t" (Ptr Size_t) (Ptr ty)
+instance HasField "unwrapSize_t" (Ptr Size_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapSize_t")
 instance HasCField Size_t "unwrapSize_t"
     where type CFieldType Size_t "unwrapSize_t" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,6 +66,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/th.txt
@@ -129,7 +129,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_a5d53f538e59b1fc" hs_bindgen_a5d53f538e59b1fc_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,6 +66,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/th.txt
@@ -49,7 +49,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,6 +66,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -49,7 +49,7 @@ deriving via (EquivStorable T) instance Storable T
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,7 +68,7 @@ instance HasCField.HasCField S "s_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
@@ -91,7 +89,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr S) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -49,7 +49,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_x"
     where type CFieldType S "s_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
+instance HasField "s_x" (Ptr S) (Ptr CInt)
     where getField = fromPtr (Proxy @"s_x")
 {-| __C declaration:__ @T@
 
@@ -61,7 +61,7 @@ newtype T
     = T {unwrapT :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,6 +71,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/th.txt
@@ -70,7 +70,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_9fc5746860ab93cb" hs_bindgen_9fc5746860ab93cb_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,6 +71,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/th.txt
@@ -70,7 +70,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,6 +71,6 @@ instance HasCField.HasCField T "t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/th.txt
@@ -70,7 +70,7 @@ set_t_x = setUnionPayload
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+instance HasField "t_x" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -75,7 +73,7 @@ instance HasCField.HasCField U "u_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"u_x")
 
@@ -96,7 +94,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance (ty ~ U) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr U) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -70,7 +70,7 @@ set_u_x = setUnionPayload
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
+instance HasField "u_x" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @T@
 
@@ -82,7 +82,7 @@ newtype T
     = T {unwrapT :: U}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty U => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr U)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = U

--- a/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -73,8 +71,7 @@ instance RIP.FromFunPtr RunDriver_Aux where
 
   fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 
-instance ( ty ~ (RIP.Ptr Driver -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapRunDriver_Aux" (RIP.Ptr RunDriver_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapRunDriver_Aux" (RIP.Ptr RunDriver_Aux) (RIP.Ptr (RIP.Ptr Driver -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapRunDriver_Aux")
@@ -104,8 +101,7 @@ newtype RunDriver = RunDriver
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr RunDriver_Aux
-         ) => RIP.HasField "unwrapRunDriver" (RIP.Ptr RunDriver) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapRunDriver" (RIP.Ptr RunDriver) (RIP.Ptr (RIP.FunPtr RunDriver_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapRunDriver")
@@ -164,8 +160,7 @@ instance HasCField.HasCField Driver "driver_run" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RunDriver
-         ) => RIP.HasField "driver_run" (RIP.Ptr Driver) (RIP.Ptr ty) where
+instance RIP.HasField "driver_run" (RIP.Ptr Driver) (RIP.Ptr RunDriver) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"driver_run")
@@ -218,8 +213,7 @@ instance HasCField.HasCField Bare "bare_callback" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
-         ) => RIP.HasField "bare_callback" (RIP.Ptr Bare) (RIP.Ptr ty) where
+instance RIP.HasField "bare_callback" (RIP.Ptr Bare) (RIP.Ptr (RIP.FunPtr (RIP.CInt -> IO ()))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"bare_callback")

--- a/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/th.txt
@@ -34,8 +34,9 @@ instance ToFunPtr RunDriver_Aux
     where toFunPtr = hs_bindgen_d86ecf261d7044c6
 instance FromFunPtr RunDriver_Aux
     where fromFunPtr = hs_bindgen_6520ae39b50ffb4e
-instance (~) ty (Ptr Driver -> IO CInt) =>
-         HasField "unwrapRunDriver_Aux" (Ptr RunDriver_Aux) (Ptr ty)
+instance HasField "unwrapRunDriver_Aux"
+                  (Ptr RunDriver_Aux)
+                  (Ptr (Ptr Driver -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapRunDriver_Aux")
 instance HasCField RunDriver_Aux "unwrapRunDriver_Aux"
     where type CFieldType RunDriver_Aux
@@ -55,8 +56,9 @@ newtype RunDriver
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr RunDriver_Aux) =>
-         HasField "unwrapRunDriver" (Ptr RunDriver) (Ptr ty)
+instance HasField "unwrapRunDriver"
+                  (Ptr RunDriver)
+                  (Ptr (FunPtr RunDriver_Aux))
     where getField = fromPtr (Proxy @"unwrapRunDriver")
 instance HasCField RunDriver "unwrapRunDriver"
     where type CFieldType RunDriver
@@ -89,8 +91,7 @@ deriving via (EquivStorable Driver) instance Storable Driver
 instance HasCField Driver "driver_run"
     where type CFieldType Driver "driver_run" = RunDriver
           offset# = \_ -> \_ -> 0
-instance (~) ty RunDriver =>
-         HasField "driver_run" (Ptr Driver) (Ptr ty)
+instance HasField "driver_run" (Ptr Driver) (Ptr RunDriver)
     where getField = fromPtr (Proxy @"driver_run")
 {-| __C declaration:__ @struct Bare@
 
@@ -119,6 +120,7 @@ deriving via (EquivStorable Bare) instance Storable Bare
 instance HasCField Bare "bare_callback"
     where type CFieldType Bare "bare_callback" = FunPtr (CInt -> IO ())
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (CInt -> IO ())) =>
-         HasField "bare_callback" (Ptr Bare) (Ptr ty)
+instance HasField "bare_callback"
+                  (Ptr Bare)
+                  (Ptr (FunPtr (CInt -> IO ())))
     where getField = fromPtr (Proxy @"bare_callback")

--- a/hs-bindgen/test-artefacts/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/globals/globals/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -82,8 +80,7 @@ instance HasCField.HasCField Config "config_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "config_x" (RIP.Ptr Config) (RIP.Ptr ty) where
+instance RIP.HasField "config_x" (RIP.Ptr Config) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"config_x")
 
@@ -93,8 +90,7 @@ instance HasCField.HasCField Config "config_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "config_y" (RIP.Ptr Config) (RIP.Ptr ty) where
+instance RIP.HasField "config_y" (RIP.Ptr Config) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"config_y")
 
@@ -155,8 +151,7 @@ instance HasCField.HasCField Inline_struct "inline_struct_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inline_struct_x" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
+instance RIP.HasField "inline_struct_x" (RIP.Ptr Inline_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inline_struct_x")
@@ -168,8 +163,7 @@ instance HasCField.HasCField Inline_struct "inline_struct_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inline_struct_y" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
+instance RIP.HasField "inline_struct_y" (RIP.Ptr Inline_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inline_struct_y")
@@ -240,8 +234,7 @@ instance HasCField.HasCField Version_t "version_t_major" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "version_t_major" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+instance RIP.HasField "version_t_major" (RIP.Ptr Version_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"version_t_major")
@@ -253,8 +246,7 @@ instance HasCField.HasCField Version_t "version_t_minor" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "version_t_minor" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+instance RIP.HasField "version_t_minor" (RIP.Ptr Version_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"version_t_minor")
@@ -266,8 +258,7 @@ instance HasCField.HasCField Version_t "version_t_patch" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "version_t_patch" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+instance RIP.HasField "version_t_patch" (RIP.Ptr Version_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"version_t_patch")
@@ -338,8 +329,7 @@ instance HasCField.HasCField Struct1_t "struct1_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "struct1_t_x" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct1_t_x" (RIP.Ptr Struct1_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct1_t_x")
@@ -350,8 +340,7 @@ instance HasCField.HasCField Struct1_t "struct1_t_y" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "struct1_t_y" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct1_t_y" (RIP.Ptr Struct1_t) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct1_t_y")
@@ -363,8 +352,7 @@ instance HasCField.HasCField Struct1_t "struct1_t_version" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Version_t
-         ) => RIP.HasField "struct1_t_version" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct1_t_version" (RIP.Ptr Struct1_t) (RIP.Ptr Version_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct1_t_version")
@@ -417,8 +405,7 @@ instance HasCField.HasCField Struct2_t "struct2_t_field1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Struct1_t
-         ) => RIP.HasField "struct2_t_field1" (RIP.Ptr Struct2_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct2_t_field1" (RIP.Ptr Struct2_t) (RIP.Ptr Struct1_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct2_t_field1")

--- a/hs-bindgen/test-artefacts/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/globals/globals/th.txt
@@ -160,12 +160,12 @@ deriving via (EquivStorable Config) instance Storable Config
 instance HasCField Config "config_x"
     where type CFieldType Config "config_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "config_x" (Ptr Config) (Ptr ty)
+instance HasField "config_x" (Ptr Config) (Ptr CInt)
     where getField = fromPtr (Proxy @"config_x")
 instance HasCField Config "config_y"
     where type CFieldType Config "config_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "config_y" (Ptr Config) (Ptr ty)
+instance HasField "config_y" (Ptr Config) (Ptr CInt)
     where getField = fromPtr (Proxy @"config_y")
 {-| __C declaration:__ @struct inline_struct@
 
@@ -202,14 +202,12 @@ deriving via (EquivStorable Inline_struct) instance Storable Inline_struct
 instance HasCField Inline_struct "inline_struct_x"
     where type CFieldType Inline_struct "inline_struct_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inline_struct_x" (Ptr Inline_struct) (Ptr ty)
+instance HasField "inline_struct_x" (Ptr Inline_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"inline_struct_x")
 instance HasCField Inline_struct "inline_struct_y"
     where type CFieldType Inline_struct "inline_struct_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "inline_struct_y" (Ptr Inline_struct) (Ptr ty)
+instance HasField "inline_struct_y" (Ptr Inline_struct) (Ptr CInt)
     where getField = fromPtr (Proxy @"inline_struct_y")
 {-| __C declaration:__ @struct version_t@
 
@@ -255,22 +253,25 @@ instance HasCField Version_t "version_t_major"
     where type CFieldType Version_t
                           "version_t_major" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "version_t_major" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_major"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"version_t_major")
 instance HasCField Version_t "version_t_minor"
     where type CFieldType Version_t
                           "version_t_minor" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 2
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "version_t_minor" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_minor"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"version_t_minor")
 instance HasCField Version_t "version_t_patch"
     where type CFieldType Version_t
                           "version_t_patch" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 4
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "version_t_patch" (Ptr Version_t) (Ptr ty)
+instance HasField "version_t_patch"
+                  (Ptr Version_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"version_t_patch")
 {-| __C declaration:__ @struct struct1_t@
 
@@ -316,20 +317,21 @@ instance HasCField Struct1_t "struct1_t_x"
     where type CFieldType Struct1_t
                           "struct1_t_x" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "struct1_t_x" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_x"
+                  (Ptr Struct1_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"struct1_t_x")
 instance HasCField Struct1_t "struct1_t_y"
     where type CFieldType Struct1_t "struct1_t_y" = CBool
           offset# = \_ -> \_ -> 2
-instance (~) ty CBool =>
-         HasField "struct1_t_y" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_y" (Ptr Struct1_t) (Ptr CBool)
     where getField = fromPtr (Proxy @"struct1_t_y")
 instance HasCField Struct1_t "struct1_t_version"
     where type CFieldType Struct1_t "struct1_t_version" = Version_t
           offset# = \_ -> \_ -> 4
-instance (~) ty Version_t =>
-         HasField "struct1_t_version" (Ptr Struct1_t) (Ptr ty)
+instance HasField "struct1_t_version"
+                  (Ptr Struct1_t)
+                  (Ptr Version_t)
     where getField = fromPtr (Proxy @"struct1_t_version")
 {-| __C declaration:__ @struct struct2_t@
 
@@ -358,8 +360,9 @@ deriving via (EquivStorable Struct2_t) instance Storable Struct2_t
 instance HasCField Struct2_t "struct2_t_field1"
     where type CFieldType Struct2_t "struct2_t_field1" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct1_t =>
-         HasField "struct2_t_field1" (Ptr Struct2_t) (Ptr ty)
+instance HasField "struct2_t_field1"
+                  (Ptr Struct2_t)
+                  (Ptr Struct1_t)
     where getField = fromPtr (Proxy @"struct2_t_field1")
 -- __unique:__ @test_globalsglobals_Example_get_simpleGlobal@
 foreign import ccall unsafe "hs_bindgen_4f8e7b3d91414aa8" hs_bindgen_4f8e7b3d91414aa8_base ::

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -95,8 +93,7 @@ instance HasCField.HasCField AnonPoint "anonPoint_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPoint_x" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
+instance RIP.HasField "anonPoint_x" (RIP.Ptr AnonPoint) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonPoint_x")
@@ -107,8 +104,7 @@ instance HasCField.HasCField AnonPoint "anonPoint_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPoint_y" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
+instance RIP.HasField "anonPoint_y" (RIP.Ptr AnonPoint) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonPoint_y")
@@ -169,8 +165,7 @@ instance HasCField.HasCField AnonPair "anonPair_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPair_a" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
+instance RIP.HasField "anonPair_a" (RIP.Ptr AnonPair) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonPair_a")
@@ -181,8 +176,7 @@ instance HasCField.HasCField AnonPair "anonPair_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPair_b" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
+instance RIP.HasField "anonPair_b" (RIP.Ptr AnonPair) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonPair_b")
@@ -265,8 +259,7 @@ instance Read AnonEnum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapAnonEnum" (RIP.Ptr AnonEnum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapAnonEnum" (RIP.Ptr AnonEnum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapAnonEnum")
@@ -363,8 +356,7 @@ instance Read AnonEnumCoords where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapAnonEnumCoords" (RIP.Ptr AnonEnumCoords) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapAnonEnumCoords" (RIP.Ptr AnonEnumCoords) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapAnonEnumCoords")
@@ -480,8 +472,7 @@ instance Read A where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -550,7 +541,7 @@ instance HasCField.HasCField B "b_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b_x" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "b_x" (RIP.Ptr B) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b_x")
 
@@ -601,6 +592,6 @@ instance HasCField.HasCField C "c_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "c_x" (RIP.Ptr C) (RIP.Ptr ty) where
+instance RIP.HasField "c_x" (RIP.Ptr C) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c_x")

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/th.txt
@@ -77,14 +77,12 @@ deriving via (EquivStorable AnonPoint) instance Storable AnonPoint
 instance HasCField AnonPoint "anonPoint_x"
     where type CFieldType AnonPoint "anonPoint_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "anonPoint_x" (Ptr AnonPoint) (Ptr ty)
+instance HasField "anonPoint_x" (Ptr AnonPoint) (Ptr CInt)
     where getField = fromPtr (Proxy @"anonPoint_x")
 instance HasCField AnonPoint "anonPoint_y"
     where type CFieldType AnonPoint "anonPoint_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "anonPoint_y" (Ptr AnonPoint) (Ptr ty)
+instance HasField "anonPoint_y" (Ptr AnonPoint) (Ptr CInt)
     where getField = fromPtr (Proxy @"anonPoint_y")
 {-| __C declaration:__ @struct \@anonPair@
 
@@ -121,14 +119,12 @@ deriving via (EquivStorable AnonPair) instance Storable AnonPair
 instance HasCField AnonPair "anonPair_a"
     where type CFieldType AnonPair "anonPair_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "anonPair_a" (Ptr AnonPair) (Ptr ty)
+instance HasField "anonPair_a" (Ptr AnonPair) (Ptr CInt)
     where getField = fromPtr (Proxy @"anonPair_a")
 instance HasCField AnonPair "anonPair_b"
     where type CFieldType AnonPair "anonPair_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "anonPair_b" (Ptr AnonPair) (Ptr ty)
+instance HasField "anonPair_b" (Ptr AnonPair) (Ptr CInt)
     where getField = fromPtr (Proxy @"anonPair_b")
 {-| __C declaration:__ @enum \@anonEnum@
 
@@ -170,8 +166,7 @@ instance Read AnonEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapAnonEnum" (Ptr AnonEnum) (Ptr ty)
+instance HasField "unwrapAnonEnum" (Ptr AnonEnum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapAnonEnum")
 instance HasCField AnonEnum "unwrapAnonEnum"
     where type CFieldType AnonEnum "unwrapAnonEnum" = CUInt
@@ -227,8 +222,9 @@ instance Read AnonEnumCoords
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapAnonEnumCoords" (Ptr AnonEnumCoords) (Ptr ty)
+instance HasField "unwrapAnonEnumCoords"
+                  (Ptr AnonEnumCoords)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapAnonEnumCoords")
 instance HasCField AnonEnumCoords "unwrapAnonEnumCoords"
     where type CFieldType AnonEnumCoords "unwrapAnonEnumCoords" = CUInt
@@ -295,7 +291,7 @@ instance Read A
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CUInt
@@ -356,7 +352,7 @@ set_b_x = setUnionPayload
 instance HasCField B "b_x"
     where type CFieldType B "b_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "b_x" (Ptr B) (Ptr ty)
+instance HasField "b_x" (Ptr B) (Ptr CInt)
     where getField = fromPtr (Proxy @"b_x")
 {-| __C declaration:__ @struct \@C@
 
@@ -385,7 +381,7 @@ deriving via (EquivStorable C) instance Storable C
 instance HasCField C "c_x"
     where type CFieldType C "c_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "c_x" (Ptr C) (Ptr ty)
+instance HasField "c_x" (Ptr C) (Ptr CInt)
     where getField = fromPtr (Proxy @"c_x")
 -- __unique:__ @test_globalsuntagged_Example_get_anonPoint@
 foreign import ccall unsafe "hs_bindgen_6629eeb3c2ffd60b" hs_bindgen_6629eeb3c2ffd60b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/Example.hs
@@ -1,13 +1,11 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -30,7 +28,7 @@ newtype B = B
   }
   deriving stock (RIP.Generic)
 
-instance (ty ~ M.A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr M.A) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/th.txt
@@ -27,7 +27,7 @@
     __exported by:__ @macros\/macro_ext_binding_dep.h@
 -}
 newtype B = B {unwrapB :: M.A} deriving stock Generic
-instance (~) ty M.A => HasField "unwrapB" (Ptr B) (Ptr ty)
+instance HasField "unwrapB" (Ptr B) (Ptr M.A)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = M.A

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -53,8 +51,7 @@ newtype I = I
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapI")
 
@@ -92,8 +89,7 @@ newtype C = C
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapC" (RIP.Ptr C) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapC" (RIP.Ptr C) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapC")
 
@@ -129,8 +125,7 @@ newtype F = F
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "unwrapF" (RIP.Ptr F) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF" (RIP.Ptr F) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF")
 
@@ -168,8 +163,7 @@ newtype L = L
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "unwrapL" (RIP.Ptr L) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapL" (RIP.Ptr L) (RIP.Ptr RIP.CLong) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapL")
 
@@ -207,8 +201,7 @@ newtype S = S
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr RIP.CShort) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/th.txt
@@ -335,7 +335,7 @@ newtype I
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
+instance HasField "unwrapI" (Ptr I) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -364,7 +364,7 @@ newtype C
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapC" (Ptr C) (Ptr ty)
+instance HasField "unwrapC" (Ptr C) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapC")
 instance HasCField C "unwrapC"
     where type CFieldType C "unwrapC" = CChar
@@ -391,7 +391,7 @@ newtype F
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CFloat => HasField "unwrapF" (Ptr F) (Ptr ty)
+instance HasField "unwrapF" (Ptr F) (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapF")
 instance HasCField F "unwrapF"
     where type CFieldType F "unwrapF" = CFloat
@@ -420,7 +420,7 @@ newtype L
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CLong => HasField "unwrapL" (Ptr L) (Ptr ty)
+instance HasField "unwrapL" (Ptr L) (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapL")
 instance HasCField L "unwrapL"
     where type CFieldType L "unwrapL" = CLong
@@ -449,7 +449,7 @@ newtype S
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort => HasField "unwrapS" (Ptr S) (Ptr ty)
+instance HasField "unwrapS" (Ptr S) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = CShort

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -57,8 +55,7 @@ newtype MC = MC
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapMC" (RIP.Ptr MC) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMC" (RIP.Ptr MC) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapMC")
 
@@ -96,8 +93,7 @@ newtype TC = TC
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapTC" (RIP.Ptr TC) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTC" (RIP.Ptr TC) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTC")
 
@@ -154,8 +150,7 @@ instance HasCField.HasCField Struct1 "struct1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct1_a" (RIP.Ptr Struct1) (RIP.Ptr ty) where
+instance RIP.HasField "struct1_a" (RIP.Ptr Struct1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"struct1_a")
 
@@ -206,8 +201,7 @@ instance HasCField.HasCField Struct2 "struct2_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct2_a" (RIP.Ptr Struct2) (RIP.Ptr ty) where
+instance RIP.HasField "struct2_a" (RIP.Ptr Struct2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"struct2_a")
 
@@ -258,8 +252,7 @@ instance HasCField.HasCField Struct3 "struct3_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct3_a" (RIP.Ptr Struct3) (RIP.Ptr ty) where
+instance RIP.HasField "struct3_a" (RIP.Ptr Struct3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"struct3_a")
 
@@ -280,8 +273,7 @@ newtype Struct3_t = Struct3_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct3
-         ) => RIP.HasField "unwrapStruct3_t" (RIP.Ptr Struct3_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct3_t" (RIP.Ptr Struct3_t) (RIP.Ptr Struct3) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct3_t")
@@ -339,7 +331,6 @@ instance HasCField.HasCField Struct4 "struct4_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct4_a" (RIP.Ptr Struct4) (RIP.Ptr ty) where
+instance RIP.HasField "struct4_a" (RIP.Ptr Struct4) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"struct4_a")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -254,7 +254,7 @@ newtype MC
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapMC" (Ptr MC) (Ptr ty)
+instance HasField "unwrapMC" (Ptr MC) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapMC")
 instance HasCField MC "unwrapMC"
     where type CFieldType MC "unwrapMC" = CChar
@@ -283,7 +283,7 @@ newtype TC
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapTC" (Ptr TC) (Ptr ty)
+instance HasField "unwrapTC" (Ptr TC) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapTC")
 instance HasCField TC "unwrapTC"
     where type CFieldType TC "unwrapTC" = CChar
@@ -315,7 +315,7 @@ deriving via (EquivStorable Struct1) instance Storable Struct1
 instance HasCField Struct1 "struct1_a"
     where type CFieldType Struct1 "struct1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct1_a" (Ptr Struct1) (Ptr ty)
+instance HasField "struct1_a" (Ptr Struct1) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct1_a")
 {-| __C declaration:__ @struct struct2@
 
@@ -344,7 +344,7 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_a"
     where type CFieldType Struct2 "struct2_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct2_a" (Ptr Struct2) (Ptr ty)
+instance HasField "struct2_a" (Ptr Struct2) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct2_a")
 {-| __C declaration:__ @struct struct3@
 
@@ -373,7 +373,7 @@ deriving via (EquivStorable Struct3) instance Storable Struct3
 instance HasCField Struct3 "struct3_a"
     where type CFieldType Struct3 "struct3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct3_a" (Ptr Struct3) (Ptr ty)
+instance HasField "struct3_a" (Ptr Struct3) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct3_a")
 {-| __C declaration:__ @struct3_t@
 
@@ -385,8 +385,7 @@ newtype Struct3_t
     = Struct3_t {unwrapStruct3_t :: Struct3}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct3 =>
-         HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr ty)
+instance HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr Struct3)
     where getField = fromPtr (Proxy @"unwrapStruct3_t")
 instance HasCField Struct3_t "unwrapStruct3_t"
     where type CFieldType Struct3_t "unwrapStruct3_t" = Struct3
@@ -418,7 +417,7 @@ deriving via (EquivStorable Struct4) instance Storable Struct4
 instance HasCField Struct4 "struct4_a"
     where type CFieldType Struct4 "struct4_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct4_a" (Ptr Struct4) (Ptr ty)
+instance HasField "struct4_a" (Ptr Struct4) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct4_a")
 -- __unique:__ @test_macrosmacro_in_fundecl_vs_typ_Example_Safe_quux1@
 foreign import ccall safe "hs_bindgen_02e0e3b28d470fd4" hs_bindgen_02e0e3b28d470fd4_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype FILE = FILE
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapFILE" (RIP.Ptr FILE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFILE" (RIP.Ptr FILE) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFILE")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/th.txt
@@ -23,7 +23,7 @@ newtype FILE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapFILE" (Ptr FILE) (Ptr ty)
+instance HasField "unwrapFILE" (Ptr FILE) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFILE")
 instance HasCField FILE "unwrapFILE"
     where type CFieldType FILE "unwrapFILE" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -44,8 +42,7 @@ newtype PtrToVoid = PtrToVoid
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "unwrapPtrToVoid" (RIP.Ptr PtrToVoid) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrToVoid" (RIP.Ptr PtrToVoid) (RIP.Ptr (RIP.Ptr RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrToVoid")
@@ -75,8 +72,7 @@ newtype PtrToConstVoidL = PtrToConstVoidL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.Void
-         ) => RIP.HasField "unwrapPtrToConstVoidL" (RIP.Ptr PtrToConstVoidL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrToConstVoidL" (RIP.Ptr PtrToConstVoidL) (RIP.Ptr (PtrConst.PtrConst RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrToConstVoidL")
@@ -106,8 +102,7 @@ newtype PtrToConstVoidR = PtrToConstVoidR
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.Void
-         ) => RIP.HasField "unwrapPtrToConstVoidR" (RIP.Ptr PtrToConstVoidR) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrToConstVoidR" (RIP.Ptr PtrToConstVoidR) (RIP.Ptr (PtrConst.PtrConst RIP.Void)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrToConstVoidR")
@@ -137,8 +132,7 @@ newtype PtrToConstIntL = PtrToConstIntL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.HasField "unwrapPtrToConstIntL" (RIP.Ptr PtrToConstIntL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrToConstIntL" (RIP.Ptr PtrToConstIntL) (RIP.Ptr (PtrConst.PtrConst RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrToConstIntL")
@@ -168,8 +162,7 @@ newtype PtrToConstIntR = PtrToConstIntR
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.HasField "unwrapPtrToConstIntR" (RIP.Ptr PtrToConstIntR) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrToConstIntR" (RIP.Ptr PtrToConstIntR) (RIP.Ptr (PtrConst.PtrConst RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrToConstIntR")
@@ -199,8 +192,7 @@ newtype ConstPtrToInt = ConstPtrToInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrapConstPtrToInt" (RIP.Ptr ConstPtrToInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConstPtrToInt" (RIP.Ptr ConstPtrToInt) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConstPtrToInt")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/th.txt
@@ -13,8 +13,9 @@ newtype PtrToVoid
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Void) =>
-         HasField "unwrapPtrToVoid" (Ptr PtrToVoid) (Ptr ty)
+instance HasField "unwrapPtrToVoid"
+                  (Ptr PtrToVoid)
+                  (Ptr (Ptr Void))
     where getField = fromPtr (Proxy @"unwrapPtrToVoid")
 instance HasCField PtrToVoid "unwrapPtrToVoid"
     where type CFieldType PtrToVoid "unwrapPtrToVoid" = Ptr Void
@@ -33,8 +34,9 @@ newtype PtrToConstVoidL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst Void) =>
-         HasField "unwrapPtrToConstVoidL" (Ptr PtrToConstVoidL) (Ptr ty)
+instance HasField "unwrapPtrToConstVoidL"
+                  (Ptr PtrToConstVoidL)
+                  (Ptr (PtrConst Void))
     where getField = fromPtr (Proxy @"unwrapPtrToConstVoidL")
 instance HasCField PtrToConstVoidL "unwrapPtrToConstVoidL"
     where type CFieldType PtrToConstVoidL
@@ -54,8 +56,9 @@ newtype PtrToConstVoidR
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst Void) =>
-         HasField "unwrapPtrToConstVoidR" (Ptr PtrToConstVoidR) (Ptr ty)
+instance HasField "unwrapPtrToConstVoidR"
+                  (Ptr PtrToConstVoidR)
+                  (Ptr (PtrConst Void))
     where getField = fromPtr (Proxy @"unwrapPtrToConstVoidR")
 instance HasCField PtrToConstVoidR "unwrapPtrToConstVoidR"
     where type CFieldType PtrToConstVoidR
@@ -75,8 +78,9 @@ newtype PtrToConstIntL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrapPtrToConstIntL" (Ptr PtrToConstIntL) (Ptr ty)
+instance HasField "unwrapPtrToConstIntL"
+                  (Ptr PtrToConstIntL)
+                  (Ptr (PtrConst CInt))
     where getField = fromPtr (Proxy @"unwrapPtrToConstIntL")
 instance HasCField PtrToConstIntL "unwrapPtrToConstIntL"
     where type CFieldType PtrToConstIntL
@@ -96,8 +100,9 @@ newtype PtrToConstIntR
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrapPtrToConstIntR" (Ptr PtrToConstIntR) (Ptr ty)
+instance HasField "unwrapPtrToConstIntR"
+                  (Ptr PtrToConstIntR)
+                  (Ptr (PtrConst CInt))
     where getField = fromPtr (Proxy @"unwrapPtrToConstIntR")
 instance HasCField PtrToConstIntR "unwrapPtrToConstIntR"
     where type CFieldType PtrToConstIntR
@@ -117,8 +122,9 @@ newtype ConstPtrToInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrapConstPtrToInt" (Ptr ConstPtrToInt) (Ptr ty)
+instance HasField "unwrapConstPtrToInt"
+                  (Ptr ConstPtrToInt)
+                  (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapConstPtrToInt")
 instance HasCField ConstPtrToInt "unwrapConstPtrToInt"
     where type CFieldType ConstPtrToInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -52,8 +50,7 @@ newtype MY_TYPE = MY_TYPE
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMY_TYPE" (RIP.Ptr MY_TYPE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMY_TYPE" (RIP.Ptr MY_TYPE) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMY_TYPE")
@@ -120,8 +117,7 @@ instance HasCField.HasCField Bar "bar_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_x" (RIP.Ptr Bar) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_x")
 
@@ -131,6 +127,6 @@ instance HasCField.HasCField Bar "bar_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ MY_TYPE) => RIP.HasField "bar_y" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_y" (RIP.Ptr Bar) (RIP.Ptr MY_TYPE) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_y")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/th.txt
@@ -23,8 +23,7 @@ newtype MY_TYPE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr ty)
+instance HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMY_TYPE")
 instance HasCField MY_TYPE "unwrapMY_TYPE"
     where type CFieldType MY_TYPE "unwrapMY_TYPE" = CInt
@@ -64,10 +63,10 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_x"
     where type CFieldType Bar "bar_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "bar_x" (Ptr Bar) (Ptr ty)
+instance HasField "bar_x" (Ptr Bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"bar_x")
 instance HasCField Bar "bar_y"
     where type CFieldType Bar "bar_y" = MY_TYPE
           offset# = \_ -> \_ -> 4
-instance (~) ty MY_TYPE => HasField "bar_y" (Ptr Bar) (Ptr ty)
+instance HasField "bar_y" (Ptr Bar) (Ptr MY_TYPE)
     where getField = fromPtr (Proxy @"bar_y")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_types/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -48,8 +46,7 @@ newtype PtrInt = PtrInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrapPtrInt" (RIP.Ptr PtrInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrInt" (RIP.Ptr PtrInt) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrInt")
@@ -89,8 +86,7 @@ newtype ShortInt = ShortInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapShortInt" (RIP.Ptr ShortInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapShortInt" (RIP.Ptr ShortInt) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapShortInt")
@@ -130,8 +126,7 @@ newtype SignedShortInt = SignedShortInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapSignedShortInt" (RIP.Ptr SignedShortInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSignedShortInt" (RIP.Ptr SignedShortInt) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSignedShortInt")
@@ -171,8 +166,7 @@ newtype UnsignedShortInt = UnsignedShortInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "unwrapUnsignedShortInt" (RIP.Ptr UnsignedShortInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUnsignedShortInt" (RIP.Ptr UnsignedShortInt) (RIP.Ptr RIP.CUShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUnsignedShortInt")
@@ -202,8 +196,7 @@ newtype PtrPtrChar = PtrPtrChar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr RIP.CChar)
-         ) => RIP.HasField "unwrapPtrPtrChar" (RIP.Ptr PtrPtrChar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPtrPtrChar" (RIP.Ptr PtrPtrChar) (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CChar))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPtrPtrChar")
@@ -241,8 +234,7 @@ newtype MTy = MTy
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "unwrapMTy" (RIP.Ptr MTy) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMTy" (RIP.Ptr MTy) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapMTy")
 
@@ -278,7 +270,7 @@ newtype Tty = Tty
     , Marshal.WriteRaw
     )
 
-instance (ty ~ MTy) => RIP.HasField "unwrapTty" (RIP.Ptr Tty) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTty" (RIP.Ptr Tty) (RIP.Ptr MTy) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTty")
 
@@ -316,8 +308,7 @@ newtype UINT8_T = UINT8_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unwrapUINT8_T" (RIP.Ptr UINT8_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUINT8_T" (RIP.Ptr UINT8_T) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUINT8_T")
@@ -356,8 +347,7 @@ newtype BOOLEAN_T = BOOLEAN_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ UINT8_T
-         ) => RIP.HasField "unwrapBOOLEAN_T" (RIP.Ptr BOOLEAN_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBOOLEAN_T" (RIP.Ptr BOOLEAN_T) (RIP.Ptr UINT8_T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBOOLEAN_T")
@@ -396,8 +386,7 @@ newtype Boolean_T = Boolean_T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ BOOLEAN_T
-         ) => RIP.HasField "unwrapBoolean_T" (RIP.Ptr Boolean_T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBoolean_T" (RIP.Ptr Boolean_T) (RIP.Ptr BOOLEAN_T) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBoolean_T")

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_types/th.txt
@@ -13,8 +13,7 @@ newtype PtrInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr ty)
+instance HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapPtrInt")
 instance HasCField PtrInt "unwrapPtrInt"
     where type CFieldType PtrInt "unwrapPtrInt" = Ptr CInt
@@ -43,8 +42,7 @@ newtype ShortInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort =>
-         HasField "unwrapShortInt" (Ptr ShortInt) (Ptr ty)
+instance HasField "unwrapShortInt" (Ptr ShortInt) (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapShortInt")
 instance HasCField ShortInt "unwrapShortInt"
     where type CFieldType ShortInt "unwrapShortInt" = CShort
@@ -73,8 +71,9 @@ newtype SignedShortInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort =>
-         HasField "unwrapSignedShortInt" (Ptr SignedShortInt) (Ptr ty)
+instance HasField "unwrapSignedShortInt"
+                  (Ptr SignedShortInt)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapSignedShortInt")
 instance HasCField SignedShortInt "unwrapSignedShortInt"
     where type CFieldType SignedShortInt
@@ -104,8 +103,9 @@ newtype UnsignedShortInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUShort =>
-         HasField "unwrapUnsignedShortInt" (Ptr UnsignedShortInt) (Ptr ty)
+instance HasField "unwrapUnsignedShortInt"
+                  (Ptr UnsignedShortInt)
+                  (Ptr CUShort)
     where getField = fromPtr (Proxy @"unwrapUnsignedShortInt")
 instance HasCField UnsignedShortInt "unwrapUnsignedShortInt"
     where type CFieldType UnsignedShortInt
@@ -125,8 +125,9 @@ newtype PtrPtrChar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr CChar)) =>
-         HasField "unwrapPtrPtrChar" (Ptr PtrPtrChar) (Ptr ty)
+instance HasField "unwrapPtrPtrChar"
+                  (Ptr PtrPtrChar)
+                  (Ptr (Ptr (Ptr CChar)))
     where getField = fromPtr (Proxy @"unwrapPtrPtrChar")
 instance HasCField PtrPtrChar "unwrapPtrPtrChar"
     where type CFieldType PtrPtrChar
@@ -154,7 +155,7 @@ newtype MTy
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CFloat => HasField "unwrapMTy" (Ptr MTy) (Ptr ty)
+instance HasField "unwrapMTy" (Ptr MTy) (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapMTy")
 instance HasCField MTy "unwrapMTy"
     where type CFieldType MTy "unwrapMTy" = CFloat
@@ -181,7 +182,7 @@ newtype Tty
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty MTy => HasField "unwrapTty" (Ptr Tty) (Ptr ty)
+instance HasField "unwrapTty" (Ptr Tty) (Ptr MTy)
     where getField = fromPtr (Proxy @"unwrapTty")
 instance HasCField Tty "unwrapTty"
     where type CFieldType Tty "unwrapTty" = MTy
@@ -210,8 +211,7 @@ newtype UINT8_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUChar =>
-         HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr ty)
+instance HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapUINT8_T")
 instance HasCField UINT8_T "unwrapUINT8_T"
     where type CFieldType UINT8_T "unwrapUINT8_T" = CUChar
@@ -240,8 +240,7 @@ newtype BOOLEAN_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty UINT8_T =>
-         HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr ty)
+instance HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr UINT8_T)
     where getField = fromPtr (Proxy @"unwrapBOOLEAN_T")
 instance HasCField BOOLEAN_T "unwrapBOOLEAN_T"
     where type CFieldType BOOLEAN_T "unwrapBOOLEAN_T" = UINT8_T
@@ -270,8 +269,7 @@ newtype Boolean_T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty BOOLEAN_T =>
-         HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr ty)
+instance HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr BOOLEAN_T)
     where getField = fromPtr (Proxy @"unwrapBoolean_T")
 instance HasCField Boolean_T "unwrapBoolean_T"
     where type CFieldType Boolean_T "unwrapBoolean_T" = BOOLEAN_T

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -83,8 +81,7 @@ newtype Outer_int = Outer_int
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapOuter_int" (RIP.Ptr Outer_int) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapOuter_int" (RIP.Ptr Outer_int) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapOuter_int")
@@ -124,8 +121,7 @@ newtype Inner_int = Inner_int
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Outer_int
-         ) => RIP.HasField "unwrapInner_int" (RIP.Ptr Inner_int) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInner_int" (RIP.Ptr Inner_int) (RIP.Ptr Outer_int) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInner_int")

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/th.txt
@@ -66,8 +66,7 @@ newtype Outer_int
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapOuter_int" (Ptr Outer_int) (Ptr ty)
+instance HasField "unwrapOuter_int" (Ptr Outer_int) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapOuter_int")
 instance HasCField Outer_int "unwrapOuter_int"
     where type CFieldType Outer_int "unwrapOuter_int" = CInt
@@ -96,8 +95,7 @@ newtype Inner_int
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty Outer_int =>
-         HasField "unwrapInner_int" (Ptr Inner_int) (Ptr ty)
+instance HasField "unwrapInner_int" (Ptr Inner_int) (Ptr Outer_int)
     where getField = fromPtr (Proxy @"unwrapInner_int")
 instance HasCField Inner_int "unwrapInner_int"
     where type CFieldType Inner_int "unwrapInner_int" = Outer_int

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -71,8 +69,7 @@ newtype TypeA = TypeA
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapTypeA" (RIP.Ptr TypeA) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTypeA" (RIP.Ptr TypeA) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTypeA")
@@ -111,8 +108,7 @@ newtype TypeB = TypeB
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ TypeA
-         ) => RIP.HasField "unwrapTypeB" (RIP.Ptr TypeB) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTypeB" (RIP.Ptr TypeB) (RIP.Ptr TypeA) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTypeB")

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/th.txt
@@ -51,7 +51,7 @@ newtype TypeA
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapTypeA" (Ptr TypeA) (Ptr ty)
+instance HasField "unwrapTypeA" (Ptr TypeA) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapTypeA")
 instance HasCField TypeA "unwrapTypeA"
     where type CFieldType TypeA "unwrapTypeA" = CInt
@@ -80,8 +80,7 @@ newtype TypeB
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty TypeA =>
-         HasField "unwrapTypeB" (Ptr TypeB) (Ptr ty)
+instance HasField "unwrapTypeB" (Ptr TypeB) (Ptr TypeA)
     where getField = fromPtr (Proxy @"unwrapTypeB")
 instance HasCField TypeB "unwrapTypeB"
     where type CFieldType TypeB "unwrapTypeB" = TypeA

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -56,8 +54,7 @@ newtype Ta = Ta
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapTa" (RIP.Ptr Ta) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTa" (RIP.Ptr Ta) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTa")
 
@@ -95,7 +92,7 @@ newtype Ma = Ma
     , Marshal.WriteRaw
     )
 
-instance (ty ~ Ta) => RIP.HasField "unwrapMa" (RIP.Ptr Ma) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMa" (RIP.Ptr Ma) (RIP.Ptr Ta) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapMa")
 
@@ -133,8 +130,7 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT1")
 
@@ -172,7 +168,7 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T1) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr T1) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM1")
 
@@ -210,7 +206,7 @@ newtype M2 = M2
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T1) => RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr T1) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM2")
 
@@ -248,8 +244,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -287,7 +282,7 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr T2) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
 
@@ -325,7 +320,7 @@ newtype M4 = M4
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T2) => RIP.HasField "unwrapM4" (RIP.Ptr M4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM4" (RIP.Ptr M4) (RIP.Ptr T2) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM4")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/th.txt
@@ -24,7 +24,7 @@ newtype Ta
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapTa" (Ptr Ta) (Ptr ty)
+instance HasField "unwrapTa" (Ptr Ta) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapTa")
 instance HasCField Ta "unwrapTa"
     where type CFieldType Ta "unwrapTa" = CInt
@@ -53,7 +53,7 @@ newtype Ma
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty Ta => HasField "unwrapMa" (Ptr Ma) (Ptr ty)
+instance HasField "unwrapMa" (Ptr Ma) (Ptr Ta)
     where getField = fromPtr (Proxy @"unwrapMa")
 instance HasCField Ma "unwrapMa"
     where type CFieldType Ma "unwrapMa" = Ta
@@ -82,7 +82,7 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -111,7 +111,7 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T1 => HasField "unwrapM1" (Ptr M1) (Ptr ty)
+instance HasField "unwrapM1" (Ptr M1) (Ptr T1)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = T1
@@ -140,7 +140,7 @@ newtype M2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T1 => HasField "unwrapM2" (Ptr M2) (Ptr ty)
+instance HasField "unwrapM2" (Ptr M2) (Ptr T1)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = T1
@@ -169,7 +169,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CInt
@@ -198,7 +198,7 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
+instance HasField "unwrapM3" (Ptr M3) (Ptr T2)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
@@ -227,7 +227,7 @@ newtype M4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T2 => HasField "unwrapM4" (Ptr M4) (Ptr ty)
+instance HasField "unwrapM4" (Ptr M4) (Ptr T2)
     where getField = fromPtr (Proxy @"unwrapM4")
 instance HasCField M4 "unwrapM4"
     where type CFieldType M4 "unwrapM4" = T2

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -51,8 +49,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -88,8 +85,7 @@ newtype T4 = T4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
 
@@ -127,8 +123,7 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT1")
 
@@ -166,8 +161,7 @@ newtype T3 = T3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
 
@@ -205,8 +199,7 @@ newtype T5 = T5
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT5" (RIP.Ptr T5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT5" (RIP.Ptr T5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT5")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/th.txt
@@ -22,7 +22,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CFloat => HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CFloat
@@ -49,7 +49,7 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CDouble => HasField "unwrapT4" (Ptr T4) (Ptr ty)
+instance HasField "unwrapT4" (Ptr T4) (Ptr CDouble)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = CDouble
@@ -78,7 +78,7 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -107,7 +107,7 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT3" (Ptr T3) (Ptr ty)
+instance HasField "unwrapT3" (Ptr T3) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = CInt
@@ -136,7 +136,7 @@ newtype T5
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT5" (Ptr T5) (Ptr ty)
+instance HasField "unwrapT5" (Ptr T5) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT5")
 instance HasCField T5 "unwrapT5"
     where type CFieldType T5 "unwrapT5" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -52,8 +50,7 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM1")
 
@@ -91,7 +88,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance (ty ~ M1) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr M1) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -129,7 +126,7 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr T2) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
 
@@ -167,7 +164,7 @@ newtype T4 = T4
     , Marshal.WriteRaw
     )
 
-instance (ty ~ M3) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr M3) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/th.txt
@@ -23,7 +23,7 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
+instance HasField "unwrapM1" (Ptr M1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
@@ -52,7 +52,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty M1 => HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr M1)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = M1
@@ -81,7 +81,7 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
+instance HasField "unwrapM3" (Ptr M3) (Ptr T2)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
@@ -110,7 +110,7 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty M3 => HasField "unwrapT4" (Ptr T4) (Ptr ty)
+instance HasField "unwrapT4" (Ptr T4) (Ptr M3)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = M3

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -52,8 +50,7 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM1")
 
@@ -91,7 +88,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance (ty ~ M1) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr M1) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -129,7 +126,7 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr T2) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
 
@@ -167,7 +164,7 @@ newtype T4 = T4
     , Marshal.WriteRaw
     )
 
-instance (ty ~ M3) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr M3) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/th.txt
@@ -25,7 +25,7 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
+instance HasField "unwrapM1" (Ptr M1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
@@ -54,7 +54,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty M1 => HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr M1)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = M1
@@ -83,7 +83,7 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
+instance HasField "unwrapM3" (Ptr M3) (Ptr T2)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
@@ -112,7 +112,7 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty M3 => HasField "unwrapT4" (Ptr T4) (Ptr ty)
+instance HasField "unwrapT4" (Ptr T4) (Ptr M3)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = M3

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/Example.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -106,8 +105,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -244,8 +242,7 @@ instance Read Some_enum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapSome_enum" (RIP.Ptr Some_enum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSome_enum" (RIP.Ptr Some_enum) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSome_enum")
@@ -278,8 +275,7 @@ newtype Arr_typedef1 = Arr_typedef1
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray A
-         ) => RIP.HasField "unwrapArr_typedef1" (RIP.Ptr Arr_typedef1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapArr_typedef1" (RIP.Ptr Arr_typedef1) (RIP.Ptr (IA.IncompleteArray A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapArr_typedef1")
@@ -303,8 +299,7 @@ newtype Arr_typedef2 = Arr_typedef2
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
-instance ( ty ~ IA.IncompleteArray (RIP.Ptr A)
-         ) => RIP.HasField "unwrapArr_typedef2" (RIP.Ptr Arr_typedef2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapArr_typedef2" (RIP.Ptr Arr_typedef2) (RIP.Ptr (IA.IncompleteArray (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapArr_typedef2")
@@ -334,8 +329,7 @@ newtype Arr_typedef3 = Arr_typedef3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 5 A
-         ) => RIP.HasField "unwrapArr_typedef3" (RIP.Ptr Arr_typedef3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapArr_typedef3" (RIP.Ptr Arr_typedef3) (RIP.Ptr (CA.ConstantArray 5 A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapArr_typedef3")
@@ -365,8 +359,7 @@ newtype Arr_typedef4 = Arr_typedef4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ CA.ConstantArray 5 (RIP.Ptr A)
-         ) => RIP.HasField "unwrapArr_typedef4" (RIP.Ptr Arr_typedef4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapArr_typedef4" (RIP.Ptr Arr_typedef4) (RIP.Ptr (CA.ConstantArray 5 (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapArr_typedef4")
@@ -408,8 +401,7 @@ newtype Typedef1 = Typedef1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ A
-         ) => RIP.HasField "unwrapTypedef1" (RIP.Ptr Typedef1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTypedef1" (RIP.Ptr Typedef1) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTypedef1")
@@ -438,8 +430,7 @@ newtype Typedef2 = Typedef2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "unwrapTypedef2" (RIP.Ptr Typedef2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTypedef2" (RIP.Ptr Typedef2) (RIP.Ptr (RIP.Ptr A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTypedef2")
@@ -468,8 +459,7 @@ newtype Typedef3 = Typedef3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr A)
-         ) => RIP.HasField "unwrapTypedef3" (RIP.Ptr Typedef3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTypedef3" (RIP.Ptr Typedef3) (RIP.Ptr (RIP.Ptr (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapTypedef3")
@@ -529,8 +519,7 @@ instance RIP.FromFunPtr Funptr_typedef1_Aux where
 
   fromFunPtr = hs_bindgen_806a46dc418a062c
 
-instance ( ty ~ IO A
-         ) => RIP.HasField "unwrapFunptr_typedef1_Aux" (RIP.Ptr Funptr_typedef1_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef1_Aux" (RIP.Ptr Funptr_typedef1_Aux) (RIP.Ptr (IO A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef1_Aux")
@@ -560,8 +549,7 @@ newtype Funptr_typedef1 = Funptr_typedef1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Funptr_typedef1_Aux
-         ) => RIP.HasField "unwrapFunptr_typedef1" (RIP.Ptr Funptr_typedef1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef1" (RIP.Ptr Funptr_typedef1) (RIP.Ptr (RIP.FunPtr Funptr_typedef1_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef1")
@@ -621,8 +609,7 @@ instance RIP.FromFunPtr Funptr_typedef2_Aux where
 
   fromFunPtr = hs_bindgen_323d07dff85b802c
 
-instance ( ty ~ IO (RIP.Ptr A)
-         ) => RIP.HasField "unwrapFunptr_typedef2_Aux" (RIP.Ptr Funptr_typedef2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef2_Aux" (RIP.Ptr Funptr_typedef2_Aux) (RIP.Ptr (IO (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef2_Aux")
@@ -652,8 +639,7 @@ newtype Funptr_typedef2 = Funptr_typedef2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Funptr_typedef2_Aux
-         ) => RIP.HasField "unwrapFunptr_typedef2" (RIP.Ptr Funptr_typedef2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef2" (RIP.Ptr Funptr_typedef2) (RIP.Ptr (RIP.FunPtr Funptr_typedef2_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef2")
@@ -713,8 +699,7 @@ instance RIP.FromFunPtr Funptr_typedef3_Aux where
 
   fromFunPtr = hs_bindgen_82dc7b932974117e
 
-instance ( ty ~ IO (RIP.Ptr (RIP.Ptr A))
-         ) => RIP.HasField "unwrapFunptr_typedef3_Aux" (RIP.Ptr Funptr_typedef3_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef3_Aux" (RIP.Ptr Funptr_typedef3_Aux) (RIP.Ptr (IO (RIP.Ptr (RIP.Ptr A)))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef3_Aux")
@@ -744,8 +729,7 @@ newtype Funptr_typedef3 = Funptr_typedef3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Funptr_typedef3_Aux
-         ) => RIP.HasField "unwrapFunptr_typedef3" (RIP.Ptr Funptr_typedef3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef3" (RIP.Ptr Funptr_typedef3) (RIP.Ptr (RIP.FunPtr Funptr_typedef3_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef3")
@@ -805,8 +789,7 @@ instance RIP.FromFunPtr Funptr_typedef4_Aux where
 
   fromFunPtr = hs_bindgen_d4a97954476da161
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.HasField "unwrapFunptr_typedef4_Aux" (RIP.Ptr Funptr_typedef4_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef4_Aux" (RIP.Ptr Funptr_typedef4_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef4_Aux")
@@ -836,8 +819,7 @@ newtype Funptr_typedef4 = Funptr_typedef4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Funptr_typedef4_Aux
-         ) => RIP.HasField "unwrapFunptr_typedef4" (RIP.Ptr Funptr_typedef4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef4" (RIP.Ptr Funptr_typedef4) (RIP.Ptr (RIP.FunPtr Funptr_typedef4_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef4")
@@ -897,8 +879,7 @@ instance RIP.FromFunPtr Funptr_typedef5_Aux where
 
   fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
-         ) => RIP.HasField "unwrapFunptr_typedef5_Aux" (RIP.Ptr Funptr_typedef5_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef5_Aux" (RIP.Ptr Funptr_typedef5_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef5_Aux")
@@ -928,8 +909,7 @@ newtype Funptr_typedef5 = Funptr_typedef5
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Funptr_typedef5_Aux
-         ) => RIP.HasField "unwrapFunptr_typedef5" (RIP.Ptr Funptr_typedef5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunptr_typedef5" (RIP.Ptr Funptr_typedef5) (RIP.Ptr (RIP.FunPtr Funptr_typedef5_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunptr_typedef5")
@@ -969,8 +949,7 @@ newtype Comments2 = Comments2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ A
-         ) => RIP.HasField "unwrapComments2" (RIP.Ptr Comments2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapComments2" (RIP.Ptr Comments2) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapComments2")
@@ -1052,8 +1031,7 @@ instance HasCField.HasCField Example_struct "example_struct_field1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ A
-         ) => RIP.HasField "example_struct_field1" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_field1" (RIP.Ptr Example_struct) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_field1")
@@ -1065,8 +1043,7 @@ instance HasCField.HasCField Example_struct "example_struct_field2" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "example_struct_field2" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_field2" (RIP.Ptr Example_struct) (RIP.Ptr (RIP.Ptr A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_field2")
@@ -1078,8 +1055,7 @@ instance HasCField.HasCField Example_struct "example_struct_field3" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr A)
-         ) => RIP.HasField "example_struct_field3" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_field3" (RIP.Ptr Example_struct) (RIP.Ptr (RIP.Ptr (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_field3")
@@ -1112,8 +1088,7 @@ newtype Const_typedef1 = Const_typedef1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ A
-         ) => RIP.HasField "unwrapConst_typedef1" (RIP.Ptr Const_typedef1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef1" (RIP.Ptr Const_typedef1) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef1")
@@ -1153,8 +1128,7 @@ newtype Const_typedef2 = Const_typedef2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ A
-         ) => RIP.HasField "unwrapConst_typedef2" (RIP.Ptr Const_typedef2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef2" (RIP.Ptr Const_typedef2) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef2")
@@ -1184,8 +1158,7 @@ newtype Const_typedef3 = Const_typedef3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "unwrapConst_typedef3" (RIP.Ptr Const_typedef3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef3" (RIP.Ptr Const_typedef3) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef3")
@@ -1215,8 +1188,7 @@ newtype Const_typedef4 = Const_typedef4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "unwrapConst_typedef4" (RIP.Ptr Const_typedef4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef4" (RIP.Ptr Const_typedef4) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef4")
@@ -1246,8 +1218,7 @@ newtype Const_typedef5 = Const_typedef5
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "unwrapConst_typedef5" (RIP.Ptr Const_typedef5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef5" (RIP.Ptr Const_typedef5) (RIP.Ptr (RIP.Ptr A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef5")
@@ -1277,8 +1248,7 @@ newtype Const_typedef6 = Const_typedef6
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "unwrapConst_typedef6" (RIP.Ptr Const_typedef6) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef6" (RIP.Ptr Const_typedef6) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef6")
@@ -1308,8 +1278,7 @@ newtype Const_typedef7 = Const_typedef7
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "unwrapConst_typedef7" (RIP.Ptr Const_typedef7) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_typedef7" (RIP.Ptr Const_typedef7) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_typedef7")
@@ -1430,8 +1399,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ A
-         ) => RIP.HasField "example_struct_with_const_const_field1" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field1" (RIP.Ptr Example_struct_with_const) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field1")
@@ -1443,8 +1411,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ A
-         ) => RIP.HasField "example_struct_with_const_const_field2" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field2" (RIP.Ptr Example_struct_with_const) (RIP.Ptr A) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field2")
@@ -1456,8 +1423,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field3" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field3" (RIP.Ptr Example_struct_with_const) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field3")
@@ -1469,8 +1435,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field4" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field4" (RIP.Ptr Example_struct_with_const) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field4")
@@ -1482,8 +1447,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "example_struct_with_const_const_field5" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field5" (RIP.Ptr Example_struct_with_const) (RIP.Ptr (RIP.Ptr A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field5")
@@ -1495,8 +1459,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field6" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field6" (RIP.Ptr Example_struct_with_const) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field6")
@@ -1508,8 +1471,7 @@ instance HasCField.HasCField Example_struct_with_const "example_struct_with_cons
 
   offset# = \_ -> \_ -> 40
 
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field7" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance RIP.HasField "example_struct_with_const_const_field7" (RIP.Ptr Example_struct_with_const) (RIP.Ptr (PtrConst.PtrConst A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field7")
@@ -1562,8 +1524,7 @@ instance RIP.FromFunPtr Const_funptr1_Aux where
 
   fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.HasField "unwrapConst_funptr1_Aux" (RIP.Ptr Const_funptr1_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr1_Aux" (RIP.Ptr Const_funptr1_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr1_Aux")
@@ -1593,8 +1554,7 @@ newtype Const_funptr1 = Const_funptr1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr1_Aux
-         ) => RIP.HasField "unwrapConst_funptr1" (RIP.Ptr Const_funptr1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr1" (RIP.Ptr Const_funptr1) (RIP.Ptr (RIP.FunPtr Const_funptr1_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr1")
@@ -1654,8 +1614,7 @@ instance RIP.FromFunPtr Const_funptr2_Aux where
 
   fromFunPtr = hs_bindgen_352cebf463125ca9
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.HasField "unwrapConst_funptr2_Aux" (RIP.Ptr Const_funptr2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr2_Aux" (RIP.Ptr Const_funptr2_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO A)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr2_Aux")
@@ -1685,8 +1644,7 @@ newtype Const_funptr2 = Const_funptr2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr2_Aux
-         ) => RIP.HasField "unwrapConst_funptr2" (RIP.Ptr Const_funptr2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr2" (RIP.Ptr Const_funptr2) (RIP.Ptr (RIP.FunPtr Const_funptr2_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr2")
@@ -1746,8 +1704,7 @@ instance RIP.FromFunPtr Const_funptr3_Aux where
 
   fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.HasField "unwrapConst_funptr3_Aux" (RIP.Ptr Const_funptr3_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr3_Aux" (RIP.Ptr Const_funptr3_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr3_Aux")
@@ -1777,8 +1734,7 @@ newtype Const_funptr3 = Const_funptr3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr3_Aux
-         ) => RIP.HasField "unwrapConst_funptr3" (RIP.Ptr Const_funptr3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr3" (RIP.Ptr Const_funptr3) (RIP.Ptr (RIP.FunPtr Const_funptr3_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr3")
@@ -1838,8 +1794,7 @@ instance RIP.FromFunPtr Const_funptr4_Aux where
 
   fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.HasField "unwrapConst_funptr4_Aux" (RIP.Ptr Const_funptr4_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr4_Aux" (RIP.Ptr Const_funptr4_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr4_Aux")
@@ -1869,8 +1824,7 @@ newtype Const_funptr4 = Const_funptr4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr4_Aux
-         ) => RIP.HasField "unwrapConst_funptr4" (RIP.Ptr Const_funptr4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr4" (RIP.Ptr Const_funptr4) (RIP.Ptr (RIP.FunPtr Const_funptr4_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr4")
@@ -1930,8 +1884,7 @@ instance RIP.FromFunPtr Const_funptr5_Aux where
 
   fromFunPtr = hs_bindgen_38a21d84bb7115b5
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
-         ) => RIP.HasField "unwrapConst_funptr5_Aux" (RIP.Ptr Const_funptr5_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr5_Aux" (RIP.Ptr Const_funptr5_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr5_Aux")
@@ -1961,8 +1914,7 @@ newtype Const_funptr5 = Const_funptr5
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr5_Aux
-         ) => RIP.HasField "unwrapConst_funptr5" (RIP.Ptr Const_funptr5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr5" (RIP.Ptr Const_funptr5) (RIP.Ptr (RIP.FunPtr Const_funptr5_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr5")
@@ -2022,8 +1974,7 @@ instance RIP.FromFunPtr Const_funptr6_Aux where
 
   fromFunPtr = hs_bindgen_45251216b04aa8b5
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.HasField "unwrapConst_funptr6_Aux" (RIP.Ptr Const_funptr6_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr6_Aux" (RIP.Ptr Const_funptr6_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr6_Aux")
@@ -2053,8 +2004,7 @@ newtype Const_funptr6 = Const_funptr6
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr6_Aux
-         ) => RIP.HasField "unwrapConst_funptr6" (RIP.Ptr Const_funptr6) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr6" (RIP.Ptr Const_funptr6) (RIP.Ptr (RIP.FunPtr Const_funptr6_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr6")
@@ -2114,8 +2064,7 @@ instance RIP.FromFunPtr Const_funptr7_Aux where
 
   fromFunPtr = hs_bindgen_42fbcebf75a973ba
 
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.HasField "unwrapConst_funptr7_Aux" (RIP.Ptr Const_funptr7_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr7_Aux" (RIP.Ptr Const_funptr7_Aux) (RIP.Ptr (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr7_Aux")
@@ -2145,8 +2094,7 @@ newtype Const_funptr7 = Const_funptr7
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr Const_funptr7_Aux
-         ) => RIP.HasField "unwrapConst_funptr7" (RIP.Ptr Const_funptr7) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapConst_funptr7" (RIP.Ptr Const_funptr7) (RIP.Ptr (RIP.FunPtr Const_funptr7_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapConst_funptr7")
@@ -2188,8 +2136,7 @@ newtype BOOL = BOOL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBOOL")
@@ -2228,8 +2175,7 @@ newtype INT = INT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapINT" (RIP.Ptr INT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapINT" (RIP.Ptr INT) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapINT")
 
@@ -2257,8 +2203,7 @@ newtype INTP = INTP
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrapINTP" (RIP.Ptr INTP) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapINTP" (RIP.Ptr INTP) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapINTP")
@@ -2287,8 +2232,7 @@ newtype INTCP = INTCP
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.HasField "unwrapINTCP" (RIP.Ptr INTCP) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapINTCP" (RIP.Ptr INTCP) (RIP.Ptr (PtrConst.PtrConst RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapINTCP")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/th.txt
@@ -584,7 +584,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype BOOL = BOOL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBOOL")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/th.txt
@@ -84,7 +84,7 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -72,7 +70,7 @@ instance HasCField.HasCField S "s_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
@@ -93,7 +91,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr S) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 
@@ -120,7 +118,7 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
-instance (ty ~ T) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr T) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
 
@@ -148,8 +146,7 @@ newtype Bar = Bar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr T
-         ) => RIP.HasField "unwrapBar" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBar" (RIP.Ptr Bar) (RIP.Ptr (RIP.Ptr T)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapBar")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_x"
     where type CFieldType S "s_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
+instance HasField "s_x" (Ptr S) (Ptr CInt)
     where getField = fromPtr (Proxy @"s_x")
 {-| __C declaration:__ @macro T@
 
@@ -38,7 +38,7 @@ newtype T
     = T {unwrapT :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S
@@ -53,7 +53,7 @@ newtype Foo
     = Foo {unwrapFoo :: T}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty T => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+instance HasField "unwrapFoo" (Ptr Foo) (Ptr T)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = T
@@ -72,7 +72,7 @@ newtype Bar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr T) => HasField "unwrapBar" (Ptr Bar) (Ptr ty)
+instance HasField "unwrapBar" (Ptr Bar) (Ptr (Ptr T))
     where getField = fromPtr (Proxy @"unwrapBar")
 instance HasCField Bar "unwrapBar"
     where type CFieldType Bar "unwrapBar" = Ptr T

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExplicitForAll #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -61,8 +59,7 @@ newtype MY_INT = MY_INT
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMY_INT" (RIP.Ptr MY_INT) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMY_INT" (RIP.Ptr MY_INT) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMY_INT")
@@ -101,8 +98,7 @@ newtype My_int_t = My_int_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ MY_INT
-         ) => RIP.HasField "unwrapMy_int_t" (RIP.Ptr My_int_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMy_int_t" (RIP.Ptr My_int_t) (RIP.Ptr MY_INT) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMy_int_t")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/th.txt
@@ -98,8 +98,7 @@ newtype MY_INT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapMY_INT" (Ptr MY_INT) (Ptr ty)
+instance HasField "unwrapMY_INT" (Ptr MY_INT) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMY_INT")
 instance HasCField MY_INT "unwrapMY_INT"
     where type CFieldType MY_INT "unwrapMY_INT" = CInt
@@ -128,8 +127,7 @@ newtype My_int_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty MY_INT =>
-         HasField "unwrapMy_int_t" (Ptr My_int_t) (Ptr ty)
+instance HasField "unwrapMy_int_t" (Ptr My_int_t) (Ptr MY_INT)
     where getField = fromPtr (Proxy @"unwrapMy_int_t")
 instance HasCField My_int_t "unwrapMy_int_t"
     where type CFieldType My_int_t "unwrapMy_int_t" = MY_INT

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype BOOL = BOOL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBOOL")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/th.txt
@@ -124,7 +124,7 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -54,8 +52,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -113,7 +110,7 @@ instance HasCField.HasCField T2 "t2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
@@ -164,7 +161,7 @@ instance HasCField.HasCField T3 "t3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
@@ -215,6 +212,6 @@ instance HasCField.HasCField T4 "t4_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t4_x" (RIP.Ptr T4) (RIP.Ptr ty) where
+instance RIP.HasField "t4_x" (RIP.Ptr T4) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t4_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -57,8 +55,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -116,7 +113,7 @@ instance HasCField.HasCField T1_x "t1_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
@@ -167,7 +164,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr T1_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -218,8 +215,7 @@ instance HasCField.HasCField T2 "t2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_x)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
@@ -270,7 +266,7 @@ instance HasCField.HasCField T2_x "t2_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
@@ -321,8 +317,7 @@ instance HasCField.HasCField T3 "t3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_x))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
@@ -373,6 +368,6 @@ instance HasCField.HasCField T3_x "t3_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -74,7 +74,7 @@ deriving via (EquivStorable T1_x) instance Storable T1_x
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+instance HasField "t1_x_x" (Ptr T1_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @struct \@T1@
 
@@ -103,7 +103,7 @@ deriving via (EquivStorable T1) instance Storable T1
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr T1_x)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @struct \@T2@
 
@@ -132,7 +132,7 @@ deriving via (EquivStorable T2) instance Storable T2
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+instance HasField "t2_x" (Ptr T2) (Ptr (Ptr T2_x))
     where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @struct \@T2_x@
 
@@ -161,7 +161,7 @@ deriving via (EquivStorable T2_x) instance Storable T2_x
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+instance HasField "t2_x_x" (Ptr T2_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @struct \@T3@
 
@@ -190,8 +190,7 @@ deriving via (EquivStorable T3) instance Storable T3
 instance HasCField T3 "t3_x"
     where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
+instance HasField "t3_x" (Ptr T3) (Ptr (Ptr (Ptr T3_x)))
     where getField = fromPtr (Proxy @"t3_x")
 {-| __C declaration:__ @struct \@T3_x@
 
@@ -220,7 +219,7 @@ deriving via (EquivStorable T3_x) instance Storable T3_x
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+instance HasField "t3_x_x" (Ptr T3_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -56,8 +54,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -115,7 +112,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -166,8 +163,7 @@ instance HasCField.HasCField T2_Aux "t2_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
 
@@ -189,8 +185,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr T2_Aux
-         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -247,8 +242,7 @@ instance HasCField.HasCField T3_Aux "t3_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
 
@@ -270,8 +264,7 @@ newtype T3 = T3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
-         ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
@@ -23,7 +23,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -55,7 +55,7 @@ deriving via (EquivStorable T1) instance Storable T1
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @struct \@T2_Aux@
 
@@ -84,7 +84,7 @@ deriving via (EquivStorable T2_Aux) instance Storable T2_Aux
 instance HasCField T2_Aux "t2_Aux_x"
     where type CFieldType T2_Aux "t2_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+instance HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_Aux_x")
 {-| __C declaration:__ @T2@
 
@@ -100,8 +100,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr T2_Aux) =>
-         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr (Ptr T2_Aux))
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
@@ -133,7 +132,7 @@ deriving via (EquivStorable T3_Aux) instance Storable T3_Aux
 instance HasCField T3_Aux "t3_Aux_x"
     where type CFieldType T3_Aux "t3_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+instance HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_Aux_x")
 {-| __C declaration:__ @T3@
 
@@ -149,8 +148,7 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr T3_Aux)) =>
-         HasField "unwrapT3" (Ptr T3) (Ptr ty)
+instance HasField "unwrapT3" (Ptr T3) (Ptr (Ptr (Ptr T3_Aux)))
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -63,8 +61,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -122,7 +119,7 @@ instance HasCField.HasCField T1_x "t1_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
@@ -176,7 +173,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr T1_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -230,8 +227,7 @@ instance HasCField.HasCField T2 "t2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_x)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
@@ -282,7 +278,7 @@ instance HasCField.HasCField T2_x "t2_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
@@ -336,8 +332,7 @@ instance HasCField.HasCField T3 "t3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_x))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
@@ -388,6 +383,6 @@ instance HasCField.HasCField T3_x "t3_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -74,7 +74,7 @@ deriving via (EquivStorable T1_x) instance Storable T1_x
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+instance HasField "t1_x_x" (Ptr T1_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @union \@T1@
 
@@ -124,7 +124,7 @@ set_t1_x = setUnionPayload
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr T1_x)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2@
 
@@ -174,7 +174,7 @@ set_t2_x = setUnionPayload
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+instance HasField "t2_x" (Ptr T2) (Ptr (Ptr T2_x))
     where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @struct \@T2_x@
 
@@ -203,7 +203,7 @@ deriving via (EquivStorable T2_x) instance Storable T2_x
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+instance HasField "t2_x_x" (Ptr T2_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @union \@T3@
 
@@ -253,8 +253,7 @@ set_t3_x = setUnionPayload
 instance HasCField T3 "t3_x"
     where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
+instance HasField "t3_x" (Ptr T3) (Ptr (Ptr (Ptr T3_x)))
     where getField = fromPtr (Proxy @"t3_x")
 {-| __C declaration:__ @struct \@T3_x@
 
@@ -283,7 +282,7 @@ deriving via (EquivStorable T3_x) instance Storable T3_x
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+instance HasField "t3_x_x" (Ptr T3_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -54,8 +52,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -113,7 +110,7 @@ instance HasCField.HasCField G1 "g1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+instance RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
 
@@ -164,7 +161,7 @@ instance HasCField.HasCField G2 "g2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+instance RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
 
@@ -215,6 +212,6 @@ instance HasCField.HasCField G3 "g3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+instance RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g3_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -74,7 +74,7 @@ deriving via (EquivStorable G1) instance Storable G1
 instance HasCField G1 "g1_x"
     where type CFieldType G1 "g1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+instance HasField "g1_x" (Ptr G1) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g1_x")
 {-| __C declaration:__ @struct \@G2@
 
@@ -103,7 +103,7 @@ deriving via (EquivStorable G2) instance Storable G2
 instance HasCField G2 "g2_x"
     where type CFieldType G2 "g2_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+instance HasField "g2_x" (Ptr G2) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g2_x")
 {-| __C declaration:__ @struct \@G3@
 
@@ -132,7 +132,7 @@ deriving via (EquivStorable G3) instance Storable G3
 instance HasCField G3 "g3_x"
     where type CFieldType G3 "g3_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+instance HasField "g3_x" (Ptr G3) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g3_x")
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
 foreign import ccall unsafe "hs_bindgen_7b488cf23d974403" hs_bindgen_7b488cf23d974403_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
@@ -23,7 +23,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -55,7 +55,7 @@ deriving via (EquivStorable T2) instance Storable T2
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x" (Ptr T2) (Ptr ty)
+instance HasField "t2_x" (Ptr T2) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @struct TS3@
 
@@ -84,7 +84,7 @@ deriving via (EquivStorable T3) instance Storable T3
 instance HasCField T3 "t3_x"
     where type CFieldType T3 "t3_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x" (Ptr T3) (Ptr ty)
+instance HasField "t3_x" (Ptr T3) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_x")
 {-| __C declaration:__ @struct T4@
 
@@ -113,5 +113,5 @@ deriving via (EquivStorable T4) instance Storable T4
 instance HasCField T4 "t4_x"
     where type CFieldType T4 "t4_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t4_x" (Ptr T4) (Ptr ty)
+instance HasField "t4_x" (Ptr T4) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t4_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -63,8 +61,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -125,7 +122,7 @@ instance HasCField.HasCField T1_x "t1_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
@@ -176,7 +173,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr T1_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -227,8 +224,7 @@ instance HasCField.HasCField T2 "t2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_x)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
@@ -282,7 +278,7 @@ instance HasCField.HasCField T2_x "t2_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
@@ -333,8 +329,7 @@ instance HasCField.HasCField T3 "t3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_x))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
@@ -388,6 +383,6 @@ instance HasCField.HasCField T3_x "t3_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -97,7 +97,7 @@ set_t1_x_x = setUnionPayload
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+instance HasField "t1_x_x" (Ptr T1_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @struct \@T1@
 
@@ -126,7 +126,7 @@ deriving via (EquivStorable T1) instance Storable T1
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr T1_x)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @struct \@T2@
 
@@ -155,7 +155,7 @@ deriving via (EquivStorable T2) instance Storable T2
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+instance HasField "t2_x" (Ptr T2) (Ptr (Ptr T2_x))
     where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @union \@T2_x@
 
@@ -207,7 +207,7 @@ set_t2_x_x = setUnionPayload
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+instance HasField "t2_x_x" (Ptr T2_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @struct \@T3@
 
@@ -236,8 +236,7 @@ deriving via (EquivStorable T3) instance Storable T3
 instance HasCField T3 "t3_x"
     where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
+instance HasField "t3_x" (Ptr T3) (Ptr (Ptr (Ptr T3_x)))
     where getField = fromPtr (Proxy @"t3_x")
 {-| __C declaration:__ @union \@T3_x@
 
@@ -289,7 +288,7 @@ set_t3_x_x = setUnionPayload
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+instance HasField "t3_x_x" (Ptr T3_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -62,8 +60,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -124,7 +121,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -178,8 +175,7 @@ instance HasCField.HasCField T2_Aux "t2_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
 
@@ -201,8 +197,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr T2_Aux
-         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -262,8 +257,7 @@ instance HasCField.HasCField T3_Aux "t3_Aux_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
 
@@ -285,8 +279,7 @@ newtype T3 = T3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
-         ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
@@ -23,7 +23,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -76,7 +76,7 @@ set_t1_x = setUnionPayload
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2_Aux@
 
@@ -128,7 +128,7 @@ set_t2_Aux_x = setUnionPayload
 instance HasCField T2_Aux "t2_Aux_x"
     where type CFieldType T2_Aux "t2_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+instance HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_Aux_x")
 {-| __C declaration:__ @T2@
 
@@ -144,8 +144,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr T2_Aux) =>
-         HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr (Ptr T2_Aux))
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
@@ -200,7 +199,7 @@ set_t3_Aux_x = setUnionPayload
 instance HasCField T3_Aux "t3_Aux_x"
     where type CFieldType T3_Aux "t3_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+instance HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_Aux_x")
 {-| __C declaration:__ @T3@
 
@@ -216,8 +215,7 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr T3_Aux)) =>
-         HasField "unwrapT3" (Ptr T3) (Ptr ty)
+instance HasField "unwrapT3" (Ptr T3) (Ptr (Ptr (Ptr T3_Aux)))
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -69,8 +67,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -131,7 +128,7 @@ instance HasCField.HasCField T1_x "t1_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
@@ -185,7 +182,7 @@ instance HasCField.HasCField T1 "t1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr T1_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
@@ -239,8 +236,7 @@ instance HasCField.HasCField T2 "t2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr (RIP.Ptr T2_x)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
@@ -294,7 +290,7 @@ instance HasCField.HasCField T2_x "t2_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+instance RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
@@ -348,8 +344,7 @@ instance HasCField.HasCField T3 "t3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr (RIP.Ptr (RIP.Ptr T3_x))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
@@ -403,6 +398,6 @@ instance HasCField.HasCField T3_x "t3_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+instance RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -97,7 +97,7 @@ set_t1_x_x = setUnionPayload
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+instance HasField "t1_x_x" (Ptr T1_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @union \@T1@
 
@@ -147,7 +147,7 @@ set_t1_x = setUnionPayload
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+instance HasField "t1_x" (Ptr T1) (Ptr T1_x)
     where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2@
 
@@ -197,7 +197,7 @@ set_t2_x = setUnionPayload
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+instance HasField "t2_x" (Ptr T2) (Ptr (Ptr T2_x))
     where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @union \@T2_x@
 
@@ -249,7 +249,7 @@ set_t2_x_x = setUnionPayload
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+instance HasField "t2_x_x" (Ptr T2_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @union \@T3@
 
@@ -299,8 +299,7 @@ set_t3_x = setUnionPayload
 instance HasCField T3 "t3_x"
     where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
+instance HasField "t3_x" (Ptr T3) (Ptr (Ptr (Ptr T3_x)))
     where getField = fromPtr (Proxy @"t3_x")
 {-| __C declaration:__ @union \@T3_x@
 
@@ -352,7 +351,7 @@ set_t3_x_x = setUnionPayload
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+instance HasField "t3_x_x" (Ptr T3_x) (Ptr MyInt)
     where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -60,8 +58,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -122,7 +119,7 @@ instance HasCField.HasCField G1 "g1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+instance RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
 
@@ -176,7 +173,7 @@ instance HasCField.HasCField G2 "g2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+instance RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
 
@@ -230,6 +227,6 @@ instance HasCField.HasCField G3 "g3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+instance RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr MyInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"g3_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
@@ -42,7 +42,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -95,7 +95,7 @@ set_g1_x = setUnionPayload
 instance HasCField G1 "g1_x"
     where type CFieldType G1 "g1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+instance HasField "g1_x" (Ptr G1) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g1_x")
 {-| __C declaration:__ @union \@G2@
 
@@ -145,7 +145,7 @@ set_g2_x = setUnionPayload
 instance HasCField G2 "g2_x"
     where type CFieldType G2 "g2_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+instance HasField "g2_x" (Ptr G2) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g2_x")
 {-| __C declaration:__ @union \@G3@
 
@@ -195,7 +195,7 @@ set_g3_x = setUnionPayload
 instance HasCField G3 "g3_x"
     where type CFieldType G3 "g3_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+instance HasField "g3_x" (Ptr G3) (Ptr MyInt)
     where getField = fromPtr (Proxy @"g3_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
 foreign import ccall unsafe "hs_bindgen_4b01ee4d60407c60" hs_bindgen_4b01ee4d60407c60_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/th.txt
@@ -2533,7 +2533,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
@@ -2608,8 +2608,7 @@ instance Read Some_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr ty)
+instance HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapSome_enum")
 instance HasCField Some_enum "unwrapSome_enum"
     where type CFieldType Some_enum "unwrapSome_enum" = CUInt
@@ -2632,8 +2631,9 @@ newtype Arr_typedef1
     = Arr_typedef1 {unwrapArr_typedef1 :: (IncompleteArray A)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray A) =>
-         HasField "unwrapArr_typedef1" (Ptr Arr_typedef1) (Ptr ty)
+instance HasField "unwrapArr_typedef1"
+                  (Ptr Arr_typedef1)
+                  (Ptr (IncompleteArray A))
     where getField = fromPtr (Proxy @"unwrapArr_typedef1")
 instance HasCField Arr_typedef1 "unwrapArr_typedef1"
     where type CFieldType Arr_typedef1
@@ -2649,8 +2649,9 @@ newtype Arr_typedef2
     = Arr_typedef2 {unwrapArr_typedef2 :: (IncompleteArray (Ptr A))}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
-instance (~) ty (IncompleteArray (Ptr A)) =>
-         HasField "unwrapArr_typedef2" (Ptr Arr_typedef2) (Ptr ty)
+instance HasField "unwrapArr_typedef2"
+                  (Ptr Arr_typedef2)
+                  (Ptr (IncompleteArray (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapArr_typedef2")
 instance HasCField Arr_typedef2 "unwrapArr_typedef2"
     where type CFieldType Arr_typedef2
@@ -2666,8 +2667,9 @@ newtype Arr_typedef3
     = Arr_typedef3 {unwrapArr_typedef3 :: (ConstantArray 5 A)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 5 A) =>
-         HasField "unwrapArr_typedef3" (Ptr Arr_typedef3) (Ptr ty)
+instance HasField "unwrapArr_typedef3"
+                  (Ptr Arr_typedef3)
+                  (Ptr (ConstantArray 5 A))
     where getField = fromPtr (Proxy @"unwrapArr_typedef3")
 instance HasCField Arr_typedef3 "unwrapArr_typedef3"
     where type CFieldType Arr_typedef3
@@ -2683,8 +2685,9 @@ newtype Arr_typedef4
     = Arr_typedef4 {unwrapArr_typedef4 :: (ConstantArray 5 (Ptr A))}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty (ConstantArray 5 (Ptr A)) =>
-         HasField "unwrapArr_typedef4" (Ptr Arr_typedef4) (Ptr ty)
+instance HasField "unwrapArr_typedef4"
+                  (Ptr Arr_typedef4)
+                  (Ptr (ConstantArray 5 (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapArr_typedef4")
 instance HasCField Arr_typedef4 "unwrapArr_typedef4"
     where type CFieldType Arr_typedef4
@@ -2716,8 +2719,7 @@ newtype Typedef1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A =>
-         HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr ty)
+instance HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapTypedef1")
 instance HasCField Typedef1 "unwrapTypedef1"
     where type CFieldType Typedef1 "unwrapTypedef1" = A
@@ -2736,8 +2738,7 @@ newtype Typedef2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr A) =>
-         HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr ty)
+instance HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"unwrapTypedef2")
 instance HasCField Typedef2 "unwrapTypedef2"
     where type CFieldType Typedef2 "unwrapTypedef2" = Ptr A
@@ -2756,8 +2757,9 @@ newtype Typedef3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr A)) =>
-         HasField "unwrapTypedef3" (Ptr Typedef3) (Ptr ty)
+instance HasField "unwrapTypedef3"
+                  (Ptr Typedef3)
+                  (Ptr (Ptr (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapTypedef3")
 instance HasCField Typedef3 "unwrapTypedef3"
     where type CFieldType Typedef3 "unwrapTypedef3" = Ptr (Ptr A)
@@ -2796,10 +2798,9 @@ instance ToFunPtr Funptr_typedef1_Aux
     where toFunPtr = hs_bindgen_c584d0f839fd43de
 instance FromFunPtr Funptr_typedef1_Aux
     where fromFunPtr = hs_bindgen_806a46dc418a062c
-instance (~) ty (IO A) =>
-         HasField "unwrapFunptr_typedef1_Aux"
+instance HasField "unwrapFunptr_typedef1_Aux"
                   (Ptr Funptr_typedef1_Aux)
-                  (Ptr ty)
+                  (Ptr (IO A))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1_Aux")
 instance HasCField Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux"
     where type CFieldType Funptr_typedef1_Aux
@@ -2819,8 +2820,9 @@ newtype Funptr_typedef1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Funptr_typedef1_Aux) =>
-         HasField "unwrapFunptr_typedef1" (Ptr Funptr_typedef1) (Ptr ty)
+instance HasField "unwrapFunptr_typedef1"
+                  (Ptr Funptr_typedef1)
+                  (Ptr (FunPtr Funptr_typedef1_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1")
 instance HasCField Funptr_typedef1 "unwrapFunptr_typedef1"
     where type CFieldType Funptr_typedef1
@@ -2860,10 +2862,9 @@ instance ToFunPtr Funptr_typedef2_Aux
     where toFunPtr = hs_bindgen_f174457a161ac5a0
 instance FromFunPtr Funptr_typedef2_Aux
     where fromFunPtr = hs_bindgen_323d07dff85b802c
-instance (~) ty (IO (Ptr A)) =>
-         HasField "unwrapFunptr_typedef2_Aux"
+instance HasField "unwrapFunptr_typedef2_Aux"
                   (Ptr Funptr_typedef2_Aux)
-                  (Ptr ty)
+                  (Ptr (IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2_Aux")
 instance HasCField Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux"
     where type CFieldType Funptr_typedef2_Aux
@@ -2883,8 +2884,9 @@ newtype Funptr_typedef2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Funptr_typedef2_Aux) =>
-         HasField "unwrapFunptr_typedef2" (Ptr Funptr_typedef2) (Ptr ty)
+instance HasField "unwrapFunptr_typedef2"
+                  (Ptr Funptr_typedef2)
+                  (Ptr (FunPtr Funptr_typedef2_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2")
 instance HasCField Funptr_typedef2 "unwrapFunptr_typedef2"
     where type CFieldType Funptr_typedef2
@@ -2924,10 +2926,9 @@ instance ToFunPtr Funptr_typedef3_Aux
     where toFunPtr = hs_bindgen_031d1a7decd790d8
 instance FromFunPtr Funptr_typedef3_Aux
     where fromFunPtr = hs_bindgen_82dc7b932974117e
-instance (~) ty (IO (Ptr (Ptr A))) =>
-         HasField "unwrapFunptr_typedef3_Aux"
+instance HasField "unwrapFunptr_typedef3_Aux"
                   (Ptr Funptr_typedef3_Aux)
-                  (Ptr ty)
+                  (Ptr (IO (Ptr (Ptr A))))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3_Aux")
 instance HasCField Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux"
     where type CFieldType Funptr_typedef3_Aux
@@ -2947,8 +2948,9 @@ newtype Funptr_typedef3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Funptr_typedef3_Aux) =>
-         HasField "unwrapFunptr_typedef3" (Ptr Funptr_typedef3) (Ptr ty)
+instance HasField "unwrapFunptr_typedef3"
+                  (Ptr Funptr_typedef3)
+                  (Ptr (FunPtr Funptr_typedef3_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3")
 instance HasCField Funptr_typedef3 "unwrapFunptr_typedef3"
     where type CFieldType Funptr_typedef3
@@ -2991,10 +2993,9 @@ instance ToFunPtr Funptr_typedef4_Aux
     where toFunPtr = hs_bindgen_da2336d254667386
 instance FromFunPtr Funptr_typedef4_Aux
     where fromFunPtr = hs_bindgen_d4a97954476da161
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapFunptr_typedef4_Aux"
+instance HasField "unwrapFunptr_typedef4_Aux"
                   (Ptr Funptr_typedef4_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4_Aux")
 instance HasCField Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux"
     where type CFieldType Funptr_typedef4_Aux
@@ -3014,8 +3015,9 @@ newtype Funptr_typedef4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Funptr_typedef4_Aux) =>
-         HasField "unwrapFunptr_typedef4" (Ptr Funptr_typedef4) (Ptr ty)
+instance HasField "unwrapFunptr_typedef4"
+                  (Ptr Funptr_typedef4)
+                  (Ptr (FunPtr Funptr_typedef4_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4")
 instance HasCField Funptr_typedef4 "unwrapFunptr_typedef4"
     where type CFieldType Funptr_typedef4
@@ -3058,10 +3060,9 @@ instance ToFunPtr Funptr_typedef5_Aux
     where toFunPtr = hs_bindgen_1f45632f07742a46
 instance FromFunPtr Funptr_typedef5_Aux
     where fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
-instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
-         HasField "unwrapFunptr_typedef5_Aux"
+instance HasField "unwrapFunptr_typedef5_Aux"
                   (Ptr Funptr_typedef5_Aux)
-                  (Ptr ty)
+                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5_Aux")
 instance HasCField Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux"
     where type CFieldType Funptr_typedef5_Aux
@@ -3081,8 +3082,9 @@ newtype Funptr_typedef5
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Funptr_typedef5_Aux) =>
-         HasField "unwrapFunptr_typedef5" (Ptr Funptr_typedef5) (Ptr ty)
+instance HasField "unwrapFunptr_typedef5"
+                  (Ptr Funptr_typedef5)
+                  (Ptr (FunPtr Funptr_typedef5_Aux))
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5")
 instance HasCField Funptr_typedef5 "unwrapFunptr_typedef5"
     where type CFieldType Funptr_typedef5
@@ -3112,8 +3114,7 @@ newtype Comments2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A =>
-         HasField "unwrapComments2" (Ptr Comments2) (Ptr ty)
+instance HasField "unwrapComments2" (Ptr Comments2) (Ptr A)
     where getField = fromPtr (Proxy @"unwrapComments2")
 instance HasCField Comments2 "unwrapComments2"
     where type CFieldType Comments2 "unwrapComments2" = A
@@ -3163,22 +3164,25 @@ deriving via (EquivStorable Example_struct) instance Storable Example_struct
 instance HasCField Example_struct "example_struct_field1"
     where type CFieldType Example_struct "example_struct_field1" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "example_struct_field1" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field1"
+                  (Ptr Example_struct)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_field1")
 instance HasCField Example_struct "example_struct_field2"
     where type CFieldType Example_struct
                           "example_struct_field2" = Ptr A
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr A) =>
-         HasField "example_struct_field2" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field2"
+                  (Ptr Example_struct)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"example_struct_field2")
 instance HasCField Example_struct "example_struct_field3"
     where type CFieldType Example_struct
                           "example_struct_field3" = Ptr (Ptr A)
           offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr (Ptr A)) =>
-         HasField "example_struct_field3" (Ptr Example_struct) (Ptr ty)
+instance HasField "example_struct_field3"
+                  (Ptr Example_struct)
+                  (Ptr (Ptr (Ptr A)))
     where getField = fromPtr (Proxy @"example_struct_field3")
 {-| __C declaration:__ @const_typedef1@
 
@@ -3204,8 +3208,9 @@ newtype Const_typedef1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A =>
-         HasField "unwrapConst_typedef1" (Ptr Const_typedef1) (Ptr ty)
+instance HasField "unwrapConst_typedef1"
+                  (Ptr Const_typedef1)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"unwrapConst_typedef1")
 instance HasCField Const_typedef1 "unwrapConst_typedef1"
     where type CFieldType Const_typedef1 "unwrapConst_typedef1" = A
@@ -3234,8 +3239,9 @@ newtype Const_typedef2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty A =>
-         HasField "unwrapConst_typedef2" (Ptr Const_typedef2) (Ptr ty)
+instance HasField "unwrapConst_typedef2"
+                  (Ptr Const_typedef2)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"unwrapConst_typedef2")
 instance HasCField Const_typedef2 "unwrapConst_typedef2"
     where type CFieldType Const_typedef2 "unwrapConst_typedef2" = A
@@ -3254,8 +3260,9 @@ newtype Const_typedef3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef3" (Ptr Const_typedef3) (Ptr ty)
+instance HasField "unwrapConst_typedef3"
+                  (Ptr Const_typedef3)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef3")
 instance HasCField Const_typedef3 "unwrapConst_typedef3"
     where type CFieldType Const_typedef3
@@ -3275,8 +3282,9 @@ newtype Const_typedef4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef4" (Ptr Const_typedef4) (Ptr ty)
+instance HasField "unwrapConst_typedef4"
+                  (Ptr Const_typedef4)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef4")
 instance HasCField Const_typedef4 "unwrapConst_typedef4"
     where type CFieldType Const_typedef4
@@ -3296,8 +3304,9 @@ newtype Const_typedef5
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr A) =>
-         HasField "unwrapConst_typedef5" (Ptr Const_typedef5) (Ptr ty)
+instance HasField "unwrapConst_typedef5"
+                  (Ptr Const_typedef5)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef5")
 instance HasCField Const_typedef5 "unwrapConst_typedef5"
     where type CFieldType Const_typedef5 "unwrapConst_typedef5" = Ptr A
@@ -3316,8 +3325,9 @@ newtype Const_typedef6
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef6" (Ptr Const_typedef6) (Ptr ty)
+instance HasField "unwrapConst_typedef6"
+                  (Ptr Const_typedef6)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef6")
 instance HasCField Const_typedef6 "unwrapConst_typedef6"
     where type CFieldType Const_typedef6
@@ -3337,8 +3347,9 @@ newtype Const_typedef7
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef7" (Ptr Const_typedef7) (Ptr ty)
+instance HasField "unwrapConst_typedef7"
+                  (Ptr Const_typedef7)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"unwrapConst_typedef7")
 instance HasCField Const_typedef7 "unwrapConst_typedef7"
     where type CFieldType Const_typedef7
@@ -3421,70 +3432,63 @@ instance HasCField Example_struct_with_const
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field1" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "example_struct_with_const_const_field1"
+instance HasField "example_struct_with_const_const_field1"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field1")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field2"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field2" = A
           offset# = \_ -> \_ -> 4
-instance (~) ty A =>
-         HasField "example_struct_with_const_const_field2"
+instance HasField "example_struct_with_const_const_field2"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr A)
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field2")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field3"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field3" = PtrConst A
           offset# = \_ -> \_ -> 8
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field3"
+instance HasField "example_struct_with_const_const_field3"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field3")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field4"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field4" = PtrConst A
           offset# = \_ -> \_ -> 16
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field4"
+instance HasField "example_struct_with_const_const_field4"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field4")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field5"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field5" = Ptr A
           offset# = \_ -> \_ -> 24
-instance (~) ty (Ptr A) =>
-         HasField "example_struct_with_const_const_field5"
+instance HasField "example_struct_with_const_const_field5"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field5")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field6"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field6" = PtrConst A
           offset# = \_ -> \_ -> 32
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field6"
+instance HasField "example_struct_with_const_const_field6"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field6")
 instance HasCField Example_struct_with_const
                    "example_struct_with_const_const_field7"
     where type CFieldType Example_struct_with_const
                           "example_struct_with_const_const_field7" = PtrConst A
           offset# = \_ -> \_ -> 40
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field7"
+instance HasField "example_struct_with_const_const_field7"
                   (Ptr Example_struct_with_const)
-                  (Ptr ty)
+                  (Ptr (PtrConst A))
     where getField = fromPtr (Proxy @"example_struct_with_const_const_field7")
 {-| Auxiliary type used by 'Const_funptr1'
 
@@ -3523,8 +3527,9 @@ instance ToFunPtr Const_funptr1_Aux
     where toFunPtr = hs_bindgen_7f125e20a9d4075b
 instance FromFunPtr Const_funptr1_Aux
     where fromFunPtr = hs_bindgen_ac4bd8d789bba94b
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapConst_funptr1_Aux" (Ptr Const_funptr1_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr1_Aux"
+                  (Ptr Const_funptr1_Aux)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapConst_funptr1_Aux")
 instance HasCField Const_funptr1_Aux "unwrapConst_funptr1_Aux"
     where type CFieldType Const_funptr1_Aux
@@ -3544,8 +3549,9 @@ newtype Const_funptr1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr1_Aux) =>
-         HasField "unwrapConst_funptr1" (Ptr Const_funptr1) (Ptr ty)
+instance HasField "unwrapConst_funptr1"
+                  (Ptr Const_funptr1)
+                  (Ptr (FunPtr Const_funptr1_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr1")
 instance HasCField Const_funptr1 "unwrapConst_funptr1"
     where type CFieldType Const_funptr1
@@ -3588,8 +3594,9 @@ instance ToFunPtr Const_funptr2_Aux
     where toFunPtr = hs_bindgen_c7b1e36d845634fb
 instance FromFunPtr Const_funptr2_Aux
     where fromFunPtr = hs_bindgen_352cebf463125ca9
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapConst_funptr2_Aux" (Ptr Const_funptr2_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr2_Aux"
+                  (Ptr Const_funptr2_Aux)
+                  (Ptr (CInt -> CDouble -> IO A))
     where getField = fromPtr (Proxy @"unwrapConst_funptr2_Aux")
 instance HasCField Const_funptr2_Aux "unwrapConst_funptr2_Aux"
     where type CFieldType Const_funptr2_Aux
@@ -3609,8 +3616,9 @@ newtype Const_funptr2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr2_Aux) =>
-         HasField "unwrapConst_funptr2" (Ptr Const_funptr2) (Ptr ty)
+instance HasField "unwrapConst_funptr2"
+                  (Ptr Const_funptr2)
+                  (Ptr (FunPtr Const_funptr2_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr2")
 instance HasCField Const_funptr2 "unwrapConst_funptr2"
     where type CFieldType Const_funptr2
@@ -3653,8 +3661,9 @@ instance ToFunPtr Const_funptr3_Aux
     where toFunPtr = hs_bindgen_2dcbfe1c2502178c
 instance FromFunPtr Const_funptr3_Aux
     where fromFunPtr = hs_bindgen_86738dcfd7c9d33c
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr3_Aux" (Ptr Const_funptr3_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr3_Aux"
+                  (Ptr Const_funptr3_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr3_Aux")
 instance HasCField Const_funptr3_Aux "unwrapConst_funptr3_Aux"
     where type CFieldType Const_funptr3_Aux
@@ -3674,8 +3683,9 @@ newtype Const_funptr3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr3_Aux) =>
-         HasField "unwrapConst_funptr3" (Ptr Const_funptr3) (Ptr ty)
+instance HasField "unwrapConst_funptr3"
+                  (Ptr Const_funptr3)
+                  (Ptr (FunPtr Const_funptr3_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr3")
 instance HasCField Const_funptr3 "unwrapConst_funptr3"
     where type CFieldType Const_funptr3
@@ -3718,8 +3728,9 @@ instance ToFunPtr Const_funptr4_Aux
     where toFunPtr = hs_bindgen_5461deeda491de0b
 instance FromFunPtr Const_funptr4_Aux
     where fromFunPtr = hs_bindgen_de7846fca3bfd1b6
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr4_Aux" (Ptr Const_funptr4_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr4_Aux"
+                  (Ptr Const_funptr4_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr4_Aux")
 instance HasCField Const_funptr4_Aux "unwrapConst_funptr4_Aux"
     where type CFieldType Const_funptr4_Aux
@@ -3739,8 +3750,9 @@ newtype Const_funptr4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr4_Aux) =>
-         HasField "unwrapConst_funptr4" (Ptr Const_funptr4) (Ptr ty)
+instance HasField "unwrapConst_funptr4"
+                  (Ptr Const_funptr4)
+                  (Ptr (FunPtr Const_funptr4_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr4")
 instance HasCField Const_funptr4 "unwrapConst_funptr4"
     where type CFieldType Const_funptr4
@@ -3783,8 +3795,9 @@ instance ToFunPtr Const_funptr5_Aux
     where toFunPtr = hs_bindgen_7b0174fc978a1ce1
 instance FromFunPtr Const_funptr5_Aux
     where fromFunPtr = hs_bindgen_38a21d84bb7115b5
-instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
-         HasField "unwrapConst_funptr5_Aux" (Ptr Const_funptr5_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr5_Aux"
+                  (Ptr Const_funptr5_Aux)
+                  (Ptr (CInt -> CDouble -> IO (Ptr A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr5_Aux")
 instance HasCField Const_funptr5_Aux "unwrapConst_funptr5_Aux"
     where type CFieldType Const_funptr5_Aux
@@ -3804,8 +3817,9 @@ newtype Const_funptr5
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr5_Aux) =>
-         HasField "unwrapConst_funptr5" (Ptr Const_funptr5) (Ptr ty)
+instance HasField "unwrapConst_funptr5"
+                  (Ptr Const_funptr5)
+                  (Ptr (FunPtr Const_funptr5_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr5")
 instance HasCField Const_funptr5 "unwrapConst_funptr5"
     where type CFieldType Const_funptr5
@@ -3848,8 +3862,9 @@ instance ToFunPtr Const_funptr6_Aux
     where toFunPtr = hs_bindgen_4e32721222f4df9f
 instance FromFunPtr Const_funptr6_Aux
     where fromFunPtr = hs_bindgen_45251216b04aa8b5
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr6_Aux" (Ptr Const_funptr6_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr6_Aux"
+                  (Ptr Const_funptr6_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr6_Aux")
 instance HasCField Const_funptr6_Aux "unwrapConst_funptr6_Aux"
     where type CFieldType Const_funptr6_Aux
@@ -3869,8 +3884,9 @@ newtype Const_funptr6
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr6_Aux) =>
-         HasField "unwrapConst_funptr6" (Ptr Const_funptr6) (Ptr ty)
+instance HasField "unwrapConst_funptr6"
+                  (Ptr Const_funptr6)
+                  (Ptr (FunPtr Const_funptr6_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr6")
 instance HasCField Const_funptr6 "unwrapConst_funptr6"
     where type CFieldType Const_funptr6
@@ -3913,8 +3929,9 @@ instance ToFunPtr Const_funptr7_Aux
     where toFunPtr = hs_bindgen_0d04fc96ffb9de06
 instance FromFunPtr Const_funptr7_Aux
     where fromFunPtr = hs_bindgen_42fbcebf75a973ba
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr7_Aux" (Ptr Const_funptr7_Aux) (Ptr ty)
+instance HasField "unwrapConst_funptr7_Aux"
+                  (Ptr Const_funptr7_Aux)
+                  (Ptr (CInt -> CDouble -> IO (PtrConst A)))
     where getField = fromPtr (Proxy @"unwrapConst_funptr7_Aux")
 instance HasCField Const_funptr7_Aux "unwrapConst_funptr7_Aux"
     where type CFieldType Const_funptr7_Aux
@@ -3934,8 +3951,9 @@ newtype Const_funptr7
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr Const_funptr7_Aux) =>
-         HasField "unwrapConst_funptr7" (Ptr Const_funptr7) (Ptr ty)
+instance HasField "unwrapConst_funptr7"
+                  (Ptr Const_funptr7)
+                  (Ptr (FunPtr Const_funptr7_Aux))
     where getField = fromPtr (Proxy @"unwrapConst_funptr7")
 instance HasCField Const_funptr7 "unwrapConst_funptr7"
     where type CFieldType Const_funptr7
@@ -3967,7 +3985,7 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -3996,7 +4014,7 @@ newtype INT
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapINT" (Ptr INT) (Ptr ty)
+instance HasField "unwrapINT" (Ptr INT) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapINT")
 instance HasCField INT "unwrapINT"
     where type CFieldType INT "unwrapINT" = CInt
@@ -4015,8 +4033,7 @@ newtype INTP
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrapINTP" (Ptr INTP) (Ptr ty)
+instance HasField "unwrapINTP" (Ptr INTP) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapINTP")
 instance HasCField INTP "unwrapINTP"
     where type CFieldType INTP "unwrapINTP" = Ptr CInt
@@ -4035,8 +4052,7 @@ newtype INTCP
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrapINTCP" (Ptr INTCP) (Ptr ty)
+instance HasField "unwrapINTCP" (Ptr INTCP) (Ptr (PtrConst CInt))
     where getField = fromPtr (Proxy @"unwrapINTCP")
 instance HasCField INTCP "unwrapINTCP"
     where type CFieldType INTCP "unwrapINTCP" = PtrConst CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/undef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/undef/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/undef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/undef/th.txt
@@ -44,7 +44,7 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -78,8 +76,7 @@ instance HasCField.HasCField UU1_fieldY "uU1_fieldY_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uU1_fieldY_fieldX" (RIP.Ptr UU1_fieldY) (RIP.Ptr ty) where
+instance RIP.HasField "uU1_fieldY_fieldX" (RIP.Ptr UU1_fieldY) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"uU1_fieldY_fieldX")
@@ -131,8 +128,7 @@ instance HasCField.HasCField UU1 "uU1_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ UU1_fieldY
-         ) => RIP.HasField "uU1_fieldY" (RIP.Ptr UU1) (RIP.Ptr ty) where
+instance RIP.HasField "uU1_fieldY" (RIP.Ptr UU1) (RIP.Ptr UU1_fieldY) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"uU1_fieldY")
@@ -185,8 +181,7 @@ instance HasCField.HasCField UU2_fieldY "uU2_fieldY_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uU2_fieldY_fieldX" (RIP.Ptr UU2_fieldY) (RIP.Ptr ty) where
+instance RIP.HasField "uU2_fieldY_fieldX" (RIP.Ptr UU2_fieldY) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"uU2_fieldY_fieldX")
@@ -238,8 +233,7 @@ instance HasCField.HasCField UU2 "uU2_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ UU2_fieldY
-         ) => RIP.HasField "uU2_fieldY" (RIP.Ptr UU2) (RIP.Ptr ty) where
+instance RIP.HasField "uU2_fieldY" (RIP.Ptr UU2) (RIP.Ptr UU2_fieldY) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"uU2_fieldY")
@@ -291,8 +285,7 @@ instance HasCField.HasCField VV1_fieldA "vV1_fieldA_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV1_fieldA_a" (RIP.Ptr VV1_fieldA) (RIP.Ptr ty) where
+instance RIP.HasField "vV1_fieldA_a" (RIP.Ptr VV1_fieldA) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV1_fieldA_a")
@@ -344,8 +337,7 @@ instance HasCField.HasCField VV1_fieldB "vV1_fieldB_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV1_fieldB_b" (RIP.Ptr VV1_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "vV1_fieldB_b" (RIP.Ptr VV1_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV1_fieldB_b")
@@ -406,8 +398,7 @@ instance HasCField.HasCField VV1 "vV1_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ VV1_fieldA
-         ) => RIP.HasField "vV1_fieldA" (RIP.Ptr VV1) (RIP.Ptr ty) where
+instance RIP.HasField "vV1_fieldA" (RIP.Ptr VV1) (RIP.Ptr VV1_fieldA) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV1_fieldA")
@@ -418,8 +409,7 @@ instance HasCField.HasCField VV1 "vV1_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ VV1_fieldB
-         ) => RIP.HasField "vV1_fieldB" (RIP.Ptr VV1) (RIP.Ptr ty) where
+instance RIP.HasField "vV1_fieldB" (RIP.Ptr VV1) (RIP.Ptr VV1_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV1_fieldB")
@@ -471,8 +461,7 @@ instance HasCField.HasCField VV2_fieldA "vV2_fieldA_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV2_fieldA_a" (RIP.Ptr VV2_fieldA) (RIP.Ptr ty) where
+instance RIP.HasField "vV2_fieldA_a" (RIP.Ptr VV2_fieldA) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV2_fieldA_a")
@@ -524,8 +513,7 @@ instance HasCField.HasCField VV2_fieldB "vV2_fieldB_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV2_fieldB_b" (RIP.Ptr VV2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "vV2_fieldB_b" (RIP.Ptr VV2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV2_fieldB_b")
@@ -586,8 +574,7 @@ instance HasCField.HasCField VV2 "vV2_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ VV2_fieldA
-         ) => RIP.HasField "vV2_fieldA" (RIP.Ptr VV2) (RIP.Ptr ty) where
+instance RIP.HasField "vV2_fieldA" (RIP.Ptr VV2) (RIP.Ptr VV2_fieldA) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV2_fieldA")
@@ -598,8 +585,7 @@ instance HasCField.HasCField VV2 "vV2_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ VV2_fieldB
-         ) => RIP.HasField "vV2_fieldB" (RIP.Ptr VV2) (RIP.Ptr ty) where
+instance RIP.HasField "vV2_fieldB" (RIP.Ptr VV2) (RIP.Ptr VV2_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"vV2_fieldB")

--- a/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable UU1_fieldY) instance Storable UU1_fieldY
 instance HasCField UU1_fieldY "uU1_fieldY_fieldX"
     where type CFieldType UU1_fieldY "uU1_fieldY_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "uU1_fieldY_fieldX" (Ptr UU1_fieldY) (Ptr ty)
+instance HasField "uU1_fieldY_fieldX" (Ptr UU1_fieldY) (Ptr CInt)
     where getField = fromPtr (Proxy @"uU1_fieldY_fieldX")
 {-| __C declaration:__ @struct UU1@
 
@@ -56,8 +55,7 @@ deriving via (EquivStorable UU1) instance Storable UU1
 instance HasCField UU1 "uU1_fieldY"
     where type CFieldType UU1 "uU1_fieldY" = UU1_fieldY
           offset# = \_ -> \_ -> 0
-instance (~) ty UU1_fieldY =>
-         HasField "uU1_fieldY" (Ptr UU1) (Ptr ty)
+instance HasField "uU1_fieldY" (Ptr UU1) (Ptr UU1_fieldY)
     where getField = fromPtr (Proxy @"uU1_fieldY")
 {-| __C declaration:__ @struct \@UU2_fieldY@
 
@@ -86,8 +84,7 @@ deriving via (EquivStorable UU2_fieldY) instance Storable UU2_fieldY
 instance HasCField UU2_fieldY "uU2_fieldY_fieldX"
     where type CFieldType UU2_fieldY "uU2_fieldY_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "uU2_fieldY_fieldX" (Ptr UU2_fieldY) (Ptr ty)
+instance HasField "uU2_fieldY_fieldX" (Ptr UU2_fieldY) (Ptr CInt)
     where getField = fromPtr (Proxy @"uU2_fieldY_fieldX")
 {-| __C declaration:__ @struct UU2@
 
@@ -116,8 +113,7 @@ deriving via (EquivStorable UU2) instance Storable UU2
 instance HasCField UU2 "uU2_fieldY"
     where type CFieldType UU2 "uU2_fieldY" = UU2_fieldY
           offset# = \_ -> \_ -> 0
-instance (~) ty UU2_fieldY =>
-         HasField "uU2_fieldY" (Ptr UU2) (Ptr ty)
+instance HasField "uU2_fieldY" (Ptr UU2) (Ptr UU2_fieldY)
     where getField = fromPtr (Proxy @"uU2_fieldY")
 {-| __C declaration:__ @struct \@VV1_fieldA@
 
@@ -146,8 +142,7 @@ deriving via (EquivStorable VV1_fieldA) instance Storable VV1_fieldA
 instance HasCField VV1_fieldA "vV1_fieldA_a"
     where type CFieldType VV1_fieldA "vV1_fieldA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV1_fieldA_a" (Ptr VV1_fieldA) (Ptr ty)
+instance HasField "vV1_fieldA_a" (Ptr VV1_fieldA) (Ptr CInt)
     where getField = fromPtr (Proxy @"vV1_fieldA_a")
 {-| __C declaration:__ @struct \@VV1_fieldB@
 
@@ -176,8 +171,7 @@ deriving via (EquivStorable VV1_fieldB) instance Storable VV1_fieldB
 instance HasCField VV1_fieldB "vV1_fieldB_b"
     where type CFieldType VV1_fieldB "vV1_fieldB_b" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV1_fieldB_b" (Ptr VV1_fieldB) (Ptr ty)
+instance HasField "vV1_fieldB_b" (Ptr VV1_fieldB) (Ptr CInt)
     where getField = fromPtr (Proxy @"vV1_fieldB_b")
 {-| __C declaration:__ @struct VV1@
 
@@ -214,14 +208,12 @@ deriving via (EquivStorable VV1) instance Storable VV1
 instance HasCField VV1 "vV1_fieldA"
     where type CFieldType VV1 "vV1_fieldA" = VV1_fieldA
           offset# = \_ -> \_ -> 0
-instance (~) ty VV1_fieldA =>
-         HasField "vV1_fieldA" (Ptr VV1) (Ptr ty)
+instance HasField "vV1_fieldA" (Ptr VV1) (Ptr VV1_fieldA)
     where getField = fromPtr (Proxy @"vV1_fieldA")
 instance HasCField VV1 "vV1_fieldB"
     where type CFieldType VV1 "vV1_fieldB" = VV1_fieldB
           offset# = \_ -> \_ -> 4
-instance (~) ty VV1_fieldB =>
-         HasField "vV1_fieldB" (Ptr VV1) (Ptr ty)
+instance HasField "vV1_fieldB" (Ptr VV1) (Ptr VV1_fieldB)
     where getField = fromPtr (Proxy @"vV1_fieldB")
 {-| __C declaration:__ @struct \@VV2_fieldA@
 
@@ -250,8 +242,7 @@ deriving via (EquivStorable VV2_fieldA) instance Storable VV2_fieldA
 instance HasCField VV2_fieldA "vV2_fieldA_a"
     where type CFieldType VV2_fieldA "vV2_fieldA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV2_fieldA_a" (Ptr VV2_fieldA) (Ptr ty)
+instance HasField "vV2_fieldA_a" (Ptr VV2_fieldA) (Ptr CInt)
     where getField = fromPtr (Proxy @"vV2_fieldA_a")
 {-| __C declaration:__ @struct \@VV2_fieldB@
 
@@ -280,8 +271,7 @@ deriving via (EquivStorable VV2_fieldB) instance Storable VV2_fieldB
 instance HasCField VV2_fieldB "vV2_fieldB_b"
     where type CFieldType VV2_fieldB "vV2_fieldB_b" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV2_fieldB_b" (Ptr VV2_fieldB) (Ptr ty)
+instance HasField "vV2_fieldB_b" (Ptr VV2_fieldB) (Ptr CInt)
     where getField = fromPtr (Proxy @"vV2_fieldB_b")
 {-| __C declaration:__ @struct VV2@
 
@@ -318,12 +308,10 @@ deriving via (EquivStorable VV2) instance Storable VV2
 instance HasCField VV2 "vV2_fieldA"
     where type CFieldType VV2 "vV2_fieldA" = VV2_fieldA
           offset# = \_ -> \_ -> 0
-instance (~) ty VV2_fieldA =>
-         HasField "vV2_fieldA" (Ptr VV2) (Ptr ty)
+instance HasField "vV2_fieldA" (Ptr VV2) (Ptr VV2_fieldA)
     where getField = fromPtr (Proxy @"vV2_fieldA")
 instance HasCField VV2 "vV2_fieldB"
     where type CFieldType VV2 "vV2_fieldB" = VV2_fieldB
           offset# = \_ -> \_ -> 4
-instance (~) ty VV2_fieldB =>
-         HasField "vV2_fieldB" (Ptr VV2) (Ptr ty)
+instance HasField "vV2_fieldB" (Ptr VV2) (Ptr VV2_fieldB)
     where getField = fromPtr (Proxy @"vV2_fieldB")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype OUTER_BEFORE_CIRCULAR_INCLUDE = OUTER_BEFORE_CIRCULAR_INCLUDE
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_BEFORE_CIRCULAR_INCLUDE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_BEFORE_CIRCULAR_INCLUDE) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE")
@@ -91,8 +88,7 @@ newtype OUTER_AFTER_CIRCULAR_INCLUDE = OUTER_AFTER_CIRCULAR_INCLUDE
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_AFTER_CIRCULAR_INCLUDE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_AFTER_CIRCULAR_INCLUDE) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/th.txt
@@ -24,10 +24,9 @@ newtype OUTER_BEFORE_CIRCULAR_INCLUDE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
+instance HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
                   (Ptr OUTER_BEFORE_CIRCULAR_INCLUDE)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE")
 instance HasCField OUTER_BEFORE_CIRCULAR_INCLUDE
                    "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
@@ -58,10 +57,9 @@ newtype OUTER_AFTER_CIRCULAR_INCLUDE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"
+instance HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"
                   (Ptr OUTER_AFTER_CIRCULAR_INCLUDE)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE")
 instance HasCField OUTER_AFTER_CIRCULAR_INCLUDE
                    "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 
@@ -89,8 +86,7 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
 

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/th.txt
@@ -65,7 +65,7 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
@@ -94,7 +94,7 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
 

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
@@ -45,7 +45,7 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
 
@@ -89,8 +86,7 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
 

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
@@ -65,7 +65,7 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+instance HasField "unwrapT" (Ptr T) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
@@ -94,7 +94,7 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
 

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
@@ -45,7 +45,7 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
+instance HasField "unwrapU" (Ptr U) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -107,8 +105,7 @@ instance Read FileOperationStatus where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapFileOperationStatus" (RIP.Ptr FileOperationStatus) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFileOperationStatus" (RIP.Ptr FileOperationStatus) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFileOperationStatus")
@@ -233,8 +230,7 @@ instance HasCField.HasCField FileOperationRecord "fileOperationRecord_status" wh
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ FileOperationStatus
-         ) => RIP.HasField "fileOperationRecord_status" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
+instance RIP.HasField "fileOperationRecord_status" (RIP.Ptr FileOperationRecord) (RIP.Ptr FileOperationStatus) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_status")
@@ -246,8 +242,7 @@ instance HasCField.HasCField FileOperationRecord "fileOperationRecord_bytes_proc
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "fileOperationRecord_bytes_processed" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
+instance RIP.HasField "fileOperationRecord_bytes_processed" (RIP.Ptr FileOperationRecord) (RIP.Ptr HsBindgen.Runtime.LibC.CSize) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_bytes_processed")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -74,10 +74,9 @@ instance Read FileOperationStatus
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CInt =>
-         HasField "unwrapFileOperationStatus"
+instance HasField "unwrapFileOperationStatus"
                   (Ptr FileOperationStatus)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapFileOperationStatus")
 instance HasCField FileOperationStatus "unwrapFileOperationStatus"
     where type CFieldType FileOperationStatus
@@ -167,20 +166,18 @@ instance HasCField FileOperationRecord "fileOperationRecord_status"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_status" = FileOperationStatus
           offset# = \_ -> \_ -> 0
-instance (~) ty FileOperationStatus =>
-         HasField "fileOperationRecord_status"
+instance HasField "fileOperationRecord_status"
                   (Ptr FileOperationRecord)
-                  (Ptr ty)
+                  (Ptr FileOperationStatus)
     where getField = fromPtr (Proxy @"fileOperationRecord_status")
 instance HasCField FileOperationRecord
                    "fileOperationRecord_bytes_processed"
     where type CFieldType FileOperationRecord
                           "fileOperationRecord_bytes_processed" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "fileOperationRecord_bytes_processed"
+instance HasField "fileOperationRecord_bytes_processed"
                   (Ptr FileOperationRecord)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.CSize)
     where getField = fromPtr (Proxy @"fileOperationRecord_bytes_processed")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_read_file_chunk@
 foreign import ccall safe "hs_bindgen_b2a91b3b7edf2ad3" hs_bindgen_b2a91b3b7edf2ad3_base ::

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -51,8 +49,7 @@ newtype Uint32_t = Uint32_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapUint32_t" (RIP.Ptr Uint32_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint32_t" (RIP.Ptr Uint32_t) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint32_t")
@@ -113,8 +110,7 @@ instance HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Foreign.Word64
-         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr Foreign.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
@@ -125,8 +121,7 @@ instance HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ Uint32_t
-         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr Uint32_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -50,8 +50,7 @@ newtype Uint32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUInt =>
-         HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr ty)
+instance HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapUint32_t")
 instance HasCField Uint32_t "unwrapUint32_t"
     where type CFieldType Uint32_t "unwrapUint32_t" = CUInt
@@ -88,14 +87,12 @@ instance Storable Foo
 instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo "foo_sixty_four" = Foreign.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty Foreign.Word64 =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+instance HasField "foo_sixty_four" (Ptr Foo) (Ptr Foreign.Word64)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo "foo_thirty_two" = Uint32_t
           offset# = \_ -> \_ -> 8
-instance (~) ty Uint32_t =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+instance HasField "foo_thirty_two" (Ptr Foo) (Ptr Uint32_t)
     where getField = fromPtr (Proxy @"foo_thirty_two")
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_48dbbf4b09b5b3c1" hs_bindgen_48dbbf4b09b5b3c1_base ::

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -49,8 +47,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/th.txt
@@ -24,7 +24,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+instance RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"okBefore_x")
@@ -122,7 +119,6 @@ instance HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+instance RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -56,5 +55,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+instance RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"okBefore_x")
@@ -122,7 +119,6 @@ instance HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+instance RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -56,5 +55,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,8 +66,7 @@ instance HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+instance RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"okBefore_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -26,6 +26,5 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance HasCField.HasCField OkBefore "okBefore_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+instance RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"okBefore_x")
@@ -122,7 +119,6 @@ instance HasCField.HasCField OkAfter "okAfter_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+instance RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/th.txt
@@ -26,8 +26,7 @@ deriving via (EquivStorable OkBefore) instance Storable OkBefore
 instance HasCField OkBefore "okBefore_x"
     where type CFieldType OkBefore "okBefore_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+instance HasField "okBefore_x" (Ptr OkBefore) (Ptr CInt)
     where getField = fromPtr (Proxy @"okBefore_x")
 {-| __C declaration:__ @struct OkAfter@
 
@@ -56,5 +55,5 @@ deriving via (EquivStorable OkAfter) instance Storable OkAfter
 instance HasCField OkAfter "okAfter_x"
     where type CFieldType OkAfter "okAfter_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+instance HasField "okAfter_x" (Ptr OkAfter) (Ptr CInt)
     where getField = fromPtr (Proxy @"okAfter_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,7 +66,6 @@ instance HasCField.HasCField NewName "newName_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "newName_x" (RIP.Ptr NewName) (RIP.Ptr ty) where
+instance RIP.HasField "newName_x" (RIP.Ptr NewName) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"newName_x")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -41,7 +41,7 @@ deriving via (EquivStorable NewName) instance Storable NewName
 instance HasCField NewName "newName_x"
     where type CFieldType NewName "newName_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "newName_x" (Ptr NewName) (Ptr ty)
+instance HasField "newName_x" (Ptr NewName) (Ptr CInt)
     where getField = fromPtr (Proxy @"newName_x")
 -- __unique:__ @test_programanalysisselection_mat_Example_Safe_FunctionWithAssignedHaskellNameByNameMangler@
 foreign import ccall safe "hs_bindgen_c9b1dc5577fd8ced" hs_bindgen_c9b1dc5577fd8ced_base ::

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,8 +67,7 @@ instance HasCField.HasCField UnrelatedDeclaration "unrelatedDeclaration_m" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unrelatedDeclaration_m" (RIP.Ptr UnrelatedDeclaration) (RIP.Ptr ty) where
+instance RIP.HasField "unrelatedDeclaration_m" (RIP.Ptr UnrelatedDeclaration) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -28,8 +28,7 @@ instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
     where type CFieldType UnrelatedDeclaration
                           "unrelatedDeclaration_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unrelatedDeclaration_m"
+instance HasField "unrelatedDeclaration_m"
                   (Ptr UnrelatedDeclaration)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unrelatedDeclaration_m")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,8 +68,7 @@ instance HasCField.HasCField Omitted "omitted_n" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "omitted_n" (RIP.Ptr Omitted) (RIP.Ptr ty) where
+instance RIP.HasField "omitted_n" (RIP.Ptr Omitted) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"omitted_n")
 
@@ -123,8 +120,7 @@ instance HasCField.HasCField DirectlyDependsOnOmitted "directlyDependsOnOmitted_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Omitted
-         ) => RIP.HasField "directlyDependsOnOmitted_o" (RIP.Ptr DirectlyDependsOnOmitted) (RIP.Ptr ty) where
+instance RIP.HasField "directlyDependsOnOmitted_o" (RIP.Ptr DirectlyDependsOnOmitted) (RIP.Ptr Omitted) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"directlyDependsOnOmitted_o")
@@ -177,8 +173,7 @@ instance HasCField.HasCField IndirectlyDependsOnOmitted "indirectlyDependsOnOmit
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ DirectlyDependsOnOmitted
-         ) => RIP.HasField "indirectlyDependsOnOmitted_d" (RIP.Ptr IndirectlyDependsOnOmitted) (RIP.Ptr ty) where
+instance RIP.HasField "indirectlyDependsOnOmitted_d" (RIP.Ptr IndirectlyDependsOnOmitted) (RIP.Ptr DirectlyDependsOnOmitted) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -27,7 +27,7 @@ deriving via (EquivStorable Omitted) instance Storable Omitted
 instance HasCField Omitted "omitted_n"
     where type CFieldType Omitted "omitted_n" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "omitted_n" (Ptr Omitted) (Ptr ty)
+instance HasField "omitted_n" (Ptr Omitted) (Ptr CInt)
     where getField = fromPtr (Proxy @"omitted_n")
 {-| __C declaration:__ @struct DirectlyDependsOnOmitted@
 
@@ -58,10 +58,9 @@ instance HasCField DirectlyDependsOnOmitted
     where type CFieldType DirectlyDependsOnOmitted
                           "directlyDependsOnOmitted_o" = Omitted
           offset# = \_ -> \_ -> 0
-instance (~) ty Omitted =>
-         HasField "directlyDependsOnOmitted_o"
+instance HasField "directlyDependsOnOmitted_o"
                   (Ptr DirectlyDependsOnOmitted)
-                  (Ptr ty)
+                  (Ptr Omitted)
     where getField = fromPtr (Proxy @"directlyDependsOnOmitted_o")
 {-| __C declaration:__ @struct IndirectlyDependsOnOmitted@
 
@@ -92,8 +91,7 @@ instance HasCField IndirectlyDependsOnOmitted
     where type CFieldType IndirectlyDependsOnOmitted
                           "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
           offset# = \_ -> \_ -> 0
-instance (~) ty DirectlyDependsOnOmitted =>
-         HasField "indirectlyDependsOnOmitted_d"
+instance HasField "indirectlyDependsOnOmitted_d"
                   (Ptr IndirectlyDependsOnOmitted)
-                  (Ptr ty)
+                  (Ptr DirectlyDependsOnOmitted)
     where getField = fromPtr (Proxy @"indirectlyDependsOnOmitted_d")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE EmptyDataDecls #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -166,8 +164,7 @@ newtype Struct5_t = Struct5_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Struct5
-         ) => RIP.HasField "unwrapStruct5_t" (RIP.Ptr Struct5_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct5_t" (RIP.Ptr Struct5_t) (RIP.Ptr (RIP.Ptr Struct5)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct5_t")
@@ -227,8 +224,7 @@ newtype Struct6 = Struct6
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr Struct6_Aux
-         ) => RIP.HasField "unwrapStruct6" (RIP.Ptr Struct6) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct6" (RIP.Ptr Struct6) (RIP.Ptr (RIP.Ptr Struct6_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct6")
@@ -287,8 +283,7 @@ newtype Struct7a = Struct7a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct7
-         ) => RIP.HasField "unwrapStruct7a" (RIP.Ptr Struct7a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct7a" (RIP.Ptr Struct7a) (RIP.Ptr Struct7) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct7a")
@@ -316,8 +311,7 @@ newtype Struct7b = Struct7b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct7
-         ) => RIP.HasField "unwrapStruct7b" (RIP.Ptr Struct7b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct7b" (RIP.Ptr Struct7b) (RIP.Ptr Struct7) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct7b")
@@ -375,8 +369,7 @@ newtype Struct8b = Struct8b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct8
-         ) => RIP.HasField "unwrapStruct8b" (RIP.Ptr Struct8b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct8b" (RIP.Ptr Struct8b) (RIP.Ptr Struct8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct8b")
@@ -434,8 +427,7 @@ newtype Struct9_t = Struct9_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct9
-         ) => RIP.HasField "unwrapStruct9_t" (RIP.Ptr Struct9_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct9_t" (RIP.Ptr Struct9_t) (RIP.Ptr Struct9) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct9_t")
@@ -493,8 +485,7 @@ newtype Struct10_t_t = Struct10_t_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ Struct10_t
-         ) => RIP.HasField "unwrapStruct10_t_t" (RIP.Ptr Struct10_t_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapStruct10_t_t" (RIP.Ptr Struct10_t_t) (RIP.Ptr Struct10_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapStruct10_t_t")
@@ -562,8 +553,7 @@ instance HasCField.HasCField Struct11_t "struct11_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct11_t_x" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct11_t_x" (RIP.Ptr Struct11_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct11_t_x")
@@ -575,8 +565,7 @@ instance HasCField.HasCField Struct11_t "struct11_t_self" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Struct11_t
-         ) => RIP.HasField "struct11_t_self" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct11_t_self" (RIP.Ptr Struct11_t) (RIP.Ptr (RIP.Ptr Struct11_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct11_t_self")
@@ -637,8 +626,7 @@ instance HasCField.HasCField Struct12_t "struct12_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct12_t_x" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct12_t_x" (RIP.Ptr Struct12_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct12_t_x")
@@ -650,8 +638,7 @@ instance HasCField.HasCField Struct12_t "struct12_t_self" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Struct12_t
-         ) => RIP.HasField "struct12_t_self" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
+instance RIP.HasField "struct12_t_self" (RIP.Ptr Struct12_t) (RIP.Ptr (RIP.Ptr Struct12_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"struct12_t_self")
@@ -875,8 +862,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct1_t" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Struct1_t
-         ) => RIP.HasField "use_sites_useTypedef_struct1_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct1_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct1_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct1_t")
@@ -888,8 +874,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct2_t" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Struct2_t
-         ) => RIP.HasField "use_sites_useTypedef_struct2_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct2_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct2_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct2_t")
@@ -901,8 +886,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct3_t" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr Struct3_t
-         ) => RIP.HasField "use_sites_useTypedef_struct3_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct3_t" (RIP.Ptr Use_sites) (RIP.Ptr (RIP.Ptr Struct3_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct3_t")
@@ -914,8 +898,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct4_t" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Struct4_t
-         ) => RIP.HasField "use_sites_useTypedef_struct4_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct4_t" (RIP.Ptr Use_sites) (RIP.Ptr (RIP.Ptr Struct4_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct4_t")
@@ -927,8 +910,7 @@ instance HasCField.HasCField Use_sites "use_sites_useStruct_struct5" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ Struct5
-         ) => RIP.HasField "use_sites_useStruct_struct5" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useStruct_struct5" (RIP.Ptr Use_sites) (RIP.Ptr Struct5) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct5")
@@ -940,8 +922,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct5_t" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ Struct5_t
-         ) => RIP.HasField "use_sites_useTypedef_struct5_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct5_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct5_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct5_t")
@@ -953,8 +934,7 @@ instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ Struct6_Aux
-         ) => RIP.HasField "use_sites_useStruct_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useStruct_struct6" (RIP.Ptr Use_sites) (RIP.Ptr Struct6_Aux) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6")
@@ -966,8 +946,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ Struct6
-         ) => RIP.HasField "use_sites_useTypedef_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct6" (RIP.Ptr Use_sites) (RIP.Ptr Struct6) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6")
@@ -979,8 +958,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7a" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct7a
-         ) => RIP.HasField "use_sites_useTypedef_struct7a" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct7a" (RIP.Ptr Use_sites) (RIP.Ptr Struct7a) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7a")
@@ -992,8 +970,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7b" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct7b
-         ) => RIP.HasField "use_sites_useTypedef_struct7b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct7b" (RIP.Ptr Use_sites) (RIP.Ptr Struct7b) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7b")
@@ -1005,8 +982,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct8
-         ) => RIP.HasField "use_sites_useTypedef_struct8" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct8" (RIP.Ptr Use_sites) (RIP.Ptr Struct8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8")
@@ -1018,8 +994,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8b" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct8b
-         ) => RIP.HasField "use_sites_useTypedef_struct8b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct8b" (RIP.Ptr Use_sites) (RIP.Ptr Struct8b) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8b")
@@ -1031,8 +1006,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct9
-         ) => RIP.HasField "use_sites_useTypedef_struct9" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct9" (RIP.Ptr Use_sites) (RIP.Ptr Struct9) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9")
@@ -1044,8 +1018,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9_t" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct9_t
-         ) => RIP.HasField "use_sites_useTypedef_struct9_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct9_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct9_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9_t")
@@ -1057,8 +1030,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct10_t
-         ) => RIP.HasField "use_sites_useTypedef_struct10_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct10_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct10_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t")
@@ -1070,8 +1042,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t_t" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct10_t_t
-         ) => RIP.HasField "use_sites_useTypedef_struct10_t_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct10_t_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct10_t_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t_t")
@@ -1083,8 +1054,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct11_t" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ Struct11_t
-         ) => RIP.HasField "use_sites_useTypedef_struct11_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct11_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct11_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct11_t")
@@ -1096,8 +1066,7 @@ instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct12_t" where
 
   offset# = \_ -> \_ -> 48
 
-instance ( ty ~ Struct12_t
-         ) => RIP.HasField "use_sites_useTypedef_struct12_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance RIP.HasField "use_sites_useTypedef_struct12_t" (RIP.Ptr Use_sites) (RIP.Ptr Struct12_t) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
@@ -75,8 +75,9 @@ newtype Struct5_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Struct5) =>
-         HasField "unwrapStruct5_t" (Ptr Struct5_t) (Ptr ty)
+instance HasField "unwrapStruct5_t"
+                  (Ptr Struct5_t)
+                  (Ptr (Ptr Struct5))
     where getField = fromPtr (Proxy @"unwrapStruct5_t")
 instance HasCField Struct5_t "unwrapStruct5_t"
     where type CFieldType Struct5_t "unwrapStruct5_t" = Ptr Struct5
@@ -113,8 +114,9 @@ newtype Struct6
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr Struct6_Aux) =>
-         HasField "unwrapStruct6" (Ptr Struct6) (Ptr ty)
+instance HasField "unwrapStruct6"
+                  (Ptr Struct6)
+                  (Ptr (Ptr Struct6_Aux))
     where getField = fromPtr (Proxy @"unwrapStruct6")
 instance HasCField Struct6 "unwrapStruct6"
     where type CFieldType Struct6 "unwrapStruct6" = Ptr Struct6_Aux
@@ -145,8 +147,7 @@ newtype Struct7a
     = Struct7a {unwrapStruct7a :: Struct7}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct7 =>
-         HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr ty)
+instance HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7a")
 instance HasCField Struct7a "unwrapStruct7a"
     where type CFieldType Struct7a "unwrapStruct7a" = Struct7
@@ -161,8 +162,7 @@ newtype Struct7b
     = Struct7b {unwrapStruct7b :: Struct7}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct7 =>
-         HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr ty)
+instance HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr Struct7)
     where getField = fromPtr (Proxy @"unwrapStruct7b")
 instance HasCField Struct7b "unwrapStruct7b"
     where type CFieldType Struct7b "unwrapStruct7b" = Struct7
@@ -193,8 +193,7 @@ newtype Struct8b
     = Struct8b {unwrapStruct8b :: Struct8}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct8 =>
-         HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr ty)
+instance HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr Struct8)
     where getField = fromPtr (Proxy @"unwrapStruct8b")
 instance HasCField Struct8b "unwrapStruct8b"
     where type CFieldType Struct8b "unwrapStruct8b" = Struct8
@@ -225,8 +224,7 @@ newtype Struct9_t
     = Struct9_t {unwrapStruct9_t :: Struct9}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct9 =>
-         HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr ty)
+instance HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr Struct9)
     where getField = fromPtr (Proxy @"unwrapStruct9_t")
 instance HasCField Struct9_t "unwrapStruct9_t"
     where type CFieldType Struct9_t "unwrapStruct9_t" = Struct9
@@ -257,8 +255,9 @@ newtype Struct10_t_t
     = Struct10_t_t {unwrapStruct10_t_t :: Struct10_t}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty Struct10_t =>
-         HasField "unwrapStruct10_t_t" (Ptr Struct10_t_t) (Ptr ty)
+instance HasField "unwrapStruct10_t_t"
+                  (Ptr Struct10_t_t)
+                  (Ptr Struct10_t)
     where getField = fromPtr (Proxy @"unwrapStruct10_t_t")
 instance HasCField Struct10_t_t "unwrapStruct10_t_t"
     where type CFieldType Struct10_t_t
@@ -299,14 +298,14 @@ deriving via (EquivStorable Struct11_t) instance Storable Struct11_t
 instance HasCField Struct11_t "struct11_t_x"
     where type CFieldType Struct11_t "struct11_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "struct11_t_x" (Ptr Struct11_t) (Ptr ty)
+instance HasField "struct11_t_x" (Ptr Struct11_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct11_t_x")
 instance HasCField Struct11_t "struct11_t_self"
     where type CFieldType Struct11_t "struct11_t_self" = Ptr Struct11_t
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct11_t) =>
-         HasField "struct11_t_self" (Ptr Struct11_t) (Ptr ty)
+instance HasField "struct11_t_self"
+                  (Ptr Struct11_t)
+                  (Ptr (Ptr Struct11_t))
     where getField = fromPtr (Proxy @"struct11_t_self")
 {-| __C declaration:__ @struct struct12@
 
@@ -343,14 +342,14 @@ deriving via (EquivStorable Struct12_t) instance Storable Struct12_t
 instance HasCField Struct12_t "struct12_t_x"
     where type CFieldType Struct12_t "struct12_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "struct12_t_x" (Ptr Struct12_t) (Ptr ty)
+instance HasField "struct12_t_x" (Ptr Struct12_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct12_t_x")
 instance HasCField Struct12_t "struct12_t_self"
     where type CFieldType Struct12_t "struct12_t_self" = Ptr Struct12_t
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct12_t) =>
-         HasField "struct12_t_self" (Ptr Struct12_t) (Ptr ty)
+instance HasField "struct12_t_self"
+                  (Ptr Struct12_t)
+                  (Ptr (Ptr Struct12_t))
     where getField = fromPtr (Proxy @"struct12_t_self")
 {-| __C declaration:__ @struct use_sites@
 
@@ -516,127 +515,143 @@ instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct1_t" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct1_t =>
-         HasField "use_sites_useTypedef_struct1_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct1_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct1_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct1_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct2_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct2_t" = Struct2_t
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct2_t =>
-         HasField "use_sites_useTypedef_struct2_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct2_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct2_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct2_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct3_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct3_t" = Ptr Struct3_t
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Struct3_t) =>
-         HasField "use_sites_useTypedef_struct3_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct3_t"
+                  (Ptr Use_sites)
+                  (Ptr (Ptr Struct3_t))
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct3_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct4_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct4_t" = Ptr Struct4_t
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct4_t) =>
-         HasField "use_sites_useTypedef_struct4_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct4_t"
+                  (Ptr Use_sites)
+                  (Ptr (Ptr Struct4_t))
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct4_t")
 instance HasCField Use_sites "use_sites_useStruct_struct5"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct5" = Struct5
           offset# = \_ -> \_ -> 16
-instance (~) ty Struct5 =>
-         HasField "use_sites_useStruct_struct5" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useStruct_struct5"
+                  (Ptr Use_sites)
+                  (Ptr Struct5)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct5")
 instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct5_t" = Struct5_t
           offset# = \_ -> \_ -> 16
-instance (~) ty Struct5_t =>
-         HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct5_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct5_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
 instance HasCField Use_sites "use_sites_useStruct_struct6"
     where type CFieldType Use_sites
                           "use_sites_useStruct_struct6" = Struct6_Aux
           offset# = \_ -> \_ -> 24
-instance (~) ty Struct6_Aux =>
-         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useStruct_struct6"
+                  (Ptr Use_sites)
+                  (Ptr Struct6_Aux)
     where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct6"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct6" = Struct6
           offset# = \_ -> \_ -> 24
-instance (~) ty Struct6 =>
-         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct6"
+                  (Ptr Use_sites)
+                  (Ptr Struct6)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
 instance HasCField Use_sites "use_sites_useTypedef_struct7a"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7a" = Struct7a
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct7a =>
-         HasField "use_sites_useTypedef_struct7a" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct7a"
+                  (Ptr Use_sites)
+                  (Ptr Struct7a)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7a")
 instance HasCField Use_sites "use_sites_useTypedef_struct7b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct7b" = Struct7b
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct7b =>
-         HasField "use_sites_useTypedef_struct7b" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct7b"
+                  (Ptr Use_sites)
+                  (Ptr Struct7b)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7b")
 instance HasCField Use_sites "use_sites_useTypedef_struct8"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8" = Struct8
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct8 =>
-         HasField "use_sites_useTypedef_struct8" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct8"
+                  (Ptr Use_sites)
+                  (Ptr Struct8)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8")
 instance HasCField Use_sites "use_sites_useTypedef_struct8b"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct8b" = Struct8b
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct8b =>
-         HasField "use_sites_useTypedef_struct8b" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct8b"
+                  (Ptr Use_sites)
+                  (Ptr Struct8b)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8b")
 instance HasCField Use_sites "use_sites_useTypedef_struct9"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9" = Struct9
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct9 =>
-         HasField "use_sites_useTypedef_struct9" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct9"
+                  (Ptr Use_sites)
+                  (Ptr Struct9)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9")
 instance HasCField Use_sites "use_sites_useTypedef_struct9_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct9_t" = Struct9_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct9_t =>
-         HasField "use_sites_useTypedef_struct9_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct9_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct9_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t" = Struct10_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct10_t =>
-         HasField "use_sites_useTypedef_struct10_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct10_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct10_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct10_t_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct10_t_t" = Struct10_t_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct10_t_t =>
-         HasField "use_sites_useTypedef_struct10_t_t"
+instance HasField "use_sites_useTypedef_struct10_t_t"
                   (Ptr Use_sites)
-                  (Ptr ty)
+                  (Ptr Struct10_t_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct11_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct11_t" = Struct11_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct11_t =>
-         HasField "use_sites_useTypedef_struct11_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct11_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct11_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct11_t")
 instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
     where type CFieldType Use_sites
                           "use_sites_useTypedef_struct12_t" = Struct12_t
           offset# = \_ -> \_ -> 48
-instance (~) ty Struct12_t =>
-         HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
+instance HasField "use_sites_useTypedef_struct12_t"
+                  (Ptr Use_sites)
+                  (Ptr Struct12_t)
     where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,8 +68,7 @@ instance HasCField.HasCField S_y_x "s_y_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s_y_x_x" (RIP.Ptr S_y_x) (RIP.Ptr ty) where
+instance RIP.HasField "s_y_x_x" (RIP.Ptr S_y_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y_x_x")
 
@@ -122,7 +119,7 @@ instance HasCField.HasCField S_y "s_y_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S_y_x) => RIP.HasField "s_y_x" (RIP.Ptr S_y) (RIP.Ptr ty) where
+instance RIP.HasField "s_y_x" (RIP.Ptr S_y) (RIP.Ptr S_y_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y_x")
 
@@ -173,6 +170,6 @@ instance HasCField.HasCField S "s_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S_y) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr S_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable S_y_x) instance Storable S_y_x
 instance HasCField S_y_x "s_y_x_x"
     where type CFieldType S_y_x "s_y_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_y_x_x" (Ptr S_y_x) (Ptr ty)
+instance HasField "s_y_x_x" (Ptr S_y_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"s_y_x_x")
 {-| __C declaration:__ @struct \@S_y@
 
@@ -55,7 +55,7 @@ deriving via (EquivStorable S_y) instance Storable S_y
 instance HasCField S_y "s_y_x"
     where type CFieldType S_y "s_y_x" = S_y_x
           offset# = \_ -> \_ -> 0
-instance (~) ty S_y_x => HasField "s_y_x" (Ptr S_y) (Ptr ty)
+instance HasField "s_y_x" (Ptr S_y) (Ptr S_y_x)
     where getField = fromPtr (Proxy @"s_y_x")
 {-| __C declaration:__ @struct S@
 
@@ -84,5 +84,5 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_y"
     where type CFieldType S "s_y" = S_y
           offset# = \_ -> \_ -> 0
-instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
+instance HasField "s_y" (Ptr S) (Ptr S_y)
     where getField = fromPtr (Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -76,8 +74,7 @@ instance HasCBitfield.HasCBitfield S1_y "s1_y_y" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s1_y_y" (RIP.Ptr S1_y) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "s1_y_y" (RIP.Ptr S1_y) (BitfieldPtr.BitfieldPtr RIP.CChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"s1_y_y")
 
@@ -137,7 +134,7 @@ instance HasCField.HasCField S1 "s1_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S1_y) => RIP.HasField "s1_y" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_y" (RIP.Ptr S1) (RIP.Ptr S1_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_y")
 
@@ -147,7 +144,7 @@ instance HasCField.HasCField S1 "s1_x" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_x" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_x" (RIP.Ptr S1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_x")
 
@@ -200,8 +197,7 @@ instance HasCBitfield.HasCBitfield S2_y_y "s2_y_y_y" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_y_y_y" (RIP.Ptr S2_y_y) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "s2_y_y_y" (RIP.Ptr S2_y_y) (BitfieldPtr.BitfieldPtr RIP.CChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"s2_y_y_y")
 
@@ -261,8 +257,7 @@ instance HasCField.HasCField S2_y "s2_y_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ S2_y_y
-         ) => RIP.HasField "s2_y_y" (RIP.Ptr S2_y) (RIP.Ptr ty) where
+instance RIP.HasField "s2_y_y" (RIP.Ptr S2_y) (RIP.Ptr S2_y_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_y_y")
 
@@ -272,8 +267,7 @@ instance HasCField.HasCField S2_y "s2_y_x" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_y_x" (RIP.Ptr S2_y) (RIP.Ptr ty) where
+instance RIP.HasField "s2_y_x" (RIP.Ptr S2_y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_y_x")
 
@@ -324,6 +318,6 @@ instance HasCField.HasCField S2 "s2_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S2_y) => RIP.HasField "s2_y" (RIP.Ptr S2) (RIP.Ptr ty) where
+instance RIP.HasField "s2_y" (RIP.Ptr S2) (RIP.Ptr S2_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/th.txt
@@ -27,8 +27,7 @@ instance HasCBitfield S1_y "s1_y_y"
     where type CBitfieldType S1_y "s1_y_y" = CChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CChar =>
-         HasField "s1_y_y" (Ptr S1_y) (BitfieldPtr ty)
+instance HasField "s1_y_y" (Ptr S1_y) (BitfieldPtr CChar)
     where getField = toPtr (Proxy @"s1_y_y")
 {-| __C declaration:__ @struct S1@
 
@@ -65,12 +64,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_y"
     where type CFieldType S1 "s1_y" = S1_y
           offset# = \_ -> \_ -> 0
-instance (~) ty S1_y => HasField "s1_y" (Ptr S1) (Ptr ty)
+instance HasField "s1_y" (Ptr S1) (Ptr S1_y)
     where getField = fromPtr (Proxy @"s1_y")
 instance HasCField S1 "s1_x"
     where type CFieldType S1 "s1_x" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s1_x" (Ptr S1) (Ptr ty)
+instance HasField "s1_x" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_x")
 {-| __C declaration:__ @struct \@S2_y_y@
 
@@ -100,8 +99,7 @@ instance HasCBitfield S2_y_y "s2_y_y_y"
     where type CBitfieldType S2_y_y "s2_y_y_y" = CChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CChar =>
-         HasField "s2_y_y_y" (Ptr S2_y_y) (BitfieldPtr ty)
+instance HasField "s2_y_y_y" (Ptr S2_y_y) (BitfieldPtr CChar)
     where getField = toPtr (Proxy @"s2_y_y_y")
 {-| __C declaration:__ @struct \@S2_y@
 
@@ -138,12 +136,12 @@ deriving via (EquivStorable S2_y) instance Storable S2_y
 instance HasCField S2_y "s2_y_y"
     where type CFieldType S2_y "s2_y_y" = S2_y_y
           offset# = \_ -> \_ -> 0
-instance (~) ty S2_y_y => HasField "s2_y_y" (Ptr S2_y) (Ptr ty)
+instance HasField "s2_y_y" (Ptr S2_y) (Ptr S2_y_y)
     where getField = fromPtr (Proxy @"s2_y_y")
 instance HasCField S2_y "s2_y_x"
     where type CFieldType S2_y "s2_y_x" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s2_y_x" (Ptr S2_y) (Ptr ty)
+instance HasField "s2_y_x" (Ptr S2_y) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_y_x")
 {-| __C declaration:__ @struct S2@
 
@@ -172,5 +170,5 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_y"
     where type CFieldType S2 "s2_y" = S2_y
           offset# = \_ -> \_ -> 0
-instance (~) ty S2_y => HasField "s2_y" (Ptr S2) (Ptr ty)
+instance HasField "s2_y" (Ptr S2) (Ptr S2_y)
     where getField = fromPtr (Proxy @"s2_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -70,8 +68,7 @@ instance HasCField.HasCField S_y_x "s_y_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s_y_x_x" (RIP.Ptr S_y_x) (RIP.Ptr ty) where
+instance RIP.HasField "s_y_x_x" (RIP.Ptr S_y_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y_x_x")
 
@@ -122,7 +119,7 @@ instance HasCField.HasCField S_y "s_y_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S_y_x) => RIP.HasField "s_y_x" (RIP.Ptr S_y) (RIP.Ptr ty) where
+instance RIP.HasField "s_y_x" (RIP.Ptr S_y) (RIP.Ptr S_y_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y_x")
 
@@ -182,7 +179,7 @@ instance HasCField.HasCField S "s_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CULLong) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr RIP.CULLong) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
@@ -192,6 +189,6 @@ instance HasCField.HasCField S "s_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ S_y) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
+instance RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr S_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable S_y_x) instance Storable S_y_x
 instance HasCField S_y_x "s_y_x_x"
     where type CFieldType S_y_x "s_y_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_y_x_x" (Ptr S_y_x) (Ptr ty)
+instance HasField "s_y_x_x" (Ptr S_y_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"s_y_x_x")
 {-| __C declaration:__ @struct \@S_y@
 
@@ -55,7 +55,7 @@ deriving via (EquivStorable S_y) instance Storable S_y
 instance HasCField S_y "s_y_x"
     where type CFieldType S_y "s_y_x" = S_y_x
           offset# = \_ -> \_ -> 0
-instance (~) ty S_y_x => HasField "s_y_x" (Ptr S_y) (Ptr ty)
+instance HasField "s_y_x" (Ptr S_y) (Ptr S_y_x)
     where getField = fromPtr (Proxy @"s_y_x")
 {-| __C declaration:__ @struct S@
 
@@ -92,10 +92,10 @@ deriving via (EquivStorable S) instance Storable S
 instance HasCField S "s_x"
     where type CFieldType S "s_x" = CULLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULLong => HasField "s_x" (Ptr S) (Ptr ty)
+instance HasField "s_x" (Ptr S) (Ptr CULLong)
     where getField = fromPtr (Proxy @"s_x")
 instance HasCField S "s_y"
     where type CFieldType S "s_y" = S_y
           offset# = \_ -> \_ -> 8
-instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
+instance HasField "s_y" (Ptr S) (Ptr S_y)
     where getField = fromPtr (Proxy @"s_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -115,8 +113,7 @@ instance HasCField.HasCField SSS_x_x "sSS_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sSS_x_x_x" (RIP.Ptr SSS_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "sSS_x_x_x" (RIP.Ptr SSS_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSS_x_x_x")
 
@@ -167,8 +164,7 @@ instance HasCField.HasCField SSS_x "sSS_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ SSS_x_x
-         ) => RIP.HasField "sSS_x_x" (RIP.Ptr SSS_x) (RIP.Ptr ty) where
+instance RIP.HasField "sSS_x_x" (RIP.Ptr SSS_x) (RIP.Ptr SSS_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSS_x_x")
 
@@ -219,7 +215,7 @@ instance HasCField.HasCField SSS "sSS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ SSS_x) => RIP.HasField "sSS_x" (RIP.Ptr SSS) (RIP.Ptr ty) where
+instance RIP.HasField "sSS_x" (RIP.Ptr SSS) (RIP.Ptr SSS_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSS_x")
 
@@ -270,8 +266,7 @@ instance HasCField.HasCField USS_x_x "uSS_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uSS_x_x_x" (RIP.Ptr USS_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "uSS_x_x_x" (RIP.Ptr USS_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSS_x_x_x")
 
@@ -322,8 +317,7 @@ instance HasCField.HasCField USS_x "uSS_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ USS_x_x
-         ) => RIP.HasField "uSS_x_x" (RIP.Ptr USS_x) (RIP.Ptr ty) where
+instance RIP.HasField "uSS_x_x" (RIP.Ptr USS_x) (RIP.Ptr USS_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSS_x_x")
 
@@ -377,7 +371,7 @@ instance HasCField.HasCField USS "uSS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ USS_x) => RIP.HasField "uSS_x" (RIP.Ptr USS) (RIP.Ptr ty) where
+instance RIP.HasField "uSS_x" (RIP.Ptr USS) (RIP.Ptr USS_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSS_x")
 
@@ -428,8 +422,7 @@ instance HasCField.HasCField SUS_x_x "sUS_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sUS_x_x_x" (RIP.Ptr SUS_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "sUS_x_x_x" (RIP.Ptr SUS_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUS_x_x_x")
 
@@ -483,8 +476,7 @@ instance HasCField.HasCField SUS_x "sUS_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ SUS_x_x
-         ) => RIP.HasField "sUS_x_x" (RIP.Ptr SUS_x) (RIP.Ptr ty) where
+instance RIP.HasField "sUS_x_x" (RIP.Ptr SUS_x) (RIP.Ptr SUS_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUS_x_x")
 
@@ -535,7 +527,7 @@ instance HasCField.HasCField SUS "sUS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ SUS_x) => RIP.HasField "sUS_x" (RIP.Ptr SUS) (RIP.Ptr ty) where
+instance RIP.HasField "sUS_x" (RIP.Ptr SUS) (RIP.Ptr SUS_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUS_x")
 
@@ -586,8 +578,7 @@ instance HasCField.HasCField UUS_x_x "uUS_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uUS_x_x_x" (RIP.Ptr UUS_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "uUS_x_x_x" (RIP.Ptr UUS_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUS_x_x_x")
 
@@ -641,8 +632,7 @@ instance HasCField.HasCField UUS_x "uUS_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ UUS_x_x
-         ) => RIP.HasField "uUS_x_x" (RIP.Ptr UUS_x) (RIP.Ptr ty) where
+instance RIP.HasField "uUS_x_x" (RIP.Ptr UUS_x) (RIP.Ptr UUS_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUS_x_x")
 
@@ -696,7 +686,7 @@ instance HasCField.HasCField UUS "uUS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ UUS_x) => RIP.HasField "uUS_x" (RIP.Ptr UUS) (RIP.Ptr ty) where
+instance RIP.HasField "uUS_x" (RIP.Ptr UUS) (RIP.Ptr UUS_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUS_x")
 
@@ -750,8 +740,7 @@ instance HasCField.HasCField SSU_x_x "sSU_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sSU_x_x_x" (RIP.Ptr SSU_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "sSU_x_x_x" (RIP.Ptr SSU_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSU_x_x_x")
 
@@ -802,8 +791,7 @@ instance HasCField.HasCField SSU_x "sSU_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ SSU_x_x
-         ) => RIP.HasField "sSU_x_x" (RIP.Ptr SSU_x) (RIP.Ptr ty) where
+instance RIP.HasField "sSU_x_x" (RIP.Ptr SSU_x) (RIP.Ptr SSU_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSU_x_x")
 
@@ -854,7 +842,7 @@ instance HasCField.HasCField SSU "sSU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ SSU_x) => RIP.HasField "sSU_x" (RIP.Ptr SSU) (RIP.Ptr ty) where
+instance RIP.HasField "sSU_x" (RIP.Ptr SSU) (RIP.Ptr SSU_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sSU_x")
 
@@ -908,8 +896,7 @@ instance HasCField.HasCField USU_x_x "uSU_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uSU_x_x_x" (RIP.Ptr USU_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "uSU_x_x_x" (RIP.Ptr USU_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSU_x_x_x")
 
@@ -960,8 +947,7 @@ instance HasCField.HasCField USU_x "uSU_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ USU_x_x
-         ) => RIP.HasField "uSU_x_x" (RIP.Ptr USU_x) (RIP.Ptr ty) where
+instance RIP.HasField "uSU_x_x" (RIP.Ptr USU_x) (RIP.Ptr USU_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSU_x_x")
 
@@ -1015,7 +1001,7 @@ instance HasCField.HasCField USU "uSU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ USU_x) => RIP.HasField "uSU_x" (RIP.Ptr USU) (RIP.Ptr ty) where
+instance RIP.HasField "uSU_x" (RIP.Ptr USU) (RIP.Ptr USU_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uSU_x")
 
@@ -1069,8 +1055,7 @@ instance HasCField.HasCField SUU_x_x "sUU_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sUU_x_x_x" (RIP.Ptr SUU_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "sUU_x_x_x" (RIP.Ptr SUU_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUU_x_x_x")
 
@@ -1124,8 +1109,7 @@ instance HasCField.HasCField SUU_x "sUU_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ SUU_x_x
-         ) => RIP.HasField "sUU_x_x" (RIP.Ptr SUU_x) (RIP.Ptr ty) where
+instance RIP.HasField "sUU_x_x" (RIP.Ptr SUU_x) (RIP.Ptr SUU_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUU_x_x")
 
@@ -1176,7 +1160,7 @@ instance HasCField.HasCField SUU "sUU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ SUU_x) => RIP.HasField "sUU_x" (RIP.Ptr SUU) (RIP.Ptr ty) where
+instance RIP.HasField "sUU_x" (RIP.Ptr SUU) (RIP.Ptr SUU_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sUU_x")
 
@@ -1230,8 +1214,7 @@ instance HasCField.HasCField UUU_x_x "uUU_x_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uUU_x_x_x" (RIP.Ptr UUU_x_x) (RIP.Ptr ty) where
+instance RIP.HasField "uUU_x_x_x" (RIP.Ptr UUU_x_x) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUU_x_x_x")
 
@@ -1285,8 +1268,7 @@ instance HasCField.HasCField UUU_x "uUU_x_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ UUU_x_x
-         ) => RIP.HasField "uUU_x_x" (RIP.Ptr UUU_x) (RIP.Ptr ty) where
+instance RIP.HasField "uUU_x_x" (RIP.Ptr UUU_x) (RIP.Ptr UUU_x_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUU_x_x")
 
@@ -1340,6 +1322,6 @@ instance HasCField.HasCField UUU "uUU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ UUU_x) => RIP.HasField "uUU_x" (RIP.Ptr UUU) (RIP.Ptr ty) where
+instance RIP.HasField "uUU_x" (RIP.Ptr UUU) (RIP.Ptr UUU_x) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uUU_x")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable SSS_x_x) instance Storable SSS_x_x
 instance HasCField SSS_x_x "sSS_x_x_x"
     where type CFieldType SSS_x_x "sSS_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "sSS_x_x_x" (Ptr SSS_x_x) (Ptr ty)
+instance HasField "sSS_x_x_x" (Ptr SSS_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"sSS_x_x_x")
 {-| __C declaration:__ @struct \@SSS_x@
 
@@ -55,7 +55,7 @@ deriving via (EquivStorable SSS_x) instance Storable SSS_x
 instance HasCField SSS_x "sSS_x_x"
     where type CFieldType SSS_x "sSS_x_x" = SSS_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SSS_x_x => HasField "sSS_x_x" (Ptr SSS_x) (Ptr ty)
+instance HasField "sSS_x_x" (Ptr SSS_x) (Ptr SSS_x_x)
     where getField = fromPtr (Proxy @"sSS_x_x")
 {-| __C declaration:__ @struct SSS@
 
@@ -84,7 +84,7 @@ deriving via (EquivStorable SSS) instance Storable SSS
 instance HasCField SSS "sSS_x"
     where type CFieldType SSS "sSS_x" = SSS_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SSS_x => HasField "sSS_x" (Ptr SSS) (Ptr ty)
+instance HasField "sSS_x" (Ptr SSS) (Ptr SSS_x)
     where getField = fromPtr (Proxy @"sSS_x")
 {-| __C declaration:__ @struct \@USS_x_x@
 
@@ -113,7 +113,7 @@ deriving via (EquivStorable USS_x_x) instance Storable USS_x_x
 instance HasCField USS_x_x "uSS_x_x_x"
     where type CFieldType USS_x_x "uSS_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uSS_x_x_x" (Ptr USS_x_x) (Ptr ty)
+instance HasField "uSS_x_x_x" (Ptr USS_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"uSS_x_x_x")
 {-| __C declaration:__ @struct \@USS_x@
 
@@ -142,7 +142,7 @@ deriving via (EquivStorable USS_x) instance Storable USS_x
 instance HasCField USS_x "uSS_x_x"
     where type CFieldType USS_x "uSS_x_x" = USS_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty USS_x_x => HasField "uSS_x_x" (Ptr USS_x) (Ptr ty)
+instance HasField "uSS_x_x" (Ptr USS_x) (Ptr USS_x_x)
     where getField = fromPtr (Proxy @"uSS_x_x")
 {-| __C declaration:__ @union USS@
 
@@ -192,7 +192,7 @@ set_uSS_x = setUnionPayload
 instance HasCField USS "uSS_x"
     where type CFieldType USS "uSS_x" = USS_x
           offset# = \_ -> \_ -> 0
-instance (~) ty USS_x => HasField "uSS_x" (Ptr USS) (Ptr ty)
+instance HasField "uSS_x" (Ptr USS) (Ptr USS_x)
     where getField = fromPtr (Proxy @"uSS_x")
 {-| __C declaration:__ @struct \@SUS_x_x@
 
@@ -221,7 +221,7 @@ deriving via (EquivStorable SUS_x_x) instance Storable SUS_x_x
 instance HasCField SUS_x_x "sUS_x_x_x"
     where type CFieldType SUS_x_x "sUS_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "sUS_x_x_x" (Ptr SUS_x_x) (Ptr ty)
+instance HasField "sUS_x_x_x" (Ptr SUS_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"sUS_x_x_x")
 {-| __C declaration:__ @union \@SUS_x@
 
@@ -273,7 +273,7 @@ set_sUS_x_x = setUnionPayload
 instance HasCField SUS_x "sUS_x_x"
     where type CFieldType SUS_x "sUS_x_x" = SUS_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUS_x_x => HasField "sUS_x_x" (Ptr SUS_x) (Ptr ty)
+instance HasField "sUS_x_x" (Ptr SUS_x) (Ptr SUS_x_x)
     where getField = fromPtr (Proxy @"sUS_x_x")
 {-| __C declaration:__ @struct SUS@
 
@@ -302,7 +302,7 @@ deriving via (EquivStorable SUS) instance Storable SUS
 instance HasCField SUS "sUS_x"
     where type CFieldType SUS "sUS_x" = SUS_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUS_x => HasField "sUS_x" (Ptr SUS) (Ptr ty)
+instance HasField "sUS_x" (Ptr SUS) (Ptr SUS_x)
     where getField = fromPtr (Proxy @"sUS_x")
 {-| __C declaration:__ @struct \@UUS_x_x@
 
@@ -331,7 +331,7 @@ deriving via (EquivStorable UUS_x_x) instance Storable UUS_x_x
 instance HasCField UUS_x_x "uUS_x_x_x"
     where type CFieldType UUS_x_x "uUS_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uUS_x_x_x" (Ptr UUS_x_x) (Ptr ty)
+instance HasField "uUS_x_x_x" (Ptr UUS_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"uUS_x_x_x")
 {-| __C declaration:__ @union \@UUS_x@
 
@@ -383,7 +383,7 @@ set_uUS_x_x = setUnionPayload
 instance HasCField UUS_x "uUS_x_x"
     where type CFieldType UUS_x "uUS_x_x" = UUS_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUS_x_x => HasField "uUS_x_x" (Ptr UUS_x) (Ptr ty)
+instance HasField "uUS_x_x" (Ptr UUS_x) (Ptr UUS_x_x)
     where getField = fromPtr (Proxy @"uUS_x_x")
 {-| __C declaration:__ @union UUS@
 
@@ -433,7 +433,7 @@ set_uUS_x = setUnionPayload
 instance HasCField UUS "uUS_x"
     where type CFieldType UUS "uUS_x" = UUS_x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUS_x => HasField "uUS_x" (Ptr UUS) (Ptr ty)
+instance HasField "uUS_x" (Ptr UUS) (Ptr UUS_x)
     where getField = fromPtr (Proxy @"uUS_x")
 {-| __C declaration:__ @union \@SSU_x_x@
 
@@ -485,7 +485,7 @@ set_sSU_x_x_x = setUnionPayload
 instance HasCField SSU_x_x "sSU_x_x_x"
     where type CFieldType SSU_x_x "sSU_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "sSU_x_x_x" (Ptr SSU_x_x) (Ptr ty)
+instance HasField "sSU_x_x_x" (Ptr SSU_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"sSU_x_x_x")
 {-| __C declaration:__ @struct \@SSU_x@
 
@@ -514,7 +514,7 @@ deriving via (EquivStorable SSU_x) instance Storable SSU_x
 instance HasCField SSU_x "sSU_x_x"
     where type CFieldType SSU_x "sSU_x_x" = SSU_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SSU_x_x => HasField "sSU_x_x" (Ptr SSU_x) (Ptr ty)
+instance HasField "sSU_x_x" (Ptr SSU_x) (Ptr SSU_x_x)
     where getField = fromPtr (Proxy @"sSU_x_x")
 {-| __C declaration:__ @struct SSU@
 
@@ -543,7 +543,7 @@ deriving via (EquivStorable SSU) instance Storable SSU
 instance HasCField SSU "sSU_x"
     where type CFieldType SSU "sSU_x" = SSU_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SSU_x => HasField "sSU_x" (Ptr SSU) (Ptr ty)
+instance HasField "sSU_x" (Ptr SSU) (Ptr SSU_x)
     where getField = fromPtr (Proxy @"sSU_x")
 {-| __C declaration:__ @union \@USU_x_x@
 
@@ -595,7 +595,7 @@ set_uSU_x_x_x = setUnionPayload
 instance HasCField USU_x_x "uSU_x_x_x"
     where type CFieldType USU_x_x "uSU_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uSU_x_x_x" (Ptr USU_x_x) (Ptr ty)
+instance HasField "uSU_x_x_x" (Ptr USU_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"uSU_x_x_x")
 {-| __C declaration:__ @struct \@USU_x@
 
@@ -624,7 +624,7 @@ deriving via (EquivStorable USU_x) instance Storable USU_x
 instance HasCField USU_x "uSU_x_x"
     where type CFieldType USU_x "uSU_x_x" = USU_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty USU_x_x => HasField "uSU_x_x" (Ptr USU_x) (Ptr ty)
+instance HasField "uSU_x_x" (Ptr USU_x) (Ptr USU_x_x)
     where getField = fromPtr (Proxy @"uSU_x_x")
 {-| __C declaration:__ @union USU@
 
@@ -674,7 +674,7 @@ set_uSU_x = setUnionPayload
 instance HasCField USU "uSU_x"
     where type CFieldType USU "uSU_x" = USU_x
           offset# = \_ -> \_ -> 0
-instance (~) ty USU_x => HasField "uSU_x" (Ptr USU) (Ptr ty)
+instance HasField "uSU_x" (Ptr USU) (Ptr USU_x)
     where getField = fromPtr (Proxy @"uSU_x")
 {-| __C declaration:__ @union \@SUU_x_x@
 
@@ -726,7 +726,7 @@ set_sUU_x_x_x = setUnionPayload
 instance HasCField SUU_x_x "sUU_x_x_x"
     where type CFieldType SUU_x_x "sUU_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "sUU_x_x_x" (Ptr SUU_x_x) (Ptr ty)
+instance HasField "sUU_x_x_x" (Ptr SUU_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"sUU_x_x_x")
 {-| __C declaration:__ @union \@SUU_x@
 
@@ -778,7 +778,7 @@ set_sUU_x_x = setUnionPayload
 instance HasCField SUU_x "sUU_x_x"
     where type CFieldType SUU_x "sUU_x_x" = SUU_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUU_x_x => HasField "sUU_x_x" (Ptr SUU_x) (Ptr ty)
+instance HasField "sUU_x_x" (Ptr SUU_x) (Ptr SUU_x_x)
     where getField = fromPtr (Proxy @"sUU_x_x")
 {-| __C declaration:__ @struct SUU@
 
@@ -807,7 +807,7 @@ deriving via (EquivStorable SUU) instance Storable SUU
 instance HasCField SUU "sUU_x"
     where type CFieldType SUU "sUU_x" = SUU_x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUU_x => HasField "sUU_x" (Ptr SUU) (Ptr ty)
+instance HasField "sUU_x" (Ptr SUU) (Ptr SUU_x)
     where getField = fromPtr (Proxy @"sUU_x")
 {-| __C declaration:__ @union \@UUU_x_x@
 
@@ -859,7 +859,7 @@ set_uUU_x_x_x = setUnionPayload
 instance HasCField UUU_x_x "uUU_x_x_x"
     where type CFieldType UUU_x_x "uUU_x_x_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uUU_x_x_x" (Ptr UUU_x_x) (Ptr ty)
+instance HasField "uUU_x_x_x" (Ptr UUU_x_x) (Ptr CInt)
     where getField = fromPtr (Proxy @"uUU_x_x_x")
 {-| __C declaration:__ @union \@UUU_x@
 
@@ -911,7 +911,7 @@ set_uUU_x_x = setUnionPayload
 instance HasCField UUU_x "uUU_x_x"
     where type CFieldType UUU_x "uUU_x_x" = UUU_x_x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUU_x_x => HasField "uUU_x_x" (Ptr UUU_x) (Ptr ty)
+instance HasField "uUU_x_x" (Ptr UUU_x) (Ptr UUU_x_x)
     where getField = fromPtr (Proxy @"uUU_x_x")
 {-| __C declaration:__ @union UUU@
 
@@ -961,5 +961,5 @@ set_uUU_x = setUnionPayload
 instance HasCField UUU "uUU_x"
     where type CFieldType UUU "uUU_x" = UUU_x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUU_x => HasField "uUU_x" (Ptr UUU) (Ptr ty)
+instance HasField "uUU_x" (Ptr UUU) (Ptr UUU_x)
     where getField = fromPtr (Proxy @"uUU_x")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -91,8 +89,7 @@ instance HasCField.HasCField SS_y "sS_y_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sS_y_y" (RIP.Ptr SS_y) (RIP.Ptr ty) where
+instance RIP.HasField "sS_y_y" (RIP.Ptr SS_y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sS_y_y")
 
@@ -161,7 +158,7 @@ instance HasCField.HasCField SS "sS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "sS_x" (RIP.Ptr SS) (RIP.Ptr ty) where
+instance RIP.HasField "sS_x" (RIP.Ptr SS) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sS_x")
 
@@ -171,7 +168,7 @@ instance HasCField.HasCField SS "sS_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ SS_y) => RIP.HasField "sS_y" (RIP.Ptr SS) (RIP.Ptr ty) where
+instance RIP.HasField "sS_y" (RIP.Ptr SS) (RIP.Ptr SS_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sS_y")
 
@@ -181,7 +178,7 @@ instance HasCField.HasCField SS "sS_z" where
 
   offset# = \_ -> \_ -> 12
 
-instance (ty ~ RIP.CInt) => RIP.HasField "sS_z" (RIP.Ptr SS) (RIP.Ptr ty) where
+instance RIP.HasField "sS_z" (RIP.Ptr SS) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sS_z")
 
@@ -235,8 +232,7 @@ instance HasCField.HasCField SU_y "sU_y_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sU_y_y" (RIP.Ptr SU_y) (RIP.Ptr ty) where
+instance RIP.HasField "sU_y_y" (RIP.Ptr SU_y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sU_y_y")
 
@@ -305,7 +301,7 @@ instance HasCField.HasCField SU "sU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "sU_x" (RIP.Ptr SU) (RIP.Ptr ty) where
+instance RIP.HasField "sU_x" (RIP.Ptr SU) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sU_x")
 
@@ -315,7 +311,7 @@ instance HasCField.HasCField SU "sU_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ SU_y) => RIP.HasField "sU_y" (RIP.Ptr SU) (RIP.Ptr ty) where
+instance RIP.HasField "sU_y" (RIP.Ptr SU) (RIP.Ptr SU_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sU_y")
 
@@ -325,7 +321,7 @@ instance HasCField.HasCField SU "sU_z" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CInt) => RIP.HasField "sU_z" (RIP.Ptr SU) (RIP.Ptr ty) where
+instance RIP.HasField "sU_z" (RIP.Ptr SU) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"sU_z")
 
@@ -376,8 +372,7 @@ instance HasCField.HasCField US_y "uS_y_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uS_y_y" (RIP.Ptr US_y) (RIP.Ptr ty) where
+instance RIP.HasField "uS_y_y" (RIP.Ptr US_y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_y_y")
 
@@ -481,7 +476,7 @@ instance HasCField.HasCField US "uS_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "uS_x" (RIP.Ptr US) (RIP.Ptr ty) where
+instance RIP.HasField "uS_x" (RIP.Ptr US) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_x")
 
@@ -491,7 +486,7 @@ instance HasCField.HasCField US "uS_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ US_y) => RIP.HasField "uS_y" (RIP.Ptr US) (RIP.Ptr ty) where
+instance RIP.HasField "uS_y" (RIP.Ptr US) (RIP.Ptr US_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_y")
 
@@ -501,7 +496,7 @@ instance HasCField.HasCField US "uS_z" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "uS_z" (RIP.Ptr US) (RIP.Ptr ty) where
+instance RIP.HasField "uS_z" (RIP.Ptr US) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_z")
 
@@ -555,8 +550,7 @@ instance HasCField.HasCField UU_y "uU_y_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uU_y_y" (RIP.Ptr UU_y) (RIP.Ptr ty) where
+instance RIP.HasField "uU_y_y" (RIP.Ptr UU_y) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_y_y")
 
@@ -660,7 +654,7 @@ instance HasCField.HasCField UU "uU_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "uU_x" (RIP.Ptr UU) (RIP.Ptr ty) where
+instance RIP.HasField "uU_x" (RIP.Ptr UU) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_x")
 
@@ -670,7 +664,7 @@ instance HasCField.HasCField UU "uU_y" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ UU_y) => RIP.HasField "uU_y" (RIP.Ptr UU) (RIP.Ptr ty) where
+instance RIP.HasField "uU_y" (RIP.Ptr UU) (RIP.Ptr UU_y) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_y")
 
@@ -680,6 +674,6 @@ instance HasCField.HasCField UU "uU_z" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "uU_z" (RIP.Ptr UU) (RIP.Ptr ty) where
+instance RIP.HasField "uU_z" (RIP.Ptr UU) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_z")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable SS_y) instance Storable SS_y
 instance HasCField SS_y "sS_y_y"
     where type CFieldType SS_y "sS_y_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "sS_y_y" (Ptr SS_y) (Ptr ty)
+instance HasField "sS_y_y" (Ptr SS_y) (Ptr CInt)
     where getField = fromPtr (Proxy @"sS_y_y")
 {-| __C declaration:__ @struct SS@
 
@@ -71,17 +71,17 @@ deriving via (EquivStorable SS) instance Storable SS
 instance HasCField SS "sS_x"
     where type CFieldType SS "sS_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "sS_x" (Ptr SS) (Ptr ty)
+instance HasField "sS_x" (Ptr SS) (Ptr CChar)
     where getField = fromPtr (Proxy @"sS_x")
 instance HasCField SS "sS_y"
     where type CFieldType SS "sS_y" = SS_y
           offset# = \_ -> \_ -> 4
-instance (~) ty SS_y => HasField "sS_y" (Ptr SS) (Ptr ty)
+instance HasField "sS_y" (Ptr SS) (Ptr SS_y)
     where getField = fromPtr (Proxy @"sS_y")
 instance HasCField SS "sS_z"
     where type CFieldType SS "sS_z" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt => HasField "sS_z" (Ptr SS) (Ptr ty)
+instance HasField "sS_z" (Ptr SS) (Ptr CInt)
     where getField = fromPtr (Proxy @"sS_z")
 {-| __C declaration:__ @union \@SU_y@
 
@@ -133,7 +133,7 @@ set_sU_y_y = setUnionPayload
 instance HasCField SU_y "sU_y_y"
     where type CFieldType SU_y "sU_y_y" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "sU_y_y" (Ptr SU_y) (Ptr ty)
+instance HasField "sU_y_y" (Ptr SU_y) (Ptr CInt)
     where getField = fromPtr (Proxy @"sU_y_y")
 {-| __C declaration:__ @struct SU@
 
@@ -178,17 +178,17 @@ deriving via (EquivStorable SU) instance Storable SU
 instance HasCField SU "sU_x"
     where type CFieldType SU "sU_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "sU_x" (Ptr SU) (Ptr ty)
+instance HasField "sU_x" (Ptr SU) (Ptr CChar)
     where getField = fromPtr (Proxy @"sU_x")
 instance HasCField SU "sU_y"
     where type CFieldType SU "sU_y" = SU_y
           offset# = \_ -> \_ -> 4
-instance (~) ty SU_y => HasField "sU_y" (Ptr SU) (Ptr ty)
+instance HasField "sU_y" (Ptr SU) (Ptr SU_y)
     where getField = fromPtr (Proxy @"sU_y")
 instance HasCField SU "sU_z"
     where type CFieldType SU "sU_z" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "sU_z" (Ptr SU) (Ptr ty)
+instance HasField "sU_z" (Ptr SU) (Ptr CInt)
     where getField = fromPtr (Proxy @"sU_z")
 {-| __C declaration:__ @struct \@US_y@
 
@@ -217,7 +217,7 @@ deriving via (EquivStorable US_y) instance Storable US_y
 instance HasCField US_y "uS_y_y"
     where type CFieldType US_y "uS_y_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "uS_y_y" (Ptr US_y) (Ptr ty)
+instance HasField "uS_y_y" (Ptr US_y) (Ptr CInt)
     where getField = fromPtr (Proxy @"uS_y_y")
 {-| __C declaration:__ @union US@
 
@@ -335,17 +335,17 @@ set_uS_z = setUnionPayload
 instance HasCField US "uS_x"
     where type CFieldType US "uS_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "uS_x" (Ptr US) (Ptr ty)
+instance HasField "uS_x" (Ptr US) (Ptr CChar)
     where getField = fromPtr (Proxy @"uS_x")
 instance HasCField US "uS_y"
     where type CFieldType US "uS_y" = US_y
           offset# = \_ -> \_ -> 0
-instance (~) ty US_y => HasField "uS_y" (Ptr US) (Ptr ty)
+instance HasField "uS_y" (Ptr US) (Ptr US_y)
     where getField = fromPtr (Proxy @"uS_y")
 instance HasCField US "uS_z"
     where type CFieldType US "uS_z" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uS_z" (Ptr US) (Ptr ty)
+instance HasField "uS_z" (Ptr US) (Ptr CInt)
     where getField = fromPtr (Proxy @"uS_z")
 {-| __C declaration:__ @union \@UU_y@
 
@@ -397,7 +397,7 @@ set_uU_y_y = setUnionPayload
 instance HasCField UU_y "uU_y_y"
     where type CFieldType UU_y "uU_y_y" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uU_y_y" (Ptr UU_y) (Ptr ty)
+instance HasField "uU_y_y" (Ptr UU_y) (Ptr CInt)
     where getField = fromPtr (Proxy @"uU_y_y")
 {-| __C declaration:__ @union UU@
 
@@ -515,15 +515,15 @@ set_uU_z = setUnionPayload
 instance HasCField UU "uU_x"
     where type CFieldType UU "uU_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "uU_x" (Ptr UU) (Ptr ty)
+instance HasField "uU_x" (Ptr UU) (Ptr CChar)
     where getField = fromPtr (Proxy @"uU_x")
 instance HasCField UU "uU_y"
     where type CFieldType UU "uU_y" = UU_y
           offset# = \_ -> \_ -> 0
-instance (~) ty UU_y => HasField "uU_y" (Ptr UU) (Ptr ty)
+instance HasField "uU_y" (Ptr UU) (Ptr UU_y)
     where getField = fromPtr (Proxy @"uU_y")
 instance HasCField UU "uU_z"
     where type CFieldType UU "uU_z" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uU_z" (Ptr UU) (Ptr ty)
+instance HasField "uU_z" (Ptr UU) (Ptr CInt)
     where getField = fromPtr (Proxy @"uU_z")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -87,8 +85,7 @@ instance HasCField.HasCField Has_implicit_fields_x2_1 "has_implicit_fields_x2_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x2_1_x2_1" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1_x2_1" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1_x2_1")
@@ -100,8 +97,7 @@ instance HasCField.HasCField Has_implicit_fields_x2_1 "has_implicit_fields_x2_1_
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x2_1_x2_2" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1_x2_2" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1_x2_2")
@@ -165,8 +161,7 @@ instance HasCField.HasCField Has_implicit_fields_x4_1 "has_implicit_fields_x4_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x4_1_x4_1" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1_x4_1" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1_x4_1")
@@ -178,8 +173,7 @@ instance HasCField.HasCField Has_implicit_fields_x4_1 "has_implicit_fields_x4_1_
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x4_1_x4_2" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1_x4_2" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1_x4_2")
@@ -264,8 +258,7 @@ instance HasCField.HasCField Has_implicit_fields_x5_1 "has_implicit_fields_x5_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5_1_x5_1" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1_x5_1" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1_x5_1")
@@ -277,8 +270,7 @@ instance HasCField.HasCField Has_implicit_fields_x5_1 "has_implicit_fields_x5_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5_1_x5_2" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1_x5_2" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1_x5_2")
@@ -382,8 +374,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x1")
@@ -395,8 +386,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x2_1" wher
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Has_implicit_fields_x2_1
-         ) => RIP.HasField "has_implicit_fields_x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x2_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1")
@@ -408,8 +398,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x3")
@@ -421,8 +410,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x4_1" wher
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ Has_implicit_fields_x4_1
-         ) => RIP.HasField "has_implicit_fields_x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x4_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1")
@@ -434,8 +422,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5_1" wher
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ Has_implicit_fields_x5_1
-         ) => RIP.HasField "has_implicit_fields_x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x5_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1")
@@ -447,8 +434,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
 
   offset# = \_ -> \_ -> 28
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/th.txt
@@ -36,20 +36,18 @@ instance HasCField Has_implicit_fields_x2_1
     where type CFieldType Has_implicit_fields_x2_1
                           "has_implicit_fields_x2_1_x2_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x2_1_x2_1"
+instance HasField "has_implicit_fields_x2_1_x2_1"
                   (Ptr Has_implicit_fields_x2_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1_x2_1")
 instance HasCField Has_implicit_fields_x2_1
                    "has_implicit_fields_x2_1_x2_2"
     where type CFieldType Has_implicit_fields_x2_1
                           "has_implicit_fields_x2_1_x2_2" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x2_1_x2_2"
+instance HasField "has_implicit_fields_x2_1_x2_2"
                   (Ptr Has_implicit_fields_x2_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1_x2_2")
 {-| __C declaration:__ @struct \@has_implicit_fields_x4_1@
 
@@ -88,20 +86,18 @@ instance HasCField Has_implicit_fields_x4_1
     where type CFieldType Has_implicit_fields_x4_1
                           "has_implicit_fields_x4_1_x4_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x4_1_x4_1"
+instance HasField "has_implicit_fields_x4_1_x4_1"
                   (Ptr Has_implicit_fields_x4_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1_x4_1")
 instance HasCField Has_implicit_fields_x4_1
                    "has_implicit_fields_x4_1_x4_2"
     where type CFieldType Has_implicit_fields_x4_1
                           "has_implicit_fields_x4_1_x4_2" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x4_1_x4_2"
+instance HasField "has_implicit_fields_x4_1_x4_2"
                   (Ptr Has_implicit_fields_x4_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1_x4_2")
 {-| __C declaration:__ @union \@has_implicit_fields_x5_1@
 
@@ -196,20 +192,18 @@ instance HasCField Has_implicit_fields_x5_1
     where type CFieldType Has_implicit_fields_x5_1
                           "has_implicit_fields_x5_1_x5_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5_1_x5_1"
+instance HasField "has_implicit_fields_x5_1_x5_1"
                   (Ptr Has_implicit_fields_x5_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1_x5_1")
 instance HasCField Has_implicit_fields_x5_1
                    "has_implicit_fields_x5_1_x5_2"
     where type CFieldType Has_implicit_fields_x5_1
                           "has_implicit_fields_x5_1_x5_2" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5_1_x5_2"
+instance HasField "has_implicit_fields_x5_1_x5_2"
                   (Ptr Has_implicit_fields_x5_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1_x5_2")
 {-| __C declaration:__ @struct has_implicit_fields@
 
@@ -279,53 +273,47 @@ instance HasCField Has_implicit_fields "has_implicit_fields_x1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x1"
+instance HasField "has_implicit_fields_x1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x2_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x2_1" = Has_implicit_fields_x2_1
           offset# = \_ -> \_ -> 4
-instance (~) ty Has_implicit_fields_x2_1 =>
-         HasField "has_implicit_fields_x2_1"
+instance HasField "has_implicit_fields_x2_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x2_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x3"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x3" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x3"
+instance HasField "has_implicit_fields_x3"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x3")
 instance HasCField Has_implicit_fields "has_implicit_fields_x4_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x4_1" = Has_implicit_fields_x4_1
           offset# = \_ -> \_ -> 16
-instance (~) ty Has_implicit_fields_x4_1 =>
-         HasField "has_implicit_fields_x4_1"
+instance HasField "has_implicit_fields_x4_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x4_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x5_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x5_1" = Has_implicit_fields_x5_1
           offset# = \_ -> \_ -> 24
-instance (~) ty Has_implicit_fields_x5_1 =>
-         HasField "has_implicit_fields_x5_1"
+instance HasField "has_implicit_fields_x5_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x5_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x5"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x5" = CInt
           offset# = \_ -> \_ -> 28
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5"
+instance HasField "has_implicit_fields_x5"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -83,8 +81,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldX")
@@ -96,8 +93,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldY")
@@ -167,8 +163,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
@@ -180,8 +175,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldX" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Outer1_fieldX
-         ) => RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr Outer1_fieldX) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX")
@@ -192,8 +186,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldC" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
@@ -255,8 +248,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
@@ -268,8 +260,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
@@ -339,8 +330,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
@@ -352,8 +342,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr Outer2_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
@@ -364,8 +353,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldC" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
@@ -426,8 +414,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
@@ -438,8 +425,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
@@ -509,8 +495,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
@@ -521,8 +506,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr Inner3) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
@@ -533,8 +517,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldC" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/th.txt
@@ -34,14 +34,16 @@ deriving via (EquivStorable Outer1_fieldX) instance Storable Outer1_fieldX
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldX"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldX" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldX"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldX")
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldY"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldY" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldY"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldY")
 {-| __C declaration:__ @struct outer1@
 
@@ -86,20 +88,17 @@ deriving via (EquivStorable Outer1) instance Storable Outer1
 instance HasCField Outer1 "outer1_fieldA"
     where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldA" (Ptr Outer1) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer1_fieldA")
 instance HasCField Outer1 "outer1_fieldX"
     where type CFieldType Outer1 "outer1_fieldX" = Outer1_fieldX
           offset# = \_ -> \_ -> 4
-instance (~) ty Outer1_fieldX =>
-         HasField "outer1_fieldX" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldX" (Ptr Outer1) (Ptr Outer1_fieldX)
     where getField = fromPtr (Proxy @"outer1_fieldX")
 instance HasCField Outer1 "outer1_fieldC"
     where type CFieldType Outer1 "outer1_fieldC" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldC" (Ptr Outer1) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldC")
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
@@ -136,14 +135,16 @@ deriving via (EquivStorable Outer2_fieldB) instance Storable Outer2_fieldB
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldX"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldY"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @struct outer2@
 
@@ -188,20 +189,17 @@ deriving via (EquivStorable Outer2) instance Storable Outer2
 instance HasCField Outer2 "outer2_fieldA"
     where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldA" (Ptr Outer2) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer2_fieldA")
 instance HasCField Outer2 "outer2_fieldB"
     where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 4
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldB" (Ptr Outer2) (Ptr Outer2_fieldB)
     where getField = fromPtr (Proxy @"outer2_fieldB")
 instance HasCField Outer2 "outer2_fieldC"
     where type CFieldType Outer2 "outer2_fieldC" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldC" (Ptr Outer2) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldC")
 {-| __C declaration:__ @struct inner3@
 
@@ -238,14 +236,12 @@ deriving via (EquivStorable Inner3) instance Storable Inner3
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldX" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldY" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @struct outer3@
 
@@ -290,18 +286,15 @@ deriving via (EquivStorable Outer3) instance Storable Outer3
 instance HasCField Outer3 "outer3_fieldA"
     where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldA" (Ptr Outer3) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer3_fieldA")
 instance HasCField Outer3 "outer3_fieldB"
     where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 4
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldB" (Ptr Outer3) (Ptr Inner3)
     where getField = fromPtr (Proxy @"outer3_fieldB")
 instance HasCField Outer3 "outer3_fieldC"
     where type CFieldType Outer3 "outer3_fieldC" = CInt
           offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldC" (Ptr Outer3) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -101,8 +99,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldX")
@@ -114,8 +111,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldY")
@@ -220,8 +216,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
@@ -233,8 +228,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Outer1_fieldX
-         ) => RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr Outer1_fieldX) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX")
@@ -245,8 +239,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
@@ -308,8 +301,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
@@ -321,8 +313,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
@@ -427,8 +418,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
@@ -440,8 +430,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr Outer2_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
@@ -452,8 +441,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
@@ -514,8 +502,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
@@ -526,8 +513,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldY" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
@@ -632,8 +618,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
@@ -644,8 +629,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr Inner3) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
@@ -656,8 +640,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/th.txt
@@ -34,14 +34,16 @@ deriving via (EquivStorable Outer1_fieldX) instance Storable Outer1_fieldX
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldX"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldX" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldX"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldX")
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldY"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldY" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldY"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldY")
 {-| __C declaration:__ @union outer1@
 
@@ -161,20 +163,17 @@ set_outer1_fieldC = setUnionPayload
 instance HasCField Outer1 "outer1_fieldA"
     where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldA" (Ptr Outer1) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer1_fieldA")
 instance HasCField Outer1 "outer1_fieldX"
     where type CFieldType Outer1 "outer1_fieldX" = Outer1_fieldX
           offset# = \_ -> \_ -> 0
-instance (~) ty Outer1_fieldX =>
-         HasField "outer1_fieldX" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldX" (Ptr Outer1) (Ptr Outer1_fieldX)
     where getField = fromPtr (Proxy @"outer1_fieldX")
 instance HasCField Outer1 "outer1_fieldC"
     where type CFieldType Outer1 "outer1_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldC" (Ptr Outer1) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldC")
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
@@ -211,14 +210,16 @@ deriving via (EquivStorable Outer2_fieldB) instance Storable Outer2_fieldB
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldX"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldY"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @union outer2@
 
@@ -338,20 +339,17 @@ set_outer2_fieldC = setUnionPayload
 instance HasCField Outer2 "outer2_fieldA"
     where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldA" (Ptr Outer2) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer2_fieldA")
 instance HasCField Outer2 "outer2_fieldB"
     where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 0
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldB" (Ptr Outer2) (Ptr Outer2_fieldB)
     where getField = fromPtr (Proxy @"outer2_fieldB")
 instance HasCField Outer2 "outer2_fieldC"
     where type CFieldType Outer2 "outer2_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldC" (Ptr Outer2) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldC")
 {-| __C declaration:__ @struct inner3@
 
@@ -388,14 +386,12 @@ deriving via (EquivStorable Inner3) instance Storable Inner3
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldX" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldY" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @union outer3@
 
@@ -515,18 +511,15 @@ set_outer3_fieldC = setUnionPayload
 instance HasCField Outer3 "outer3_fieldA"
     where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldA" (Ptr Outer3) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer3_fieldA")
 instance HasCField Outer3 "outer3_fieldB"
     where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 0
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldB" (Ptr Outer3) (Ptr Inner3)
     where getField = fromPtr (Proxy @"outer3_fieldB")
 instance HasCField Outer3 "outer3_fieldC"
     where type CFieldType Outer3 "outer3_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldC" (Ptr Outer3) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -99,8 +97,7 @@ instance HasCField.HasCField Has_implicit_fields_x2_1 "has_implicit_fields_x2_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x2_1_x2_1" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1_x2_1" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1_x2_1")
@@ -112,8 +109,7 @@ instance HasCField.HasCField Has_implicit_fields_x2_1 "has_implicit_fields_x2_1_
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x2_1_x2_2" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1_x2_2" (RIP.Ptr Has_implicit_fields_x2_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1_x2_2")
@@ -177,8 +173,7 @@ instance HasCField.HasCField Has_implicit_fields_x4_1 "has_implicit_fields_x4_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x4_1_x4_1" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1_x4_1" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1_x4_1")
@@ -190,8 +185,7 @@ instance HasCField.HasCField Has_implicit_fields_x4_1 "has_implicit_fields_x4_1_
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x4_1_x4_2" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1_x4_2" (RIP.Ptr Has_implicit_fields_x4_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1_x4_2")
@@ -276,8 +270,7 @@ instance HasCField.HasCField Has_implicit_fields_x5_1 "has_implicit_fields_x5_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5_1_x5_1" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1_x5_1" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1_x5_1")
@@ -289,8 +282,7 @@ instance HasCField.HasCField Has_implicit_fields_x5_1 "has_implicit_fields_x5_1_
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5_1_x5_2" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1_x5_2" (RIP.Ptr Has_implicit_fields_x5_1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1_x5_2")
@@ -471,8 +463,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x1")
@@ -484,8 +475,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x2_1" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Has_implicit_fields_x2_1
-         ) => RIP.HasField "has_implicit_fields_x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x2_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x2_1")
@@ -497,8 +487,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x3")
@@ -510,8 +499,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x4_1" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Has_implicit_fields_x4_1
-         ) => RIP.HasField "has_implicit_fields_x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x4_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x4_1")
@@ -523,8 +511,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5_1" wher
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Has_implicit_fields_x5_1
-         ) => RIP.HasField "has_implicit_fields_x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr Has_implicit_fields_x5_1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5_1")
@@ -536,8 +523,7 @@ instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/th.txt
@@ -36,20 +36,18 @@ instance HasCField Has_implicit_fields_x2_1
     where type CFieldType Has_implicit_fields_x2_1
                           "has_implicit_fields_x2_1_x2_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x2_1_x2_1"
+instance HasField "has_implicit_fields_x2_1_x2_1"
                   (Ptr Has_implicit_fields_x2_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1_x2_1")
 instance HasCField Has_implicit_fields_x2_1
                    "has_implicit_fields_x2_1_x2_2"
     where type CFieldType Has_implicit_fields_x2_1
                           "has_implicit_fields_x2_1_x2_2" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x2_1_x2_2"
+instance HasField "has_implicit_fields_x2_1_x2_2"
                   (Ptr Has_implicit_fields_x2_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1_x2_2")
 {-| __C declaration:__ @struct \@has_implicit_fields_x4_1@
 
@@ -88,20 +86,18 @@ instance HasCField Has_implicit_fields_x4_1
     where type CFieldType Has_implicit_fields_x4_1
                           "has_implicit_fields_x4_1_x4_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x4_1_x4_1"
+instance HasField "has_implicit_fields_x4_1_x4_1"
                   (Ptr Has_implicit_fields_x4_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1_x4_1")
 instance HasCField Has_implicit_fields_x4_1
                    "has_implicit_fields_x4_1_x4_2"
     where type CFieldType Has_implicit_fields_x4_1
                           "has_implicit_fields_x4_1_x4_2" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x4_1_x4_2"
+instance HasField "has_implicit_fields_x4_1_x4_2"
                   (Ptr Has_implicit_fields_x4_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1_x4_2")
 {-| __C declaration:__ @union \@has_implicit_fields_x5_1@
 
@@ -196,20 +192,18 @@ instance HasCField Has_implicit_fields_x5_1
     where type CFieldType Has_implicit_fields_x5_1
                           "has_implicit_fields_x5_1_x5_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5_1_x5_1"
+instance HasField "has_implicit_fields_x5_1_x5_1"
                   (Ptr Has_implicit_fields_x5_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1_x5_1")
 instance HasCField Has_implicit_fields_x5_1
                    "has_implicit_fields_x5_1_x5_2"
     where type CFieldType Has_implicit_fields_x5_1
                           "has_implicit_fields_x5_1_x5_2" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5_1_x5_2"
+instance HasField "has_implicit_fields_x5_1_x5_2"
                   (Ptr Has_implicit_fields_x5_1)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1_x5_2")
 {-| __C declaration:__ @union has_implicit_fields@
 
@@ -441,53 +435,47 @@ instance HasCField Has_implicit_fields "has_implicit_fields_x1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x1"
+instance HasField "has_implicit_fields_x1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x2_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x2_1" = Has_implicit_fields_x2_1
           offset# = \_ -> \_ -> 0
-instance (~) ty Has_implicit_fields_x2_1 =>
-         HasField "has_implicit_fields_x2_1"
+instance HasField "has_implicit_fields_x2_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x2_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x2_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x3"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x3" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x3"
+instance HasField "has_implicit_fields_x3"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x3")
 instance HasCField Has_implicit_fields "has_implicit_fields_x4_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x4_1" = Has_implicit_fields_x4_1
           offset# = \_ -> \_ -> 0
-instance (~) ty Has_implicit_fields_x4_1 =>
-         HasField "has_implicit_fields_x4_1"
+instance HasField "has_implicit_fields_x4_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x4_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x4_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x5_1"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x5_1" = Has_implicit_fields_x5_1
           offset# = \_ -> \_ -> 0
-instance (~) ty Has_implicit_fields_x5_1 =>
-         HasField "has_implicit_fields_x5_1"
+instance HasField "has_implicit_fields_x5_1"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr Has_implicit_fields_x5_1)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5_1")
 instance HasCField Has_implicit_fields "has_implicit_fields_x5"
     where type CFieldType Has_implicit_fields
                           "has_implicit_fields_x5" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5"
+instance HasField "has_implicit_fields_x5"
                   (Ptr Has_implicit_fields)
-                  (Ptr ty)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -114,8 +112,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldX")
@@ -127,8 +124,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldY")
@@ -198,8 +194,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
@@ -211,8 +206,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldX" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Outer1_fieldX
-         ) => RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr Outer1_fieldX) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX")
@@ -223,8 +217,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldC" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
@@ -305,8 +298,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
@@ -318,8 +310,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
@@ -389,8 +380,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
@@ -402,8 +392,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr Outer2_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
@@ -414,8 +403,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldC" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
@@ -495,8 +483,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
@@ -507,8 +494,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
@@ -578,8 +564,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
@@ -590,8 +575,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr Inner3) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
@@ -602,8 +586,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldC" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/th.txt
@@ -83,14 +83,16 @@ set_outer1_fieldX_fieldY = setUnionPayload
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldX"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldX" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldX"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldX")
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldY"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldY" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldY"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldY")
 {-| __C declaration:__ @struct outer1@
 
@@ -135,20 +137,17 @@ deriving via (EquivStorable Outer1) instance Storable Outer1
 instance HasCField Outer1 "outer1_fieldA"
     where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldA" (Ptr Outer1) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer1_fieldA")
 instance HasCField Outer1 "outer1_fieldX"
     where type CFieldType Outer1 "outer1_fieldX" = Outer1_fieldX
           offset# = \_ -> \_ -> 4
-instance (~) ty Outer1_fieldX =>
-         HasField "outer1_fieldX" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldX" (Ptr Outer1) (Ptr Outer1_fieldX)
     where getField = fromPtr (Proxy @"outer1_fieldX")
 instance HasCField Outer1 "outer1_fieldC"
     where type CFieldType Outer1 "outer1_fieldC" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldC" (Ptr Outer1) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldC")
 {-| __C declaration:__ @union \@outer2_fieldB@
 
@@ -234,14 +233,16 @@ set_outer2_fieldB_fieldY = setUnionPayload
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldX"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldY"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @struct outer2@
 
@@ -286,20 +287,17 @@ deriving via (EquivStorable Outer2) instance Storable Outer2
 instance HasCField Outer2 "outer2_fieldA"
     where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldA" (Ptr Outer2) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer2_fieldA")
 instance HasCField Outer2 "outer2_fieldB"
     where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 4
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldB" (Ptr Outer2) (Ptr Outer2_fieldB)
     where getField = fromPtr (Proxy @"outer2_fieldB")
 instance HasCField Outer2 "outer2_fieldC"
     where type CFieldType Outer2 "outer2_fieldC" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldC" (Ptr Outer2) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldC")
 {-| __C declaration:__ @union inner3@
 
@@ -385,14 +383,12 @@ set_inner3_fieldY = setUnionPayload
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldX" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldY" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @struct outer3@
 
@@ -437,18 +433,15 @@ deriving via (EquivStorable Outer3) instance Storable Outer3
 instance HasCField Outer3 "outer3_fieldA"
     where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldA" (Ptr Outer3) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer3_fieldA")
 instance HasCField Outer3 "outer3_fieldB"
     where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 4
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldB" (Ptr Outer3) (Ptr Inner3)
     where getField = fromPtr (Proxy @"outer3_fieldB")
 instance HasCField Outer3 "outer3_fieldC"
     where type CFieldType Outer3 "outer3_fieldC" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldC" (Ptr Outer3) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -132,8 +130,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldX" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldX")
@@ -145,8 +142,7 @@ instance HasCField.HasCField Outer1_fieldX "outer1_fieldX_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX_fieldY" (RIP.Ptr Outer1_fieldX) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX_fieldY")
@@ -251,8 +247,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
@@ -264,8 +259,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Outer1_fieldX
-         ) => RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldX" (RIP.Ptr Outer1) (RIP.Ptr Outer1_fieldX) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldX")
@@ -276,8 +270,7 @@ instance HasCField.HasCField Outer1 "outer1_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
@@ -358,8 +351,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
@@ -371,8 +363,7 @@ instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
@@ -477,8 +468,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
@@ -490,8 +480,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr Outer2_fieldB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
@@ -502,8 +491,7 @@ instance HasCField.HasCField Outer2 "outer2_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
@@ -583,8 +571,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
@@ -595,8 +582,7 @@ instance HasCField.HasCField Inner3 "inner3_fieldY" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+instance RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
@@ -701,8 +687,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
@@ -713,8 +698,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr Inner3) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
@@ -725,8 +709,7 @@ instance HasCField.HasCField Outer3 "outer3_fieldC" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/th.txt
@@ -83,14 +83,16 @@ set_outer1_fieldX_fieldY = setUnionPayload
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldX"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldX" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldX"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldX")
 instance HasCField Outer1_fieldX "outer1_fieldX_fieldY"
     where type CFieldType Outer1_fieldX "outer1_fieldX_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldX_fieldY" (Ptr Outer1_fieldX) (Ptr ty)
+instance HasField "outer1_fieldX_fieldY"
+                  (Ptr Outer1_fieldX)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldX_fieldY")
 {-| __C declaration:__ @union outer1@
 
@@ -210,20 +212,17 @@ set_outer1_fieldC = setUnionPayload
 instance HasCField Outer1 "outer1_fieldA"
     where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldA" (Ptr Outer1) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer1_fieldA")
 instance HasCField Outer1 "outer1_fieldX"
     where type CFieldType Outer1 "outer1_fieldX" = Outer1_fieldX
           offset# = \_ -> \_ -> 0
-instance (~) ty Outer1_fieldX =>
-         HasField "outer1_fieldX" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldX" (Ptr Outer1) (Ptr Outer1_fieldX)
     where getField = fromPtr (Proxy @"outer1_fieldX")
 instance HasCField Outer1 "outer1_fieldC"
     where type CFieldType Outer1 "outer1_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+instance HasField "outer1_fieldC" (Ptr Outer1) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer1_fieldC")
 {-| __C declaration:__ @union \@outer2_fieldB@
 
@@ -309,14 +308,16 @@ set_outer2_fieldB_fieldY = setUnionPayload
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldX"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+instance HasField "outer2_fieldB_fieldY"
+                  (Ptr Outer2_fieldB)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @union outer2@
 
@@ -436,20 +437,17 @@ set_outer2_fieldC = setUnionPayload
 instance HasCField Outer2 "outer2_fieldA"
     where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldA" (Ptr Outer2) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer2_fieldA")
 instance HasCField Outer2 "outer2_fieldB"
     where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 0
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldB" (Ptr Outer2) (Ptr Outer2_fieldB)
     where getField = fromPtr (Proxy @"outer2_fieldB")
 instance HasCField Outer2 "outer2_fieldC"
     where type CFieldType Outer2 "outer2_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+instance HasField "outer2_fieldC" (Ptr Outer2) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer2_fieldC")
 {-| __C declaration:__ @union inner3@
 
@@ -535,14 +533,12 @@ set_inner3_fieldY = setUnionPayload
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldX" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+instance HasField "inner3_fieldY" (Ptr Inner3) (Ptr CInt)
     where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @union outer3@
 
@@ -662,18 +658,15 @@ set_outer3_fieldC = setUnionPayload
 instance HasCField Outer3 "outer3_fieldA"
     where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldA" (Ptr Outer3) (Ptr CChar)
     where getField = fromPtr (Proxy @"outer3_fieldA")
 instance HasCField Outer3 "outer3_fieldB"
     where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 0
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldB" (Ptr Outer3) (Ptr Inner3)
     where getField = fromPtr (Proxy @"outer3_fieldB")
 instance HasCField Outer3 "outer3_fieldC"
     where type CFieldType Outer3 "outer3_fieldC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+instance HasField "outer3_fieldC" (Ptr Outer3) (Ptr CInt)
     where getField = fromPtr (Proxy @"outer3_fieldC")

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -90,8 +88,7 @@ instance HasCField.HasCField Complex_object_t "complex_object_t_velocity" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Complex RIP.CFloat
-         ) => RIP.HasField "complex_object_t_velocity" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+instance RIP.HasField "complex_object_t_velocity" (RIP.Ptr Complex_object_t) (RIP.Ptr (RIP.Complex RIP.CFloat)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"complex_object_t_velocity")
@@ -103,8 +100,7 @@ instance HasCField.HasCField Complex_object_t "complex_object_t_position" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Complex RIP.CDouble
-         ) => RIP.HasField "complex_object_t_position" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+instance RIP.HasField "complex_object_t_position" (RIP.Ptr Complex_object_t) (RIP.Ptr (RIP.Complex RIP.CDouble)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"complex_object_t_position")
@@ -116,8 +112,7 @@ instance HasCField.HasCField Complex_object_t "complex_object_t_id" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "complex_object_t_id" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+instance RIP.HasField "complex_object_t_id" (RIP.Ptr Complex_object_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"complex_object_t_id")

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/th.txt
@@ -179,25 +179,24 @@ instance HasCField Complex_object_t "complex_object_t_velocity"
     where type CFieldType Complex_object_t
                           "complex_object_t_velocity" = Complex CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty (Complex CFloat) =>
-         HasField "complex_object_t_velocity"
+instance HasField "complex_object_t_velocity"
                   (Ptr Complex_object_t)
-                  (Ptr ty)
+                  (Ptr (Complex CFloat))
     where getField = fromPtr (Proxy @"complex_object_t_velocity")
 instance HasCField Complex_object_t "complex_object_t_position"
     where type CFieldType Complex_object_t
                           "complex_object_t_position" = Complex CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty (Complex CDouble) =>
-         HasField "complex_object_t_position"
+instance HasField "complex_object_t_position"
                   (Ptr Complex_object_t)
-                  (Ptr ty)
+                  (Ptr (Complex CDouble))
     where getField = fromPtr (Proxy @"complex_object_t_position")
 instance HasCField Complex_object_t "complex_object_t_id"
     where type CFieldType Complex_object_t "complex_object_t_id" = CInt
           offset# = \_ -> \_ -> 24
-instance (~) ty CInt =>
-         HasField "complex_object_t_id" (Ptr Complex_object_t) (Ptr ty)
+instance HasField "complex_object_t_id"
+                  (Ptr Complex_object_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"complex_object_t_id")
 -- __unique:__ @test_typescomplexhsb_complex_test_Example_Safe_multiply_complex_f@
 foreign import ccall safe "hs_bindgen_687af703c95fba0e" hs_bindgen_687af703c95fba0e_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -77,8 +75,7 @@ instance HasCField.HasCField Vector "vector_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "vector_x" (RIP.Ptr Vector) (RIP.Ptr ty) where
+instance RIP.HasField "vector_x" (RIP.Ptr Vector) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"vector_x")
 
@@ -88,7 +85,6 @@ instance HasCField.HasCField Vector "vector_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "vector_y" (RIP.Ptr Vector) (RIP.Ptr ty) where
+instance RIP.HasField "vector_y" (RIP.Ptr Vector) (RIP.Ptr RIP.CDouble) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"vector_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/th.txt
@@ -58,14 +58,12 @@ deriving via (EquivStorable Vector) instance Storable Vector
 instance HasCField Vector "vector_x"
     where type CFieldType Vector "vector_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "vector_x" (Ptr Vector) (Ptr ty)
+instance HasField "vector_x" (Ptr Vector) (Ptr CDouble)
     where getField = fromPtr (Proxy @"vector_x")
 instance HasCField Vector "vector_y"
     where type CFieldType Vector "vector_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty CDouble =>
-         HasField "vector_y" (Ptr Vector) (Ptr ty)
+instance HasField "vector_y" (Ptr Vector) (Ptr CDouble)
     where getField = fromPtr (Proxy @"vector_y")
 -- __unique:__ @test_typescomplexvector_test_Example_Safe_new_vector@
 foreign import ccall safe "hs_bindgen_cd5f566bc96dcba0" hs_bindgen_cd5f566bc96dcba0_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -107,8 +105,7 @@ instance Read Foo_enum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapFoo_enum" (RIP.Ptr Foo_enum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFoo_enum" (RIP.Ptr Foo_enum) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFoo_enum")

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -42,8 +42,9 @@ instance Read Foo_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapFoo_enum" (Ptr Foo_enum) (Ptr ty)
+instance HasField "unwrapFoo_enum"
+                  (Ptr Foo_enum)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapFoo_enum")
 instance HasCField Foo_enum "unwrapFoo_enum"
     where type CFieldType Foo_enum

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -102,8 +100,7 @@ instance Read Uint8_enum where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapUint8_enum" (RIP.Ptr Uint8_enum) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint8_enum" (RIP.Ptr Uint8_enum) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint8_enum")

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/th.txt
@@ -39,8 +39,9 @@ instance Read Uint8_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint8_enum" (Ptr Uint8_enum) (Ptr ty)
+instance HasField "unwrapUint8_enum"
+                  (Ptr Uint8_enum)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapUint8_enum")
 instance HasCField Uint8_enum "unwrapUint8_enum"
     where type CFieldType Uint8_enum

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -132,8 +130,7 @@ instance Read First where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapFirst" (RIP.Ptr First) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFirst" (RIP.Ptr First) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFirst")
@@ -243,8 +240,7 @@ instance Read Second where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapSecond" (RIP.Ptr Second) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSecond" (RIP.Ptr Second) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSecond")
@@ -359,8 +355,7 @@ instance Read Same where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapSame" (RIP.Ptr Same) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapSame" (RIP.Ptr Same) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapSame")
@@ -460,8 +455,7 @@ instance Read Nonseq where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapNonseq" (RIP.Ptr Nonseq) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapNonseq" (RIP.Ptr Nonseq) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapNonseq")
@@ -580,8 +574,7 @@ instance Read Packed where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unwrapPacked" (RIP.Ptr Packed) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPacked" (RIP.Ptr Packed) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPacked")
@@ -697,8 +690,7 @@ instance Read EnumA where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEnumA")
@@ -805,8 +797,7 @@ instance Read EnumB where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapEnumB" (RIP.Ptr EnumB) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEnumB" (RIP.Ptr EnumB) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEnumB")
@@ -913,8 +904,7 @@ instance Read EnumC where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapEnumC" (RIP.Ptr EnumC) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEnumC" (RIP.Ptr EnumC) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEnumC")
@@ -1021,8 +1011,7 @@ instance Read EnumD_t where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapEnumD_t" (RIP.Ptr EnumD_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEnumD_t" (RIP.Ptr EnumD_t) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEnumD_t")

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/th.txt
@@ -39,8 +39,7 @@ instance Read First
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapFirst" (Ptr First) (Ptr ty)
+instance HasField "unwrapFirst" (Ptr First) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapFirst")
 instance HasCField First "unwrapFirst"
     where type CFieldType First "unwrapFirst" = CUInt
@@ -102,8 +101,7 @@ instance Read Second
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CInt =>
-         HasField "unwrapSecond" (Ptr Second) (Ptr ty)
+instance HasField "unwrapSecond" (Ptr Second) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapSecond")
 instance HasCField Second "unwrapSecond"
     where type CFieldType Second "unwrapSecond" = CInt
@@ -171,7 +169,7 @@ instance Read Same
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapSame" (Ptr Same) (Ptr ty)
+instance HasField "unwrapSame" (Ptr Same) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapSame")
 instance HasCField Same "unwrapSame"
     where type CFieldType Same "unwrapSame" = CUInt
@@ -228,8 +226,7 @@ instance Read Nonseq
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapNonseq" (Ptr Nonseq) (Ptr ty)
+instance HasField "unwrapNonseq" (Ptr Nonseq) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapNonseq")
 instance HasCField Nonseq "unwrapNonseq"
     where type CFieldType Nonseq "unwrapNonseq" = CUInt
@@ -299,8 +296,7 @@ instance Read Packed
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUChar =>
-         HasField "unwrapPacked" (Ptr Packed) (Ptr ty)
+instance HasField "unwrapPacked" (Ptr Packed) (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapPacked")
 instance HasCField Packed "unwrapPacked"
     where type CFieldType Packed "unwrapPacked" = CUChar
@@ -369,8 +365,7 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
+instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -431,8 +426,7 @@ instance Read EnumB
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapEnumB" (Ptr EnumB) (Ptr ty)
+instance HasField "unwrapEnumB" (Ptr EnumB) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumB")
 instance HasCField EnumB "unwrapEnumB"
     where type CFieldType EnumB "unwrapEnumB" = CUInt
@@ -493,8 +487,7 @@ instance Read EnumC
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapEnumC" (Ptr EnumC) (Ptr ty)
+instance HasField "unwrapEnumC" (Ptr EnumC) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumC")
 instance HasCField EnumC "unwrapEnumC"
     where type CFieldType EnumC "unwrapEnumC" = CUInt
@@ -555,8 +548,7 @@ instance Read EnumD_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr ty)
+instance HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumD_t")
 instance HasCField EnumD_t "unwrapEnumD_t"
     where type CFieldType EnumD_t "unwrapEnumD_t" = CUInt

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -110,8 +108,7 @@ instance Read EnumA where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapEnumA")
@@ -187,8 +184,7 @@ instance HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ EnumA
-         ) => RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr ty) where
+instance RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr EnumA) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exA_fieldA1")
@@ -271,8 +267,7 @@ instance Read ExB_fieldB1 where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapExB_fieldB1" (RIP.Ptr ExB_fieldB1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapExB_fieldB1" (RIP.Ptr ExB_fieldB1) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapExB_fieldB1")
@@ -349,8 +344,7 @@ instance HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ ExB_fieldB1
-         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
+instance RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ExB_fieldB1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/th.txt
@@ -39,8 +39,7 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
+instance HasField "unwrapEnumA" (Ptr EnumA) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
@@ -88,7 +87,7 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = EnumA
           offset# = \_ -> \_ -> 0
-instance (~) ty EnumA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+instance HasField "exA_fieldA1" (Ptr ExA) (Ptr EnumA)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @enum \@exB_fieldB1@
 
@@ -130,8 +129,7 @@ instance Read ExB_fieldB1
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt =>
-         HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapExB_fieldB1")
 instance HasCField ExB_fieldB1 "unwrapExB_fieldB1"
     where type CFieldType ExB_fieldB1 "unwrapExB_fieldB1" = CUInt
@@ -179,6 +177,5 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance (~) ty ExB_fieldB1 =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -82,8 +80,7 @@ instance HasCField.HasCField Foo "foo_i" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
 
@@ -93,8 +90,7 @@ instance HasCField.HasCField Foo "foo_c" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
 
@@ -154,7 +150,7 @@ instance HasCField.HasCField Bar "bar_foo1" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ Foo) => RIP.HasField "bar_foo1" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_foo1" (RIP.Ptr Bar) (RIP.Ptr Foo) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_foo1")
 
@@ -164,7 +160,7 @@ instance HasCField.HasCField Bar "bar_foo2" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ Foo) => RIP.HasField "bar_foo2" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_foo2" (RIP.Ptr Bar) (RIP.Ptr Foo) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_foo2")
 
@@ -225,8 +221,7 @@ instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ex3_ex3_struct_ex3_a" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ex3_ex3_struct_ex3_a" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_a")
@@ -238,8 +233,7 @@ instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "ex3_ex3_struct_ex3_b" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
+instance RIP.HasField "ex3_ex3_struct_ex3_b" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_b")
@@ -300,8 +294,7 @@ instance HasCField.HasCField Ex3 "ex3_ex3_struct" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Ex3_ex3_struct
-         ) => RIP.HasField "ex3_ex3_struct" (RIP.Ptr Ex3) (RIP.Ptr ty) where
+instance RIP.HasField "ex3_ex3_struct" (RIP.Ptr Ex3) (RIP.Ptr Ex3_ex3_struct) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct")
@@ -312,8 +305,7 @@ instance HasCField.HasCField Ex3 "ex3_ex3_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "ex3_ex3_c" (RIP.Ptr Ex3) (RIP.Ptr ty) where
+instance RIP.HasField "ex3_ex3_c" (RIP.Ptr Ex3) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"ex3_ex3_c")
 
@@ -373,8 +365,7 @@ instance HasCField.HasCField Ex4_odd "ex4_odd_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ex4_odd_value" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
+instance RIP.HasField "ex4_odd_value" (RIP.Ptr Ex4_odd) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex4_odd_value")
@@ -386,8 +377,7 @@ instance HasCField.HasCField Ex4_odd "ex4_odd_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Ex4_even
-         ) => RIP.HasField "ex4_odd_next" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
+instance RIP.HasField "ex4_odd_next" (RIP.Ptr Ex4_odd) (RIP.Ptr (RIP.Ptr Ex4_even)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex4_odd_next")
@@ -449,8 +439,7 @@ instance HasCField.HasCField Ex4_even "ex4_even_value" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "ex4_even_value" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
+instance RIP.HasField "ex4_even_value" (RIP.Ptr Ex4_even) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex4_even_value")
@@ -462,8 +451,7 @@ instance HasCField.HasCField Ex4_even "ex4_even_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Ex4_odd
-         ) => RIP.HasField "ex4_even_next" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
+instance RIP.HasField "ex4_even_next" (RIP.Ptr Ex4_even) (RIP.Ptr (RIP.Ptr Ex4_odd)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"ex4_even_next")

--- a/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_i"
     where type CFieldType Foo "foo_i" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
+instance HasField "foo_i" (Ptr Foo) (Ptr CInt)
     where getField = fromPtr (Proxy @"foo_i")
 instance HasCField Foo "foo_c"
     where type CFieldType Foo "foo_c" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
+instance HasField "foo_c" (Ptr Foo) (Ptr CChar)
     where getField = fromPtr (Proxy @"foo_c")
 {-| __C declaration:__ @struct bar@
 
@@ -76,12 +76,12 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_foo1"
     where type CFieldType Bar "bar_foo1" = Foo
           offset# = \_ -> \_ -> 0
-instance (~) ty Foo => HasField "bar_foo1" (Ptr Bar) (Ptr ty)
+instance HasField "bar_foo1" (Ptr Bar) (Ptr Foo)
     where getField = fromPtr (Proxy @"bar_foo1")
 instance HasCField Bar "bar_foo2"
     where type CFieldType Bar "bar_foo2" = Foo
           offset# = \_ -> \_ -> 8
-instance (~) ty Foo => HasField "bar_foo2" (Ptr Bar) (Ptr ty)
+instance HasField "bar_foo2" (Ptr Bar) (Ptr Foo)
     where getField = fromPtr (Proxy @"bar_foo2")
 {-| __C declaration:__ @struct \@ex3_ex3_struct@
 
@@ -118,14 +118,16 @@ deriving via (EquivStorable Ex3_ex3_struct) instance Storable Ex3_ex3_struct
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "ex3_ex3_struct_ex3_a" (Ptr Ex3_ex3_struct) (Ptr ty)
+instance HasField "ex3_ex3_struct_ex3_a"
+                  (Ptr Ex3_ex3_struct)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_a")
 instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b"
     where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar =>
-         HasField "ex3_ex3_struct_ex3_b" (Ptr Ex3_ex3_struct) (Ptr ty)
+instance HasField "ex3_ex3_struct_ex3_b"
+                  (Ptr Ex3_ex3_struct)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_b")
 {-| __C declaration:__ @struct ex3@
 
@@ -162,13 +164,12 @@ deriving via (EquivStorable Ex3) instance Storable Ex3
 instance HasCField Ex3 "ex3_ex3_struct"
     where type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
           offset# = \_ -> \_ -> 0
-instance (~) ty Ex3_ex3_struct =>
-         HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr ty)
+instance HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr Ex3_ex3_struct)
     where getField = fromPtr (Proxy @"ex3_ex3_struct")
 instance HasCField Ex3 "ex3_ex3_c"
     where type CFieldType Ex3 "ex3_ex3_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "ex3_ex3_c" (Ptr Ex3) (Ptr ty)
+instance HasField "ex3_ex3_c" (Ptr Ex3) (Ptr CFloat)
     where getField = fromPtr (Proxy @"ex3_ex3_c")
 {-| __C declaration:__ @struct ex4_odd@
 
@@ -205,14 +206,12 @@ deriving via (EquivStorable Ex4_odd) instance Storable Ex4_odd
 instance HasCField Ex4_odd "ex4_odd_value"
     where type CFieldType Ex4_odd "ex4_odd_value" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr ty)
+instance HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr CInt)
     where getField = fromPtr (Proxy @"ex4_odd_value")
 instance HasCField Ex4_odd "ex4_odd_next"
     where type CFieldType Ex4_odd "ex4_odd_next" = Ptr Ex4_even
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Ex4_even) =>
-         HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr ty)
+instance HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr (Ptr Ex4_even))
     where getField = fromPtr (Proxy @"ex4_odd_next")
 {-| __C declaration:__ @struct ex4_even@
 
@@ -249,12 +248,12 @@ deriving via (EquivStorable Ex4_even) instance Storable Ex4_even
 instance HasCField Ex4_even "ex4_even_value"
     where type CFieldType Ex4_even "ex4_even_value" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "ex4_even_value" (Ptr Ex4_even) (Ptr ty)
+instance HasField "ex4_even_value" (Ptr Ex4_even) (Ptr CDouble)
     where getField = fromPtr (Proxy @"ex4_even_value")
 instance HasCField Ex4_even "ex4_even_next"
     where type CFieldType Ex4_even "ex4_even_next" = Ptr Ex4_odd
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Ex4_odd) =>
-         HasField "ex4_even_next" (Ptr Ex4_even) (Ptr ty)
+instance HasField "ex4_even_next"
+                  (Ptr Ex4_even)
+                  (Ptr (Ptr Ex4_odd))
     where getField = fromPtr (Proxy @"ex4_even_next")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -82,8 +80,7 @@ instance HasCField.HasCField Bools1 "bools1_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools1_x" (RIP.Ptr Bools1) (RIP.Ptr ty) where
+instance RIP.HasField "bools1_x" (RIP.Ptr Bools1) (RIP.Ptr RIP.CBool) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools1_x")
 
@@ -93,8 +90,7 @@ instance HasCField.HasCField Bools1 "bools1_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools1_y" (RIP.Ptr Bools1) (RIP.Ptr ty) where
+instance RIP.HasField "bools1_y" (RIP.Ptr Bools1) (RIP.Ptr RIP.CBool) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools1_y")
 
@@ -154,8 +150,7 @@ instance HasCField.HasCField Bools2 "bools2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools2_x" (RIP.Ptr Bools2) (RIP.Ptr ty) where
+instance RIP.HasField "bools2_x" (RIP.Ptr Bools2) (RIP.Ptr RIP.CBool) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools2_x")
 
@@ -165,8 +160,7 @@ instance HasCField.HasCField Bools2 "bools2_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools2_y" (RIP.Ptr Bools2) (RIP.Ptr ty) where
+instance RIP.HasField "bools2_y" (RIP.Ptr Bools2) (RIP.Ptr RIP.CBool) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools2_y")
 
@@ -198,8 +192,7 @@ newtype BOOL = BOOL
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBOOL")
@@ -266,8 +259,7 @@ instance HasCField.HasCField Bools3 "bools3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ BOOL
-         ) => RIP.HasField "bools3_x" (RIP.Ptr Bools3) (RIP.Ptr ty) where
+instance RIP.HasField "bools3_x" (RIP.Ptr Bools3) (RIP.Ptr BOOL) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools3_x")
 
@@ -277,7 +269,6 @@ instance HasCField.HasCField Bools3 "bools3_y" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ BOOL
-         ) => RIP.HasField "bools3_y" (RIP.Ptr Bools3) (RIP.Ptr ty) where
+instance RIP.HasField "bools3_y" (RIP.Ptr Bools3) (RIP.Ptr BOOL) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bools3_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/th.txt
@@ -35,12 +35,12 @@ deriving via (EquivStorable Bools1) instance Storable Bools1
 instance HasCField Bools1 "bools1_x"
     where type CFieldType Bools1 "bools1_x" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "bools1_x" (Ptr Bools1) (Ptr ty)
+instance HasField "bools1_x" (Ptr Bools1) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools1_x")
 instance HasCField Bools1 "bools1_y"
     where type CFieldType Bools1 "bools1_y" = CBool
           offset# = \_ -> \_ -> 1
-instance (~) ty CBool => HasField "bools1_y" (Ptr Bools1) (Ptr ty)
+instance HasField "bools1_y" (Ptr Bools1) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools1_y")
 {-| __C declaration:__ @struct bools2@
 
@@ -77,12 +77,12 @@ deriving via (EquivStorable Bools2) instance Storable Bools2
 instance HasCField Bools2 "bools2_x"
     where type CFieldType Bools2 "bools2_x" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "bools2_x" (Ptr Bools2) (Ptr ty)
+instance HasField "bools2_x" (Ptr Bools2) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools2_x")
 instance HasCField Bools2 "bools2_y"
     where type CFieldType Bools2 "bools2_y" = CBool
           offset# = \_ -> \_ -> 1
-instance (~) ty CBool => HasField "bools2_y" (Ptr Bools2) (Ptr ty)
+instance HasField "bools2_y" (Ptr Bools2) (Ptr CBool)
     where getField = fromPtr (Proxy @"bools2_y")
 {-| __C declaration:__ @macro BOOL@
 
@@ -108,7 +108,7 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
+instance HasField "unwrapBOOL" (Ptr BOOL) (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
@@ -148,10 +148,10 @@ deriving via (EquivStorable Bools3) instance Storable Bools3
 instance HasCField Bools3 "bools3_x"
     where type CFieldType Bools3 "bools3_x" = BOOL
           offset# = \_ -> \_ -> 0
-instance (~) ty BOOL => HasField "bools3_x" (Ptr Bools3) (Ptr ty)
+instance HasField "bools3_x" (Ptr Bools3) (Ptr BOOL)
     where getField = fromPtr (Proxy @"bools3_x")
 instance HasCField Bools3 "bools3_y"
     where type CFieldType Bools3 "bools3_y" = BOOL
           offset# = \_ -> \_ -> 1
-instance (~) ty BOOL => HasField "bools3_y" (Ptr Bools3) (Ptr ty)
+instance HasField "bools3_y" (Ptr Bools3) (Ptr BOOL)
     where getField = fromPtr (Proxy @"bools3_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -89,8 +86,7 @@ newtype Bool' = Bool'
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBool'")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/th.txt
@@ -70,7 +70,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
@@ -99,7 +99,7 @@ newtype Bool'
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapBool'" (Ptr Bool') (Ptr ty)
+instance HasField "unwrapBool'" (Ptr Bool') (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapBool'")
 instance HasCField Bool' "unwrapBool'"
     where type CFieldType Bool' "unwrapBool'" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -50,8 +48,7 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
 
@@ -89,8 +86,7 @@ newtype Bool' = Bool'
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr ty) where
+instance RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapBool'")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/th.txt
@@ -47,7 +47,7 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
+instance HasField "unwrapA" (Ptr A) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
@@ -76,7 +76,7 @@ newtype Bool'
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapBool'" (Ptr Bool') (Ptr ty)
+instance HasField "unwrapBool'" (Ptr Bool') (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapBool'")
 instance HasCField Bool' "unwrapBool'"
     where type CFieldType Bool' "unwrapBool'" = CInt

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -79,8 +77,7 @@ instance HasCField.HasCField Foo "foo_sixty_four" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
@@ -92,8 +89,7 @@ instance HasCField.HasCField Foo "foo_thirty_two" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/th.txt
@@ -38,13 +38,15 @@ instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo
                           "foo_sixty_four" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+instance HasField "foo_sixty_four"
+                  (Ptr Foo)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"foo_sixty_four")
 instance HasCField Foo "foo_thirty_two"
     where type CFieldType Foo
                           "foo_thirty_two" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+instance HasField "foo_thirty_two"
+                  (Ptr Foo)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"foo_thirty_two")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -65,8 +63,7 @@ newtype Int_fast16_t = Int_fast16_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapInt_fast16_t" (RIP.Ptr Int_fast16_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_fast16_t" (RIP.Ptr Int_fast16_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_fast16_t")
@@ -106,8 +103,7 @@ newtype Int_fast32_t = Int_fast32_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapInt_fast32_t" (RIP.Ptr Int_fast32_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_fast32_t" (RIP.Ptr Int_fast32_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_fast32_t")
@@ -147,8 +143,7 @@ newtype Uint_fast16_t = Uint_fast16_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapUint_fast16_t" (RIP.Ptr Uint_fast16_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_fast16_t" (RIP.Ptr Uint_fast16_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_fast16_t")
@@ -188,8 +183,7 @@ newtype Uint_fast32_t = Uint_fast32_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapUint_fast32_t" (RIP.Ptr Uint_fast32_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_fast32_t" (RIP.Ptr Uint_fast32_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_fast32_t")
@@ -229,8 +223,7 @@ newtype Int_fast8_t = Int_fast8_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.HasField "unwrapInt_fast8_t" (RIP.Ptr Int_fast8_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_fast8_t" (RIP.Ptr Int_fast8_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_fast8_t")
@@ -270,8 +263,7 @@ newtype Int_fast64_t = Int_fast64_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.HasField "unwrapInt_fast64_t" (RIP.Ptr Int_fast64_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_fast64_t" (RIP.Ptr Int_fast64_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_fast64_t")
@@ -311,8 +303,7 @@ newtype Int_least8_t = Int_least8_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.HasField "unwrapInt_least8_t" (RIP.Ptr Int_least8_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_least8_t" (RIP.Ptr Int_least8_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_least8_t")
@@ -352,8 +343,7 @@ newtype Int_least16_t = Int_least16_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.HasField "unwrapInt_least16_t" (RIP.Ptr Int_least16_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_least16_t" (RIP.Ptr Int_least16_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_least16_t")
@@ -393,8 +383,7 @@ newtype Int_least32_t = Int_least32_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapInt_least32_t" (RIP.Ptr Int_least32_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_least32_t" (RIP.Ptr Int_least32_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_least32_t")
@@ -434,8 +423,7 @@ newtype Int_least64_t = Int_least64_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.HasField "unwrapInt_least64_t" (RIP.Ptr Int_least64_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt_least64_t" (RIP.Ptr Int_least64_t) (RIP.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt_least64_t")
@@ -475,8 +463,7 @@ newtype Uint_fast8_t = Uint_fast8_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapUint_fast8_t" (RIP.Ptr Uint_fast8_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_fast8_t" (RIP.Ptr Uint_fast8_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_fast8_t")
@@ -516,8 +503,7 @@ newtype Uint_fast64_t = Uint_fast64_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "unwrapUint_fast64_t" (RIP.Ptr Uint_fast64_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_fast64_t" (RIP.Ptr Uint_fast64_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_fast64_t")
@@ -557,8 +543,7 @@ newtype Uint_least8_t = Uint_least8_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapUint_least8_t" (RIP.Ptr Uint_least8_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_least8_t" (RIP.Ptr Uint_least8_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_least8_t")
@@ -598,8 +583,7 @@ newtype Uint_least16_t = Uint_least16_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "unwrapUint_least16_t" (RIP.Ptr Uint_least16_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_least16_t" (RIP.Ptr Uint_least16_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_least16_t")
@@ -639,8 +623,7 @@ newtype Uint_least32_t = Uint_least32_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapUint_least32_t" (RIP.Ptr Uint_least32_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_least32_t" (RIP.Ptr Uint_least32_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_least32_t")
@@ -680,8 +663,7 @@ newtype Uint_least64_t = Uint_least64_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "unwrapUint_least64_t" (RIP.Ptr Uint_least64_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint_least64_t" (RIP.Ptr Uint_least64_t) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint_least64_t")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/th.txt
@@ -251,8 +251,9 @@ newtype Int_fast16_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_fast16_t" (Ptr Int_fast16_t) (Ptr ty)
+instance HasField "unwrapInt_fast16_t"
+                  (Ptr Int_fast16_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapInt_fast16_t")
 instance HasCField Int_fast16_t "unwrapInt_fast16_t"
     where type CFieldType Int_fast16_t
@@ -282,8 +283,9 @@ newtype Int_fast32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_fast32_t" (Ptr Int_fast32_t) (Ptr ty)
+instance HasField "unwrapInt_fast32_t"
+                  (Ptr Int_fast32_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapInt_fast32_t")
 instance HasCField Int_fast32_t "unwrapInt_fast32_t"
     where type CFieldType Int_fast32_t
@@ -313,8 +315,9 @@ newtype Uint_fast16_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_fast16_t" (Ptr Uint_fast16_t) (Ptr ty)
+instance HasField "unwrapUint_fast16_t"
+                  (Ptr Uint_fast16_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapUint_fast16_t")
 instance HasCField Uint_fast16_t "unwrapUint_fast16_t"
     where type CFieldType Uint_fast16_t
@@ -344,8 +347,9 @@ newtype Uint_fast32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_fast32_t" (Ptr Uint_fast32_t) (Ptr ty)
+instance HasField "unwrapUint_fast32_t"
+                  (Ptr Uint_fast32_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapUint_fast32_t")
 instance HasCField Uint_fast32_t "unwrapUint_fast32_t"
     where type CFieldType Uint_fast32_t
@@ -375,8 +379,9 @@ newtype Int_fast8_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapInt_fast8_t" (Ptr Int_fast8_t) (Ptr ty)
+instance HasField "unwrapInt_fast8_t"
+                  (Ptr Int_fast8_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapInt_fast8_t")
 instance HasCField Int_fast8_t "unwrapInt_fast8_t"
     where type CFieldType Int_fast8_t
@@ -406,8 +411,9 @@ newtype Int_fast64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapInt_fast64_t" (Ptr Int_fast64_t) (Ptr ty)
+instance HasField "unwrapInt_fast64_t"
+                  (Ptr Int_fast64_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapInt_fast64_t")
 instance HasCField Int_fast64_t "unwrapInt_fast64_t"
     where type CFieldType Int_fast64_t
@@ -437,8 +443,9 @@ newtype Int_least8_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapInt_least8_t" (Ptr Int_least8_t) (Ptr ty)
+instance HasField "unwrapInt_least8_t"
+                  (Ptr Int_least8_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapInt_least8_t")
 instance HasCField Int_least8_t "unwrapInt_least8_t"
     where type CFieldType Int_least8_t
@@ -468,8 +475,9 @@ newtype Int_least16_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapInt_least16_t" (Ptr Int_least16_t) (Ptr ty)
+instance HasField "unwrapInt_least16_t"
+                  (Ptr Int_least16_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapInt_least16_t")
 instance HasCField Int_least16_t "unwrapInt_least16_t"
     where type CFieldType Int_least16_t
@@ -499,8 +507,9 @@ newtype Int_least32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_least32_t" (Ptr Int_least32_t) (Ptr ty)
+instance HasField "unwrapInt_least32_t"
+                  (Ptr Int_least32_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapInt_least32_t")
 instance HasCField Int_least32_t "unwrapInt_least32_t"
     where type CFieldType Int_least32_t
@@ -530,8 +539,9 @@ newtype Int_least64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapInt_least64_t" (Ptr Int_least64_t) (Ptr ty)
+instance HasField "unwrapInt_least64_t"
+                  (Ptr Int_least64_t)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapInt_least64_t")
 instance HasCField Int_least64_t "unwrapInt_least64_t"
     where type CFieldType Int_least64_t
@@ -561,8 +571,9 @@ newtype Uint_fast8_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint_fast8_t" (Ptr Uint_fast8_t) (Ptr ty)
+instance HasField "unwrapUint_fast8_t"
+                  (Ptr Uint_fast8_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapUint_fast8_t")
 instance HasCField Uint_fast8_t "unwrapUint_fast8_t"
     where type CFieldType Uint_fast8_t
@@ -592,8 +603,9 @@ newtype Uint_fast64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapUint_fast64_t" (Ptr Uint_fast64_t) (Ptr ty)
+instance HasField "unwrapUint_fast64_t"
+                  (Ptr Uint_fast64_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapUint_fast64_t")
 instance HasCField Uint_fast64_t "unwrapUint_fast64_t"
     where type CFieldType Uint_fast64_t
@@ -623,8 +635,9 @@ newtype Uint_least8_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint_least8_t" (Ptr Uint_least8_t) (Ptr ty)
+instance HasField "unwrapUint_least8_t"
+                  (Ptr Uint_least8_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapUint_least8_t")
 instance HasCField Uint_least8_t "unwrapUint_least8_t"
     where type CFieldType Uint_least8_t
@@ -654,8 +667,9 @@ newtype Uint_least16_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapUint_least16_t" (Ptr Uint_least16_t) (Ptr ty)
+instance HasField "unwrapUint_least16_t"
+                  (Ptr Uint_least16_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapUint_least16_t")
 instance HasCField Uint_least16_t "unwrapUint_least16_t"
     where type CFieldType Uint_least16_t
@@ -685,8 +699,9 @@ newtype Uint_least32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_least32_t" (Ptr Uint_least32_t) (Ptr ty)
+instance HasField "unwrapUint_least32_t"
+                  (Ptr Uint_least32_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapUint_least32_t")
 instance HasCField Uint_least32_t "unwrapUint_least32_t"
     where type CFieldType Uint_least32_t
@@ -716,8 +731,9 @@ newtype Uint_least64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapUint_least64_t" (Ptr Uint_least64_t) (Ptr ty)
+instance HasField "unwrapUint_least64_t"
+                  (Ptr Uint_least64_t)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapUint_least64_t")
 instance HasCField Uint_least64_t "unwrapUint_least64_t"
     where type CFieldType Uint_least64_t

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -72,8 +70,7 @@ newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.HasField "unwrapPrim_HsPrimCPtrdiff" (RIP.Ptr Prim_HsPrimCPtrdiff) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCPtrdiff" (RIP.Ptr Prim_HsPrimCPtrdiff) (RIP.Ptr HsBindgen.Runtime.LibC.CPtrdiff) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCPtrdiff")
@@ -113,8 +110,7 @@ newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.HasField "unwrapPrim_HsPrimInt8" (RIP.Ptr Prim_HsPrimInt8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimInt8" (RIP.Ptr Prim_HsPrimInt8) (RIP.Ptr HsBindgen.Runtime.LibC.Int8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimInt8")
@@ -154,8 +150,7 @@ newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.HasField "unwrapPrim_HsPrimInt16" (RIP.Ptr Prim_HsPrimInt16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimInt16" (RIP.Ptr Prim_HsPrimInt16) (RIP.Ptr HsBindgen.Runtime.LibC.Int16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimInt16")
@@ -195,8 +190,7 @@ newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.HasField "unwrapPrim_HsPrimInt32" (RIP.Ptr Prim_HsPrimInt32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimInt32" (RIP.Ptr Prim_HsPrimInt32) (RIP.Ptr HsBindgen.Runtime.LibC.Int32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimInt32")
@@ -236,8 +230,7 @@ newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.HasField "unwrapPrim_HsPrimInt64" (RIP.Ptr Prim_HsPrimInt64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimInt64" (RIP.Ptr Prim_HsPrimInt64) (RIP.Ptr HsBindgen.Runtime.LibC.Int64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimInt64")
@@ -277,8 +270,7 @@ newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "unwrapPrim_HsPrimWord8" (RIP.Ptr Prim_HsPrimWord8) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimWord8" (RIP.Ptr Prim_HsPrimWord8) (RIP.Ptr HsBindgen.Runtime.LibC.Word8) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimWord8")
@@ -318,8 +310,7 @@ newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "unwrapPrim_HsPrimWord16" (RIP.Ptr Prim_HsPrimWord16) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimWord16" (RIP.Ptr Prim_HsPrimWord16) (RIP.Ptr HsBindgen.Runtime.LibC.Word16) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimWord16")
@@ -359,8 +350,7 @@ newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "unwrapPrim_HsPrimWord32" (RIP.Ptr Prim_HsPrimWord32) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimWord32" (RIP.Ptr Prim_HsPrimWord32) (RIP.Ptr HsBindgen.Runtime.LibC.Word32) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimWord32")
@@ -400,8 +390,7 @@ newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "unwrapPrim_HsPrimWord64" (RIP.Ptr Prim_HsPrimWord64) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimWord64" (RIP.Ptr Prim_HsPrimWord64) (RIP.Ptr HsBindgen.Runtime.LibC.Word64) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimWord64")
@@ -441,8 +430,7 @@ newtype Prim_HsPrimCChar = Prim_HsPrimCChar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapPrim_HsPrimCChar" (RIP.Ptr Prim_HsPrimCChar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCChar" (RIP.Ptr Prim_HsPrimCChar) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCChar")
@@ -482,8 +470,7 @@ newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "unwrapPrim_HsPrimCSChar" (RIP.Ptr Prim_HsPrimCSChar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCSChar" (RIP.Ptr Prim_HsPrimCSChar) (RIP.Ptr RIP.CSChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCSChar")
@@ -523,8 +510,7 @@ newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unwrapPrim_HsPrimCUChar" (RIP.Ptr Prim_HsPrimCUChar) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCUChar" (RIP.Ptr Prim_HsPrimCUChar) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCUChar")
@@ -564,8 +550,7 @@ newtype Prim_HsPrimCShort = Prim_HsPrimCShort
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "unwrapPrim_HsPrimCShort" (RIP.Ptr Prim_HsPrimCShort) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCShort" (RIP.Ptr Prim_HsPrimCShort) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCShort")
@@ -605,8 +590,7 @@ newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "unwrapPrim_HsPrimCUShort" (RIP.Ptr Prim_HsPrimCUShort) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCUShort" (RIP.Ptr Prim_HsPrimCUShort) (RIP.Ptr RIP.CUShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCUShort")
@@ -646,8 +630,7 @@ newtype Prim_HsPrimCInt = Prim_HsPrimCInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapPrim_HsPrimCInt" (RIP.Ptr Prim_HsPrimCInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCInt" (RIP.Ptr Prim_HsPrimCInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCInt")
@@ -687,8 +670,7 @@ newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapPrim_HsPrimCUInt" (RIP.Ptr Prim_HsPrimCUInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCUInt" (RIP.Ptr Prim_HsPrimCUInt) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCUInt")
@@ -728,8 +710,7 @@ newtype Prim_HsPrimCLong = Prim_HsPrimCLong
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "unwrapPrim_HsPrimCLong" (RIP.Ptr Prim_HsPrimCLong) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCLong" (RIP.Ptr Prim_HsPrimCLong) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCLong")
@@ -769,8 +750,7 @@ newtype Prim_HsPrimCULong = Prim_HsPrimCULong
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "unwrapPrim_HsPrimCULong" (RIP.Ptr Prim_HsPrimCULong) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCULong" (RIP.Ptr Prim_HsPrimCULong) (RIP.Ptr RIP.CULong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCULong")
@@ -810,8 +790,7 @@ newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "unwrapPrim_HsPrimCLLong" (RIP.Ptr Prim_HsPrimCLLong) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCLLong" (RIP.Ptr Prim_HsPrimCLLong) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCLLong")
@@ -851,8 +830,7 @@ newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "unwrapPrim_HsPrimCULLong" (RIP.Ptr Prim_HsPrimCULLong) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCULLong" (RIP.Ptr Prim_HsPrimCULLong) (RIP.Ptr RIP.CULLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCULLong")
@@ -892,8 +870,7 @@ newtype Prim_HsPrimCBool = Prim_HsPrimCBool
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "unwrapPrim_HsPrimCBool" (RIP.Ptr Prim_HsPrimCBool) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCBool" (RIP.Ptr Prim_HsPrimCBool) (RIP.Ptr RIP.CBool) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCBool")
@@ -931,8 +908,7 @@ newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "unwrapPrim_HsPrimCFloat" (RIP.Ptr Prim_HsPrimCFloat) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCFloat" (RIP.Ptr Prim_HsPrimCFloat) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCFloat")
@@ -970,8 +946,7 @@ newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "unwrapPrim_HsPrimCDouble" (RIP.Ptr Prim_HsPrimCDouble) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapPrim_HsPrimCDouble" (RIP.Ptr Prim_HsPrimCDouble) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapPrim_HsPrimCDouble")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/th.txt
@@ -28,10 +28,9 @@ newtype Prim_HsPrimCPtrdiff
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapPrim_HsPrimCPtrdiff"
+instance HasField "unwrapPrim_HsPrimCPtrdiff"
                   (Ptr Prim_HsPrimCPtrdiff)
-                  (Ptr ty)
+                  (Ptr HsBindgen.Runtime.LibC.CPtrdiff)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCPtrdiff")
 instance HasCField Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff"
     where type CFieldType Prim_HsPrimCPtrdiff
@@ -61,8 +60,9 @@ newtype Prim_HsPrimInt8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapPrim_HsPrimInt8" (Ptr Prim_HsPrimInt8) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt8"
+                  (Ptr Prim_HsPrimInt8)
+                  (Ptr HsBindgen.Runtime.LibC.Int8)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt8")
 instance HasCField Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8"
     where type CFieldType Prim_HsPrimInt8
@@ -92,8 +92,9 @@ newtype Prim_HsPrimInt16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapPrim_HsPrimInt16" (Ptr Prim_HsPrimInt16) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt16"
+                  (Ptr Prim_HsPrimInt16)
+                  (Ptr HsBindgen.Runtime.LibC.Int16)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt16")
 instance HasCField Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16"
     where type CFieldType Prim_HsPrimInt16
@@ -123,8 +124,9 @@ newtype Prim_HsPrimInt32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapPrim_HsPrimInt32" (Ptr Prim_HsPrimInt32) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt32"
+                  (Ptr Prim_HsPrimInt32)
+                  (Ptr HsBindgen.Runtime.LibC.Int32)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt32")
 instance HasCField Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32"
     where type CFieldType Prim_HsPrimInt32
@@ -154,8 +156,9 @@ newtype Prim_HsPrimInt64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapPrim_HsPrimInt64" (Ptr Prim_HsPrimInt64) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimInt64"
+                  (Ptr Prim_HsPrimInt64)
+                  (Ptr HsBindgen.Runtime.LibC.Int64)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt64")
 instance HasCField Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64"
     where type CFieldType Prim_HsPrimInt64
@@ -185,8 +188,9 @@ newtype Prim_HsPrimWord8
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapPrim_HsPrimWord8" (Ptr Prim_HsPrimWord8) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord8"
+                  (Ptr Prim_HsPrimWord8)
+                  (Ptr HsBindgen.Runtime.LibC.Word8)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord8")
 instance HasCField Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8"
     where type CFieldType Prim_HsPrimWord8
@@ -216,8 +220,9 @@ newtype Prim_HsPrimWord16
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapPrim_HsPrimWord16" (Ptr Prim_HsPrimWord16) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord16"
+                  (Ptr Prim_HsPrimWord16)
+                  (Ptr HsBindgen.Runtime.LibC.Word16)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord16")
 instance HasCField Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16"
     where type CFieldType Prim_HsPrimWord16
@@ -247,8 +252,9 @@ newtype Prim_HsPrimWord32
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapPrim_HsPrimWord32" (Ptr Prim_HsPrimWord32) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord32"
+                  (Ptr Prim_HsPrimWord32)
+                  (Ptr HsBindgen.Runtime.LibC.Word32)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord32")
 instance HasCField Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32"
     where type CFieldType Prim_HsPrimWord32
@@ -278,8 +284,9 @@ newtype Prim_HsPrimWord64
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapPrim_HsPrimWord64" (Ptr Prim_HsPrimWord64) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimWord64"
+                  (Ptr Prim_HsPrimWord64)
+                  (Ptr HsBindgen.Runtime.LibC.Word64)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord64")
 instance HasCField Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64"
     where type CFieldType Prim_HsPrimWord64
@@ -309,8 +316,9 @@ newtype Prim_HsPrimCChar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar =>
-         HasField "unwrapPrim_HsPrimCChar" (Ptr Prim_HsPrimCChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCChar"
+                  (Ptr Prim_HsPrimCChar)
+                  (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCChar")
 instance HasCField Prim_HsPrimCChar "unwrapPrim_HsPrimCChar"
     where type CFieldType Prim_HsPrimCChar
@@ -340,8 +348,9 @@ newtype Prim_HsPrimCSChar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CSChar =>
-         HasField "unwrapPrim_HsPrimCSChar" (Ptr Prim_HsPrimCSChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCSChar"
+                  (Ptr Prim_HsPrimCSChar)
+                  (Ptr CSChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCSChar")
 instance HasCField Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar"
     where type CFieldType Prim_HsPrimCSChar
@@ -371,8 +380,9 @@ newtype Prim_HsPrimCUChar
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUChar =>
-         HasField "unwrapPrim_HsPrimCUChar" (Ptr Prim_HsPrimCUChar) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCUChar"
+                  (Ptr Prim_HsPrimCUChar)
+                  (Ptr CUChar)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUChar")
 instance HasCField Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar"
     where type CFieldType Prim_HsPrimCUChar
@@ -402,8 +412,9 @@ newtype Prim_HsPrimCShort
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CShort =>
-         HasField "unwrapPrim_HsPrimCShort" (Ptr Prim_HsPrimCShort) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCShort"
+                  (Ptr Prim_HsPrimCShort)
+                  (Ptr CShort)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCShort")
 instance HasCField Prim_HsPrimCShort "unwrapPrim_HsPrimCShort"
     where type CFieldType Prim_HsPrimCShort
@@ -433,10 +444,9 @@ newtype Prim_HsPrimCUShort
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUShort =>
-         HasField "unwrapPrim_HsPrimCUShort"
+instance HasField "unwrapPrim_HsPrimCUShort"
                   (Ptr Prim_HsPrimCUShort)
-                  (Ptr ty)
+                  (Ptr CUShort)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUShort")
 instance HasCField Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort"
     where type CFieldType Prim_HsPrimCUShort
@@ -466,8 +476,9 @@ newtype Prim_HsPrimCInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapPrim_HsPrimCInt" (Ptr Prim_HsPrimCInt) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCInt"
+                  (Ptr Prim_HsPrimCInt)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCInt")
 instance HasCField Prim_HsPrimCInt "unwrapPrim_HsPrimCInt"
     where type CFieldType Prim_HsPrimCInt
@@ -497,8 +508,9 @@ newtype Prim_HsPrimCUInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CUInt =>
-         HasField "unwrapPrim_HsPrimCUInt" (Ptr Prim_HsPrimCUInt) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCUInt"
+                  (Ptr Prim_HsPrimCUInt)
+                  (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUInt")
 instance HasCField Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt"
     where type CFieldType Prim_HsPrimCUInt
@@ -528,8 +540,9 @@ newtype Prim_HsPrimCLong
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CLong =>
-         HasField "unwrapPrim_HsPrimCLong" (Ptr Prim_HsPrimCLong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCLong"
+                  (Ptr Prim_HsPrimCLong)
+                  (Ptr CLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLong")
 instance HasCField Prim_HsPrimCLong "unwrapPrim_HsPrimCLong"
     where type CFieldType Prim_HsPrimCLong
@@ -559,8 +572,9 @@ newtype Prim_HsPrimCULong
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CULong =>
-         HasField "unwrapPrim_HsPrimCULong" (Ptr Prim_HsPrimCULong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCULong"
+                  (Ptr Prim_HsPrimCULong)
+                  (Ptr CULong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULong")
 instance HasCField Prim_HsPrimCULong "unwrapPrim_HsPrimCULong"
     where type CFieldType Prim_HsPrimCULong
@@ -590,8 +604,9 @@ newtype Prim_HsPrimCLLong
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CLLong =>
-         HasField "unwrapPrim_HsPrimCLLong" (Ptr Prim_HsPrimCLLong) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCLLong"
+                  (Ptr Prim_HsPrimCLLong)
+                  (Ptr CLLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLLong")
 instance HasCField Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong"
     where type CFieldType Prim_HsPrimCLLong
@@ -621,10 +636,9 @@ newtype Prim_HsPrimCULLong
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CULLong =>
-         HasField "unwrapPrim_HsPrimCULLong"
+instance HasField "unwrapPrim_HsPrimCULLong"
                   (Ptr Prim_HsPrimCULLong)
-                  (Ptr ty)
+                  (Ptr CULLong)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULLong")
 instance HasCField Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong"
     where type CFieldType Prim_HsPrimCULLong
@@ -654,8 +668,9 @@ newtype Prim_HsPrimCBool
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CBool =>
-         HasField "unwrapPrim_HsPrimCBool" (Ptr Prim_HsPrimCBool) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCBool"
+                  (Ptr Prim_HsPrimCBool)
+                  (Ptr CBool)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCBool")
 instance HasCField Prim_HsPrimCBool "unwrapPrim_HsPrimCBool"
     where type CFieldType Prim_HsPrimCBool
@@ -683,8 +698,9 @@ newtype Prim_HsPrimCFloat
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CFloat =>
-         HasField "unwrapPrim_HsPrimCFloat" (Ptr Prim_HsPrimCFloat) (Ptr ty)
+instance HasField "unwrapPrim_HsPrimCFloat"
+                  (Ptr Prim_HsPrimCFloat)
+                  (Ptr CFloat)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCFloat")
 instance HasCField Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat"
     where type CFieldType Prim_HsPrimCFloat
@@ -712,10 +728,9 @@ newtype Prim_HsPrimCDouble
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CDouble =>
-         HasField "unwrapPrim_HsPrimCDouble"
+instance HasField "unwrapPrim_HsPrimCDouble"
                   (Ptr Prim_HsPrimCDouble)
-                  (Ptr ty)
+                  (Ptr CDouble)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCDouble")
 instance HasCField Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble"
     where type CFieldType Prim_HsPrimCDouble

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -339,8 +337,7 @@ instance HasCField.HasCField Primitive "primitive_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "primitive_c" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_c" (RIP.Ptr Primitive) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_c")
@@ -351,8 +348,7 @@ instance HasCField.HasCField Primitive "primitive_sc" where
 
   offset# = \_ -> \_ -> 1
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "primitive_sc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_sc" (RIP.Ptr Primitive) (RIP.Ptr RIP.CSChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_sc")
@@ -363,8 +359,7 @@ instance HasCField.HasCField Primitive "primitive_uc" where
 
   offset# = \_ -> \_ -> 2
 
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "primitive_uc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_uc" (RIP.Ptr Primitive) (RIP.Ptr RIP.CUChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_uc")
@@ -375,8 +370,7 @@ instance HasCField.HasCField Primitive "primitive_s" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_s" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_s" (RIP.Ptr Primitive) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_s")
@@ -387,8 +381,7 @@ instance HasCField.HasCField Primitive "primitive_si" where
 
   offset# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_si" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_si" (RIP.Ptr Primitive) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_si")
@@ -399,8 +392,7 @@ instance HasCField.HasCField Primitive "primitive_ss" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_ss" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ss" (RIP.Ptr Primitive) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ss")
@@ -412,8 +404,7 @@ instance HasCField.HasCField Primitive "primitive_ssi" where
 
   offset# = \_ -> \_ -> 10
 
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_ssi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ssi" (RIP.Ptr Primitive) (RIP.Ptr RIP.CShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ssi")
@@ -425,8 +416,7 @@ instance HasCField.HasCField Primitive "primitive_us" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "primitive_us" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_us" (RIP.Ptr Primitive) (RIP.Ptr RIP.CUShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_us")
@@ -438,8 +428,7 @@ instance HasCField.HasCField Primitive "primitive_usi" where
 
   offset# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "primitive_usi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_usi" (RIP.Ptr Primitive) (RIP.Ptr RIP.CUShort) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_usi")
@@ -450,8 +439,7 @@ instance HasCField.HasCField Primitive "primitive_i" where
 
   offset# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_i" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_i" (RIP.Ptr Primitive) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_i")
@@ -462,8 +450,7 @@ instance HasCField.HasCField Primitive "primitive_s2" where
 
   offset# = \_ -> \_ -> 20
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_s2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_s2" (RIP.Ptr Primitive) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_s2")
@@ -474,8 +461,7 @@ instance HasCField.HasCField Primitive "primitive_si2" where
 
   offset# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_si2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_si2" (RIP.Ptr Primitive) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_si2")
@@ -486,8 +472,7 @@ instance HasCField.HasCField Primitive "primitive_u" where
 
   offset# = \_ -> \_ -> 28
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "primitive_u" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_u" (RIP.Ptr Primitive) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_u")
@@ -498,8 +483,7 @@ instance HasCField.HasCField Primitive "primitive_ui" where
 
   offset# = \_ -> \_ -> 32
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "primitive_ui" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ui" (RIP.Ptr Primitive) (RIP.Ptr RIP.CUInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ui")
@@ -510,8 +494,7 @@ instance HasCField.HasCField Primitive "primitive_l" where
 
   offset# = \_ -> \_ -> 40
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_l" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_l" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_l")
@@ -522,8 +505,7 @@ instance HasCField.HasCField Primitive "primitive_li" where
 
   offset# = \_ -> \_ -> 48
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_li" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_li" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_li")
@@ -534,8 +516,7 @@ instance HasCField.HasCField Primitive "primitive_sl" where
 
   offset# = \_ -> \_ -> 56
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_sl" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_sl" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_sl")
@@ -546,8 +527,7 @@ instance HasCField.HasCField Primitive "primitive_sli" where
 
   offset# = \_ -> \_ -> 64
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_sli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_sli" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_sli")
@@ -558,8 +538,7 @@ instance HasCField.HasCField Primitive "primitive_ul" where
 
   offset# = \_ -> \_ -> 72
 
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "primitive_ul" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ul" (RIP.Ptr Primitive) (RIP.Ptr RIP.CULong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ul")
@@ -571,8 +550,7 @@ instance HasCField.HasCField Primitive "primitive_uli" where
 
   offset# = \_ -> \_ -> 80
 
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "primitive_uli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_uli" (RIP.Ptr Primitive) (RIP.Ptr RIP.CULong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_uli")
@@ -583,8 +561,7 @@ instance HasCField.HasCField Primitive "primitive_ll" where
 
   offset# = \_ -> \_ -> 88
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_ll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ll" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ll")
@@ -596,8 +573,7 @@ instance HasCField.HasCField Primitive "primitive_lli" where
 
   offset# = \_ -> \_ -> 96
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_lli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_lli" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_lli")
@@ -609,8 +585,7 @@ instance HasCField.HasCField Primitive "primitive_sll" where
 
   offset# = \_ -> \_ -> 104
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_sll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_sll" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_sll")
@@ -622,8 +597,7 @@ instance HasCField.HasCField Primitive "primitive_slli" where
 
   offset# = \_ -> \_ -> 112
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_slli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_slli" (RIP.Ptr Primitive) (RIP.Ptr RIP.CLLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_slli")
@@ -635,8 +609,7 @@ instance HasCField.HasCField Primitive "primitive_ull" where
 
   offset# = \_ -> \_ -> 120
 
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "primitive_ull" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ull" (RIP.Ptr Primitive) (RIP.Ptr RIP.CULLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ull")
@@ -648,8 +621,7 @@ instance HasCField.HasCField Primitive "primitive_ulli" where
 
   offset# = \_ -> \_ -> 128
 
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "primitive_ulli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_ulli" (RIP.Ptr Primitive) (RIP.Ptr RIP.CULLong) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_ulli")
@@ -660,8 +632,7 @@ instance HasCField.HasCField Primitive "primitive_f" where
 
   offset# = \_ -> \_ -> 136
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "primitive_f" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_f" (RIP.Ptr Primitive) (RIP.Ptr RIP.CFloat) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_f")
@@ -672,8 +643,7 @@ instance HasCField.HasCField Primitive "primitive_d" where
 
   offset# = \_ -> \_ -> 144
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "primitive_d" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance RIP.HasField "primitive_d" (RIP.Ptr Primitive) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"primitive_d")

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/th.txt
@@ -242,168 +242,140 @@ deriving via (EquivStorable Primitive) instance Storable Primitive
 instance HasCField Primitive "primitive_c"
     where type CFieldType Primitive "primitive_c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "primitive_c" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_c" (Ptr Primitive) (Ptr CChar)
     where getField = fromPtr (Proxy @"primitive_c")
 instance HasCField Primitive "primitive_sc"
     where type CFieldType Primitive "primitive_sc" = CSChar
           offset# = \_ -> \_ -> 1
-instance (~) ty CSChar =>
-         HasField "primitive_sc" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sc" (Ptr Primitive) (Ptr CSChar)
     where getField = fromPtr (Proxy @"primitive_sc")
 instance HasCField Primitive "primitive_uc"
     where type CFieldType Primitive "primitive_uc" = CUChar
           offset# = \_ -> \_ -> 2
-instance (~) ty CUChar =>
-         HasField "primitive_uc" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_uc" (Ptr Primitive) (Ptr CUChar)
     where getField = fromPtr (Proxy @"primitive_uc")
 instance HasCField Primitive "primitive_s"
     where type CFieldType Primitive "primitive_s" = CShort
           offset# = \_ -> \_ -> 4
-instance (~) ty CShort =>
-         HasField "primitive_s" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_s" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_s")
 instance HasCField Primitive "primitive_si"
     where type CFieldType Primitive "primitive_si" = CShort
           offset# = \_ -> \_ -> 6
-instance (~) ty CShort =>
-         HasField "primitive_si" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_si" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_si")
 instance HasCField Primitive "primitive_ss"
     where type CFieldType Primitive "primitive_ss" = CShort
           offset# = \_ -> \_ -> 8
-instance (~) ty CShort =>
-         HasField "primitive_ss" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ss" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_ss")
 instance HasCField Primitive "primitive_ssi"
     where type CFieldType Primitive "primitive_ssi" = CShort
           offset# = \_ -> \_ -> 10
-instance (~) ty CShort =>
-         HasField "primitive_ssi" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ssi" (Ptr Primitive) (Ptr CShort)
     where getField = fromPtr (Proxy @"primitive_ssi")
 instance HasCField Primitive "primitive_us"
     where type CFieldType Primitive "primitive_us" = CUShort
           offset# = \_ -> \_ -> 12
-instance (~) ty CUShort =>
-         HasField "primitive_us" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_us" (Ptr Primitive) (Ptr CUShort)
     where getField = fromPtr (Proxy @"primitive_us")
 instance HasCField Primitive "primitive_usi"
     where type CFieldType Primitive "primitive_usi" = CUShort
           offset# = \_ -> \_ -> 14
-instance (~) ty CUShort =>
-         HasField "primitive_usi" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_usi" (Ptr Primitive) (Ptr CUShort)
     where getField = fromPtr (Proxy @"primitive_usi")
 instance HasCField Primitive "primitive_i"
     where type CFieldType Primitive "primitive_i" = CInt
           offset# = \_ -> \_ -> 16
-instance (~) ty CInt =>
-         HasField "primitive_i" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_i" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_i")
 instance HasCField Primitive "primitive_s2"
     where type CFieldType Primitive "primitive_s2" = CInt
           offset# = \_ -> \_ -> 20
-instance (~) ty CInt =>
-         HasField "primitive_s2" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_s2" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_s2")
 instance HasCField Primitive "primitive_si2"
     where type CFieldType Primitive "primitive_si2" = CInt
           offset# = \_ -> \_ -> 24
-instance (~) ty CInt =>
-         HasField "primitive_si2" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_si2" (Ptr Primitive) (Ptr CInt)
     where getField = fromPtr (Proxy @"primitive_si2")
 instance HasCField Primitive "primitive_u"
     where type CFieldType Primitive "primitive_u" = CUInt
           offset# = \_ -> \_ -> 28
-instance (~) ty CUInt =>
-         HasField "primitive_u" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_u" (Ptr Primitive) (Ptr CUInt)
     where getField = fromPtr (Proxy @"primitive_u")
 instance HasCField Primitive "primitive_ui"
     where type CFieldType Primitive "primitive_ui" = CUInt
           offset# = \_ -> \_ -> 32
-instance (~) ty CUInt =>
-         HasField "primitive_ui" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ui" (Ptr Primitive) (Ptr CUInt)
     where getField = fromPtr (Proxy @"primitive_ui")
 instance HasCField Primitive "primitive_l"
     where type CFieldType Primitive "primitive_l" = CLong
           offset# = \_ -> \_ -> 40
-instance (~) ty CLong =>
-         HasField "primitive_l" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_l" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_l")
 instance HasCField Primitive "primitive_li"
     where type CFieldType Primitive "primitive_li" = CLong
           offset# = \_ -> \_ -> 48
-instance (~) ty CLong =>
-         HasField "primitive_li" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_li" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_li")
 instance HasCField Primitive "primitive_sl"
     where type CFieldType Primitive "primitive_sl" = CLong
           offset# = \_ -> \_ -> 56
-instance (~) ty CLong =>
-         HasField "primitive_sl" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sl" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_sl")
 instance HasCField Primitive "primitive_sli"
     where type CFieldType Primitive "primitive_sli" = CLong
           offset# = \_ -> \_ -> 64
-instance (~) ty CLong =>
-         HasField "primitive_sli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sli" (Ptr Primitive) (Ptr CLong)
     where getField = fromPtr (Proxy @"primitive_sli")
 instance HasCField Primitive "primitive_ul"
     where type CFieldType Primitive "primitive_ul" = CULong
           offset# = \_ -> \_ -> 72
-instance (~) ty CULong =>
-         HasField "primitive_ul" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ul" (Ptr Primitive) (Ptr CULong)
     where getField = fromPtr (Proxy @"primitive_ul")
 instance HasCField Primitive "primitive_uli"
     where type CFieldType Primitive "primitive_uli" = CULong
           offset# = \_ -> \_ -> 80
-instance (~) ty CULong =>
-         HasField "primitive_uli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_uli" (Ptr Primitive) (Ptr CULong)
     where getField = fromPtr (Proxy @"primitive_uli")
 instance HasCField Primitive "primitive_ll"
     where type CFieldType Primitive "primitive_ll" = CLLong
           offset# = \_ -> \_ -> 88
-instance (~) ty CLLong =>
-         HasField "primitive_ll" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ll" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_ll")
 instance HasCField Primitive "primitive_lli"
     where type CFieldType Primitive "primitive_lli" = CLLong
           offset# = \_ -> \_ -> 96
-instance (~) ty CLLong =>
-         HasField "primitive_lli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_lli" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_lli")
 instance HasCField Primitive "primitive_sll"
     where type CFieldType Primitive "primitive_sll" = CLLong
           offset# = \_ -> \_ -> 104
-instance (~) ty CLLong =>
-         HasField "primitive_sll" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_sll" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_sll")
 instance HasCField Primitive "primitive_slli"
     where type CFieldType Primitive "primitive_slli" = CLLong
           offset# = \_ -> \_ -> 112
-instance (~) ty CLLong =>
-         HasField "primitive_slli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_slli" (Ptr Primitive) (Ptr CLLong)
     where getField = fromPtr (Proxy @"primitive_slli")
 instance HasCField Primitive "primitive_ull"
     where type CFieldType Primitive "primitive_ull" = CULLong
           offset# = \_ -> \_ -> 120
-instance (~) ty CULLong =>
-         HasField "primitive_ull" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ull" (Ptr Primitive) (Ptr CULLong)
     where getField = fromPtr (Proxy @"primitive_ull")
 instance HasCField Primitive "primitive_ulli"
     where type CFieldType Primitive "primitive_ulli" = CULLong
           offset# = \_ -> \_ -> 128
-instance (~) ty CULLong =>
-         HasField "primitive_ulli" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_ulli" (Ptr Primitive) (Ptr CULLong)
     where getField = fromPtr (Proxy @"primitive_ulli")
 instance HasCField Primitive "primitive_f"
     where type CFieldType Primitive "primitive_f" = CFloat
           offset# = \_ -> \_ -> 136
-instance (~) ty CFloat =>
-         HasField "primitive_f" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_f" (Ptr Primitive) (Ptr CFloat)
     where getField = fromPtr (Proxy @"primitive_f")
 instance HasCField Primitive "primitive_d"
     where type CFieldType Primitive "primitive_d" = CDouble
           offset# = \_ -> \_ -> 144
-instance (~) ty CDouble =>
-         HasField "primitive_d" (Ptr Primitive) (Ptr ty)
+instance HasField "primitive_d" (Ptr Primitive) (Ptr CDouble)
     where getField = fromPtr (Proxy @"primitive_d")

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -65,8 +63,7 @@ newtype I = I
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapI")
 
@@ -202,8 +199,7 @@ instance Read E where
 
   readListPrec = RIP.readListPrecDefault
 
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr RIP.CUInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
 
@@ -250,7 +246,7 @@ newtype TI = TI
     , Marshal.WriteRaw
     )
 
-instance (ty ~ I) => RIP.HasField "unwrapTI" (RIP.Ptr TI) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTI" (RIP.Ptr TI) (RIP.Ptr I) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTI")
 
@@ -277,7 +273,7 @@ newtype TS = TS
     , Marshal.WriteRaw
     )
 
-instance (ty ~ S) => RIP.HasField "unwrapTS" (RIP.Ptr TS) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTS" (RIP.Ptr TS) (RIP.Ptr S) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTS")
 
@@ -304,7 +300,7 @@ newtype TU = TU
     , Marshal.WriteRaw
     )
 
-instance (ty ~ U) => RIP.HasField "unwrapTU" (RIP.Ptr TU) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTU" (RIP.Ptr TU) (RIP.Ptr U) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTU")
 
@@ -333,7 +329,7 @@ newtype TE = TE
     , Marshal.WriteRaw
     )
 
-instance (ty ~ E) => RIP.HasField "unwrapTE" (RIP.Ptr TE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTE" (RIP.Ptr TE) (RIP.Ptr E) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTE")
 
@@ -371,7 +367,7 @@ newtype TTI = TTI
     , Marshal.WriteRaw
     )
 
-instance (ty ~ TI) => RIP.HasField "unwrapTTI" (RIP.Ptr TTI) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTTI" (RIP.Ptr TTI) (RIP.Ptr TI) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTI")
 
@@ -398,7 +394,7 @@ newtype TTS = TTS
     , Marshal.WriteRaw
     )
 
-instance (ty ~ TS) => RIP.HasField "unwrapTTS" (RIP.Ptr TTS) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTTS" (RIP.Ptr TTS) (RIP.Ptr TS) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTS")
 
@@ -425,7 +421,7 @@ newtype TTU = TTU
     , Marshal.WriteRaw
     )
 
-instance (ty ~ TU) => RIP.HasField "unwrapTTU" (RIP.Ptr TTU) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTTU" (RIP.Ptr TTU) (RIP.Ptr TU) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTU")
 
@@ -454,7 +450,7 @@ newtype TTE = TTE
     , Marshal.WriteRaw
     )
 
-instance (ty ~ TE) => RIP.HasField "unwrapTTE" (RIP.Ptr TTE) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapTTE" (RIP.Ptr TTE) (RIP.Ptr TE) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTE")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -96,7 +96,7 @@ newtype I
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
+instance HasField "unwrapI" (Ptr I) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
@@ -167,7 +167,7 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
-instance (~) ty CUInt => HasField "unwrapE" (Ptr E) (Ptr ty)
+instance HasField "unwrapE" (Ptr E) (Ptr CUInt)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = CUInt
@@ -204,7 +204,7 @@ newtype TI
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty I => HasField "unwrapTI" (Ptr TI) (Ptr ty)
+instance HasField "unwrapTI" (Ptr TI) (Ptr I)
     where getField = fromPtr (Proxy @"unwrapTI")
 instance HasCField TI "unwrapTI"
     where type CFieldType TI "unwrapTI" = I
@@ -219,7 +219,7 @@ newtype TS
     = TS {unwrapTS :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty S => HasField "unwrapTS" (Ptr TS) (Ptr ty)
+instance HasField "unwrapTS" (Ptr TS) (Ptr S)
     where getField = fromPtr (Proxy @"unwrapTS")
 instance HasCField TS "unwrapTS"
     where type CFieldType TS "unwrapTS" = S
@@ -234,7 +234,7 @@ newtype TU
     = TU {unwrapTU :: U}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty U => HasField "unwrapTU" (Ptr TU) (Ptr ty)
+instance HasField "unwrapTU" (Ptr TU) (Ptr U)
     where getField = fromPtr (Proxy @"unwrapTU")
 instance HasCField TU "unwrapTU"
     where type CFieldType TU "unwrapTU" = U
@@ -254,7 +254,7 @@ newtype TE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty E => HasField "unwrapTE" (Ptr TE) (Ptr ty)
+instance HasField "unwrapTE" (Ptr TE) (Ptr E)
     where getField = fromPtr (Proxy @"unwrapTE")
 instance HasCField TE "unwrapTE"
     where type CFieldType TE "unwrapTE" = E
@@ -283,7 +283,7 @@ newtype TTI
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty TI => HasField "unwrapTTI" (Ptr TTI) (Ptr ty)
+instance HasField "unwrapTTI" (Ptr TTI) (Ptr TI)
     where getField = fromPtr (Proxy @"unwrapTTI")
 instance HasCField TTI "unwrapTTI"
     where type CFieldType TTI "unwrapTTI" = TI
@@ -298,7 +298,7 @@ newtype TTS
     = TTS {unwrapTTS :: TS}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty TS => HasField "unwrapTTS" (Ptr TTS) (Ptr ty)
+instance HasField "unwrapTTS" (Ptr TTS) (Ptr TS)
     where getField = fromPtr (Proxy @"unwrapTTS")
 instance HasCField TTS "unwrapTTS"
     where type CFieldType TTS "unwrapTTS" = TS
@@ -313,7 +313,7 @@ newtype TTU
     = TTU {unwrapTTU :: TU}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
-instance (~) ty TU => HasField "unwrapTTU" (Ptr TTU) (Ptr ty)
+instance HasField "unwrapTTU" (Ptr TTU) (Ptr TU)
     where getField = fromPtr (Proxy @"unwrapTTU")
 instance HasCField TTU "unwrapTTU"
     where type CFieldType TTU "unwrapTTU" = TU
@@ -333,7 +333,7 @@ newtype TTE
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty TE => HasField "unwrapTTE" (Ptr TTE) (Ptr ty)
+instance HasField "unwrapTTE" (Ptr TTE) (Ptr TE)
     where getField = fromPtr (Proxy @"unwrapTTE")
 instance HasCField TTE "unwrapTTE"
     where type CFieldType TTE "unwrapTTE" = TE

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,8 +66,7 @@ instance HasCField.HasCField Baz "baz_x1_2_1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_x1_2_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
+instance RIP.HasField "baz_x1_2_1" (RIP.Ptr Baz) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"baz_x1_2_1")

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/th.txt
@@ -33,7 +33,7 @@ deriving via (EquivStorable Baz) instance Storable Baz
 instance HasCField Baz "baz_x1_2_1"
     where type CFieldType Baz "baz_x1_2_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "baz_x1_2_1" (Ptr Baz) (Ptr ty)
+instance HasField "baz_x1_2_1" (Ptr Baz) (Ptr CInt)
     where getField = fromPtr (Proxy @"baz_x1_2_1")
 -- __unique:__ @test_typesscopingdeep_nesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_d6029a840689b228" hs_bindgen_d6029a840689b228_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -72,7 +70,6 @@ instance HasCField.HasCField Bar "bar_x1_1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_x1_1" (RIP.Ptr Bar) (RIP.Ptr ty) where
+instance RIP.HasField "bar_x1_1" (RIP.Ptr Bar) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"bar_x1_1")

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/th.txt
@@ -37,7 +37,7 @@ deriving via (EquivStorable Bar) instance Storable Bar
 instance HasCField Bar "bar_x1_1"
     where type CFieldType Bar "bar_x1_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "bar_x1_1" (Ptr Bar) (Ptr ty)
+instance HasField "bar_x1_1" (Ptr Bar) (Ptr CInt)
     where getField = fromPtr (Proxy @"bar_x1_1")
 -- __unique:__ @test_typesscopingnesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_7640032abd722ca9" hs_bindgen_7640032abd722ca9_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,7 +66,6 @@ instance HasCField.HasCField Baz "baz_x3_1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_x3_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
+instance RIP.HasField "baz_x3_1" (RIP.Ptr Baz) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"baz_x3_1")

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/th.txt
@@ -33,7 +33,7 @@ deriving via (EquivStorable Baz) instance Storable Baz
 instance HasCField Baz "baz_x3_1"
     where type CFieldType Baz "baz_x3_1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "baz_x3_1" (Ptr Baz) (Ptr ty)
+instance HasField "baz_x3_1" (Ptr Baz) (Ptr CInt)
     where getField = fromPtr (Proxy @"baz_x3_1")
 -- __unique:__ @test_typesscopingwide_nesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_a295757aed8ccce9" hs_bindgen_a295757aed8ccce9_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,7 +66,6 @@ instance HasCField.HasCField Struct2 "struct2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct2_x" (RIP.Ptr Struct2) (RIP.Ptr ty) where
+instance RIP.HasField "struct2_x" (RIP.Ptr Struct2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"struct2_x")

--- a/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/th.txt
@@ -47,7 +47,7 @@ deriving via (EquivStorable Struct2) instance Storable Struct2
 instance HasCField Struct2 "struct2_x"
     where type CFieldType Struct2 "struct2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct2_x" (Ptr Struct2) (Ptr ty)
+instance HasField "struct2_x" (Ptr Struct2) (Ptr CInt)
     where getField = fromPtr (Proxy @"struct2_x")
 -- __unique:__ @test_typesspecialparse_failure_lo_Example_Safe_fun2@
 foreign import ccall safe "hs_bindgen_a1252a3becef09a6" hs_bindgen_a1252a3becef09a6_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -83,8 +81,7 @@ instance HasCField.HasCField S1_c "s1_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_c_a" (RIP.Ptr S1_c) (RIP.Ptr ty) where
+instance RIP.HasField "s1_c_a" (RIP.Ptr S1_c) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_c_a")
 
@@ -94,8 +91,7 @@ instance HasCField.HasCField S1_c "s1_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_c_b" (RIP.Ptr S1_c) (RIP.Ptr ty) where
+instance RIP.HasField "s1_c_b" (RIP.Ptr S1_c) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_c_b")
 
@@ -155,7 +151,7 @@ instance HasCField.HasCField S1 "s1_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ S1_c) => RIP.HasField "s1_c" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_c" (RIP.Ptr S1) (RIP.Ptr S1_c) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_c")
 
@@ -165,7 +161,7 @@ instance HasCField.HasCField S1 "s1_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_d" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_d" (RIP.Ptr S1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_d")
 
@@ -217,8 +213,7 @@ instance HasCField.HasCField S2_inner_deep "s2_inner_deep_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_inner_deep_b" (RIP.Ptr S2_inner_deep) (RIP.Ptr ty) where
+instance RIP.HasField "s2_inner_deep_b" (RIP.Ptr S2_inner_deep) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"s2_inner_deep_b")
@@ -279,8 +274,7 @@ instance HasCField.HasCField S2_inner "s2_inner_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_inner_a" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
+instance RIP.HasField "s2_inner_a" (RIP.Ptr S2_inner) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"s2_inner_a")
@@ -292,8 +286,7 @@ instance HasCField.HasCField S2_inner "s2_inner_deep" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ S2_inner_deep
-         ) => RIP.HasField "s2_inner_deep" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
+instance RIP.HasField "s2_inner_deep" (RIP.Ptr S2_inner) (RIP.Ptr S2_inner_deep) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"s2_inner_deep")
@@ -354,8 +347,7 @@ instance HasCField.HasCField S2 "s2_inner" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ S2_inner
-         ) => RIP.HasField "s2_inner" (RIP.Ptr S2) (RIP.Ptr ty) where
+instance RIP.HasField "s2_inner" (RIP.Ptr S2) (RIP.Ptr S2_inner) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_inner")
 
@@ -365,7 +357,7 @@ instance HasCField.HasCField S2 "s2_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s2_d" (RIP.Ptr S2) (RIP.Ptr ty) where
+instance RIP.HasField "s2_d" (RIP.Ptr S2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_d")
 
@@ -425,8 +417,7 @@ instance HasCField.HasCField S3 "s3_c" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr S3_c)
-         ) => RIP.HasField "s3_c" (RIP.Ptr S3) (RIP.Ptr ty) where
+instance RIP.HasField "s3_c" (RIP.Ptr S3) (RIP.Ptr (RIP.Ptr (RIP.Ptr S3_c))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_c")
 
@@ -436,7 +427,7 @@ instance HasCField.HasCField S3 "s3_d" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s3_d" (RIP.Ptr S3) (RIP.Ptr ty) where
+instance RIP.HasField "s3_d" (RIP.Ptr S3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_d")
 
@@ -496,8 +487,7 @@ instance HasCField.HasCField S3_c "s3_c_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s3_c_a" (RIP.Ptr S3_c) (RIP.Ptr ty) where
+instance RIP.HasField "s3_c_a" (RIP.Ptr S3_c) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_c_a")
 
@@ -507,7 +497,6 @@ instance HasCField.HasCField S3_c "s3_c_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s3_c_b" (RIP.Ptr S3_c) (RIP.Ptr ty) where
+instance RIP.HasField "s3_c_b" (RIP.Ptr S3_c) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_c_b")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable S1_c) instance Storable S1_c
 instance HasCField S1_c "s1_c_a"
     where type CFieldType S1_c "s1_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_c_a" (Ptr S1_c) (Ptr ty)
+instance HasField "s1_c_a" (Ptr S1_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_c_a")
 instance HasCField S1_c "s1_c_b"
     where type CFieldType S1_c "s1_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s1_c_b" (Ptr S1_c) (Ptr ty)
+instance HasField "s1_c_b" (Ptr S1_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_c_b")
 {-| __C declaration:__ @struct S1@
 
@@ -76,12 +76,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_c"
     where type CFieldType S1 "s1_c" = S1_c
           offset# = \_ -> \_ -> 0
-instance (~) ty S1_c => HasField "s1_c" (Ptr S1) (Ptr ty)
+instance HasField "s1_c" (Ptr S1) (Ptr S1_c)
     where getField = fromPtr (Proxy @"s1_c")
 instance HasCField S1 "s1_d"
     where type CFieldType S1 "s1_d" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s1_d" (Ptr S1) (Ptr ty)
+instance HasField "s1_d" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_d")
 {-| __C declaration:__ @struct \@S2_inner_deep@
 
@@ -110,8 +110,7 @@ deriving via (EquivStorable S2_inner_deep) instance Storable S2_inner_deep
 instance HasCField S2_inner_deep "s2_inner_deep_b"
     where type CFieldType S2_inner_deep "s2_inner_deep_b" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr ty)
+instance HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_inner_deep_b")
 {-| __C declaration:__ @struct \@S2_inner@
 
@@ -148,14 +147,14 @@ deriving via (EquivStorable S2_inner) instance Storable S2_inner
 instance HasCField S2_inner "s2_inner_a"
     where type CFieldType S2_inner "s2_inner_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s2_inner_a" (Ptr S2_inner) (Ptr ty)
+instance HasField "s2_inner_a" (Ptr S2_inner) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_inner_a")
 instance HasCField S2_inner "s2_inner_deep"
     where type CFieldType S2_inner "s2_inner_deep" = S2_inner_deep
           offset# = \_ -> \_ -> 4
-instance (~) ty S2_inner_deep =>
-         HasField "s2_inner_deep" (Ptr S2_inner) (Ptr ty)
+instance HasField "s2_inner_deep"
+                  (Ptr S2_inner)
+                  (Ptr S2_inner_deep)
     where getField = fromPtr (Proxy @"s2_inner_deep")
 {-| __C declaration:__ @struct S2@
 
@@ -192,12 +191,12 @@ deriving via (EquivStorable S2) instance Storable S2
 instance HasCField S2 "s2_inner"
     where type CFieldType S2 "s2_inner" = S2_inner
           offset# = \_ -> \_ -> 0
-instance (~) ty S2_inner => HasField "s2_inner" (Ptr S2) (Ptr ty)
+instance HasField "s2_inner" (Ptr S2) (Ptr S2_inner)
     where getField = fromPtr (Proxy @"s2_inner")
 instance HasCField S2 "s2_d"
     where type CFieldType S2 "s2_d" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s2_d" (Ptr S2) (Ptr ty)
+instance HasField "s2_d" (Ptr S2) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_d")
 {-| __C declaration:__ @struct S3@
 
@@ -234,13 +233,12 @@ deriving via (EquivStorable S3) instance Storable S3
 instance HasCField S3 "s3_c"
     where type CFieldType S3 "s3_c" = Ptr (Ptr S3_c)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr S3_c)) =>
-         HasField "s3_c" (Ptr S3) (Ptr ty)
+instance HasField "s3_c" (Ptr S3) (Ptr (Ptr (Ptr S3_c)))
     where getField = fromPtr (Proxy @"s3_c")
 instance HasCField S3 "s3_d"
     where type CFieldType S3 "s3_d" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s3_d" (Ptr S3) (Ptr ty)
+instance HasField "s3_d" (Ptr S3) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_d")
 {-| __C declaration:__ @struct \@S3_c@
 
@@ -277,10 +275,10 @@ deriving via (EquivStorable S3_c) instance Storable S3_c
 instance HasCField S3_c "s3_c_a"
     where type CFieldType S3_c "s3_c_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s3_c_a" (Ptr S3_c) (Ptr ty)
+instance HasField "s3_c_a" (Ptr S3_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_c_a")
 instance HasCField S3_c "s3_c_b"
     where type CFieldType S3_c "s3_c_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s3_c_b" (Ptr S3_c) (Ptr ty)
+instance HasField "s3_c_b" (Ptr S3_c) (Ptr CInt)
     where getField = fromPtr (Proxy @"s3_c_b")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -129,8 +127,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_a" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_a" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_a" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_a")
 
@@ -142,8 +139,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_b" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_b" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_b" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_b")
 
@@ -155,8 +151,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_c" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_c" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_c" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_c")
 
@@ -168,8 +163,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_d" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_d" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_d" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_d")
 
@@ -181,8 +175,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_e" where
 
   bitfieldWidth# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_e" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_e" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_e")
 
@@ -194,8 +187,7 @@ instance HasCBitfield.HasCBitfield Foo_8 "foo_8_f" where
 
   bitfieldWidth# = \_ -> \_ -> 5
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_f" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_8_f" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_f")
 
@@ -293,8 +285,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_a" where
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_16_a" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_a" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_a")
 
@@ -306,8 +297,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_b" where
 
   bitfieldWidth# = \_ -> \_ -> 10
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_b" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_b" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_b")
 
@@ -319,8 +309,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_c" where
 
   bitfieldWidth# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_c" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_c" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_c")
 
@@ -332,8 +321,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_d" where
 
   bitfieldWidth# = \_ -> \_ -> 16
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_d" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_d" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_d")
 
@@ -345,8 +333,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_e" where
 
   bitfieldWidth# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_e" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_e" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_e")
 
@@ -358,8 +345,7 @@ instance HasCBitfield.HasCBitfield Foo_16 "foo_16_f" where
 
   bitfieldWidth# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_f" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_16_f" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_f")
 
@@ -466,8 +452,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_a" where
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_32_a" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_a" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_a")
 
@@ -479,8 +464,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_b" where
 
   bitfieldWidth# = \_ -> \_ -> 12
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_b" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_b" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_b")
 
@@ -492,8 +476,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_c" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_c" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_c" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_c")
 
@@ -505,8 +488,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_d" where
 
   bitfieldWidth# = \_ -> \_ -> 10
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_d" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_d" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_d")
 
@@ -518,8 +500,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_e" where
 
   bitfieldWidth# = \_ -> \_ -> 32
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_32_e" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_e" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_e")
 
@@ -531,8 +512,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_f" where
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_f" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_f" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_f")
 
@@ -544,8 +524,7 @@ instance HasCBitfield.HasCBitfield Foo_32 "foo_32_g" where
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_32_g" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_32_g" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_g")
 
@@ -625,8 +604,7 @@ instance HasCBitfield.HasCBitfield Foo_64 "foo_64_a" where
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_64_a" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_64_a" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_a")
 
@@ -638,8 +616,7 @@ instance HasCBitfield.HasCBitfield Foo_64 "foo_64_b" where
 
   bitfieldWidth# = \_ -> \_ -> 40
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_b" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_64_b" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_b")
 
@@ -651,8 +628,7 @@ instance HasCBitfield.HasCBitfield Foo_64 "foo_64_c" where
 
   bitfieldWidth# = \_ -> \_ -> 64
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_c" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_64_c" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_c")
 
@@ -664,8 +640,7 @@ instance HasCBitfield.HasCBitfield Foo_64 "foo_64_d" where
 
   bitfieldWidth# = \_ -> \_ -> 36
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_d" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_64_d" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_d")
 
@@ -727,8 +702,7 @@ instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_a" where
 
   bitfieldWidth# = \_ -> \_ -> 6
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_8_8_a" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_8_a" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_a")
@@ -741,8 +715,7 @@ instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_b" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_8_b" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_8_b" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_b")
@@ -805,8 +778,7 @@ instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_a" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_16_a" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_16_a" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_a")
@@ -819,8 +791,7 @@ instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_b" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_16_b" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_16_b" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_b")
@@ -883,8 +854,7 @@ instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_a" where
 
   bitfieldWidth# = \_ -> \_ -> 30
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_8_32_a" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_32_a" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_a")
@@ -897,8 +867,7 @@ instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_b" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_32_b" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_32_b" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_b")
@@ -961,8 +930,7 @@ instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_a" where
 
   bitfieldWidth# = \_ -> \_ -> 62
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_8_64_a" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_64_a" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_a")
@@ -975,8 +943,7 @@ instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_b" where
 
   bitfieldWidth# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_64_b" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_8_64_b" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_b")
@@ -1039,8 +1006,7 @@ instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_a" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_16_a" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_16_a" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_a")
@@ -1053,8 +1019,7 @@ instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_b" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_16_b" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_16_b" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_b")
@@ -1118,8 +1083,7 @@ instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_a" where
 
   bitfieldWidth# = \_ -> \_ -> 24
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_16_32_a" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_32_a" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_a")
@@ -1132,8 +1096,7 @@ instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_b" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_32_b" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_32_b" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_b")
@@ -1197,8 +1160,7 @@ instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_a" where
 
   bitfieldWidth# = \_ -> \_ -> 56
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_16_64_a" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_64_a" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_a")
@@ -1211,8 +1173,7 @@ instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_b" where
 
   bitfieldWidth# = \_ -> \_ -> 14
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_64_b" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_16_64_b" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr RIP.CInt) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_b")
@@ -1276,8 +1237,7 @@ instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_a" where
 
   bitfieldWidth# = \_ -> \_ -> 30
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_32_a" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_32_32_a" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_a")
@@ -1291,8 +1251,7 @@ instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_b" where
 
   bitfieldWidth# = \_ -> \_ -> 30
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_32_b" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_32_32_b" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_b")
@@ -1356,8 +1315,7 @@ instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_a" where
 
   bitfieldWidth# = \_ -> \_ -> 56
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_32_64_a" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_32_64_a" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_a")
@@ -1371,8 +1329,7 @@ instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_b" where
 
   bitfieldWidth# = \_ -> \_ -> 30
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_64_b" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_32_64_b" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr RIP.CLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_b")
@@ -1436,8 +1393,7 @@ instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_a" where
 
   bitfieldWidth# = \_ -> \_ -> 56
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_64_64_a" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_64_64_a" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_a")
@@ -1451,8 +1407,7 @@ instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_b" where
 
   bitfieldWidth# = \_ -> \_ -> 40
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_64_64_b" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_64_64_b" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr RIP.CLLong) where
 
   getField =
     HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_b")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/th.txt
@@ -67,43 +67,37 @@ instance HasCBitfield Foo_8 "foo_8_a"
     where type CBitfieldType Foo_8 "foo_8_a" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_8_a" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_a" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_a")
 instance HasCBitfield Foo_8 "foo_8_b"
     where type CBitfieldType Foo_8 "foo_8_b" = CSChar
           bitfieldOffset# = \_ -> \_ -> 3
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_8_b" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_b" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_b")
 instance HasCBitfield Foo_8 "foo_8_c"
     where type CBitfieldType Foo_8 "foo_8_c" = CSChar
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 2
-instance (~) ty CSChar =>
-         HasField "foo_8_c" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_c" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_c")
 instance HasCBitfield Foo_8 "foo_8_d"
     where type CBitfieldType Foo_8 "foo_8_d" = CSChar
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_8_d" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_d" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_d")
 instance HasCBitfield Foo_8 "foo_8_e"
     where type CBitfieldType Foo_8 "foo_8_e" = CSChar
           bitfieldOffset# = \_ -> \_ -> 16
           bitfieldWidth# = \_ -> \_ -> 8
-instance (~) ty CSChar =>
-         HasField "foo_8_e" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_e" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_e")
 instance HasCBitfield Foo_8 "foo_8_f"
     where type CBitfieldType Foo_8 "foo_8_f" = CSChar
           bitfieldOffset# = \_ -> \_ -> 24
           bitfieldWidth# = \_ -> \_ -> 5
-instance (~) ty CSChar =>
-         HasField "foo_8_f" (Ptr Foo_8) (BitfieldPtr ty)
+instance HasField "foo_8_f" (Ptr Foo_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_8_f")
 {-| __C declaration:__ @struct foo_16@
 
@@ -173,43 +167,37 @@ instance HasCBitfield Foo_16 "foo_16_a"
     where type CBitfieldType Foo_16 "foo_16_a" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "foo_16_a" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_a" (Ptr Foo_16) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_16_a")
 instance HasCBitfield Foo_16 "foo_16_b"
     where type CBitfieldType Foo_16 "foo_16_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 10
-instance (~) ty CInt =>
-         HasField "foo_16_b" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_b" (Ptr Foo_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_16_b")
 instance HasCBitfield Foo_16 "foo_16_c"
     where type CBitfieldType Foo_16 "foo_16_c" = CInt
           bitfieldOffset# = \_ -> \_ -> 16
           bitfieldWidth# = \_ -> \_ -> 16
-instance (~) ty CInt =>
-         HasField "foo_16_c" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_c" (Ptr Foo_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_16_c")
 instance HasCBitfield Foo_16 "foo_16_d"
     where type CBitfieldType Foo_16 "foo_16_d" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 16
-instance (~) ty CInt =>
-         HasField "foo_16_d" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_d" (Ptr Foo_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_16_d")
 instance HasCBitfield Foo_16 "foo_16_e"
     where type CBitfieldType Foo_16 "foo_16_e" = CInt
           bitfieldOffset# = \_ -> \_ -> 48
           bitfieldWidth# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "foo_16_e" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_e" (Ptr Foo_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_16_e")
 instance HasCBitfield Foo_16 "foo_16_f"
     where type CBitfieldType Foo_16 "foo_16_f" = CInt
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "foo_16_f" (Ptr Foo_16) (BitfieldPtr ty)
+instance HasField "foo_16_f" (Ptr Foo_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_16_f")
 {-| __C declaration:__ @struct foo_32@
 
@@ -287,50 +275,43 @@ instance HasCBitfield Foo_32 "foo_32_a"
     where type CBitfieldType Foo_32 "foo_32_a" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "foo_32_a" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_a" (Ptr Foo_32) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_32_a")
 instance HasCBitfield Foo_32 "foo_32_b"
     where type CBitfieldType Foo_32 "foo_32_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "foo_32_b" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_b" (Ptr Foo_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_32_b")
 instance HasCBitfield Foo_32 "foo_32_c"
     where type CBitfieldType Foo_32 "foo_32_c" = CInt
           bitfieldOffset# = \_ -> \_ -> 18
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "foo_32_c" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_c" (Ptr Foo_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_32_c")
 instance HasCBitfield Foo_32 "foo_32_d"
     where type CBitfieldType Foo_32 "foo_32_d" = CInt
           bitfieldOffset# = \_ -> \_ -> 32
           bitfieldWidth# = \_ -> \_ -> 10
-instance (~) ty CInt =>
-         HasField "foo_32_d" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_d" (Ptr Foo_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_32_d")
 instance HasCBitfield Foo_32 "foo_32_e"
     where type CBitfieldType Foo_32 "foo_32_e" = CLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 32
-instance (~) ty CLong =>
-         HasField "foo_32_e" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_e" (Ptr Foo_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"foo_32_e")
 instance HasCBitfield Foo_32 "foo_32_f"
     where type CBitfieldType Foo_32 "foo_32_f" = CInt
           bitfieldOffset# = \_ -> \_ -> 96
           bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CInt =>
-         HasField "foo_32_f" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_f" (Ptr Foo_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"foo_32_f")
 instance HasCBitfield Foo_32 "foo_32_g"
     where type CBitfieldType Foo_32 "foo_32_g" = CLong
           bitfieldOffset# = \_ -> \_ -> 102
           bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "foo_32_g" (Ptr Foo_32) (BitfieldPtr ty)
+instance HasField "foo_32_g" (Ptr Foo_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"foo_32_g")
 {-| __C declaration:__ @struct foo_64@
 
@@ -384,29 +365,25 @@ instance HasCBitfield Foo_64 "foo_64_a"
     where type CBitfieldType Foo_64 "foo_64_a" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "foo_64_a" (Ptr Foo_64) (BitfieldPtr ty)
+instance HasField "foo_64_a" (Ptr Foo_64) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"foo_64_a")
 instance HasCBitfield Foo_64 "foo_64_b"
     where type CBitfieldType Foo_64 "foo_64_b" = CLLong
           bitfieldOffset# = \_ -> \_ -> 24
           bitfieldWidth# = \_ -> \_ -> 40
-instance (~) ty CLLong =>
-         HasField "foo_64_b" (Ptr Foo_64) (BitfieldPtr ty)
+instance HasField "foo_64_b" (Ptr Foo_64) (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"foo_64_b")
 instance HasCBitfield Foo_64 "foo_64_c"
     where type CBitfieldType Foo_64 "foo_64_c" = CLLong
           bitfieldOffset# = \_ -> \_ -> 64
           bitfieldWidth# = \_ -> \_ -> 64
-instance (~) ty CLLong =>
-         HasField "foo_64_c" (Ptr Foo_64) (BitfieldPtr ty)
+instance HasField "foo_64_c" (Ptr Foo_64) (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"foo_64_c")
 instance HasCBitfield Foo_64 "foo_64_d"
     where type CBitfieldType Foo_64 "foo_64_d" = CLLong
           bitfieldOffset# = \_ -> \_ -> 128
           bitfieldWidth# = \_ -> \_ -> 36
-instance (~) ty CLLong =>
-         HasField "foo_64_d" (Ptr Foo_64) (BitfieldPtr ty)
+instance HasField "foo_64_d" (Ptr Foo_64) (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"foo_64_d")
 {-| __C declaration:__ @struct bar_8_8@
 
@@ -444,15 +421,13 @@ instance HasCBitfield Bar_8_8 "bar_8_8_a"
     where type CBitfieldType Bar_8_8 "bar_8_8_a" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "bar_8_8_a" (Ptr Bar_8_8) (BitfieldPtr ty)
+instance HasField "bar_8_8_a" (Ptr Bar_8_8) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"bar_8_8_a")
 instance HasCBitfield Bar_8_8 "bar_8_8_b"
     where type CBitfieldType Bar_8_8 "bar_8_8_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_8_b" (Ptr Bar_8_8) (BitfieldPtr ty)
+instance HasField "bar_8_8_b" (Ptr Bar_8_8) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_8_8_b")
 {-| __C declaration:__ @struct bar_8_16@
 
@@ -490,15 +465,13 @@ instance HasCBitfield Bar_8_16 "bar_8_16_a"
     where type CBitfieldType Bar_8_16 "bar_8_16_a" = CInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_8_16_a" (Ptr Bar_8_16) (BitfieldPtr ty)
+instance HasField "bar_8_16_a" (Ptr Bar_8_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_8_16_a")
 instance HasCBitfield Bar_8_16 "bar_8_16_b"
     where type CBitfieldType Bar_8_16 "bar_8_16_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 14
           bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_16_b" (Ptr Bar_8_16) (BitfieldPtr ty)
+instance HasField "bar_8_16_b" (Ptr Bar_8_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_8_16_b")
 {-| __C declaration:__ @struct bar_8_32@
 
@@ -536,15 +509,13 @@ instance HasCBitfield Bar_8_32 "bar_8_32_a"
     where type CBitfieldType Bar_8_32 "bar_8_32_a" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_8_32_a" (Ptr Bar_8_32) (BitfieldPtr ty)
+instance HasField "bar_8_32_a" (Ptr Bar_8_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"bar_8_32_a")
 instance HasCBitfield Bar_8_32 "bar_8_32_b"
     where type CBitfieldType Bar_8_32 "bar_8_32_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 30
           bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_32_b" (Ptr Bar_8_32) (BitfieldPtr ty)
+instance HasField "bar_8_32_b" (Ptr Bar_8_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_8_32_b")
 {-| __C declaration:__ @struct bar_8_64@
 
@@ -582,15 +553,13 @@ instance HasCBitfield Bar_8_64 "bar_8_64_a"
     where type CBitfieldType Bar_8_64 "bar_8_64_a" = CLLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 62
-instance (~) ty CLLong =>
-         HasField "bar_8_64_a" (Ptr Bar_8_64) (BitfieldPtr ty)
+instance HasField "bar_8_64_a" (Ptr Bar_8_64) (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"bar_8_64_a")
 instance HasCBitfield Bar_8_64 "bar_8_64_b"
     where type CBitfieldType Bar_8_64 "bar_8_64_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 62
           bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_64_b" (Ptr Bar_8_64) (BitfieldPtr ty)
+instance HasField "bar_8_64_b" (Ptr Bar_8_64) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_8_64_b")
 {-| __C declaration:__ @struct bar_16_16@
 
@@ -628,15 +597,13 @@ instance HasCBitfield Bar_16_16 "bar_16_16_a"
     where type CBitfieldType Bar_16_16 "bar_16_16_a" = CInt
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_16_a" (Ptr Bar_16_16) (BitfieldPtr ty)
+instance HasField "bar_16_16_a" (Ptr Bar_16_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_16_16_a")
 instance HasCBitfield Bar_16_16 "bar_16_16_b"
     where type CBitfieldType Bar_16_16 "bar_16_16_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 14
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_16_b" (Ptr Bar_16_16) (BitfieldPtr ty)
+instance HasField "bar_16_16_b" (Ptr Bar_16_16) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_16_16_b")
 {-| __C declaration:__ @struct bar_16_32@
 
@@ -674,15 +641,13 @@ instance HasCBitfield Bar_16_32 "bar_16_32_a"
     where type CBitfieldType Bar_16_32 "bar_16_32_a" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "bar_16_32_a" (Ptr Bar_16_32) (BitfieldPtr ty)
+instance HasField "bar_16_32_a" (Ptr Bar_16_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"bar_16_32_a")
 instance HasCBitfield Bar_16_32 "bar_16_32_b"
     where type CBitfieldType Bar_16_32 "bar_16_32_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 24
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_32_b" (Ptr Bar_16_32) (BitfieldPtr ty)
+instance HasField "bar_16_32_b" (Ptr Bar_16_32) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_16_32_b")
 {-| __C declaration:__ @struct bar_16_64@
 
@@ -720,15 +685,15 @@ instance HasCBitfield Bar_16_64 "bar_16_64_a"
     where type CBitfieldType Bar_16_64 "bar_16_64_a" = CLLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_16_64_a" (Ptr Bar_16_64) (BitfieldPtr ty)
+instance HasField "bar_16_64_a"
+                  (Ptr Bar_16_64)
+                  (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"bar_16_64_a")
 instance HasCBitfield Bar_16_64 "bar_16_64_b"
     where type CBitfieldType Bar_16_64 "bar_16_64_b" = CInt
           bitfieldOffset# = \_ -> \_ -> 56
           bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_64_b" (Ptr Bar_16_64) (BitfieldPtr ty)
+instance HasField "bar_16_64_b" (Ptr Bar_16_64) (BitfieldPtr CInt)
     where getField = toPtr (Proxy @"bar_16_64_b")
 {-| __C declaration:__ @struct bar_32_32@
 
@@ -766,15 +731,13 @@ instance HasCBitfield Bar_32_32 "bar_32_32_a"
     where type CBitfieldType Bar_32_32 "bar_32_32_a" = CLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_32_32_a" (Ptr Bar_32_32) (BitfieldPtr ty)
+instance HasField "bar_32_32_a" (Ptr Bar_32_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"bar_32_32_a")
 instance HasCBitfield Bar_32_32 "bar_32_32_b"
     where type CBitfieldType Bar_32_32 "bar_32_32_b" = CLong
           bitfieldOffset# = \_ -> \_ -> 30
           bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_32_32_b" (Ptr Bar_32_32) (BitfieldPtr ty)
+instance HasField "bar_32_32_b" (Ptr Bar_32_32) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"bar_32_32_b")
 {-| __C declaration:__ @struct bar_32_64@
 
@@ -812,15 +775,15 @@ instance HasCBitfield Bar_32_64 "bar_32_64_a"
     where type CBitfieldType Bar_32_64 "bar_32_64_a" = CLLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_32_64_a" (Ptr Bar_32_64) (BitfieldPtr ty)
+instance HasField "bar_32_64_a"
+                  (Ptr Bar_32_64)
+                  (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"bar_32_64_a")
 instance HasCBitfield Bar_32_64 "bar_32_64_b"
     where type CBitfieldType Bar_32_64 "bar_32_64_b" = CLong
           bitfieldOffset# = \_ -> \_ -> 56
           bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_32_64_b" (Ptr Bar_32_64) (BitfieldPtr ty)
+instance HasField "bar_32_64_b" (Ptr Bar_32_64) (BitfieldPtr CLong)
     where getField = toPtr (Proxy @"bar_32_64_b")
 {-| __C declaration:__ @struct bar_64_64@
 
@@ -858,13 +821,15 @@ instance HasCBitfield Bar_64_64 "bar_64_64_a"
     where type CBitfieldType Bar_64_64 "bar_64_64_a" = CLLong
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_64_64_a" (Ptr Bar_64_64) (BitfieldPtr ty)
+instance HasField "bar_64_64_a"
+                  (Ptr Bar_64_64)
+                  (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"bar_64_64_a")
 instance HasCBitfield Bar_64_64 "bar_64_64_b"
     where type CBitfieldType Bar_64_64 "bar_64_64_b" = CLLong
           bitfieldOffset# = \_ -> \_ -> 56
           bitfieldWidth# = \_ -> \_ -> 40
-instance (~) ty CLLong =>
-         HasField "bar_64_64_b" (Ptr Bar_64_64) (BitfieldPtr ty)
+instance HasField "bar_64_64_b"
+                  (Ptr Bar_64_64)
+                  (BitfieldPtr CLLong)
     where getField = toPtr (Proxy @"bar_64_64_b")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -69,7 +67,7 @@ instance HasCField.HasCField B "b_toA" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.Ptr A) => RIP.HasField "b_toA" (RIP.Ptr B) (RIP.Ptr ty) where
+instance RIP.HasField "b_toA" (RIP.Ptr B) (RIP.Ptr (RIP.Ptr A)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b_toA")
 
@@ -120,6 +118,6 @@ instance HasCField.HasCField A "a_toB" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ B) => RIP.HasField "a_toB" (RIP.Ptr A) (RIP.Ptr ty) where
+instance RIP.HasField "a_toB" (RIP.Ptr A) (RIP.Ptr B) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a_toB")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -26,7 +26,7 @@ deriving via (EquivStorable B) instance Storable B
 instance HasCField B "b_toA"
     where type CFieldType B "b_toA" = Ptr A
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr A) => HasField "b_toA" (Ptr B) (Ptr ty)
+instance HasField "b_toA" (Ptr B) (Ptr (Ptr A))
     where getField = fromPtr (Proxy @"b_toA")
 {-| __C declaration:__ @struct a@
 
@@ -55,5 +55,5 @@ deriving via (EquivStorable A) instance Storable A
 instance HasCField A "a_toB"
     where type CFieldType A "a_toB" = B
           offset# = \_ -> \_ -> 0
-instance (~) ty B => HasField "a_toB" (Ptr A) (Ptr ty)
+instance HasField "a_toB" (Ptr A) (Ptr B)
     where getField = fromPtr (Proxy @"a_toB")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/padding/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/padding/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -90,8 +88,7 @@ instance HasCBitfield.HasCBitfield Foo "foo_a" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_a" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_a")
 
@@ -103,8 +100,7 @@ instance HasCBitfield.HasCBitfield Foo "foo_b" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_b" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_b" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_b")
 
@@ -116,8 +112,7 @@ instance HasCBitfield.HasCBitfield Foo "foo_c" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "foo_c" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"foo_c")
 
@@ -179,8 +174,7 @@ instance HasCBitfield.HasCBitfield Bar "bar_x" where
 
   bitfieldWidth# = \_ -> \_ -> 3
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_x" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"bar_x")
 
@@ -192,7 +186,6 @@ instance HasCBitfield.HasCBitfield Bar "bar_y" where
 
   bitfieldWidth# = \_ -> \_ -> 2
 
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_y" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
+instance RIP.HasField "bar_y" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr RIP.CSChar) where
 
   getField = HasCBitfield.toPtr (RIP.Proxy @"bar_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/padding/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/padding/th.txt
@@ -43,22 +43,19 @@ instance HasCBitfield Foo "foo_a"
     where type CBitfieldType Foo "foo_a" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_a" (Ptr Foo) (BitfieldPtr ty)
+instance HasField "foo_a" (Ptr Foo) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_a")
 instance HasCBitfield Foo "foo_b"
     where type CBitfieldType Foo "foo_b" = CSChar
           bitfieldOffset# = \_ -> \_ -> 3
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_b" (Ptr Foo) (BitfieldPtr ty)
+instance HasField "foo_b" (Ptr Foo) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_b")
 instance HasCBitfield Foo "foo_c"
     where type CBitfieldType Foo "foo_c" = CSChar
           bitfieldOffset# = \_ -> \_ -> 8
           bitfieldWidth# = \_ -> \_ -> 2
-instance (~) ty CSChar =>
-         HasField "foo_c" (Ptr Foo) (BitfieldPtr ty)
+instance HasField "foo_c" (Ptr Foo) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"foo_c")
 {-| __C declaration:__ @struct bar@
 
@@ -96,13 +93,11 @@ instance HasCBitfield Bar "bar_x"
     where type CBitfieldType Bar "bar_x" = CSChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "bar_x" (Ptr Bar) (BitfieldPtr ty)
+instance HasField "bar_x" (Ptr Bar) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"bar_x")
 instance HasCBitfield Bar "bar_y"
     where type CBitfieldType Bar "bar_y" = CSChar
           bitfieldOffset# = \_ -> \_ -> 6
           bitfieldWidth# = \_ -> \_ -> 2
-instance (~) ty CSChar =>
-         HasField "bar_y" (Ptr Bar) (BitfieldPtr ty)
+instance HasField "bar_y" (Ptr Bar) (BitfieldPtr CSChar)
     where getField = toPtr (Proxy @"bar_y")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -79,8 +77,7 @@ instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "linked_list_A_t_x" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
+instance RIP.HasField "linked_list_A_t_x" (RIP.Ptr Linked_list_A_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_x")
@@ -92,8 +89,7 @@ instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Linked_list_A_t
-         ) => RIP.HasField "linked_list_A_t_next" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
+instance RIP.HasField "linked_list_A_t_next" (RIP.Ptr Linked_list_A_t) (RIP.Ptr (RIP.Ptr Linked_list_A_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_next")
@@ -155,8 +151,7 @@ instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "linked_list_B_t_x" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
+instance RIP.HasField "linked_list_B_t_x" (RIP.Ptr Linked_list_B_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_x")
@@ -168,8 +163,7 @@ instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_next" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr Linked_list_B_t
-         ) => RIP.HasField "linked_list_B_t_next" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
+instance RIP.HasField "linked_list_B_t_next" (RIP.Ptr Linked_list_B_t) (RIP.Ptr (RIP.Ptr Linked_list_B_t)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/th.txt
@@ -34,15 +34,17 @@ deriving via (EquivStorable Linked_list_A_t) instance Storable Linked_list_A_t
 instance HasCField Linked_list_A_t "linked_list_A_t_x"
     where type CFieldType Linked_list_A_t "linked_list_A_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "linked_list_A_t_x" (Ptr Linked_list_A_t) (Ptr ty)
+instance HasField "linked_list_A_t_x"
+                  (Ptr Linked_list_A_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"linked_list_A_t_x")
 instance HasCField Linked_list_A_t "linked_list_A_t_next"
     where type CFieldType Linked_list_A_t
                           "linked_list_A_t_next" = Ptr Linked_list_A_t
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Linked_list_A_t) =>
-         HasField "linked_list_A_t_next" (Ptr Linked_list_A_t) (Ptr ty)
+instance HasField "linked_list_A_t_next"
+                  (Ptr Linked_list_A_t)
+                  (Ptr (Ptr Linked_list_A_t))
     where getField = fromPtr (Proxy @"linked_list_A_t_next")
 {-| __C declaration:__ @struct linked_list_B_t@
 
@@ -79,13 +81,15 @@ deriving via (EquivStorable Linked_list_B_t) instance Storable Linked_list_B_t
 instance HasCField Linked_list_B_t "linked_list_B_t_x"
     where type CFieldType Linked_list_B_t "linked_list_B_t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "linked_list_B_t_x" (Ptr Linked_list_B_t) (Ptr ty)
+instance HasField "linked_list_B_t_x"
+                  (Ptr Linked_list_B_t)
+                  (Ptr CInt)
     where getField = fromPtr (Proxy @"linked_list_B_t_x")
 instance HasCField Linked_list_B_t "linked_list_B_t_next"
     where type CFieldType Linked_list_B_t
                           "linked_list_B_t_next" = Ptr Linked_list_B_t
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Linked_list_B_t) =>
-         HasField "linked_list_B_t_next" (Ptr Linked_list_B_t) (Ptr ty)
+instance HasField "linked_list_B_t_next"
+                  (Ptr Linked_list_B_t)
+                  (Ptr (Ptr Linked_list_B_t))
     where getField = fromPtr (Proxy @"linked_list_B_t_next")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/Example.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -88,7 +86,7 @@ instance HasCField.HasCField S1 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -98,7 +96,7 @@ instance HasCField.HasCField S1 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S1) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -167,7 +165,7 @@ instance HasCField.HasCField S2_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S2_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -177,7 +175,7 @@ instance HasCField.HasCField S2_t "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S2_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -187,7 +185,7 @@ instance HasCField.HasCField S2_t "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance (ty ~ RIP.CFloat) => RIP.HasField "c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "c" (RIP.Ptr S2_t) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c")
 
@@ -238,7 +236,7 @@ instance HasCField.HasCField S3_t "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S3_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -307,7 +305,7 @@ instance HasCField.HasCField S4 "b" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S4) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -317,7 +315,7 @@ instance HasCField.HasCField S4 "a" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S4) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -327,8 +325,7 @@ instance HasCField.HasCField S4 "c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "c" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "c" (RIP.Ptr S4) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c")
 
@@ -388,7 +385,7 @@ instance HasCField.HasCField S5 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S5) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -398,7 +395,7 @@ instance HasCField.HasCField S5 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -458,7 +455,7 @@ instance HasCField.HasCField S6 "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S6) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -468,7 +465,7 @@ instance HasCField.HasCField S6 "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S6) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -528,8 +525,7 @@ instance HasCField.HasCField S7a_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -539,8 +535,7 @@ instance HasCField.HasCField S7a_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -562,8 +557,7 @@ newtype S7a = S7a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.HasField "unwrap" (RIP.Ptr S7a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr S7a) (RIP.Ptr (RIP.Ptr S7a_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 
@@ -629,8 +623,7 @@ instance HasCField.HasCField S7b_Aux "a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "a" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
@@ -640,8 +633,7 @@ instance HasCField.HasCField S7b_Aux "b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "b" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"b")
 
@@ -663,8 +655,7 @@ newtype S7b = S7b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.HasField "unwrap" (RIP.Ptr S7b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrap" (RIP.Ptr S7b) (RIP.Ptr (RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "a"
     where type CFieldType S1 "a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr S1) (Ptr ty)
+instance HasField "a" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S1 "b"
     where type CFieldType S1 "b" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "b" (Ptr S1) (Ptr ty)
+instance HasField "b" (Ptr S1) (Ptr CChar)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S2@
 
@@ -84,17 +84,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "a"
     where type CFieldType S2_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S2_t) (Ptr ty)
+instance HasField "a" (Ptr S2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S2_t "b"
     where type CFieldType S2_t "b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S2_t) (Ptr ty)
+instance HasField "b" (Ptr S2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S2_t "c"
     where type CFieldType S2_t "c" = CFloat
           offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "c" (Ptr S2_t) (Ptr ty)
+instance HasField "c" (Ptr S2_t) (Ptr CFloat)
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -123,7 +123,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "a"
     where type CFieldType S3_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S3_t) (Ptr ty)
+instance HasField "a" (Ptr S3_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 {-| __C declaration:__ @struct S4@
 
@@ -168,17 +168,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "b"
     where type CFieldType S4 "b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "b" (Ptr S4) (Ptr ty)
+instance HasField "b" (Ptr S4) (Ptr CChar)
     where getField = fromPtr (Proxy @"b")
 instance HasCField S4 "a"
     where type CFieldType S4 "a" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "a" (Ptr S4) (Ptr ty)
+instance HasField "a" (Ptr S4) (Ptr CInt)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S4 "c"
     where type CFieldType S4 "c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "c" (Ptr S4) (Ptr ty)
+instance HasField "c" (Ptr S4) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct S5@
 
@@ -215,12 +215,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "a"
     where type CFieldType S5 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S5) (Ptr ty)
+instance HasField "a" (Ptr S5) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S5 "b"
     where type CFieldType S5 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S5) (Ptr ty)
+instance HasField "b" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct S6@
 
@@ -257,12 +257,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "a"
     where type CFieldType S6 "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S6) (Ptr ty)
+instance HasField "a" (Ptr S6) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S6 "b"
     where type CFieldType S6 "b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S6) (Ptr ty)
+instance HasField "b" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -299,12 +299,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "a"
     where type CFieldType S7a_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "a" (Ptr S7a_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7a_Aux "b"
     where type CFieldType S7a_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "b" (Ptr S7a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7a@
 
@@ -320,8 +320,7 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr S7a_Aux) =>
-         HasField "unwrap" (Ptr S7a) (Ptr ty)
+instance HasField "unwrap" (Ptr S7a) (Ptr (Ptr S7a_Aux))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7a "unwrap"
     where type CFieldType S7a "unwrap" = Ptr S7a_Aux
@@ -361,12 +360,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "a"
     where type CFieldType S7b_Aux "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "a" (Ptr S7b_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"a")
 instance HasCField S7b_Aux "b"
     where type CFieldType S7b_Aux "b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "b" (Ptr S7b_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"b")
 {-| __C declaration:__ @S7b@
 
@@ -382,8 +381,9 @@ newtype S7b
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrap" (Ptr S7b) (Ptr ty)
+instance HasField "unwrap"
+                  (Ptr S7b)
+                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7b "unwrap"
     where type CFieldType S7b "unwrap" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ImportQualifiedPost #-}
@@ -11,7 +10,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -88,7 +86,7 @@ instance HasCField.HasCField S1 "s1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
 
@@ -98,7 +96,7 @@ instance HasCField.HasCField S1 "s1_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
 
@@ -167,8 +165,7 @@ instance HasCField.HasCField S2_t "s2_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
 
@@ -178,8 +175,7 @@ instance HasCField.HasCField S2_t "s2_t_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
 
@@ -189,8 +185,7 @@ instance HasCField.HasCField S2_t "s2_t_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
 
@@ -241,8 +236,7 @@ instance HasCField.HasCField S3_t "s3_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
+instance RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
 
@@ -311,7 +305,7 @@ instance HasCField.HasCField S4 "s4_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
 
@@ -321,7 +315,7 @@ instance HasCField.HasCField S4 "s4_a" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
 
@@ -331,8 +325,7 @@ instance HasCField.HasCField S4 "s4_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
 
@@ -392,7 +385,7 @@ instance HasCField.HasCField S5 "s5_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
 
@@ -402,7 +395,7 @@ instance HasCField.HasCField S5 "s5_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
 
@@ -462,7 +455,7 @@ instance HasCField.HasCField S6 "s6_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
 
@@ -472,7 +465,7 @@ instance HasCField.HasCField S6 "s6_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
 
@@ -532,8 +525,7 @@ instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
 
@@ -543,8 +535,7 @@ instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
 
@@ -566,8 +557,7 @@ newtype S7a = S7a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr (RIP.Ptr S7a_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7a")
 
@@ -633,8 +623,7 @@ instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
 
@@ -644,8 +633,7 @@ instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
 
@@ -667,8 +655,7 @@ newtype S7b = S7b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr (RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7b")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_a"
     where type CFieldType S1 "s1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
+instance HasField "s1_a" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_a")
 instance HasCField S1 "s1_b"
     where type CFieldType S1 "s1_b" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
+instance HasField "s1_b" (Ptr S1) (Ptr CChar)
     where getField = fromPtr (Proxy @"s1_b")
 {-| __C declaration:__ @struct S2@
 
@@ -84,17 +84,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "s2_t_a"
     where type CFieldType S2_t "s2_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_a" (Ptr S2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s2_t_a")
 instance HasCField S2_t "s2_t_b"
     where type CFieldType S2_t "s2_t_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_b" (Ptr S2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_t_b")
 instance HasCField S2_t "s2_t_c"
     where type CFieldType S2_t "s2_t_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_c" (Ptr S2_t) (Ptr CFloat)
     where getField = fromPtr (Proxy @"s2_t_c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -123,7 +123,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "s3_t_a"
     where type CFieldType S3_t "s3_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
+instance HasField "s3_t_a" (Ptr S3_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s3_t_a")
 {-| __C declaration:__ @struct S4@
 
@@ -168,17 +168,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "s4_b"
     where type CFieldType S4 "s4_b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
+instance HasField "s4_b" (Ptr S4) (Ptr CChar)
     where getField = fromPtr (Proxy @"s4_b")
 instance HasCField S4 "s4_a"
     where type CFieldType S4 "s4_a" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
+instance HasField "s4_a" (Ptr S4) (Ptr CInt)
     where getField = fromPtr (Proxy @"s4_a")
 instance HasCField S4 "s4_c"
     where type CFieldType S4 "s4_c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
+instance HasField "s4_c" (Ptr S4) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"s4_c")
 {-| __C declaration:__ @struct S5@
 
@@ -215,12 +215,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "s5_a"
     where type CFieldType S5 "s5_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
+instance HasField "s5_a" (Ptr S5) (Ptr CChar)
     where getField = fromPtr (Proxy @"s5_a")
 instance HasCField S5 "s5_b"
     where type CFieldType S5 "s5_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
+instance HasField "s5_b" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"s5_b")
 {-| __C declaration:__ @struct S6@
 
@@ -257,12 +257,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "s6_a"
     where type CFieldType S6 "s6_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
+instance HasField "s6_a" (Ptr S6) (Ptr CChar)
     where getField = fromPtr (Proxy @"s6_a")
 instance HasCField S6 "s6_b"
     where type CFieldType S6 "s6_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
+instance HasField "s6_b" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"s6_b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -299,13 +299,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "s7a_Aux_a"
     where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance HasCField S7a_Aux "s7a_Aux_b"
     where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7a_Aux_b")
 {-| __C declaration:__ @S7a@
 
@@ -321,8 +320,7 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr S7a_Aux) =>
-         HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
+instance HasField "unwrapS7a" (Ptr S7a) (Ptr (Ptr S7a_Aux))
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
@@ -362,13 +360,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "s7b_Aux_a"
     where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance HasCField S7b_Aux "s7b_Aux_b"
     where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7b_Aux_b")
 {-| __C declaration:__ @S7b@
 
@@ -384,8 +381,9 @@ newtype S7b
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
+instance HasField "unwrapS7b"
+                  (Ptr S7b)
+                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -87,7 +85,7 @@ instance HasCField.HasCField S1 "s1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
 
@@ -97,7 +95,7 @@ instance HasCField.HasCField S1 "s1_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+instance RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
 
@@ -166,8 +164,7 @@ instance HasCField.HasCField S2_t "s2_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
 
@@ -177,8 +174,7 @@ instance HasCField.HasCField S2_t "s2_t_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
 
@@ -188,8 +184,7 @@ instance HasCField.HasCField S2_t "s2_t_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+instance RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr RIP.CFloat) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
 
@@ -240,8 +235,7 @@ instance HasCField.HasCField S3_t "s3_t_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
+instance RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
 
@@ -310,7 +304,7 @@ instance HasCField.HasCField S4 "s4_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
 
@@ -320,7 +314,7 @@ instance HasCField.HasCField S4 "s4_a" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
 
@@ -330,8 +324,7 @@ instance HasCField.HasCField S4 "s4_c" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+instance RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
 
@@ -391,7 +384,7 @@ instance HasCField.HasCField S5 "s5_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
 
@@ -401,7 +394,7 @@ instance HasCField.HasCField S5 "s5_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+instance RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
 
@@ -461,7 +454,7 @@ instance HasCField.HasCField S6 "s6_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
 
@@ -471,7 +464,7 @@ instance HasCField.HasCField S6 "s6_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+instance RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
 
@@ -531,8 +524,7 @@ instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
 
@@ -542,8 +534,7 @@ instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
 
@@ -565,8 +556,7 @@ newtype S7a = S7a
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr (RIP.Ptr S7a_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7a")
 
@@ -632,8 +622,7 @@ instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
 
@@ -643,8 +632,7 @@ instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
 
@@ -666,8 +654,7 @@ newtype S7b = S7b
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr (RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7b")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable S1) instance Storable S1
 instance HasCField S1 "s1_a"
     where type CFieldType S1 "s1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
+instance HasField "s1_a" (Ptr S1) (Ptr CInt)
     where getField = fromPtr (Proxy @"s1_a")
 instance HasCField S1 "s1_b"
     where type CFieldType S1 "s1_b" = CChar
           offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
+instance HasField "s1_b" (Ptr S1) (Ptr CChar)
     where getField = fromPtr (Proxy @"s1_b")
 {-| __C declaration:__ @struct S2@
 
@@ -84,17 +84,17 @@ deriving via (EquivStorable S2_t) instance Storable S2_t
 instance HasCField S2_t "s2_t_a"
     where type CFieldType S2_t "s2_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_a" (Ptr S2_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s2_t_a")
 instance HasCField S2_t "s2_t_b"
     where type CFieldType S2_t "s2_t_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_b" (Ptr S2_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"s2_t_b")
 instance HasCField S2_t "s2_t_c"
     where type CFieldType S2_t "s2_t_c" = CFloat
           offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
+instance HasField "s2_t_c" (Ptr S2_t) (Ptr CFloat)
     where getField = fromPtr (Proxy @"s2_t_c")
 {-| __C declaration:__ @struct S3_t@
 
@@ -123,7 +123,7 @@ deriving via (EquivStorable S3_t) instance Storable S3_t
 instance HasCField S3_t "s3_t_a"
     where type CFieldType S3_t "s3_t_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
+instance HasField "s3_t_a" (Ptr S3_t) (Ptr CChar)
     where getField = fromPtr (Proxy @"s3_t_a")
 {-| __C declaration:__ @struct S4@
 
@@ -168,17 +168,17 @@ deriving via (EquivStorable S4) instance Storable S4
 instance HasCField S4 "s4_b"
     where type CFieldType S4 "s4_b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
+instance HasField "s4_b" (Ptr S4) (Ptr CChar)
     where getField = fromPtr (Proxy @"s4_b")
 instance HasCField S4 "s4_a"
     where type CFieldType S4 "s4_a" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
+instance HasField "s4_a" (Ptr S4) (Ptr CInt)
     where getField = fromPtr (Proxy @"s4_a")
 instance HasCField S4 "s4_c"
     where type CFieldType S4 "s4_c" = Ptr CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
+instance HasField "s4_c" (Ptr S4) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"s4_c")
 {-| __C declaration:__ @struct S5@
 
@@ -215,12 +215,12 @@ deriving via (EquivStorable S5) instance Storable S5
 instance HasCField S5 "s5_a"
     where type CFieldType S5 "s5_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
+instance HasField "s5_a" (Ptr S5) (Ptr CChar)
     where getField = fromPtr (Proxy @"s5_a")
 instance HasCField S5 "s5_b"
     where type CFieldType S5 "s5_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
+instance HasField "s5_b" (Ptr S5) (Ptr CInt)
     where getField = fromPtr (Proxy @"s5_b")
 {-| __C declaration:__ @struct S6@
 
@@ -257,12 +257,12 @@ deriving via (EquivStorable S6) instance Storable S6
 instance HasCField S6 "s6_a"
     where type CFieldType S6 "s6_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
+instance HasField "s6_a" (Ptr S6) (Ptr CChar)
     where getField = fromPtr (Proxy @"s6_a")
 instance HasCField S6 "s6_b"
     where type CFieldType S6 "s6_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
+instance HasField "s6_b" (Ptr S6) (Ptr CInt)
     where getField = fromPtr (Proxy @"s6_b")
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -299,13 +299,12 @@ deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
 instance HasCField S7a_Aux "s7a_Aux_a"
     where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance HasCField S7a_Aux "s7a_Aux_b"
     where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+instance HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7a_Aux_b")
 {-| __C declaration:__ @S7a@
 
@@ -321,8 +320,7 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr S7a_Aux) =>
-         HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
+instance HasField "unwrapS7a" (Ptr S7a) (Ptr (Ptr S7a_Aux))
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
@@ -362,13 +360,12 @@ deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
 instance HasCField S7b_Aux "s7b_Aux_a"
     where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr CChar)
     where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance HasCField S7b_Aux "s7b_Aux_b"
     where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+instance HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr CInt)
     where getField = fromPtr (Proxy @"s7b_Aux_b")
 {-| __C declaration:__ @S7b@
 
@@ -384,8 +381,9 @@ newtype S7b
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
+instance HasField "unwrapS7b"
+                  (Ptr S7b)
+                  (Ptr (Ptr (Ptr (Ptr S7b_Aux))))
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -68,7 +66,6 @@ instance HasCField.HasCField Thing "thing_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "thing_x" (RIP.Ptr Thing) (RIP.Ptr ty) where
+instance RIP.HasField "thing_x" (RIP.Ptr Thing) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"thing_x")

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/th.txt
@@ -123,7 +123,7 @@ deriving via (EquivStorable Thing) instance Storable Thing
 instance HasCField Thing "thing_x"
     where type CFieldType Thing "thing_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "thing_x" (Ptr Thing) (Ptr ty)
+instance HasField "thing_x" (Ptr Thing) (Ptr CInt)
     where getField = fromPtr (Proxy @"thing_x")
 -- __unique:__ @test_typesstructsstruct_arg_Example_Safe_thing_fun_1@
 foreign import ccall safe "hs_bindgen_4ad25504590fdd2b" hs_bindgen_4ad25504590fdd2b_base ::

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/multi_level_function_pointer/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -81,8 +79,7 @@ instance RIP.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr (RIP.CInt -> RIP.CInt -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF1_Aux")
@@ -112,8 +109,7 @@ newtype F1 = F1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr F1_Aux
-         ) => RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr (RIP.FunPtr F1_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF1")
 
@@ -171,8 +167,7 @@ instance RIP.FromFunPtr F2_Aux where
 
   fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.HasField "unwrapF2_Aux" (RIP.Ptr F2_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF2_Aux" (RIP.Ptr F2_Aux) (RIP.Ptr (RIP.CInt -> RIP.CInt -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF2_Aux")
@@ -202,8 +197,7 @@ newtype F2 = F2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F2_Aux)
-         ) => RIP.HasField "unwrapF2" (RIP.Ptr F2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF2" (RIP.Ptr F2) (RIP.Ptr (RIP.Ptr (RIP.FunPtr F2_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF2")
 
@@ -262,8 +256,7 @@ instance RIP.FromFunPtr F3_Aux where
 
   fromFunPtr = hs_bindgen_66460422a7197535
 
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.HasField "unwrapF3_Aux" (RIP.Ptr F3_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF3_Aux" (RIP.Ptr F3_Aux) (RIP.Ptr (RIP.CInt -> RIP.CInt -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF3_Aux")
@@ -293,8 +286,7 @@ newtype F3 = F3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux))
-         ) => RIP.HasField "unwrapF3" (RIP.Ptr F3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF3" (RIP.Ptr F3) (RIP.Ptr (RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux)))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF3")
 
@@ -353,8 +345,7 @@ instance RIP.FromFunPtr F4_Aux where
 
   fromFunPtr = hs_bindgen_40f9a8d432b9eb97
 
-instance ( ty ~ IO RIP.CInt
-         ) => RIP.HasField "unwrapF4_Aux" (RIP.Ptr F4_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF4_Aux" (RIP.Ptr F4_Aux) (RIP.Ptr (IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF4_Aux")
@@ -383,8 +374,7 @@ newtype F4 = F4
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F4_Aux)
-         ) => RIP.HasField "unwrapF4" (RIP.Ptr F4) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF4" (RIP.Ptr F4) (RIP.Ptr (RIP.Ptr (RIP.FunPtr F4_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF4")
 
@@ -443,8 +433,7 @@ instance RIP.FromFunPtr F5_Aux where
 
   fromFunPtr = hs_bindgen_586f6635c057975f
 
-instance ( ty ~ IO ()
-         ) => RIP.HasField "unwrapF5_Aux" (RIP.Ptr F5_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF5_Aux" (RIP.Ptr F5_Aux) (RIP.Ptr (IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF5_Aux")
@@ -473,8 +462,7 @@ newtype F5 = F5
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F5_Aux)
-         ) => RIP.HasField "unwrapF5" (RIP.Ptr F5) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF5" (RIP.Ptr F5) (RIP.Ptr (RIP.Ptr (RIP.FunPtr F5_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF5")
 
@@ -513,8 +501,7 @@ newtype MyInt = MyInt
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyInt")
@@ -573,8 +560,7 @@ instance RIP.FromFunPtr F6_Aux where
 
   fromFunPtr = hs_bindgen_a887947b26e58f0c
 
-instance ( ty ~ (MyInt -> IO ())
-         ) => RIP.HasField "unwrapF6_Aux" (RIP.Ptr F6_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF6_Aux" (RIP.Ptr F6_Aux) (RIP.Ptr (MyInt -> IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF6_Aux")
@@ -604,8 +590,7 @@ newtype F6 = F6
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F6_Aux)
-         ) => RIP.HasField "unwrapF6" (RIP.Ptr F6) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF6" (RIP.Ptr F6) (RIP.Ptr (RIP.Ptr (RIP.FunPtr F6_Aux))) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF6")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/multi_level_function_pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/multi_level_function_pointer/th.txt
@@ -33,8 +33,9 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
+instance HasField "unwrapF1_Aux"
+                  (Ptr F1_Aux)
+                  (Ptr (CInt -> CInt -> IO ()))
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = CInt -> CInt -> IO ()
@@ -53,8 +54,7 @@ newtype F1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr F1_Aux) =>
-         HasField "unwrapF1" (Ptr F1) (Ptr ty)
+instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -93,8 +93,9 @@ instance ToFunPtr F2_Aux
     where toFunPtr = hs_bindgen_c39d7524b75b54e8
 instance FromFunPtr F2_Aux
     where fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF2_Aux" (Ptr F2_Aux) (Ptr ty)
+instance HasField "unwrapF2_Aux"
+                  (Ptr F2_Aux)
+                  (Ptr (CInt -> CInt -> IO ()))
     where getField = fromPtr (Proxy @"unwrapF2_Aux")
 instance HasCField F2_Aux "unwrapF2_Aux"
     where type CFieldType F2_Aux "unwrapF2_Aux" = CInt -> CInt -> IO ()
@@ -113,8 +114,7 @@ newtype F2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (FunPtr F2_Aux)) =>
-         HasField "unwrapF2" (Ptr F2) (Ptr ty)
+instance HasField "unwrapF2" (Ptr F2) (Ptr (Ptr (FunPtr F2_Aux)))
     where getField = fromPtr (Proxy @"unwrapF2")
 instance HasCField F2 "unwrapF2"
     where type CFieldType F2 "unwrapF2" = Ptr (FunPtr F2_Aux)
@@ -153,8 +153,9 @@ instance ToFunPtr F3_Aux
     where toFunPtr = hs_bindgen_4a960721e7d1dcef
 instance FromFunPtr F3_Aux
     where fromFunPtr = hs_bindgen_66460422a7197535
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF3_Aux" (Ptr F3_Aux) (Ptr ty)
+instance HasField "unwrapF3_Aux"
+                  (Ptr F3_Aux)
+                  (Ptr (CInt -> CInt -> IO ()))
     where getField = fromPtr (Proxy @"unwrapF3_Aux")
 instance HasCField F3_Aux "unwrapF3_Aux"
     where type CFieldType F3_Aux "unwrapF3_Aux" = CInt -> CInt -> IO ()
@@ -173,8 +174,9 @@ newtype F3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (Ptr (FunPtr F3_Aux))) =>
-         HasField "unwrapF3" (Ptr F3) (Ptr ty)
+instance HasField "unwrapF3"
+                  (Ptr F3)
+                  (Ptr (Ptr (Ptr (FunPtr F3_Aux))))
     where getField = fromPtr (Proxy @"unwrapF3")
 instance HasCField F3 "unwrapF3"
     where type CFieldType F3 "unwrapF3" = Ptr (Ptr (FunPtr F3_Aux))
@@ -211,8 +213,7 @@ instance ToFunPtr F4_Aux
     where toFunPtr = hs_bindgen_83bcff023b3bc648
 instance FromFunPtr F4_Aux
     where fromFunPtr = hs_bindgen_40f9a8d432b9eb97
-instance (~) ty (IO CInt) =>
-         HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr ty)
+instance HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr (IO CInt))
     where getField = fromPtr (Proxy @"unwrapF4_Aux")
 instance HasCField F4_Aux "unwrapF4_Aux"
     where type CFieldType F4_Aux "unwrapF4_Aux" = IO CInt
@@ -231,8 +232,7 @@ newtype F4
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (FunPtr F4_Aux)) =>
-         HasField "unwrapF4" (Ptr F4) (Ptr ty)
+instance HasField "unwrapF4" (Ptr F4) (Ptr (Ptr (FunPtr F4_Aux)))
     where getField = fromPtr (Proxy @"unwrapF4")
 instance HasCField F4 "unwrapF4"
     where type CFieldType F4 "unwrapF4" = Ptr (FunPtr F4_Aux)
@@ -269,8 +269,7 @@ instance ToFunPtr F5_Aux
     where toFunPtr = hs_bindgen_6891cbd81d6f42b9
 instance FromFunPtr F5_Aux
     where fromFunPtr = hs_bindgen_586f6635c057975f
-instance (~) ty (IO ()) =>
-         HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr ty)
+instance HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapF5_Aux")
 instance HasCField F5_Aux "unwrapF5_Aux"
     where type CFieldType F5_Aux "unwrapF5_Aux" = IO ()
@@ -289,8 +288,7 @@ newtype F5
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (FunPtr F5_Aux)) =>
-         HasField "unwrapF5" (Ptr F5) (Ptr ty)
+instance HasField "unwrapF5" (Ptr F5) (Ptr (Ptr (FunPtr F5_Aux)))
     where getField = fromPtr (Proxy @"unwrapF5")
 instance HasCField F5 "unwrapF5"
     where type CFieldType F5 "unwrapF5" = Ptr (FunPtr F5_Aux)
@@ -319,7 +317,7 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
+instance HasField "unwrapMyInt" (Ptr MyInt) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
@@ -357,8 +355,9 @@ instance ToFunPtr F6_Aux
     where toFunPtr = hs_bindgen_c1baf73f98614f45
 instance FromFunPtr F6_Aux
     where fromFunPtr = hs_bindgen_a887947b26e58f0c
-instance (~) ty (MyInt -> IO ()) =>
-         HasField "unwrapF6_Aux" (Ptr F6_Aux) (Ptr ty)
+instance HasField "unwrapF6_Aux"
+                  (Ptr F6_Aux)
+                  (Ptr (MyInt -> IO ()))
     where getField = fromPtr (Proxy @"unwrapF6_Aux")
 instance HasCField F6_Aux "unwrapF6_Aux"
     where type CFieldType F6_Aux "unwrapF6_Aux" = MyInt -> IO ()
@@ -377,8 +376,7 @@ newtype F6
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr (FunPtr F6_Aux)) =>
-         HasField "unwrapF6" (Ptr F6) (Ptr ty)
+instance HasField "unwrapF6" (Ptr F6) (Ptr (Ptr (FunPtr F6_Aux)))
     where getField = fromPtr (Proxy @"unwrapF6")
 instance HasCField F6 "unwrapF6"
     where type CFieldType F6 "unwrapF6" = Ptr (FunPtr F6_Aux)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
@@ -10,7 +9,6 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -58,8 +56,7 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT1")
 
@@ -97,8 +94,7 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
 
@@ -136,8 +132,7 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM1")
 
@@ -175,8 +170,7 @@ newtype M2 = M2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM2")
 
@@ -204,8 +198,7 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
 
@@ -293,8 +286,7 @@ instance HasCField.HasCField ExampleStruct "exampleStruct_t1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ T1
-         ) => RIP.HasField "exampleStruct_t1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance RIP.HasField "exampleStruct_t1" (RIP.Ptr ExampleStruct) (RIP.Ptr T1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exampleStruct_t1")
@@ -305,8 +297,7 @@ instance HasCField.HasCField ExampleStruct "exampleStruct_t2" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ T2
-         ) => RIP.HasField "exampleStruct_t2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance RIP.HasField "exampleStruct_t2" (RIP.Ptr ExampleStruct) (RIP.Ptr T2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exampleStruct_t2")
@@ -317,8 +308,7 @@ instance HasCField.HasCField ExampleStruct "exampleStruct_m1" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ M1
-         ) => RIP.HasField "exampleStruct_m1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance RIP.HasField "exampleStruct_m1" (RIP.Ptr ExampleStruct) (RIP.Ptr M1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exampleStruct_m1")
@@ -329,8 +319,7 @@ instance HasCField.HasCField ExampleStruct "exampleStruct_m2" where
 
   offset# = \_ -> \_ -> 12
 
-instance ( ty ~ M2
-         ) => RIP.HasField "exampleStruct_m2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance RIP.HasField "exampleStruct_m2" (RIP.Ptr ExampleStruct) (RIP.Ptr M2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exampleStruct_m2")
@@ -363,8 +352,7 @@ newtype Uint64_t = Uint64_t
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapUint64_t" (RIP.Ptr Uint64_t) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapUint64_t" (RIP.Ptr Uint64_t) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapUint64_t")
@@ -422,7 +410,6 @@ instance HasCField.HasCField Foo "foo_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.Ptr Uint64_t
-         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance RIP.HasField "foo_a" (RIP.Ptr Foo) (RIP.Ptr (RIP.Ptr Uint64_t)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"foo_a")

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -23,7 +23,7 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
+instance HasField "unwrapT1" (Ptr T1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
@@ -52,7 +52,7 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapT2" (Ptr T2) (Ptr ty)
+instance HasField "unwrapT2" (Ptr T2) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CChar
@@ -81,7 +81,7 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
+instance HasField "unwrapM1" (Ptr M1) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
@@ -110,7 +110,7 @@ newtype M2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CChar => HasField "unwrapM2" (Ptr M2) (Ptr ty)
+instance HasField "unwrapM2" (Ptr M2) (Ptr CChar)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = CChar
@@ -129,7 +129,7 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) => HasField "unwrapM3" (Ptr M3) (Ptr ty)
+instance HasField "unwrapM3" (Ptr M3) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = Ptr CInt
@@ -185,26 +185,22 @@ deriving via (EquivStorable ExampleStruct) instance Storable ExampleStruct
 instance HasCField ExampleStruct "exampleStruct_t1"
     where type CFieldType ExampleStruct "exampleStruct_t1" = T1
           offset# = \_ -> \_ -> 0
-instance (~) ty T1 =>
-         HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr T1)
     where getField = fromPtr (Proxy @"exampleStruct_t1")
 instance HasCField ExampleStruct "exampleStruct_t2"
     where type CFieldType ExampleStruct "exampleStruct_t2" = T2
           offset# = \_ -> \_ -> 4
-instance (~) ty T2 =>
-         HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr T2)
     where getField = fromPtr (Proxy @"exampleStruct_t2")
 instance HasCField ExampleStruct "exampleStruct_m1"
     where type CFieldType ExampleStruct "exampleStruct_m1" = M1
           offset# = \_ -> \_ -> 8
-instance (~) ty M1 =>
-         HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr M1)
     where getField = fromPtr (Proxy @"exampleStruct_m1")
 instance HasCField ExampleStruct "exampleStruct_m2"
     where type CFieldType ExampleStruct "exampleStruct_m2" = M2
           offset# = \_ -> \_ -> 12
-instance (~) ty M2 =>
-         HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr ty)
+instance HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr M2)
     where getField = fromPtr (Proxy @"exampleStruct_m2")
 {-| __C declaration:__ @macro uint64_t@
 
@@ -230,8 +226,7 @@ newtype Uint64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt =>
-         HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr ty)
+instance HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapUint64_t")
 instance HasCField Uint64_t "unwrapUint64_t"
     where type CFieldType Uint64_t "unwrapUint64_t" = CInt
@@ -263,6 +258,5 @@ deriving via (EquivStorable Foo) instance Storable Foo
 instance HasCField Foo "foo_a"
     where type CFieldType Foo "foo_a" = Ptr Uint64_t
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Uint64_t) =>
-         HasField "foo_a" (Ptr Foo) (Ptr ty)
+instance HasField "foo_a" (Ptr Foo) (Ptr (Ptr Uint64_t))
     where getField = fromPtr (Proxy @"foo_a")

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/Example.hs
@@ -1,14 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UnboxedTuples #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -61,8 +59,7 @@ newtype Myint = Myint
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapMyint" (RIP.Ptr Myint) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapMyint" (RIP.Ptr Myint) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapMyint")
@@ -91,8 +88,7 @@ newtype Intptr = Intptr
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "unwrapIntptr" (RIP.Ptr Intptr) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapIntptr" (RIP.Ptr Intptr) (RIP.Ptr (RIP.Ptr RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapIntptr")
@@ -150,8 +146,7 @@ instance RIP.FromFunPtr Int2int where
 
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapInt2int" (RIP.Ptr Int2int) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapInt2int" (RIP.Ptr Int2int) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapInt2int")
@@ -211,8 +206,7 @@ instance RIP.FromFunPtr FunctionPointer_Function_Aux where
 
   fromFunPtr = hs_bindgen_4c3da8240a31e036
 
-instance ( ty ~ IO ()
-         ) => RIP.HasField "unwrapFunctionPointer_Function_Aux" (RIP.Ptr FunctionPointer_Function_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunctionPointer_Function_Aux" (RIP.Ptr FunctionPointer_Function_Aux) (RIP.Ptr (IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunctionPointer_Function_Aux")
@@ -242,8 +236,7 @@ newtype FunctionPointer_Function = FunctionPointer_Function
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr FunctionPointer_Function_Aux
-         ) => RIP.HasField "unwrapFunctionPointer_Function" (RIP.Ptr FunctionPointer_Function) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapFunctionPointer_Function" (RIP.Ptr FunctionPointer_Function) (RIP.Ptr (RIP.FunPtr FunctionPointer_Function_Aux)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapFunctionPointer_Function")
@@ -301,8 +294,7 @@ instance RIP.FromFunPtr NonFunctionPointer_Function where
 
   fromFunPtr = hs_bindgen_36c7108d046bcbc3
 
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "unwrapNonFunctionPointer_Function" (RIP.Ptr NonFunctionPointer_Function) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapNonFunctionPointer_Function" (RIP.Ptr NonFunctionPointer_Function) (RIP.Ptr (RIP.CInt -> IO RIP.CInt)) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapNonFunctionPointer_Function")
@@ -362,8 +354,7 @@ instance RIP.FromFunPtr F1_Aux where
 
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
-instance ( ty ~ IO ()
-         ) => RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr (IO ())) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"unwrapF1_Aux")
@@ -392,8 +383,7 @@ newtype F1 = F1
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr F1_Aux
-         ) => RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr (RIP.FunPtr F1_Aux)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF1")
 
@@ -449,7 +439,7 @@ instance RIP.FromFunPtr G1 where
 
   fromFunPtr = hs_bindgen_8405c8e75aa78be5
 
-instance (ty ~ IO ()) => RIP.HasField "unwrapG1" (RIP.Ptr G1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapG1" (RIP.Ptr G1) (RIP.Ptr (IO ())) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapG1")
 
@@ -477,8 +467,7 @@ newtype G2 = G2
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr G1
-         ) => RIP.HasField "unwrapG2" (RIP.Ptr G2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapG2" (RIP.Ptr G2) (RIP.Ptr (RIP.FunPtr G1)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapG2")
 
@@ -534,7 +523,7 @@ instance RIP.FromFunPtr H1 where
 
   fromFunPtr = hs_bindgen_1a33688324e1924f
 
-instance (ty ~ IO ()) => RIP.HasField "unwrapH1" (RIP.Ptr H1) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapH1" (RIP.Ptr H1) (RIP.Ptr (IO ())) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH1")
 
@@ -556,7 +545,7 @@ newtype H2 = H2
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
-instance (ty ~ H1) => RIP.HasField "unwrapH2" (RIP.Ptr H2) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapH2" (RIP.Ptr H2) (RIP.Ptr H1) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH2")
 
@@ -584,8 +573,7 @@ newtype H3 = H3
     , Marshal.WriteRaw
     )
 
-instance ( ty ~ RIP.FunPtr H2
-         ) => RIP.HasField "unwrapH3" (RIP.Ptr H3) (RIP.Ptr ty) where
+instance RIP.HasField "unwrapH3" (RIP.Ptr H3) (RIP.Ptr (RIP.FunPtr H2)) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH3")
 

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/th.txt
@@ -23,7 +23,7 @@ newtype Myint
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty CInt => HasField "unwrapMyint" (Ptr Myint) (Ptr ty)
+instance HasField "unwrapMyint" (Ptr Myint) (Ptr CInt)
     where getField = fromPtr (Proxy @"unwrapMyint")
 instance HasCField Myint "unwrapMyint"
     where type CFieldType Myint "unwrapMyint" = CInt
@@ -42,8 +42,7 @@ newtype Intptr
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrapIntptr" (Ptr Intptr) (Ptr ty)
+instance HasField "unwrapIntptr" (Ptr Intptr) (Ptr (Ptr CInt))
     where getField = fromPtr (Proxy @"unwrapIntptr")
 instance HasCField Intptr "unwrapIntptr"
     where type CFieldType Intptr "unwrapIntptr" = Ptr CInt
@@ -79,8 +78,9 @@ instance ToFunPtr Int2int
     where toFunPtr = hs_bindgen_a6c7dd49f5b9d470
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
+instance HasField "unwrapInt2int"
+                  (Ptr Int2int)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
@@ -119,10 +119,9 @@ instance ToFunPtr FunctionPointer_Function_Aux
     where toFunPtr = hs_bindgen_b171c028cdc0781d
 instance FromFunPtr FunctionPointer_Function_Aux
     where fromFunPtr = hs_bindgen_4c3da8240a31e036
-instance (~) ty (IO ()) =>
-         HasField "unwrapFunctionPointer_Function_Aux"
+instance HasField "unwrapFunctionPointer_Function_Aux"
                   (Ptr FunctionPointer_Function_Aux)
-                  (Ptr ty)
+                  (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function_Aux")
 instance HasCField FunctionPointer_Function_Aux
                    "unwrapFunctionPointer_Function_Aux"
@@ -143,10 +142,9 @@ newtype FunctionPointer_Function
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr FunctionPointer_Function_Aux) =>
-         HasField "unwrapFunctionPointer_Function"
+instance HasField "unwrapFunctionPointer_Function"
                   (Ptr FunctionPointer_Function)
-                  (Ptr ty)
+                  (Ptr (FunPtr FunctionPointer_Function_Aux))
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function")
 instance HasCField FunctionPointer_Function
                    "unwrapFunctionPointer_Function"
@@ -187,10 +185,9 @@ instance ToFunPtr NonFunctionPointer_Function
     where toFunPtr = hs_bindgen_766ae751d60365e9
 instance FromFunPtr NonFunctionPointer_Function
     where fromFunPtr = hs_bindgen_36c7108d046bcbc3
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapNonFunctionPointer_Function"
+instance HasField "unwrapNonFunctionPointer_Function"
                   (Ptr NonFunctionPointer_Function)
-                  (Ptr ty)
+                  (Ptr (CInt -> IO CInt))
     where getField = fromPtr (Proxy @"unwrapNonFunctionPointer_Function")
 instance HasCField NonFunctionPointer_Function
                    "unwrapNonFunctionPointer_Function"
@@ -229,8 +226,7 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
-instance (~) ty (IO ()) =>
-         HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
+instance HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = IO ()
@@ -249,8 +245,7 @@ newtype F1
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr F1_Aux) =>
-         HasField "unwrapF1" (Ptr F1) (Ptr ty)
+instance HasField "unwrapF1" (Ptr F1) (Ptr (FunPtr F1_Aux))
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
@@ -285,7 +280,7 @@ instance ToFunPtr G1
     where toFunPtr = hs_bindgen_fa5806570b682579
 instance FromFunPtr G1
     where fromFunPtr = hs_bindgen_8405c8e75aa78be5
-instance (~) ty (IO ()) => HasField "unwrapG1" (Ptr G1) (Ptr ty)
+instance HasField "unwrapG1" (Ptr G1) (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapG1")
 instance HasCField G1 "unwrapG1"
     where type CFieldType G1 "unwrapG1" = IO ()
@@ -304,8 +299,7 @@ newtype G2
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr G1) =>
-         HasField "unwrapG2" (Ptr G2) (Ptr ty)
+instance HasField "unwrapG2" (Ptr G2) (Ptr (FunPtr G1))
     where getField = fromPtr (Proxy @"unwrapG2")
 instance HasCField G2 "unwrapG2"
     where type CFieldType G2 "unwrapG2" = FunPtr G1
@@ -340,7 +334,7 @@ instance ToFunPtr H1
     where toFunPtr = hs_bindgen_ffae0d1234ed018f
 instance FromFunPtr H1
     where fromFunPtr = hs_bindgen_1a33688324e1924f
-instance (~) ty (IO ()) => HasField "unwrapH1" (Ptr H1) (Ptr ty)
+instance HasField "unwrapH1" (Ptr H1) (Ptr (IO ()))
     where getField = fromPtr (Proxy @"unwrapH1")
 instance HasCField H1 "unwrapH1"
     where type CFieldType H1 "unwrapH1" = IO ()
@@ -355,7 +349,7 @@ newtype H2
     = H2 {unwrapH2 :: H1}
     deriving stock Generic
     deriving newtype HasFFIType
-instance (~) ty H1 => HasField "unwrapH2" (Ptr H2) (Ptr ty)
+instance HasField "unwrapH2" (Ptr H2) (Ptr H1)
     where getField = fromPtr (Proxy @"unwrapH2")
 instance HasCField H2 "unwrapH2"
     where type CFieldType H2 "unwrapH2" = H1
@@ -374,8 +368,7 @@ newtype H3
                       StaticSize,
                       Storable,
                       WriteRaw)
-instance (~) ty (FunPtr H2) =>
-         HasField "unwrapH3" (Ptr H3) (Ptr ty)
+instance HasField "unwrapH3" (Ptr H3) (Ptr (FunPtr H2))
     where getField = fromPtr (Proxy @"unwrapH3")
 instance HasCField H3 "unwrapH3"
     where type CFieldType H3 "unwrapH3" = FunPtr H2

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -107,8 +105,7 @@ instance HasCField.HasCField UnionA "unionA_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unionA_a" (RIP.Ptr UnionA) (RIP.Ptr ty) where
+instance RIP.HasField "unionA_a" (RIP.Ptr UnionA) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unionA_a")
 
@@ -118,8 +115,7 @@ instance HasCField.HasCField UnionA "unionA_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "unionA_b" (RIP.Ptr UnionA) (RIP.Ptr ty) where
+instance RIP.HasField "unionA_b" (RIP.Ptr UnionA) (RIP.Ptr RIP.CChar) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unionA_b")
 
@@ -170,8 +166,7 @@ instance HasCField.HasCField ExA "exA_fieldA1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ UnionA
-         ) => RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr ty) where
+instance RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr UnionA) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exA_fieldA1")
@@ -252,8 +247,7 @@ instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_a" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "exB_fieldB1_a" (RIP.Ptr ExB_fieldB1) (RIP.Ptr ty) where
+instance RIP.HasField "exB_fieldB1_a" (RIP.Ptr ExB_fieldB1) (RIP.Ptr RIP.CInt) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1_a")
@@ -265,8 +259,7 @@ instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_b" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "exB_fieldB1_b" (RIP.Ptr ExB_fieldB1) (RIP.Ptr ty) where
+instance RIP.HasField "exB_fieldB1_b" (RIP.Ptr ExB_fieldB1) (RIP.Ptr RIP.CChar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1_b")
@@ -318,8 +311,7 @@ instance HasCField.HasCField ExB "exB_fieldB1" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ ExB_fieldB1
-         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
+instance RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ExB_fieldB1) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/th.txt
@@ -83,12 +83,12 @@ set_unionA_b = setUnionPayload
 instance HasCField UnionA "unionA_a"
     where type CFieldType UnionA "unionA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unionA_a" (Ptr UnionA) (Ptr ty)
+instance HasField "unionA_a" (Ptr UnionA) (Ptr CInt)
     where getField = fromPtr (Proxy @"unionA_a")
 instance HasCField UnionA "unionA_b"
     where type CFieldType UnionA "unionA_b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unionA_b" (Ptr UnionA) (Ptr ty)
+instance HasField "unionA_b" (Ptr UnionA) (Ptr CChar)
     where getField = fromPtr (Proxy @"unionA_b")
 {-| __C declaration:__ @struct exA@
 
@@ -117,7 +117,7 @@ deriving via (EquivStorable ExA) instance Storable ExA
 instance HasCField ExA "exA_fieldA1"
     where type CFieldType ExA "exA_fieldA1" = UnionA
           offset# = \_ -> \_ -> 0
-instance (~) ty UnionA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+instance HasField "exA_fieldA1" (Ptr ExA) (Ptr UnionA)
     where getField = fromPtr (Proxy @"exA_fieldA1")
 {-| __C declaration:__ @union \@exB_fieldB1@
 
@@ -203,14 +203,12 @@ set_exB_fieldB1_b = setUnionPayload
 instance HasCField ExB_fieldB1 "exB_fieldB1_a"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr CInt)
     where getField = fromPtr (Proxy @"exB_fieldB1_a")
 instance HasCField ExB_fieldB1 "exB_fieldB1_b"
     where type CFieldType ExB_fieldB1 "exB_fieldB1_b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr ty)
+instance HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr CChar)
     where getField = fromPtr (Proxy @"exB_fieldB1_b")
 {-| __C declaration:__ @struct exB@
 
@@ -239,6 +237,5 @@ deriving via (EquivStorable ExB) instance Storable ExB
 instance HasCField ExB "exB_fieldB1"
     where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
           offset# = \_ -> \_ -> 0
-instance (~) ty ExB_fieldB1 =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+instance HasField "exB_fieldB1" (Ptr ExB) (Ptr ExB_fieldB1)
     where getField = fromPtr (Proxy @"exB_fieldB1")

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/unions/Example.hs
@@ -2,14 +2,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Example
@@ -97,8 +95,7 @@ instance HasCField.HasCField Dim2 "dim2_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim2_x" (RIP.Ptr Dim2) (RIP.Ptr ty) where
+instance RIP.HasField "dim2_x" (RIP.Ptr Dim2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim2_x")
 
@@ -108,8 +105,7 @@ instance HasCField.HasCField Dim2 "dim2_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim2_y" (RIP.Ptr Dim2) (RIP.Ptr ty) where
+instance RIP.HasField "dim2_y" (RIP.Ptr Dim2) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim2_y")
 
@@ -178,8 +174,7 @@ instance HasCField.HasCField Dim3 "dim3_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_x" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+instance RIP.HasField "dim3_x" (RIP.Ptr Dim3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim3_x")
 
@@ -189,8 +184,7 @@ instance HasCField.HasCField Dim3 "dim3_y" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_y" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+instance RIP.HasField "dim3_y" (RIP.Ptr Dim3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim3_y")
 
@@ -200,8 +194,7 @@ instance HasCField.HasCField Dim3 "dim3_z" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_z" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+instance RIP.HasField "dim3_z" (RIP.Ptr Dim3) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim3_z")
 
@@ -280,8 +273,7 @@ instance HasCField.HasCField DimPayload "dimPayload_dim2" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Dim2
-         ) => RIP.HasField "dimPayload_dim2" (RIP.Ptr DimPayload) (RIP.Ptr ty) where
+instance RIP.HasField "dimPayload_dim2" (RIP.Ptr DimPayload) (RIP.Ptr Dim2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayload_dim2")
@@ -292,8 +284,7 @@ instance HasCField.HasCField DimPayload "dimPayload_dim3" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Dim2
-         ) => RIP.HasField "dimPayload_dim3" (RIP.Ptr DimPayload) (RIP.Ptr ty) where
+instance RIP.HasField "dimPayload_dim3" (RIP.Ptr DimPayload) (RIP.Ptr Dim2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayload_dim3")
@@ -354,8 +345,7 @@ instance HasCField.HasCField Dim "dim_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim_tag" (RIP.Ptr Dim) (RIP.Ptr ty) where
+instance RIP.HasField "dim_tag" (RIP.Ptr Dim) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dim_tag")
 
@@ -365,8 +355,7 @@ instance HasCField.HasCField Dim "dim_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ DimPayload
-         ) => RIP.HasField "dim_payload" (RIP.Ptr Dim) (RIP.Ptr ty) where
+instance RIP.HasField "dim_payload" (RIP.Ptr Dim) (RIP.Ptr DimPayload) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dim_payload")
@@ -446,8 +435,7 @@ instance HasCField.HasCField DimPayloadB "dimPayloadB_dim2" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Dim2
-         ) => RIP.HasField "dimPayloadB_dim2" (RIP.Ptr DimPayloadB) (RIP.Ptr ty) where
+instance RIP.HasField "dimPayloadB_dim2" (RIP.Ptr DimPayloadB) (RIP.Ptr Dim2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayloadB_dim2")
@@ -458,8 +446,7 @@ instance HasCField.HasCField DimPayloadB "dimPayloadB_dim3" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ Dim2
-         ) => RIP.HasField "dimPayloadB_dim3" (RIP.Ptr DimPayloadB) (RIP.Ptr ty) where
+instance RIP.HasField "dimPayloadB_dim3" (RIP.Ptr DimPayloadB) (RIP.Ptr Dim2) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayloadB_dim3")
@@ -520,8 +507,7 @@ instance HasCField.HasCField DimB "dimB_tag" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dimB_tag" (RIP.Ptr DimB) (RIP.Ptr ty) where
+instance RIP.HasField "dimB_tag" (RIP.Ptr DimB) (RIP.Ptr RIP.CInt) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dimB_tag")
 
@@ -531,8 +517,7 @@ instance HasCField.HasCField DimB "dimB_payload" where
 
   offset# = \_ -> \_ -> 4
 
-instance ( ty ~ DimPayloadB
-         ) => RIP.HasField "dimB_payload" (RIP.Ptr DimB) (RIP.Ptr ty) where
+instance RIP.HasField "dimB_payload" (RIP.Ptr DimB) (RIP.Ptr DimPayloadB) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimB_payload")
@@ -593,8 +578,7 @@ instance HasCField.HasCField AnonA_xy "anonA_xy_x" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_xy_x" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_xy_x" (RIP.Ptr AnonA_xy) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_xy_x")
@@ -605,8 +589,7 @@ instance HasCField.HasCField AnonA_xy "anonA_xy_y" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_xy_y" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_xy_y" (RIP.Ptr AnonA_xy) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_xy_y")
@@ -668,8 +651,7 @@ instance HasCField.HasCField AnonA_polar "anonA_polar_r" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_polar_r" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_polar_r" (RIP.Ptr AnonA_polar) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_polar_r")
@@ -681,8 +663,7 @@ instance HasCField.HasCField AnonA_polar "anonA_polar_p" where
 
   offset# = \_ -> \_ -> 8
 
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_polar_p" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_polar_p" (RIP.Ptr AnonA_polar) (RIP.Ptr RIP.CDouble) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_polar_p")
@@ -762,8 +743,7 @@ instance HasCField.HasCField AnonA "anonA_xy" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ AnonA_xy
-         ) => RIP.HasField "anonA_xy" (RIP.Ptr AnonA) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_xy" (RIP.Ptr AnonA) (RIP.Ptr AnonA_xy) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"anonA_xy")
 
@@ -773,8 +753,7 @@ instance HasCField.HasCField AnonA "anonA_polar" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ AnonA_polar
-         ) => RIP.HasField "anonA_polar" (RIP.Ptr AnonA) (RIP.Ptr ty) where
+instance RIP.HasField "anonA_polar" (RIP.Ptr AnonA) (RIP.Ptr AnonA_polar) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_polar")

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/unions/th.txt
@@ -34,12 +34,12 @@ deriving via (EquivStorable Dim2) instance Storable Dim2
 instance HasCField Dim2 "dim2_x"
     where type CFieldType Dim2 "dim2_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim2_x" (Ptr Dim2) (Ptr ty)
+instance HasField "dim2_x" (Ptr Dim2) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim2_x")
 instance HasCField Dim2 "dim2_y"
     where type CFieldType Dim2 "dim2_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "dim2_y" (Ptr Dim2) (Ptr ty)
+instance HasField "dim2_y" (Ptr Dim2) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim2_y")
 {-| __C declaration:__ @struct Dim3@
 
@@ -84,17 +84,17 @@ deriving via (EquivStorable Dim3) instance Storable Dim3
 instance HasCField Dim3 "dim3_x"
     where type CFieldType Dim3 "dim3_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim3_x" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_x" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_x")
 instance HasCField Dim3 "dim3_y"
     where type CFieldType Dim3 "dim3_y" = CInt
           offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "dim3_y" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_y" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_y")
 instance HasCField Dim3 "dim3_z"
     where type CFieldType Dim3 "dim3_z" = CInt
           offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "dim3_z" (Ptr Dim3) (Ptr ty)
+instance HasField "dim3_z" (Ptr Dim3) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim3_z")
 {-| __C declaration:__ @union DimPayload@
 
@@ -180,14 +180,12 @@ set_dimPayload_dim3 = setUnionPayload
 instance HasCField DimPayload "dimPayload_dim2"
     where type CFieldType DimPayload "dimPayload_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr ty)
+instance HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayload_dim2")
 instance HasCField DimPayload "dimPayload_dim3"
     where type CFieldType DimPayload "dimPayload_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr ty)
+instance HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayload_dim3")
 {-| __C declaration:__ @struct Dim@
 
@@ -224,13 +222,12 @@ deriving via (EquivStorable Dim) instance Storable Dim
 instance HasCField Dim "dim_tag"
     where type CFieldType Dim "dim_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim_tag" (Ptr Dim) (Ptr ty)
+instance HasField "dim_tag" (Ptr Dim) (Ptr CInt)
     where getField = fromPtr (Proxy @"dim_tag")
 instance HasCField Dim "dim_payload"
     where type CFieldType Dim "dim_payload" = DimPayload
           offset# = \_ -> \_ -> 4
-instance (~) ty DimPayload =>
-         HasField "dim_payload" (Ptr Dim) (Ptr ty)
+instance HasField "dim_payload" (Ptr Dim) (Ptr DimPayload)
     where getField = fromPtr (Proxy @"dim_payload")
 {-| __C declaration:__ @union DimPayloadB@
 
@@ -316,14 +313,12 @@ set_dimPayloadB_dim3 = setUnionPayload
 instance HasCField DimPayloadB "dimPayloadB_dim2"
     where type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr ty)
+instance HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayloadB_dim2")
 instance HasCField DimPayloadB "dimPayloadB_dim3"
     where type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr ty)
+instance HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr Dim2)
     where getField = fromPtr (Proxy @"dimPayloadB_dim3")
 {-| __C declaration:__ @struct DimB@
 
@@ -360,13 +355,12 @@ deriving via (EquivStorable DimB) instance Storable DimB
 instance HasCField DimB "dimB_tag"
     where type CFieldType DimB "dimB_tag" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dimB_tag" (Ptr DimB) (Ptr ty)
+instance HasField "dimB_tag" (Ptr DimB) (Ptr CInt)
     where getField = fromPtr (Proxy @"dimB_tag")
 instance HasCField DimB "dimB_payload"
     where type CFieldType DimB "dimB_payload" = DimPayloadB
           offset# = \_ -> \_ -> 4
-instance (~) ty DimPayloadB =>
-         HasField "dimB_payload" (Ptr DimB) (Ptr ty)
+instance HasField "dimB_payload" (Ptr DimB) (Ptr DimPayloadB)
     where getField = fromPtr (Proxy @"dimB_payload")
 {-| __C declaration:__ @struct \@AnonA_xy@
 
@@ -403,14 +397,12 @@ deriving via (EquivStorable AnonA_xy) instance Storable AnonA_xy
 instance HasCField AnonA_xy "anonA_xy_x"
     where type CFieldType AnonA_xy "anonA_xy_x" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr ty)
+instance HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_xy_x")
 instance HasCField AnonA_xy "anonA_xy_y"
     where type CFieldType AnonA_xy "anonA_xy_y" = CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty CDouble =>
-         HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr ty)
+instance HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_xy_y")
 {-| __C declaration:__ @struct \@AnonA_polar@
 
@@ -447,14 +439,12 @@ deriving via (EquivStorable AnonA_polar) instance Storable AnonA_polar
 instance HasCField AnonA_polar "anonA_polar_r"
     where type CFieldType AnonA_polar "anonA_polar_r" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr ty)
+instance HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_polar_r")
 instance HasCField AnonA_polar "anonA_polar_p"
     where type CFieldType AnonA_polar "anonA_polar_p" = CDouble
           offset# = \_ -> \_ -> 8
-instance (~) ty CDouble =>
-         HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr ty)
+instance HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr CDouble)
     where getField = fromPtr (Proxy @"anonA_polar_p")
 {-| __C declaration:__ @union AnonA@
 
@@ -540,12 +530,10 @@ set_anonA_polar = setUnionPayload
 instance HasCField AnonA "anonA_xy"
     where type CFieldType AnonA "anonA_xy" = AnonA_xy
           offset# = \_ -> \_ -> 0
-instance (~) ty AnonA_xy =>
-         HasField "anonA_xy" (Ptr AnonA) (Ptr ty)
+instance HasField "anonA_xy" (Ptr AnonA) (Ptr AnonA_xy)
     where getField = fromPtr (Proxy @"anonA_xy")
 instance HasCField AnonA "anonA_polar"
     where type CFieldType AnonA "anonA_polar" = AnonA_polar
           offset# = \_ -> \_ -> 0
-instance (~) ty AnonA_polar =>
-         HasField "anonA_polar" (Ptr AnonA) (Ptr ty)
+instance HasField "anonA_polar" (Ptr AnonA) (Ptr AnonA_polar)
     where getField = fromPtr (Proxy @"anonA_polar")


### PR DESCRIPTION
The `Elem` type family can otherwise appear in class instance heads, which is not valid Haskell. We also can't expand the type family because instances can be defined by users as part of an external binding specification, because of which we should consider the type to be "opaque" in a way