### PR TITLE
`CI`: fix `Examples` failures

### DIFF
--- a/examples/botan/hs-project/cabal.project
+++ b/examples/botan/hs-project/cabal.project
@@ -1,4 +1,4 @@
 import: ../../../cabal.project.base
 
 packages: .
-          ../../../hs-bindgen-runtime,
+          ../../../hs-bindgen-runtime


### PR DESCRIPTION
Let's merge this after the weekend so that we can first see if the notifications for failing nightly CI work