### PR TITLE
`BindingSpec`: add `HasFieldPtr` type class name for the pointer manipulation API

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -23,6 +23,11 @@
   ticks are not allowed in C identifiers. Since anonymous structs and unions are
   named after the generated fields, these names will now also include an `anon'`
   infix. See [issue #2064][is-2064] and [PR #2070][pr-2070].
+* Add a new `HasFieldPtr` type class name to external binding specs. We now use
+  the name `HasFieldPtr` in external binding specs to specify that a type has
+  `HasField` instances for the pointer manipulation API. The old `HasField` name
+  is now only used to record that a type has the usual `HasField` instances for
+  fields in record datatypes. See [PR #2094][pr-2094].
 
 ### New features
 
@@ -246,6 +251,7 @@
 [pr-2070]: https://github.com/well-typed/hs-bindgen/pull/2070
 [pr-2075]: https://github.com/well-typed/hs-bindgen/pull/2075
 [pr-2087]: https://github.com/well-typed/hs-bindgen/pull/2087
+[pr-2094]: https://github.com/well-typed/hs-bindgen/pull/2094
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -111,11 +111,13 @@ fieldExtensions field = typeExtensions field.typ
 
 typeClassExtensions :: Inst.TypeClass -> Set TH.Extension
 typeClassExtensions = \case
-    Inst.HasCField    -> Set.singleton TH.MagicHash
-    Inst.HasCBitfield -> Set.singleton TH.MagicHash
-    Inst.HasField     -> Set.singleton TH.UndecidableInstances
-    Inst.HasFFIType   -> Set.singleton TH.UndecidableInstances
-    Inst.Prim         -> Set.fromList [TH.MagicHash, TH.UnboxedTuples]
+    Inst.HasCField      -> Set.singleton TH.MagicHash
+    Inst.HasCBitfield   -> Set.singleton TH.MagicHash
+    Inst.HasField       -> Set.singleton TH.UndecidableInstances
+    Inst.HasFieldCompat -> Set.singleton TH.UndecidableInstances
+    Inst.HasFieldPtr    -> Set.singleton TH.UndecidableInstances
+    Inst.HasFFIType     -> Set.singleton TH.UndecidableInstances
+    Inst.Prim           -> Set.fromList [TH.MagicHash, TH.UnboxedTuples]
     _ -> mempty
 
 exprExtensions :: SExpr ctx -> Set TH.Extension

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Global.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Global.hs
@@ -247,8 +247,8 @@ data BindgenGlobalTerm =
     -- HasField
   | HasField_getField
 
-    -- CompatHasField
-  | CompatHasField_hasField
+    -- Compat.HasField
+  | HasFieldCompat_hasField
 
     -- Proxy
   | Proxy_constructor
@@ -403,7 +403,8 @@ typeClassGlobal = globalType . \case
     Inst.HasCField       -> (IRuntimeModule "HasCField",    ''HasCField.HasCField)
     Inst.HasFFIType      -> (IRuntimeInternalPrelude,       ''RIP.HasFFIType)
     Inst.HasField        -> (IRuntimeInternalPrelude,       ''RIP.HasField)
-    Inst.CompatHasField  -> (IRuntimeInternalPreludeCompatHasField, ''RIP.CompatHasField.HasField)
+    Inst.HasFieldCompat  -> (IRuntimeInternalPreludeCompatHasField, ''RIP.CompatHasField.HasField)
+    Inst.HasFieldPtr     -> (IRuntimeInternalPrelude,       ''RIP.HasField)
     Inst.Flam_Offset     -> (IRuntimeModule "FLAM",         ''FLAM.Offset)
     Inst.Integral        -> (IHaskellPrelude,               ''Integral)
     Inst.IsArray         -> (IRuntimeModule "IsA",          ''IsA.IsArray)
@@ -484,7 +485,7 @@ bindgenGlobalTerm = globalExpr . \case
     HasField_getField -> (IRuntimeInternalPrelude, GVar, 'RIP.getField)
 
     -- Compat.HasField
-    CompatHasField_hasField -> (IRuntimeInternalPreludeCompatHasField, GVar, 'RIP.CompatHasField.hasField)
+    HasFieldCompat_hasField -> (IRuntimeInternalPreludeCompatHasField, GVar, 'RIP.CompatHasField.hasField)
 
     -- Proxy
     Proxy_constructor -> (IRuntimeInternalPrelude, GCon, 'RIP.Proxy)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -65,11 +65,13 @@ module HsBindgen.Backend.Hs.AST (
   , HasCFieldInstance(..)
     -- ** 'HsBindgen.Runtime.HasCBitfield.HasCBitfield'
   , HasCBitfieldInstance(..)
-    -- ** 'GHC.Records.HasField'
-  , HasFieldInstance(..)
-  , HasFieldInstanceVia(..)
     -- ** 'GHC.Records.Compat.HasField'
-  , CompatHasFieldInstance(..)
+  , HasFieldCompatInstance(..)
+  , HasFieldCompatImpl(..)
+  , HasFieldCompatImplRecord(..)
+    -- ** 'GHC.Records.HasField' for the pointer manipulation API
+  , HasFieldPtrInstance(..)
+  , HasFieldPtrInstanceVia(..)
     -- ** 'HasFlam'
   , HasFlamInstance(..)
     -- ** 'CEnum'
@@ -280,8 +282,8 @@ data InstanceDecl where
     InstanceStorable        :: Struct -> StorableInstance -> InstanceDecl
     InstanceHasCField       :: HasCFieldInstance -> InstanceDecl
     InstanceHasCBitfield    :: HasCBitfieldInstance -> InstanceDecl
-    InstanceHasField        :: HasFieldInstance -> InstanceDecl
-    InstanceCompatHasField  :: CompatHasFieldInstance -> InstanceDecl
+    InstanceHasFieldCompat  :: HasFieldCompatInstance -> InstanceDecl
+    InstanceHasFieldPtr     :: HasFieldPtrInstance -> InstanceDecl
     InstanceHasFlam         :: Struct -> HasFlamInstance -> InstanceDecl
     -- | The 'Struct' wraps the C enum's underlying integer field. Invariant:
     -- exactly one field. Established at 'HsBindgen.Backend.Hs.Translation'
@@ -676,51 +678,62 @@ data HasCBitfieldInstance = HasCBitfieldInstance {
   deriving stock (Generic, Show)
 
 {-------------------------------------------------------------------------------
-  'GHC.Records.HasField'
--------------------------------------------------------------------------------}
-
--- | 'GHC.Records.HasField' instance
-data HasFieldInstance = HasFieldInstance {
-      -- | The Haskell type of the parent C object
-      parentType :: Hs.Type
-
-      -- | The name of the (bit-)field
-    , fieldName :: Hs.Name Hs.NsVar
-
-      -- | The haskell type of the (bit-)field
-    , fieldType :: Hs.Type
-
-      -- | Implement the instance via a 'HsBindgen.Runtime.HasCField.HasCField'
-      -- or 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance.
-    , deriveVia :: HasFieldInstanceVia
-    }
-  deriving stock (Generic, Show)
-
--- | See the @deriveVia@ field of 'HasFieldInstance'.
-data HasFieldInstanceVia = ViaHasCField | ViaHasCBitfield
-  deriving stock (Generic, Show)
-
-{-------------------------------------------------------------------------------
   'GHC.Records.Compat.HasField'
 -------------------------------------------------------------------------------}
 
 -- | 'GHC.Records.Compat.HasField' instance
-data CompatHasFieldInstance = CompatHasFieldInstance {
+data HasFieldCompatInstance = HasFieldCompatInstance {
       -- | The Haskell type of the parent C object
       parentType :: Hs.Type
 
-      -- | The name of the (bit-)field we want to set/get
+      -- | The name of the field
     , fieldName :: Hs.Name Hs.NsVar
 
-      -- | The haskell type of the (bit-)field
+      -- | The haskell type of the field
     , fieldType :: Hs.Type
 
-      -- | The other fields of the haskell type
-    , otherFields :: [Hs.Name Hs.NsVar]
-
-      -- | The constructor of the haskell type
-    , constr :: Hs.Name Hs.NsConstr
+      -- | Implementation of member functions
+    , impl :: HasFieldCompatImpl
     }
+  deriving stock (Generic, Show)
+
+-- | 'GHC.Records.Compat.HasField.hasField' implementation
+data HasFieldCompatImpl =
+    -- | structs, typedefs, enums, and macro types
+    HasFieldCompatImplRecord HasFieldCompatImplRecord
+  deriving stock (Generic, Show)
+
+-- | 'GHC.Records.Compat.HasField.hasField' for C types that are translated to
+-- Haskell record types
+data HasFieldCompatImplRecord = HFCImplRecord {
+    constr :: Hs.Name Hs.NsConstr
+  , otherFields :: [Hs.Name Hs.NsVar]
+  }
+  deriving stock (Generic, Show)
+
+{-------------------------------------------------------------------------------
+  'GHC.Records.HasField' for the pointer manipulation API
+-------------------------------------------------------------------------------}
+
+-- | 'GHC.Records.HasField' instance for the pointer manipulation API
+data HasFieldPtrInstance = HasFieldPtrInstance {
+      -- | The Haskell type of the parent C object
+      parentType :: Hs.Type
+
+      -- | The name of the field
+    , fieldName :: Hs.Name Hs.NsVar
+
+      -- | The haskell type of the field
+    , fieldType :: Hs.Type
+
+      -- | Implement the instance via a 'HsBindgen.Runtime.HasCField.HasCField'
+      -- or 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance.
+    , deriveVia :: HasFieldPtrInstanceVia
+    }
+  deriving stock (Generic, Show)
+
+-- | See the @deriveVia@ field of 'HasFieldPtrInstance'.
+data HasFieldPtrInstanceVia = ViaHasCField | ViaHasCBitfield
   deriving stock (Generic, Show)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -341,7 +341,8 @@ enumDecs info enum spec = do
           , Just Inst.Generic
           , Just Inst.HasCField
           , Just Inst.HasField
-          , Just Inst.CompatHasField
+          , Just Inst.HasFieldCompat
+          , Just Inst.HasFieldPtr
           , Just Inst.Prim
           , Just Inst.Read
           , Just Inst.ReadRaw
@@ -360,7 +361,8 @@ enumDecs info enum spec = do
         ++ primDecl
         : optDecls
         ++ cEnumInstanceDecls
-        ++ Hs.newtypeFieldDecs nt
+        ++ Hs.hasFieldCompatDecs nt
+        ++ Hs.hasFieldPtrDecs nt
         ++ valueDecls
       where
         -- Singleton field: 'InstanceCEnum' and its siblings rely on this
@@ -525,7 +527,8 @@ typedefDecs info mkNewtypeOrigin typedef spec = do
           , Just Inst.Generic
           , Just Inst.HasCField
           , Just Inst.HasField
-          , Just Inst.CompatHasField
+          , Just Inst.HasFieldCompat
+          , Just Inst.HasFieldPtr
           , Inst.ToFunPtr <$ isFunType
           ]
 
@@ -542,7 +545,8 @@ typedefDecs info mkNewtypeOrigin typedef spec = do
         Hs.DeclNewtype nt
         : newtypeWrapper
         ++ optDecls
-        ++ Hs.newtypeFieldDecs nt
+        ++ Hs.hasFieldCompatDecs nt
+        ++ Hs.hasFieldPtrDecs nt
       where
         optDecls :: [Hs.Decl l]
         optDecls = catMaybes [
@@ -744,13 +748,18 @@ macroDecsTypedef macroLang info macroType spec = do
         knownInsts = Set.fromList [
               Inst.HasCField
             , Inst.HasField
-            , Inst.CompatHasField
+            , Inst.HasFieldCompat
+            , Inst.HasFieldPtr
             , Inst.Generic
             ]
 
     -- everything in aux is state-dependent
     aux :: HsM.Env -> Hs.Newtype -> [Hs.Decl l]
-    aux env nt = Hs.DeclNewtype nt : optDecls ++ Hs.newtypeFieldDecs nt
+    aux env nt =
+        Hs.DeclNewtype nt
+        : optDecls
+        ++ Hs.hasFieldCompatDecs nt
+        ++ Hs.hasFieldPtrDecs nt
       where
         optDecls :: [Hs.Decl l]
         optDecls = catMaybes [

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Newtype.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Newtype.hs
@@ -1,7 +1,8 @@
 module HsBindgen.Backend.Hs.Translation.Newtype (
     newtypeDec
   , hasFFITypeDecs
-  , newtypeFieldDecs
+  , hasFieldCompatDecs
+  , hasFieldPtrDecs
   ) where
 
 import Control.Monad.State qualified as State
@@ -69,9 +70,11 @@ hasFFITypeDecs nt =
         , comment  = Nothing
         }
 
--- | 'HsBindgen.Runtime.HasCField.HasCField',
--- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield', 'GHC.Records.HasField', and
--- 'GHC.Records.Compat.HasField' instances for newtypes
+{-------------------------------------------------------------------------------
+  HasField
+-------------------------------------------------------------------------------}
+
+-- | Class instances for 'GHC.Records.Compat.HasField'
 --
 -- Given a generated newtype (for a @typedef@, @enum@, or macro type):
 --
@@ -80,25 +83,54 @@ hasFFITypeDecs nt =
 -- GHC automatically generates 'GHC.Records.HasField' instances for the
 -- @unwrapMyType@ field.
 --
--- Then, 'newtypeFieldDecls' will generate roughly the following class
--- instances.
+-- 'hasFieldCompatDecs' will generate roughly the following class instances:
+--
+-- > instance GHC.Records.Compat.HasField "unwrapMyType" MyType CInt
+--
+hasFieldCompatDecs :: Hs.Newtype -> [Hs.Decl l]
+hasFieldCompatDecs nt =
+    [ Hs.DeclDefineInstance $
+        Hs.DefineInstance {
+              comment      = Nothing
+            , instanceDecl = Hs.InstanceHasFieldCompat hasFieldCompatDecl
+            }
+    | Inst.HasFieldCompat `elem` nt.instances
+    ]
+  where
+    parentType :: Hs.Type
+    parentType = Hs.TypRef nt.name (Just nt.field.typ)
+
+    hasFieldCompatDecl :: Hs.HasFieldCompatInstance
+    hasFieldCompatDecl = Hs.HasFieldCompatInstance {
+          parentType  = parentType
+        , fieldName   = nt.field.name
+        , fieldType   = nt.field.typ
+        , impl = Hs.HasFieldCompatImplRecord $ Hs.HFCImplRecord {
+              otherFields = []
+            , constr = nt.constr
+            }
+        }
+
+-- | Class instances for 'GHC.Records.HasField' for the pointer manipulation API
+--
+-- Given a generated newtype (for a @typedef@, @enum@, or macro type):
+--
+-- > newtype MyType = MyType { unwrapMyType :: CInt }
+--
+-- 'hasFieldPtrDecs' will generate roughly the following class instances:
 --
 -- > instance HasCField "unwrapMyType" MyType where
 -- >   type CFieldType "unwrapMyType" MyType = CInt
 -- > instance GHC.Records.HasField "unwrapMyType" (Ptr MyType) (Ptr CInt)
--- > instance GHC.Records.Compat.HasField "unwrapMyType" MyType CInt
 --
--- The first two instances help eliminating newtypes from 'Foreign.Ptr.Ptr'
--- types. Naturally, newtypes can also be introduced in 'Foreign.Ptr.Ptr' types,
--- but this should be done using 'Foreign.Ptr.castPtr' or some similar function.
-newtypeFieldDecs :: Hs.Newtype -> [Hs.Decl l]
-newtypeFieldDecs nt = concat [
+hasFieldPtrDecs :: Hs.Newtype -> [Hs.Decl l]
+hasFieldPtrDecs nt = concat [
       [ Hs.DeclDefineInstance $
           Hs.DefineInstance {
               comment      = Nothing
-            , instanceDecl = Hs.InstanceHasField hasFieldDecl
+            , instanceDecl = Hs.InstanceHasFieldPtr hasFieldPtrDecl
             }
-      | Inst.HasField `elem` nt.instances
+      | Inst.HasFieldPtr `elem` nt.instances
       ]
     , [ Hs.DeclDefineInstance $
           Hs.DefineInstance {
@@ -107,20 +139,13 @@ newtypeFieldDecs nt = concat [
             }
       | Inst.HasCField `elem` nt.instances
       ]
-    , [ Hs.DeclDefineInstance $
-          Hs.DefineInstance {
-                comment      = Nothing
-              , instanceDecl = Hs.InstanceCompatHasField compatHasFieldDecl
-              }
-      | Inst.CompatHasField `elem` nt.instances
-      ]
     ]
   where
     parentType :: Hs.Type
     parentType = Hs.TypRef nt.name (Just nt.field.typ)
 
-    hasFieldDecl :: Hs.HasFieldInstance
-    hasFieldDecl = Hs.HasFieldInstance{
+    hasFieldPtrDecl :: Hs.HasFieldPtrInstance
+    hasFieldPtrDecl = Hs.HasFieldPtrInstance{
           parentType = parentType
         , fieldName  = nt.field.name
         , fieldType  = nt.field.typ
@@ -133,13 +158,4 @@ newtypeFieldDecs nt = concat [
         , fieldName   = nt.field.name
         , cFieldType  = nt.field.typ
         , fieldOffset = 0
-        }
-
-    compatHasFieldDecl :: Hs.CompatHasFieldInstance
-    compatHasFieldDecl = Hs.CompatHasFieldInstance {
-          parentType  = parentType
-        , fieldName   = nt.field.name
-        , fieldType   = nt.field.typ
-        , otherFields = []
-        , constr      = nt.constr
         }

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -261,7 +261,9 @@ getDecls supInsts hCfg spec structName info struct insts =
       ]
 
     fieldDecls :: [Hs.Decl l]
-    fieldDecls = concatMap (getFieldDecls structName struct hsStruct) struct.fields
+    fieldDecls = flip concatMap struct.fields $ \field ->
+        hasFieldCompatDecs structName struct hsStruct field ++
+        hasFieldPtrDecs hsStruct field
 
     knownInsts :: Set Inst.TypeClass
     knownInsts = Set.fromList $ catMaybes [
@@ -272,16 +274,17 @@ getDecls supInsts hCfg spec structName info struct insts =
           then Just Inst.HasCField
           else Nothing
       , if null struct.fields then Nothing else Just Inst.HasField
-      , if null struct.fields then Nothing else Just Inst.CompatHasField
+      , if null struct.fields then Nothing else Just Inst.HasFieldPtr
+      , if null struct.fields then Nothing else Just Inst.HasFieldCompat
       ]
 
 {-------------------------------------------------------------------------------
-  Fields
+  HasField
 -------------------------------------------------------------------------------}
 
--- | 'HsBindgen.Runtime.HasCField.HasCField',
--- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield', 'GHC.Records.HasField', and
--- 'GHC.Records.Compat.HasField' instances for a field of a struct declaration
+
+-- | Class instances for 'GHC.Records.Compat.HasField' instances for a struct
+-- field
 --
 -- Given a struct:
 --
@@ -289,52 +292,27 @@ getDecls supInsts hCfg spec structName info struct insts =
 --
 -- We generate roughly this datatype:
 --
--- > newtype MyStruct = MyStruct { myStruct_x :: CInt, myStruct_y :: CChar }
+-- > data MyStruct = MyStruct { myStruct_x :: CInt, myStruct_y :: CChar }
 --
--- GHC automatically generates 'GHC.Records.HasField' instances for the the two
--- fields.
+-- 'hasFieldCompatDecs' will generate roughly the following class instances for
+-- the fields @x@ and @y@ respectively:
 --
--- Then, 'getFieldDecls' will generate roughly the following class instances
--- for the fields @x@ and @y@ respectively:
---
--- > instance HasCField "myStruct_x" MyStruct where
--- >   type CFieldType "myStruct_x" MyStruct = CInt
--- > instance GHC.Records.HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
 -- > instance GHC.Records.Compat.HasField "myStruct_x" MyStruct CInt
---
--- > instance HasCField "myStruct_y" MyStruct where
--- >  type CFieldType "myStruct_y" MyStruct = CChar
--- > instance GHC.Records.HasField "myStruct_y" (Ptr MyStruct) (Ptr CChar)
 -- > instance GHC.Records.Compat.HasField "myStruct_y" MyStruct CChar
 --
--- This works similarly for bit-fields, but those get a
--- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance instead of a
--- 'HsBindgen.Runtime.HasCField.HasCField' instance.
-getFieldDecls ::
+hasFieldCompatDecs ::
      Hs.Name Hs.NsTypeConstr
   -> C.Struct Final
   -> Hs.Struct
   -> C.StructField Final
   -> [Hs.Decl l]
-getFieldDecls structName cStruct hsStruct field = [
+hasFieldCompatDecs structName cStruct hsStruct field = [
       Hs.DeclDefineInstance $
         Hs.DefineInstance {
             comment      = Nothing
-          , instanceDecl =
-              case field.width of
-                Nothing -> Hs.InstanceHasCField $ hasCFieldDecl
-                Just w  -> Hs.InstanceHasCBitfield $ hasCBitfieldDecl w
+          , instanceDecl = Hs.InstanceHasFieldCompat hasFieldCompatDecl
           }
-    , Hs.DeclDefineInstance $
-        Hs.DefineInstance {
-            comment      = Nothing
-          , instanceDecl = Hs.InstanceHasField hasFieldDecl
-          }
-    , Hs.DeclDefineInstance $
-        Hs.DefineInstance {
-            comment      = Nothing
-          , instanceDecl = Hs.InstanceCompatHasField compatHasFieldDecl
-          }
+    | Inst.HasFieldCompat `elem` hsStruct.instances
     ]
   where
     parentType :: Hs.Type
@@ -346,8 +324,86 @@ getFieldDecls structName cStruct hsStruct field = [
     fieldType :: Hs.Type
     fieldType = Type.topLevel field.typ
 
-    hasFieldDecl :: Hs.HasFieldInstance
-    hasFieldDecl = Hs.HasFieldInstance {
+    hasFieldCompatDecl :: Hs.HasFieldCompatInstance
+    hasFieldCompatDecl = Hs.HasFieldCompatInstance {
+          parentType = parentType
+        , fieldName  = fieldName
+        , fieldType  = fieldType
+        , impl = Hs.HasFieldCompatImplRecord $ Hs.HFCImplRecord {
+              otherFields = otherFields
+            , constr = hsStruct.constr
+            }
+        }
+      where
+        -- All fields that are /not/ the field we are creating an instance for
+        -- should stay unmodified
+        otherFields = flip mapMaybe cStruct.fields $ \field' ->
+            let fieldName' = Hs.assertNs (Proxy @Hs.NsVar) field'.info.name.hsName in
+            if fieldName == fieldName' then Nothing else Just fieldName'
+
+-- | Class instances for 'GHC.Records.HasField' for a struct field the pointer
+-- manipulation API
+--
+-- Given a struct:
+--
+-- > struct myStruct { int x; char y };
+--
+-- We generate roughly this datatype:
+--
+-- > data MyStruct = MyStruct { myStruct_x :: CInt, myStruct_y :: CChar }
+--
+-- 'hasFieldPtrDecs' will generate roughly the following class instances for the
+-- fields @x@ and @y@ respectively:
+--
+-- > instance HasCField "myStruct_x" MyStruct where
+-- >   type CFieldType "myStruct_x" MyStruct = CInt
+-- > instance GHC.Records.HasField "myStruct_x" (Ptr MyStruct) (Ptr CInt)
+--
+-- > instance HasCField "myStruct_y" MyStruct where
+-- >  type CFieldType "myStruct_y" MyStruct = CChar
+-- > instance GHC.Records.HasField "myStruct_y" (Ptr MyStruct) (Ptr CChar)
+--
+-- This works similarly for bit-fields, but those get a
+-- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance instead of a
+-- 'HsBindgen.Runtime.HasCField.HasCField' instance.
+--
+hasFieldPtrDecs ::
+     Hs.Struct
+  -> C.StructField Final
+  -> [Hs.Decl l]
+hasFieldPtrDecs struct field = concat [
+      [ Hs.DeclDefineInstance $
+          Hs.DefineInstance {
+              comment      = Nothing
+            , instanceDecl = Hs.InstanceHasFieldPtr hasFieldPtrDecl
+            }
+      | Inst.HasFieldPtr `elem` struct.instances
+      ]
+    , [ Hs.DeclDefineInstance $
+          Hs.DefineInstance {
+              comment      = Nothing
+            , instanceDecl =
+                case field.width of
+                  Nothing -> Hs.InstanceHasCField $ hasCFieldDecl
+                  Just w  -> Hs.InstanceHasCBitfield $ hasCBitfieldDecl w
+            }
+      | case field.width of
+          Nothing -> Inst.HasCField `elem` struct.instances
+          Just{}  -> Inst.HasCBitfield `elem` struct.instances
+      ]
+    ]
+  where
+    parentType :: Hs.Type
+    parentType = Hs.TypRef struct.name Nothing
+
+    fieldName :: Hs.Name Hs.NsVar
+    fieldName = Hs.assertNs (Proxy @Hs.NsVar) field.info.name.hsName
+
+    fieldType :: Hs.Type
+    fieldType = Type.topLevel field.typ
+
+    hasFieldPtrDecl :: Hs.HasFieldPtrInstance
+    hasFieldPtrDecl = Hs.HasFieldPtrInstance {
           parentType = parentType
         , fieldName  = fieldName
         , fieldType  = fieldType
@@ -374,20 +430,9 @@ getFieldDecls structName cStruct hsStruct field = [
         , bitWidth      = w
         }
 
-    compatHasFieldDecl :: Hs.CompatHasFieldInstance
-    compatHasFieldDecl = Hs.CompatHasFieldInstance {
-          parentType = parentType
-        , fieldName  = fieldName
-        , fieldType  = fieldType
-        , otherFields = otherFields
-        , constr = hsStruct.constr
-        }
-      where
-        -- All fields that are /not/ the field we are creating an instance for
-        -- should stay unmodified
-        otherFields = flip mapMaybe cStruct.fields $ \field' ->
-            let fieldName' = Hs.assertNs (Proxy @Hs.NsVar) field'.info.name.hsName in
-            if fieldName == fieldName' then Nothing else Just fieldName'
+{-------------------------------------------------------------------------------
+  Field I\/O
+-------------------------------------------------------------------------------}
 
 peekField :: Idx ctx -> C.StructField Final -> Hs.PeekCField ctx
 peekField ptr field = case field.width of

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
@@ -76,7 +76,7 @@ unionDecs info union spec = do
           -- Should correctly detect 'Inst.HasCBitfield' and 'Inst.HasCField'
           -- when bit-fields in unions are supported.
           , if null union.fields then Nothing else Just Inst.HasCField
-          , if null union.fields then Nothing else Just Inst.HasField
+          , if null union.fields then Nothing else Just Inst.HasFieldPtr
           , Just Inst.ReadRaw
           , Just Inst.StaticSize
           , Just Inst.Storable
@@ -85,9 +85,9 @@ unionDecs info union spec = do
 
     -- everything in aux is state-dependent
     aux :: HsM.St -> HsM.Env -> Hs.Newtype -> [Hs.Decl l]
-    aux transState env nt =
+    aux st env nt =
         Hs.DeclNewtype nt : marshalDecls ++ accessorDecls ++
-        concatMap (unionFieldDecls nt.name) union.fields
+        fieldDecls
       where
         marshalDecls :: [Hs.Decl l]
         marshalDecls = [
@@ -129,6 +129,10 @@ unionDecs info union spec = do
               (fromIntegral union.sizeof)
               (fromIntegral union.alignment)
 
+        fieldDecls :: [Hs.Decl l]
+        fieldDecls = flip concatMap union.fields $ \field ->
+          hasFieldPtrDecs nt field
+
         accessorDecls :: [Hs.Decl l]
         accessorDecls = concatMap getAccessorDecls union.fields
 
@@ -155,7 +159,7 @@ unionDecs info union spec = do
             hsType :: Hs.Type
             hsType     = Type.topLevel field.typ
             fInsts     = Hs.getInstances
-                            transState.instanceMap
+                            st.instanceMap
                             (Just nt.name)
                             (Set.singleton Inst.Storable)
                             [hsType]
@@ -170,8 +174,12 @@ unionDecs info union spec = do
               , HsDoc.Identifier name
               ]
 
--- | 'HsBindgen.Runtime.HasCField.HasCField' and 'GHC.Records.HasField' instances for a field of a
--- union declaration
+{-------------------------------------------------------------------------------
+  HasField
+-------------------------------------------------------------------------------}
+
+-- | Class instances for 'GHC.Records.HasField' for a union field for the
+-- pointer manipulation API
 --
 -- Given a union:
 --
@@ -181,34 +189,42 @@ unionDecs info union spec = do
 --
 -- > newtype MyUnion = MyUnion { unwrapMyUnion :: ByteArray }
 --
--- Then, 'unionFieldDecls' will generate roughly the following class instances
+-- Then, 'hasFieldPtrDecs' will generate roughly the following class instances
 -- for the fields @option1@ and @option@ respectively:
 --
 -- > instance HasCField "myUnion_option1" MyUnion where
 -- >   type CFieldType "myUnion_option1" MyUnion = CInt
--- > instance HasField "myUnion_option1" (Ptr MyUnion) (Ptr CInt)
+-- > instance GHC.Records.HasField "myUnion_option1" (Ptr MyUnion) (Ptr CInt)
 --
 -- > instance HasCField "myUnion_option2" MyUnion where
 -- >   type CFieldType "myUnion_option2" MyUnion = CChar
--- > instance HasField "myUnion_option2" (Ptr MyUnion) (Ptr CChar)
+-- > instance GHC.Records.HasField "myUnion_option2" (Ptr MyUnion) (Ptr CChar)
 --
--- This works similarly for bit-fields, but those get a 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance
--- instead of a 'HsBindgen.Runtime.HasCField.HasCField' instance.
-unionFieldDecls :: Hs.Name Hs.NsTypeConstr -> C.UnionField Final -> [Hs.Decl l]
-unionFieldDecls unionName field = [
-      Hs.DeclDefineInstance $
-        Hs.DefineInstance {
-            comment      = Nothing
-          , instanceDecl =
-              case unionFieldWidth field of
-                Nothing -> Hs.InstanceHasCField $ hasCFieldDecl
-                Just w  -> Hs.InstanceHasCBitfield $ hasCBitfieldDecl w
-          }
-    , Hs.DeclDefineInstance $
-        Hs.DefineInstance {
-            comment      = Nothing
-          , instanceDecl = Hs.InstanceHasField hasFieldDecl
-          }
+-- This works similarly for bit-fields, but those get a
+-- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance instead of a
+-- 'HsBindgen.Runtime.HasCField.HasCField' instance.
+--
+hasFieldPtrDecs :: Hs.Newtype -> C.UnionField Final -> [Hs.Decl l]
+hasFieldPtrDecs nt field = concat [
+      [ Hs.DeclDefineInstance $
+          Hs.DefineInstance {
+              comment      = Nothing
+            , instanceDecl = Hs.InstanceHasFieldPtr hasFieldPtrDecl
+            }
+      | Inst.HasFieldPtr `elem` nt.instances
+      ]
+    , [ Hs.DeclDefineInstance $
+          Hs.DefineInstance {
+              comment      = Nothing
+            , instanceDecl =
+                case unionFieldWidth field of
+                  Nothing -> Hs.InstanceHasCField $ hasCFieldDecl
+                  Just w  -> Hs.InstanceHasCBitfield $ hasCBitfieldDecl w
+            }
+      | case unionFieldWidth field of
+          Nothing -> Inst.HasCField `elem` nt.instances
+          Just{} -> Inst.HasCBitfield `elem` nt.instances
+      ]
     ]
   where
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
@@ -218,7 +234,7 @@ unionFieldDecls unionName field = [
     unionFieldWidth _f = Nothing
 
     parentType :: Hs.Type
-    parentType = Hs.TypRef unionName Nothing
+    parentType = Hs.TypRef nt.name Nothing
 
     fieldName :: Hs.Name Hs.NsVar
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) field.info.name.hsName
@@ -226,8 +242,8 @@ unionFieldDecls unionName field = [
     fieldType :: Hs.Type
     fieldType = Type.topLevel field.typ
 
-    hasFieldDecl :: Hs.HasFieldInstance
-    hasFieldDecl = Hs.HasFieldInstance {
+    hasFieldPtrDecl :: Hs.HasFieldPtrInstance
+    hasFieldPtrDecl = Hs.HasFieldPtrInstance {
           parentType = parentType
         , fieldName  = fieldName
         , fieldType  = fieldType

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -106,10 +106,10 @@ translateDefineInstanceDecl defInst =
         DInst $ translateHasCFieldInstance i defInst.comment
       Hs.InstanceHasCBitfield i ->
         DInst $ translateHasCBitfieldInstance i defInst.comment
-      Hs.InstanceHasField i ->
-        DInst $ translateHasFieldInstance i defInst.comment
-      Hs.InstanceCompatHasField i ->
-        DInst $ translateCompatHasFieldInstance i defInst.comment
+      Hs.InstanceHasFieldCompat i ->
+        DInst $ translateHasFieldCompatInstance i defInst.comment
+      Hs.InstanceHasFieldPtr i ->
+        DInst $ translateHasFieldPtrInstance i defInst.comment
       Hs.InstanceHasFlam struct i ->
         DInst Instance{
             clss    = Inst.Flam_Offset
@@ -571,14 +571,73 @@ translateHasCBitfieldInstance inst mbComment = Instance{
     w         = fromIntegral inst.bitWidth
 
 {-------------------------------------------------------------------------------
-  'HasField'
+  'GHC.Records.Compat.HasField'
 -------------------------------------------------------------------------------}
 
-translateHasFieldInstance ::
-     Hs.HasFieldInstance
+translateHasFieldCompatInstance ::
+     Hs.HasFieldCompatInstance
   -> Maybe HsDoc.Comment
   -> Instance
-translateHasFieldInstance inst mbComment = Instance{
+translateHasFieldCompatInstance inst mbComment = Instance{
+      clss   = Inst.HasFieldCompat
+    , args    = [fieldLit, parent, tyTypeVar]
+    , types   = []
+    , comment = mbComment
+    , super   = [ TApp (TApp TEq tyTypeVar) field ]
+    , decs    = [ ( bindgenGlobalTerm HasFieldCompat_hasField
+                  , ELam (NameHint "x") $ appManyExpr (EBoxedTup $ Plus2 0) [
+                        exprSetter
+                      , exprGetter
+                      ]
+                  )
+                ]
+    }
+  where
+    parent    = translateType inst.parentType
+    field     = translateType inst.fieldType
+    fieldLit  = translateType $ Hs.StrLit $ Hs.nameToStr inst.fieldName
+
+    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1287>
+    -- This is not actually a free type variable.
+    tyTypeVar = TFree $ Hs.UnsafeName "ty"
+
+    exprGetter :: SExpr (S Z)
+    exprGetter = eBindgenGlobal HasField_getField `ETypeApp` fieldLit `EApp` EBound IZ
+
+    -- For the setter we use total record construction. The advantage with
+    -- record fields is that they can be used in any order regardless of the
+    -- order in which the fields were defined the datatype. This leads to a
+    -- simpler implementation compared to non-record construction. However,
+    -- because we use record fields we need total record construction instead of
+    -- a partial record update because the latter can cause warnings about
+    -- ambiguous field names. The implementation cost for record construction
+    -- compared to record update is low.
+    exprSetter :: SExpr (S Z)
+    exprSetter =
+        case inst.impl of
+          Hs.HasFieldCompatImplRecord impl ->
+            ELam (NameHint "y") $
+              ERecCon impl.constr $ concat [
+                  [ FBind (Hs.nameToStr inst.fieldName) (EBound IZ) ]
+                , map mkFBindIdentity impl.otherFields
+                ]
+      where
+        -- An 'FBind' that leaves the original field unchanged
+        mkFBindIdentity :: Hs.Name Hs.NsVar -> FBind (S (S n))
+        mkFBindIdentity fieldName = FBind (Hs.nameToStr fieldName) $
+                      eBindgenGlobal HasField_getField
+            `ETypeApp` (translateType (Hs.StrLit (Hs.nameToStr fieldName)))
+            `EApp`      EBound (IS IZ)
+
+{-------------------------------------------------------------------------------
+  'GHC.Records.HasField' for the pointer manipulation API
+-------------------------------------------------------------------------------}
+
+translateHasFieldPtrInstance ::
+     Hs.HasFieldPtrInstance
+  -> Maybe HsDoc.Comment
+  -> Instance
+translateHasFieldPtrInstance inst mbComment = Instance{
       clss   = Inst.HasField
     , args    = [fieldLit, parentPtr, tyPtr]
     , types   = []
@@ -610,63 +669,6 @@ translateHasFieldInstance inst mbComment = Instance{
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1287>
     -- This is not actually a free type variable.
     tyTypeVar = TFree $ Hs.UnsafeName "ty"
-
-{-------------------------------------------------------------------------------
-  'HasField'
--------------------------------------------------------------------------------}
-
-translateCompatHasFieldInstance ::
-     Hs.CompatHasFieldInstance
-  -> Maybe HsDoc.Comment
-  -> Instance
-translateCompatHasFieldInstance inst mbComment = Instance{
-      clss   = Inst.CompatHasField
-    , args    = [fieldLit, parent, tyTypeVar]
-    , types   = []
-    , comment = mbComment
-    , super   = [ TApp (TApp TEq tyTypeVar) field ]
-    , decs    = [ ( bindgenGlobalTerm CompatHasField_hasField
-                  , ELam (NameHint "x") $ appManyExpr (EBoxedTup $ Plus2 0) [
-                        exprSetter
-                      , exprGetter
-                      ]
-                  )
-                ]
-    }
-  where
-    parent    = translateType inst.parentType
-    field     = translateType inst.fieldType
-    fieldLit  = translateType $ Hs.StrLit $ Hs.nameToStr inst.fieldName
-
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1287>
-    -- This is not actually a free type variable.
-    tyTypeVar = TFree $ Hs.UnsafeName "ty"
-
-    exprGetter :: SExpr (S Z)
-    exprGetter = eBindgenGlobal HasField_getField `ETypeApp` fieldLit `EApp` EBound IZ
-
-    -- For the setter we use total record construction. The advantage with
-    -- record fields is that they can be used in any order regardless of the
-    -- order in which the fields were defined the datatype. This leads to a
-    -- simpler implementation compared to non-record construction. However,
-    -- because we use record fields we need total record construction instead of
-    -- a partial record update because the latter can cause warnings about
-    -- ambiguous field names. The implementation cost for record construction
-    -- compared to record update is low.
-    exprSetter :: SExpr (S Z)
-    exprSetter =
-        ELam (NameHint "y") $
-          ERecCon inst.constr $ concat [
-              [ FBind (Hs.nameToStr inst.fieldName) (EBound IZ) ]
-            , map mkFBindIdentity inst.otherFields
-            ]
-      where
-        -- An 'FBind' that leaves the original field unchanged
-        mkFBindIdentity :: Hs.Name Hs.NsVar -> FBind (S (S n))
-        mkFBindIdentity fieldName = FBind (Hs.nameToStr fieldName) $
-                      eBindgenGlobal HasField_getField
-            `ETypeApp` (translateType (Hs.StrLit (Hs.nameToStr fieldName)))
-            `EApp`      EBound (IS IZ)
 
 {-------------------------------------------------------------------------------
   Unions

--- a/hs-bindgen/src-internal/HsBindgen/Instances.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Instances.hs
@@ -45,8 +45,18 @@ data TypeClass =
   | HasCBitfield  -- Indicates instances for all bit fields
   | HasCField     -- Indicates instances for all non-bit fields
   | HasFFIType
-  | HasField      -- Indicates instances for all fields
-  | CompatHasField -- Indicates instances for all fields
+    -- | 'GHC.Records.HasField'
+    --
+    -- Indicates instances for all fields.
+  | HasField
+    -- | 'GHC.Records.Compat.HasField' instance
+    --
+    -- Indicates instances for all fields.
+  | HasFieldCompat
+    -- | 'GHC.Records.HasField' for the pointer manipulation API
+    --
+    -- Indicates instances for all fields.
+  | HasFieldPtr
   | Integral
   | IsArray
   | Ix
@@ -170,13 +180,14 @@ instance Default SupportedInstances where
   def =
     SupportedInstances{
         struct = Map.fromList [
-            mkDef CompatHasField Independent HsBindgen []
-          , mkDef Eq             Dependent   Stock     []
+            mkDef Eq             Dependent   Stock     []
           , mkDef Flam_Offset    Independent HsBindgen []
           , mkDef Generic        Independent Stock     []
           , mkDef HasCBitfield   Independent HsBindgen []
           , mkDef HasCField      Independent HsBindgen []
           , mkDef HasField       Independent HsBindgen []
+          , mkDef HasFieldCompat Independent HsBindgen []
+          , mkDef HasFieldPtr    Independent HsBindgen []
           , mkOpt Ord            Dependent             [Stock]
           , mkDef ReadRaw        Dependent   HsBindgen []
           , mkDef Show           Dependent   Stock     []
@@ -185,25 +196,27 @@ instance Default SupportedInstances where
           , mkDef WriteRaw       Dependent   HsBindgen []
           ]
       , union = Map.fromList [
-            mkDef Generic      Independent Stock     []
-          , mkDef HasCBitfield Independent HsBindgen []
-          , mkDef HasCField    Independent HsBindgen []
-          , mkDef HasField     Independent HsBindgen []
-          , mkDef ReadRaw      Independent HsBindgen []
-          , mkDef StaticSize   Independent HsBindgen []
-          , mkDef Storable     Independent HsBindgen []
-          , mkDef WriteRaw     Independent HsBindgen []
+            mkDef Generic        Independent Stock     []
+          , mkDef HasCBitfield   Independent HsBindgen []
+          , mkDef HasCField      Independent HsBindgen []
+          , mkDef HasFieldCompat Independent HsBindgen []
+          , mkDef HasFieldPtr    Independent HsBindgen []
+          , mkDef ReadRaw        Independent HsBindgen []
+          , mkDef StaticSize     Independent HsBindgen []
+          , mkDef Storable       Independent HsBindgen []
+          , mkDef WriteRaw       Independent HsBindgen []
           ]
       , enum = Map.fromList [
             mkOpt Bounded         Independent           [HsBindgen, Newtype]
           , mkDef CEnum           Independent HsBindgen []
-          , mkDef CompatHasField  Independent HsBindgen []
           , mkOpt Enum            Independent           [HsBindgen, Newtype]
           , mkDef Eq              Dependent   Stock     []
           , mkDef Generic         Independent Stock     []
           , mkDef HasCField       Independent HsBindgen []
           , mkDef HasFFIType      Dependent   Newtype   []
           , mkDef HasField        Independent HsBindgen []
+          , mkDef HasFieldCompat  Independent HsBindgen []
+          , mkDef HasFieldPtr     Independent HsBindgen []
           , mkDef Ord             Dependent   Stock     []
           , mkDef Prim            Independent HsBindgen []
           , mkDef Read            Independent HsBindgen [Newtype, Stock]
@@ -218,7 +231,6 @@ instance Default SupportedInstances where
             mkDef Bitfield        Dependent   Newtype   []
           , mkDef Bits            Dependent   Newtype   []
           , mkDef Bounded         Dependent   Newtype   []
-          , mkDef CompatHasField  Independent HsBindgen []
           , mkDef Enum            Dependent   Newtype   []
           , mkDef Eq              Dependent   Stock     []
           , mkDef FiniteBits      Dependent   Newtype   []
@@ -229,6 +241,8 @@ instance Default SupportedInstances where
           , mkDef HasCField       Independent HsBindgen []
           , mkDef HasFFIType      Dependent   Newtype   []
           , mkDef HasField        Independent HsBindgen []
+          , mkDef HasFieldCompat  Independent HsBindgen []
+          , mkDef HasFieldPtr     Independent HsBindgen []
           , mkDef Integral        Dependent   Newtype   []
             -- TODO: instance resolution for 'IsArray' is currently
             -- special-cased because for 'IsArray' instances we don't have to

--- a/hs-bindgen/test-artefacts/fixtures/arrays/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/array/Example.hs
@@ -50,6 +50,14 @@ newtype Triplet = Triplet
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapTriplet" Triplet ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Triplet {unwrapTriplet = y1}, RIP.getField @"unwrapTriplet" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr ty) where
 
   getField =
@@ -61,14 +69,6 @@ instance HasCField.HasCField Triplet "unwrapTriplet" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapTriplet" Triplet ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Triplet {unwrapTriplet = y1}, RIP.getField @"unwrapTriplet" x0)
 
 {-| __C declaration:__ @list@
 
@@ -83,6 +83,14 @@ newtype List = List
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapList" List ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         List {unwrapList = y1}, RIP.getField @"unwrapList" x0)
+
+instance ( ty ~ IA.IncompleteArray RIP.CInt
          ) => RIP.HasField "unwrapList" (RIP.Ptr List) (RIP.Ptr ty) where
 
   getField =
@@ -94,14 +102,6 @@ instance HasCField.HasCField List "unwrapList" where
     IA.IncompleteArray RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapList" List ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         List {unwrapList = y1}, RIP.getField @"unwrapList" x0)
 
 {-| __C declaration:__ @matrix@
 
@@ -122,6 +122,14 @@ newtype Matrix = Matrix
     )
 
 instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapMatrix" Matrix ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Matrix {unwrapMatrix = y1}, RIP.getField @"unwrapMatrix" x0)
+
+instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
          ) => RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr ty) where
 
   getField =
@@ -133,14 +141,6 @@ instance HasCField.HasCField Matrix "unwrapMatrix" where
     CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapMatrix" Matrix ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Matrix {unwrapMatrix = y1}, RIP.getField @"unwrapMatrix" x0)
 
 {-| __C declaration:__ @tripletlist@
 
@@ -155,6 +155,15 @@ newtype Tripletlist = Tripletlist
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapTripletlist" Tripletlist ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Tripletlist {unwrapTripletlist = y1}
+      , RIP.getField @"unwrapTripletlist" x0
+      )
+
+instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
          ) => RIP.HasField "unwrapTripletlist" (RIP.Ptr Tripletlist) (RIP.Ptr ty) where
 
   getField =
@@ -166,15 +175,6 @@ instance HasCField.HasCField Tripletlist "unwrapTripletlist" where
     IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapTripletlist" Tripletlist ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Tripletlist {unwrapTripletlist = y1}
-      , RIP.getField @"unwrapTripletlist" x0
-      )
 
 {-| __C declaration:__ @struct Example@
 
@@ -226,19 +226,6 @@ instance Marshal.WriteRaw Example where
 
 deriving via Marshal.EquivStorable Example instance RIP.Storable Example
 
-instance HasCField.HasCField Example "example_triple" where
-
-  type CFieldType Example "example_triple" =
-    CA.ConstantArray 3 RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.HasField "example_triple" (RIP.Ptr Example) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"example_triple")
-
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.CompatHasField.HasField "example_triple" Example ty where
 
@@ -249,18 +236,18 @@ instance ( ty ~ CA.ConstantArray 3 RIP.CInt
       , RIP.getField @"example_triple" x0
       )
 
-instance HasCField.HasCField Example "example_sudoku" where
-
-  type CFieldType Example "example_sudoku" =
-    CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.HasField "example_sudoku" (RIP.Ptr Example) (RIP.Ptr ty) where
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.HasField "example_triple" (RIP.Ptr Example) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_sudoku")
+    HasCField.fromPtr (RIP.Proxy @"example_triple")
+
+instance HasCField.HasCField Example "example_triple" where
+
+  type CFieldType Example "example_triple" =
+    CA.ConstantArray 3 RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
          ) => RIP.CompatHasField.HasField "example_sudoku" Example ty where
@@ -271,6 +258,19 @@ instance ( ty ~ CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
           Example {example_sudoku = y1, example_triple = RIP.getField @"example_triple" x0}
       , RIP.getField @"example_sudoku" x0
       )
+
+instance ( ty ~ CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
+         ) => RIP.HasField "example_sudoku" (RIP.Ptr Example) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"example_sudoku")
+
+instance HasCField.HasCField Example "example_sudoku" where
+
+  type CFieldType Example "example_sudoku" =
+    CA.ConstantArray 3 (CA.ConstantArray 3 RIP.CInt)
+
+  offset# = \_ -> \_ -> 12
 
 {-| Typedef-in-typedef.
 
@@ -293,6 +293,14 @@ newtype Sudoku = Sudoku
     )
 
 instance ( ty ~ CA.ConstantArray 3 Triplet
+         ) => RIP.CompatHasField.HasField "unwrapSudoku" Sudoku ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Sudoku {unwrapSudoku = y1}, RIP.getField @"unwrapSudoku" x0)
+
+instance ( ty ~ CA.ConstantArray 3 Triplet
          ) => RIP.HasField "unwrapSudoku" (RIP.Ptr Sudoku) (RIP.Ptr ty) where
 
   getField =
@@ -304,11 +312,3 @@ instance HasCField.HasCField Sudoku "unwrapSudoku" where
     CA.ConstantArray 3 Triplet
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 Triplet
-         ) => RIP.CompatHasField.HasField "unwrapSudoku" Sudoku ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Sudoku {unwrapSudoku = y1}, RIP.getField @"unwrapSudoku" x0)

--- a/hs-bindgen/test-artefacts/fixtures/arrays/array/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/array/bindingspec.yaml
@@ -30,11 +30,12 @@ hstypes:
       - example_triple
       - example_sudoku
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -47,11 +48,12 @@ hstypes:
       fields:
       - unwrapList
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: Matrix
@@ -61,11 +63,12 @@ hstypes:
       fields:
       - unwrapMatrix
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -79,11 +82,12 @@ hstypes:
       fields:
       - unwrapSudoku
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -97,11 +101,12 @@ hstypes:
       fields:
       - unwrapTriplet
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -115,10 +120,11 @@ hstypes:
       fields:
       - unwrapTripletlist
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/arrays/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/array/th.txt
@@ -680,16 +680,16 @@ newtype Triplet
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" Triplet ty
+    where hasField = \x_0 -> (\y_1 -> Triplet{unwrapTriplet = y_1},
+                              getField @"unwrapTriplet" x_0)
+instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
                                                                   CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapTriplet" Triplet ty
-    where hasField = \x_0 -> (\y_1 -> Triplet{unwrapTriplet = y_1},
-                              getField @"unwrapTriplet" x_0)
 {-| __C declaration:__ @list@
 
     __defined at:__ @arrays\/array.h 43:13@
@@ -701,15 +701,15 @@ newtype List
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray CInt) =>
+         HasField "unwrapList" List ty
+    where hasField = \x_0 -> (\y_1 -> List{unwrapList = y_1},
+                              getField @"unwrapList" x_0)
+instance (~) ty (IncompleteArray CInt) =>
          HasField "unwrapList" (Ptr List) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapList")
 instance HasCField List "unwrapList"
     where type CFieldType List "unwrapList" = IncompleteArray CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapList" List ty
-    where hasField = \x_0 -> (\y_1 -> List{unwrapList = y_1},
-                              getField @"unwrapList" x_0)
 {-| __C declaration:__ @matrix@
 
     __defined at:__ @arrays\/array.h 45:13@
@@ -721,16 +721,16 @@ newtype Matrix
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
+         HasField "unwrapMatrix" Matrix ty
+    where hasField = \x_0 -> (\y_1 -> Matrix{unwrapMatrix = y_1},
+                              getField @"unwrapMatrix" x_0)
+instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
          HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
                                                                 (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
-         HasField "unwrapMatrix" Matrix ty
-    where hasField = \x_0 -> (\y_1 -> Matrix{unwrapMatrix = y_1},
-                              getField @"unwrapMatrix" x_0)
 {-| __C declaration:__ @tripletlist@
 
     __defined at:__ @arrays\/array.h 47:13@
@@ -743,16 +743,16 @@ newtype Tripletlist
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
+         HasField "unwrapTripletlist" Tripletlist ty
+    where hasField = \x_0 -> (\y_1 -> Tripletlist{unwrapTripletlist = y_1},
+                              getField @"unwrapTripletlist" x_0)
+instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
          HasField "unwrapTripletlist" (Ptr Tripletlist) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTripletlist")
 instance HasCField Tripletlist "unwrapTripletlist"
     where type CFieldType Tripletlist
                           "unwrapTripletlist" = IncompleteArray (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
-         HasField "unwrapTripletlist" Tripletlist ty
-    where hasField = \x_0 -> (\y_1 -> Tripletlist{unwrapTripletlist = y_1},
-                              getField @"unwrapTripletlist" x_0)
 {-| __C declaration:__ @struct Example@
 
     __defined at:__ @arrays\/array.h 49:8@
@@ -785,30 +785,30 @@ instance WriteRaw Example
                                        Example example_triple_2
                                                example_sudoku_3 -> writeRaw (Proxy @"example_triple") ptr_0 example_triple_2 >> writeRaw (Proxy @"example_sudoku") ptr_0 example_sudoku_3
 deriving via (EquivStorable Example) instance Storable Example
-instance HasCField Example "example_triple"
-    where type CFieldType Example "example_triple" = ConstantArray 3
-                                                                   CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "example_triple" (Ptr Example) (Ptr ty)
-    where getField = fromPtr (Proxy @"example_triple")
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "example_triple" Example ty
     where hasField = \x_0 -> (\y_1 -> Example{example_triple = y_1,
                                               example_sudoku = getField @"example_sudoku" x_0},
                               getField @"example_triple" x_0)
-instance HasCField Example "example_sudoku"
-    where type CFieldType Example "example_sudoku" = ConstantArray 3
-                                                                   (ConstantArray 3 CInt)
-          offset# = \_ -> \_ -> 12
-instance (~) ty (ConstantArray 3 (ConstantArray 3 CInt)) =>
-         HasField "example_sudoku" (Ptr Example) (Ptr ty)
-    where getField = fromPtr (Proxy @"example_sudoku")
+instance (~) ty (ConstantArray 3 CInt) =>
+         HasField "example_triple" (Ptr Example) (Ptr ty)
+    where getField = fromPtr (Proxy @"example_triple")
+instance HasCField Example "example_triple"
+    where type CFieldType Example "example_triple" = ConstantArray 3
+                                                                   CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (ConstantArray 3 (ConstantArray 3 CInt)) =>
          HasField "example_sudoku" Example ty
     where hasField = \x_0 -> (\y_1 -> Example{example_sudoku = y_1,
                                               example_triple = getField @"example_triple" x_0},
                               getField @"example_sudoku" x_0)
+instance (~) ty (ConstantArray 3 (ConstantArray 3 CInt)) =>
+         HasField "example_sudoku" (Ptr Example) (Ptr ty)
+    where getField = fromPtr (Proxy @"example_sudoku")
+instance HasCField Example "example_sudoku"
+    where type CFieldType Example "example_sudoku" = ConstantArray 3
+                                                                   (ConstantArray 3 CInt)
+          offset# = \_ -> \_ -> 12
 {-| Typedef-in-typedef.
 
     __C declaration:__ @sudoku@
@@ -822,16 +822,16 @@ newtype Sudoku
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 3 Triplet) =>
+         HasField "unwrapSudoku" Sudoku ty
+    where hasField = \x_0 -> (\y_1 -> Sudoku{unwrapSudoku = y_1},
+                              getField @"unwrapSudoku" x_0)
+instance (~) ty (ConstantArray 3 Triplet) =>
          HasField "unwrapSudoku" (Ptr Sudoku) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSudoku")
 instance HasCField Sudoku "unwrapSudoku"
     where type CFieldType Sudoku "unwrapSudoku" = ConstantArray 3
                                                                 Triplet
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 Triplet) =>
-         HasField "unwrapSudoku" Sudoku ty
-    where hasField = \x_0 -> (\y_1 -> Sudoku{unwrapSudoku = y_1},
-                              getField @"unwrapSudoku" x_0)
 -- __unique:__ @test_arraysarray_Example_Safe_fun_1@
 foreign import ccall safe "hs_bindgen_a836491d63ff3a2c" hs_bindgen_a836491d63ff3a2c_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/Example.hs
@@ -42,6 +42,13 @@ newtype S = S
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapS" S ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> S {unwrapS = y1}, RIP.getField @"unwrapS" x0)
+
+instance ( ty ~ IA.IncompleteArray RIP.CInt
          ) => RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS")
@@ -52,13 +59,6 @@ instance HasCField.HasCField S "unwrapS" where
     IA.IncompleteArray RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapS" S ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> S {unwrapS = y1}, RIP.getField @"unwrapS" x0)
 
 {-| __C declaration:__ @T@
 
@@ -73,6 +73,13 @@ newtype T = T
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ IA.IncompleteArray RIP.CInt
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -83,13 +90,6 @@ instance HasCField.HasCField T "unwrapT" where
     IA.IncompleteArray RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 {-| __C declaration:__ @U@
 
@@ -110,6 +110,13 @@ newtype U = U
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
@@ -120,13 +127,6 @@ instance HasCField.HasCField U "unwrapU" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
 
 {-| __C declaration:__ @V@
 
@@ -147,6 +147,13 @@ newtype V = V
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapV" V ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> V {unwrapV = y1}, RIP.getField @"unwrapV" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapV" (RIP.Ptr V) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapV")
@@ -157,13 +164,6 @@ instance HasCField.HasCField V "unwrapV" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapV" V ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> V {unwrapV = y1}, RIP.getField @"unwrapV" x0)
 
 {-| __C declaration:__ @W@
 
@@ -184,6 +184,13 @@ newtype W = W
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapW" W ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> W {unwrapW = y1}, RIP.getField @"unwrapW" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapW" (RIP.Ptr W) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapW")
@@ -194,13 +201,6 @@ instance HasCField.HasCField W "unwrapW" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapW" W ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> W {unwrapW = y1}, RIP.getField @"unwrapW" x0)
 
 {-| __C declaration:__ @X@
 
@@ -221,6 +221,13 @@ newtype X = X
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapX" X ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> X {unwrapX = y1}, RIP.getField @"unwrapX" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapX" (RIP.Ptr X) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapX")
@@ -231,10 +238,3 @@ instance HasCField.HasCField X "unwrapX" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapX" X ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> X {unwrapX = y1}, RIP.getField @"unwrapX" x0)

--- a/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/bindingspec.yaml
@@ -29,11 +29,12 @@ hstypes:
       fields:
       - unwrapS
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: T
@@ -43,11 +44,12 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: U
@@ -57,11 +59,12 @@ hstypes:
       fields:
       - unwrapU
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -75,11 +78,12 @@ hstypes:
       fields:
       - unwrapV
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -93,11 +97,12 @@ hstypes:
       fields:
       - unwrapW
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -111,11 +116,12 @@ hstypes:
       fields:
       - unwrapX
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/const_qualifier/th.txt
@@ -250,15 +250,15 @@ newtype S
     = S {unwrapS :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty (IncompleteArray CInt) => HasField "unwrapS" S ty
+    where hasField = \x_0 -> (\y_1 -> S{unwrapS = y_1},
+                              getField @"unwrapS" x_0)
 instance (~) ty (IncompleteArray CInt) =>
          HasField "unwrapS" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = IncompleteArray CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray CInt) => HasField "unwrapS" S ty
-    where hasField = \x_0 -> (\y_1 -> S{unwrapS = y_1},
-                              getField @"unwrapS" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @arrays\/const_qualifier.h 8:19@
@@ -269,15 +269,15 @@ newtype T
     = T {unwrapT :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty (IncompleteArray CInt) => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty (IncompleteArray CInt) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = IncompleteArray CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray CInt) => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 {-| __C declaration:__ @U@
 
     __defined at:__ @arrays\/const_qualifier.h 18:19@
@@ -288,15 +288,15 @@ newtype U
     = U {unwrapU :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)
 {-| __C declaration:__ @V@
 
     __defined at:__ @arrays\/const_qualifier.h 19:19@
@@ -307,15 +307,15 @@ newtype V
     = V {unwrapV :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapV" V ty
+    where hasField = \x_0 -> (\y_1 -> V{unwrapV = y_1},
+                              getField @"unwrapV" x_0)
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapV" (Ptr V) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapV")
 instance HasCField V "unwrapV"
     where type CFieldType V "unwrapV" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapV" V ty
-    where hasField = \x_0 -> (\y_1 -> V{unwrapV = y_1},
-                              getField @"unwrapV" x_0)
 {-| __C declaration:__ @W@
 
     __defined at:__ @arrays\/const_qualifier.h 29:19@
@@ -326,15 +326,15 @@ newtype W
     = W {unwrapW :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapW" W ty
+    where hasField = \x_0 -> (\y_1 -> W{unwrapW = y_1},
+                              getField @"unwrapW" x_0)
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapW" (Ptr W) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapW")
 instance HasCField W "unwrapW"
     where type CFieldType W "unwrapW" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapW" W ty
-    where hasField = \x_0 -> (\y_1 -> W{unwrapW = y_1},
-                              getField @"unwrapW" x_0)
 {-| __C declaration:__ @X@
 
     __defined at:__ @arrays\/const_qualifier.h 30:19@
@@ -345,15 +345,15 @@ newtype X
     = X {unwrapX :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapX" X ty
+    where hasField = \x_0 -> (\y_1 -> X{unwrapX = y_1},
+                              getField @"unwrapX" x_0)
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapX" (Ptr X) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapX")
 instance HasCField X "unwrapX"
     where type CFieldType X "unwrapX" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapX" X ty
-    where hasField = \x_0 -> (\y_1 -> X{unwrapX = y_1},
-                              getField @"unwrapX" x_0)
 -- __unique:__ @test_arraysconst_qualifier_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_41e3579627406714" hs_bindgen_41e3579627406714_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/Example.hs
@@ -44,6 +44,14 @@ newtype Matrix = Matrix
     )
 
 instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapMatrix" Matrix ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Matrix {unwrapMatrix = y1}, RIP.getField @"unwrapMatrix" x0)
+
+instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
          ) => RIP.HasField "unwrapMatrix" (RIP.Ptr Matrix) (RIP.Ptr ty) where
 
   getField =
@@ -55,14 +63,6 @@ instance HasCField.HasCField Matrix "unwrapMatrix" where
     CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 4 (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapMatrix" Matrix ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Matrix {unwrapMatrix = y1}, RIP.getField @"unwrapMatrix" x0)
 
 {-| __C declaration:__ @triplets@
 
@@ -77,6 +77,14 @@ newtype Triplets = Triplets
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapTriplets" Triplets ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Triplets {unwrapTriplets = y1}, RIP.getField @"unwrapTriplets" x0)
+
+instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
          ) => RIP.HasField "unwrapTriplets" (RIP.Ptr Triplets) (RIP.Ptr ty) where
 
   getField =
@@ -88,11 +96,3 @@ instance HasCField.HasCField Triplets "unwrapTriplets" where
     IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray (CA.ConstantArray 3 RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapTriplets" Triplets ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Triplets {unwrapTriplets = y1}, RIP.getField @"unwrapTriplets" x0)

--- a/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - unwrapMatrix
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -35,10 +36,11 @@ hstypes:
       fields:
       - unwrapTriplets
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/arrays/multi_dim/th.txt
@@ -171,16 +171,16 @@ newtype Matrix
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
+         HasField "unwrapMatrix" Matrix ty
+    where hasField = \x_0 -> (\y_1 -> Matrix{unwrapMatrix = y_1},
+                              getField @"unwrapMatrix" x_0)
+instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
          HasField "unwrapMatrix" (Ptr Matrix) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMatrix")
 instance HasCField Matrix "unwrapMatrix"
     where type CFieldType Matrix "unwrapMatrix" = ConstantArray 4
                                                                 (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 (ConstantArray 3 CInt)) =>
-         HasField "unwrapMatrix" Matrix ty
-    where hasField = \x_0 -> (\y_1 -> Matrix{unwrapMatrix = y_1},
-                              getField @"unwrapMatrix" x_0)
 {-| __C declaration:__ @triplets@
 
     __defined at:__ @arrays\/multi_dim.h 17:13@
@@ -193,16 +193,16 @@ newtype Triplets
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
+         HasField "unwrapTriplets" Triplets ty
+    where hasField = \x_0 -> (\y_1 -> Triplets{unwrapTriplets = y_1},
+                              getField @"unwrapTriplets" x_0)
+instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
          HasField "unwrapTriplets" (Ptr Triplets) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplets")
 instance HasCField Triplets "unwrapTriplets"
     where type CFieldType Triplets
                           "unwrapTriplets" = IncompleteArray (ConstantArray 3 CInt)
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray (ConstantArray 3 CInt)) =>
-         HasField "unwrapTriplets" Triplets ty
-    where hasField = \x_0 -> (\y_1 -> Triplets{unwrapTriplets = y_1},
-                              getField @"unwrapTriplets" x_0)
 -- __unique:__ @test_arraysmulti_dim_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_57b00b79dd5b838e" hs_bindgen_57b00b79dd5b838e_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/attributes/attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/attributes/Example.hs
@@ -76,17 +76,6 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCField.HasCField Foo "foo_c" where
-
-  type CFieldType Foo "foo_c" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
 
   hasField =
@@ -96,16 +85,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
       , RIP.getField @"foo_c" x0
       )
 
-instance HasCField.HasCField Foo "foo_i" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
-  type CFieldType Foo "foo_i" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
 
-  offset# = \_ -> \_ -> 1
+instance HasCField.HasCField Foo "foo_c" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
+  type CFieldType Foo "foo_c" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_i" Foo ty where
 
@@ -115,6 +104,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_i" Foo ty where
           Foo {foo_i = y1, foo_c = RIP.getField @"foo_c" x0}
       , RIP.getField @"foo_i" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
+
+instance HasCField.HasCField Foo "foo_i" where
+
+  type CFieldType Foo "foo_i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @struct bar@
 
@@ -166,17 +166,6 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCField.HasCField Bar "bar_c" where
-
-  type CFieldType Bar "bar_c" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "bar_c" (RIP.Ptr Bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_c")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "bar_c" Bar ty where
 
   hasField =
@@ -186,16 +175,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "bar_c" Bar ty where
       , RIP.getField @"bar_c" x0
       )
 
-instance HasCField.HasCField Bar "bar_i" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "bar_c" (RIP.Ptr Bar) (RIP.Ptr ty) where
 
-  type CFieldType Bar "bar_i" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_c")
 
-  offset# = \_ -> \_ -> 1
+instance HasCField.HasCField Bar "bar_c" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_i" (RIP.Ptr Bar) (RIP.Ptr ty) where
+  type CFieldType Bar "bar_c" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_i")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "bar_i" Bar ty where
 
@@ -205,6 +194,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "bar_i" Bar ty where
           Bar {bar_i = y1, bar_c = RIP.getField @"bar_c" x0}
       , RIP.getField @"bar_i" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_i" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_i")
+
+instance HasCField.HasCField Bar "bar_i" where
+
+  type CFieldType Bar "bar_i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @struct baz@
 
@@ -256,17 +256,6 @@ instance Marshal.WriteRaw Baz where
 
 deriving via Marshal.EquivStorable Baz instance RIP.Storable Baz
 
-instance HasCField.HasCField Baz "baz_c" where
-
-  type CFieldType Baz "baz_c" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "baz_c" (RIP.Ptr Baz) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"baz_c")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "baz_c" Baz ty where
 
   hasField =
@@ -276,16 +265,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "baz_c" Baz ty where
       , RIP.getField @"baz_c" x0
       )
 
-instance HasCField.HasCField Baz "baz_i" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "baz_c" (RIP.Ptr Baz) (RIP.Ptr ty) where
 
-  type CFieldType Baz "baz_i" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"baz_c")
 
-  offset# = \_ -> \_ -> 1
+instance HasCField.HasCField Baz "baz_c" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_i" (RIP.Ptr Baz) (RIP.Ptr ty) where
+  type CFieldType Baz "baz_c" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"baz_i")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "baz_i" Baz ty where
 
@@ -295,6 +284,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "baz_i" Baz ty where
           Baz {baz_i = y1, baz_c = RIP.getField @"baz_c" x0}
       , RIP.getField @"baz_i" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "baz_i" (RIP.Ptr Baz) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"baz_i")
+
+instance HasCField.HasCField Baz "baz_i" where
+
+  type CFieldType Baz "baz_i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @struct qux@
 
@@ -346,17 +346,6 @@ instance Marshal.WriteRaw Qux where
 
 deriving via Marshal.EquivStorable Qux instance RIP.Storable Qux
 
-instance HasCField.HasCField Qux "qux_c" where
-
-  type CFieldType Qux "qux_c" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "qux_c" (RIP.Ptr Qux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"qux_c")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "qux_c" Qux ty where
 
   hasField =
@@ -366,16 +355,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "qux_c" Qux ty where
       , RIP.getField @"qux_c" x0
       )
 
-instance HasCField.HasCField Qux "qux_i" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "qux_c" (RIP.Ptr Qux) (RIP.Ptr ty) where
 
-  type CFieldType Qux "qux_i" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"qux_c")
 
-  offset# = \_ -> \_ -> 1
+instance HasCField.HasCField Qux "qux_c" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "qux_i" (RIP.Ptr Qux) (RIP.Ptr ty) where
+  type CFieldType Qux "qux_c" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"qux_i")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "qux_i" Qux ty where
 
@@ -385,6 +374,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "qux_i" Qux ty where
           Qux {qux_i = y1, qux_c = RIP.getField @"qux_c" x0}
       , RIP.getField @"qux_i" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "qux_i" (RIP.Ptr Qux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"qux_i")
+
+instance HasCField.HasCField Qux "qux_i" where
+
+  type CFieldType Qux "qux_i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @struct __sFILE@
 
@@ -445,17 +445,6 @@ instance Marshal.WriteRaw FILE where
 
 deriving via Marshal.EquivStorable FILE instance RIP.Storable FILE
 
-instance HasCField.HasCField FILE "fILE__r" where
-
-  type CFieldType FILE "fILE__r" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "fILE__r" (RIP.Ptr FILE) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"fILE__r")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "fILE__r" FILE ty where
 
   hasField =
@@ -468,16 +457,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "fILE__r" FILE ty where
       , RIP.getField @"fILE__r" x0
       )
 
-instance HasCField.HasCField FILE "fILE__w" where
-
-  type CFieldType FILE "fILE__w" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "fILE__w" (RIP.Ptr FILE) (RIP.Ptr ty) where
+         ) => RIP.HasField "fILE__r" (RIP.Ptr FILE) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"fILE__w")
+  getField = HasCField.fromPtr (RIP.Proxy @"fILE__r")
+
+instance HasCField.HasCField FILE "fILE__r" where
+
+  type CFieldType FILE "fILE__r" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "fILE__w" FILE ty where
 
@@ -491,18 +480,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "fILE__w" FILE ty where
       , RIP.getField @"fILE__w" x0
       )
 
-instance HasCField.HasCField FILE "fILE__close" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "fILE__w" (RIP.Ptr FILE) (RIP.Ptr ty) where
 
-  type CFieldType FILE "fILE__close" =
-    RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
+  getField = HasCField.fromPtr (RIP.Proxy @"fILE__w")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField FILE "fILE__w" where
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.HasField "fILE__close" (RIP.Ptr FILE) (RIP.Ptr ty) where
+  type CFieldType FILE "fILE__w" = RIP.CInt
 
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"fILE__close")
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
          ) => RIP.CompatHasField.HasField "fILE__close" FILE ty where
@@ -516,3 +503,16 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
                }
       , RIP.getField @"fILE__close" x0
       )
+
+instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
+         ) => RIP.HasField "fILE__close" (RIP.Ptr FILE) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"fILE__close")
+
+instance HasCField.HasCField FILE "fILE__close" where
+
+  type CFieldType FILE "fILE__close" =
+    RIP.FunPtr (RIP.Ptr RIP.Void -> IO RIP.CInt)
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/attributes/attributes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/attributes/bindingspec.yaml
@@ -36,11 +36,12 @@ hstypes:
       - bar_c
       - bar_i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,11 +55,12 @@ hstypes:
       - baz_c
       - baz_i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,11 +75,12 @@ hstypes:
       - fILE__w
       - fILE__close
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -91,11 +94,12 @@ hstypes:
       - foo_c
       - foo_i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,11 +113,12 @@ hstypes:
       - qux_c
       - qux_i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/attributes/attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/attributes/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw Foo
                                        Foo foo_c_2
                                            foo_i_3 -> writeRaw (Proxy @"foo_c") ptr_0 foo_c_2 >> writeRaw (Proxy @"foo_i") ptr_0 foo_i_3
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCField Foo "foo_c"
-    where type CFieldType Foo "foo_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_c")
 instance (~) ty CChar => HasField "foo_c" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_c = y_1,
                                           foo_i = getField @"foo_i" x_0},
                               getField @"foo_c" x_0)
-instance HasCField Foo "foo_i"
-    where type CFieldType Foo "foo_i" = CInt
-          offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_i")
+instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_c")
+instance HasCField Foo "foo_c"
+    where type CFieldType Foo "foo_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "foo_i" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_i = y_1,
                                           foo_c = getField @"foo_c" x_0},
                               getField @"foo_i" x_0)
+instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_i")
+instance HasCField Foo "foo_i"
+    where type CFieldType Foo "foo_i" = CInt
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @struct bar@
 
     __defined at:__ @attributes\/attributes.h 16:15@
@@ -81,24 +81,24 @@ instance WriteRaw Bar
                                        Bar bar_c_2
                                            bar_i_3 -> writeRaw (Proxy @"bar_c") ptr_0 bar_c_2 >> writeRaw (Proxy @"bar_i") ptr_0 bar_i_3
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCField Bar "bar_c"
-    where type CFieldType Bar "bar_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "bar_c" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_c")
 instance (~) ty CChar => HasField "bar_c" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_c = y_1,
                                           bar_i = getField @"bar_i" x_0},
                               getField @"bar_c" x_0)
-instance HasCField Bar "bar_i"
-    where type CFieldType Bar "bar_i" = CInt
-          offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "bar_i" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_i")
+instance (~) ty CChar => HasField "bar_c" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_c")
+instance HasCField Bar "bar_c"
+    where type CFieldType Bar "bar_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "bar_i" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_i = y_1,
                                           bar_c = getField @"bar_c" x_0},
                               getField @"bar_i" x_0)
+instance (~) ty CInt => HasField "bar_i" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_i")
+instance HasCField Bar "bar_i"
+    where type CFieldType Bar "bar_i" = CInt
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @struct baz@
 
     __defined at:__ @attributes\/attributes.h 22:9@
@@ -131,24 +131,24 @@ instance WriteRaw Baz
                                        Baz baz_c_2
                                            baz_i_3 -> writeRaw (Proxy @"baz_c") ptr_0 baz_c_2 >> writeRaw (Proxy @"baz_i") ptr_0 baz_i_3
 deriving via (EquivStorable Baz) instance Storable Baz
-instance HasCField Baz "baz_c"
-    where type CFieldType Baz "baz_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "baz_c" (Ptr Baz) (Ptr ty)
-    where getField = fromPtr (Proxy @"baz_c")
 instance (~) ty CChar => HasField "baz_c" Baz ty
     where hasField = \x_0 -> (\y_1 -> Baz{baz_c = y_1,
                                           baz_i = getField @"baz_i" x_0},
                               getField @"baz_c" x_0)
-instance HasCField Baz "baz_i"
-    where type CFieldType Baz "baz_i" = CInt
-          offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "baz_i" (Ptr Baz) (Ptr ty)
-    where getField = fromPtr (Proxy @"baz_i")
+instance (~) ty CChar => HasField "baz_c" (Ptr Baz) (Ptr ty)
+    where getField = fromPtr (Proxy @"baz_c")
+instance HasCField Baz "baz_c"
+    where type CFieldType Baz "baz_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "baz_i" Baz ty
     where hasField = \x_0 -> (\y_1 -> Baz{baz_i = y_1,
                                           baz_c = getField @"baz_c" x_0},
                               getField @"baz_i" x_0)
+instance (~) ty CInt => HasField "baz_i" (Ptr Baz) (Ptr ty)
+    where getField = fromPtr (Proxy @"baz_i")
+instance HasCField Baz "baz_i"
+    where type CFieldType Baz "baz_i" = CInt
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @struct qux@
 
     __defined at:__ @attributes\/attributes.h 28:9@
@@ -181,24 +181,24 @@ instance WriteRaw Qux
                                        Qux qux_c_2
                                            qux_i_3 -> writeRaw (Proxy @"qux_c") ptr_0 qux_c_2 >> writeRaw (Proxy @"qux_i") ptr_0 qux_i_3
 deriving via (EquivStorable Qux) instance Storable Qux
-instance HasCField Qux "qux_c"
-    where type CFieldType Qux "qux_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "qux_c" (Ptr Qux) (Ptr ty)
-    where getField = fromPtr (Proxy @"qux_c")
 instance (~) ty CChar => HasField "qux_c" Qux ty
     where hasField = \x_0 -> (\y_1 -> Qux{qux_c = y_1,
                                           qux_i = getField @"qux_i" x_0},
                               getField @"qux_c" x_0)
-instance HasCField Qux "qux_i"
-    where type CFieldType Qux "qux_i" = CInt
-          offset# = \_ -> \_ -> 1
-instance (~) ty CInt => HasField "qux_i" (Ptr Qux) (Ptr ty)
-    where getField = fromPtr (Proxy @"qux_i")
+instance (~) ty CChar => HasField "qux_c" (Ptr Qux) (Ptr ty)
+    where getField = fromPtr (Proxy @"qux_c")
+instance HasCField Qux "qux_c"
+    where type CFieldType Qux "qux_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "qux_i" Qux ty
     where hasField = \x_0 -> (\y_1 -> Qux{qux_i = y_1,
                                           qux_c = getField @"qux_c" x_0},
                               getField @"qux_i" x_0)
+instance (~) ty CInt => HasField "qux_i" (Ptr Qux) (Ptr ty)
+    where getField = fromPtr (Proxy @"qux_i")
+instance HasCField Qux "qux_i"
+    where type CFieldType Qux "qux_i" = CInt
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @struct __sFILE@
 
     __defined at:__ @attributes\/attributes.h 34:16@
@@ -239,36 +239,36 @@ instance WriteRaw FILE
                                             fILE__w_3
                                             fILE__close_4 -> writeRaw (Proxy @"fILE__r") ptr_0 fILE__r_2 >> (writeRaw (Proxy @"fILE__w") ptr_0 fILE__w_3 >> writeRaw (Proxy @"fILE__close") ptr_0 fILE__close_4)
 deriving via (EquivStorable FILE) instance Storable FILE
-instance HasCField FILE "fILE__r"
-    where type CFieldType FILE "fILE__r" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "fILE__r" (Ptr FILE) (Ptr ty)
-    where getField = fromPtr (Proxy @"fILE__r")
 instance (~) ty CInt => HasField "fILE__r" FILE ty
     where hasField = \x_0 -> (\y_1 -> FILE{fILE__r = y_1,
                                            fILE__w = getField @"fILE__w" x_0,
                                            fILE__close = getField @"fILE__close" x_0},
                               getField @"fILE__r" x_0)
-instance HasCField FILE "fILE__w"
-    where type CFieldType FILE "fILE__w" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "fILE__w" (Ptr FILE) (Ptr ty)
-    where getField = fromPtr (Proxy @"fILE__w")
+instance (~) ty CInt => HasField "fILE__r" (Ptr FILE) (Ptr ty)
+    where getField = fromPtr (Proxy @"fILE__r")
+instance HasCField FILE "fILE__r"
+    where type CFieldType FILE "fILE__r" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "fILE__w" FILE ty
     where hasField = \x_0 -> (\y_1 -> FILE{fILE__w = y_1,
                                            fILE__r = getField @"fILE__r" x_0,
                                            fILE__close = getField @"fILE__close" x_0},
                               getField @"fILE__w" x_0)
-instance HasCField FILE "fILE__close"
-    where type CFieldType FILE "fILE__close" = FunPtr (Ptr Void ->
-                                                       IO CInt)
-          offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Void -> IO CInt)) =>
-         HasField "fILE__close" (Ptr FILE) (Ptr ty)
-    where getField = fromPtr (Proxy @"fILE__close")
+instance (~) ty CInt => HasField "fILE__w" (Ptr FILE) (Ptr ty)
+    where getField = fromPtr (Proxy @"fILE__w")
+instance HasCField FILE "fILE__w"
+    where type CFieldType FILE "fILE__w" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty (FunPtr (Ptr Void -> IO CInt)) =>
          HasField "fILE__close" FILE ty
     where hasField = \x_0 -> (\y_1 -> FILE{fILE__close = y_1,
                                            fILE__r = getField @"fILE__r" x_0,
                                            fILE__w = getField @"fILE__w" x_0},
                               getField @"fILE__close" x_0)
+instance (~) ty (FunPtr (Ptr Void -> IO CInt)) =>
+         HasField "fILE__close" (Ptr FILE) (Ptr ty)
+    where getField = fromPtr (Proxy @"fILE__close")
+instance HasCField FILE "fILE__close"
+    where type CFieldType FILE "fILE__close" = FunPtr (Ptr Void ->
+                                                       IO CInt)
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/Example.hs
@@ -79,23 +79,23 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_f" where
+instance ( ty ~ CA.ConstantArray 3 RIP.CShort
+         ) => RIP.CompatHasField.HasField "s_f" S ty where
 
-  type CFieldType S "s_f" =
-    CA.ConstantArray 3 RIP.CShort
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S {s_f = y1}, RIP.getField @"s_f" x0)
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CShort
          ) => RIP.HasField "s_f" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_f")
 
-instance ( ty ~ CA.ConstantArray 3 RIP.CShort
-         ) => RIP.CompatHasField.HasField "s_f" S ty where
+instance HasCField.HasCField S "s_f" where
 
-  hasField =
-    \x0 -> (\y1 -> S {s_f = y1}, RIP.getField @"s_f" x0)
+  type CFieldType S "s_f" =
+    CA.ConstantArray 3 RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @more_aligned_int@
 
@@ -126,6 +126,16 @@ newtype More_aligned_int = More_aligned_int
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMore_aligned_int" More_aligned_int ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          More_aligned_int {unwrapMore_aligned_int = y1}
+      , RIP.getField @"unwrapMore_aligned_int" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMore_aligned_int" (RIP.Ptr More_aligned_int) (RIP.Ptr ty) where
 
   getField =
@@ -137,16 +147,6 @@ instance HasCField.HasCField More_aligned_int "unwrapMore_aligned_int" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMore_aligned_int" More_aligned_int ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          More_aligned_int {unwrapMore_aligned_int = y1}
-      , RIP.getField @"unwrapMore_aligned_int" x0
-      )
 
 {-| __C declaration:__ @struct S2@
 
@@ -189,24 +189,24 @@ instance Marshal.WriteRaw S2 where
 
 deriving via Marshal.EquivStorable S2 instance RIP.Storable S2
 
-instance HasCField.HasCField S2 "s2_f" where
-
-  type CFieldType S2 "s2_f" =
-    CA.ConstantArray 3 RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CShort
-         ) => RIP.HasField "s2_f" (RIP.Ptr S2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_f")
-
 instance ( ty ~ CA.ConstantArray 3 RIP.CShort
          ) => RIP.CompatHasField.HasField "s2_f" S2 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S2 {s2_f = y1}, RIP.getField @"s2_f" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CShort
+         ) => RIP.HasField "s2_f" (RIP.Ptr S2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_f")
+
+instance HasCField.HasCField S2 "s2_f" where
+
+  type CFieldType S2 "s2_f" =
+    CA.ConstantArray 3 RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct my_unpacked_struct@
 
@@ -258,19 +258,6 @@ instance Marshal.WriteRaw My_unpacked_struct where
 
 deriving via Marshal.EquivStorable My_unpacked_struct instance RIP.Storable My_unpacked_struct
 
-instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_c" where
-
-  type CFieldType My_unpacked_struct "my_unpacked_struct_c" =
-    RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "my_unpacked_struct_c" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_c")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "my_unpacked_struct_c" My_unpacked_struct ty where
 
@@ -283,18 +270,18 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"my_unpacked_struct_c" x0
       )
 
-instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_i" where
-
-  type CFieldType My_unpacked_struct "my_unpacked_struct_i" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "my_unpacked_struct_i" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "my_unpacked_struct_c" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_i")
+    HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_c")
+
+instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_c" where
+
+  type CFieldType My_unpacked_struct "my_unpacked_struct_c" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "my_unpacked_struct_i" My_unpacked_struct ty where
@@ -307,6 +294,19 @@ instance ( ty ~ RIP.CInt
                              }
       , RIP.getField @"my_unpacked_struct_i" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "my_unpacked_struct_i" (RIP.Ptr My_unpacked_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"my_unpacked_struct_i")
+
+instance HasCField.HasCField My_unpacked_struct "my_unpacked_struct_i" where
+
+  type CFieldType My_unpacked_struct "my_unpacked_struct_i" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct my_packed_struct@
 
@@ -367,19 +367,6 @@ instance Marshal.WriteRaw My_packed_struct where
 
 deriving via Marshal.EquivStorable My_packed_struct instance RIP.Storable My_packed_struct
 
-instance HasCField.HasCField My_packed_struct "my_packed_struct_c" where
-
-  type CFieldType My_packed_struct "my_packed_struct_c" =
-    RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "my_packed_struct_c" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_c")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "my_packed_struct_c" My_packed_struct ty where
 
@@ -393,18 +380,18 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"my_packed_struct_c" x0
       )
 
-instance HasCField.HasCField My_packed_struct "my_packed_struct_i" where
-
-  type CFieldType My_packed_struct "my_packed_struct_i" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 1
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "my_packed_struct_i" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "my_packed_struct_c" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_i")
+    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_c")
+
+instance HasCField.HasCField My_packed_struct "my_packed_struct_c" where
+
+  type CFieldType My_packed_struct "my_packed_struct_c" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "my_packed_struct_i" My_packed_struct ty where
@@ -419,18 +406,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"my_packed_struct_i" x0
       )
 
-instance HasCField.HasCField My_packed_struct "my_packed_struct_s" where
-
-  type CFieldType My_packed_struct "my_packed_struct_s" =
-    My_unpacked_struct
-
-  offset# = \_ -> \_ -> 5
-
-instance ( ty ~ My_unpacked_struct
-         ) => RIP.HasField "my_packed_struct_s" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "my_packed_struct_i" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_s")
+    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_i")
+
+instance HasCField.HasCField My_packed_struct "my_packed_struct_i" where
+
+  type CFieldType My_packed_struct "my_packed_struct_i" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 1
 
 instance ( ty ~ My_unpacked_struct
          ) => RIP.CompatHasField.HasField "my_packed_struct_s" My_packed_struct ty where
@@ -444,6 +431,19 @@ instance ( ty ~ My_unpacked_struct
                            }
       , RIP.getField @"my_packed_struct_s" x0
       )
+
+instance ( ty ~ My_unpacked_struct
+         ) => RIP.HasField "my_packed_struct_s" (RIP.Ptr My_packed_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"my_packed_struct_s")
+
+instance HasCField.HasCField My_packed_struct "my_packed_struct_s" where
+
+  type CFieldType My_packed_struct "my_packed_struct_s" =
+    My_unpacked_struct
+
+  offset# = \_ -> \_ -> 5
 
 {-| __C declaration:__ @union wait_status_ptr_t@
 
@@ -514,23 +514,16 @@ set_wait_status_ptr_t___up ::
   -> Wait_status_ptr_t
 set_wait_status_ptr_t___up = RIP.setUnionPayload
 
-instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___ip" where
-
-  type CFieldType Wait_status_ptr_t "wait_status_ptr_t___ip" =
-    RIP.Ptr RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "wait_status_ptr_t___ip" (RIP.Ptr Wait_status_ptr_t) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"wait_status_ptr_t___ip")
 
-instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___up" where
+instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___ip" where
 
-  type CFieldType Wait_status_ptr_t "wait_status_ptr_t___up" =
-    RIP.Ptr Wait
+  type CFieldType Wait_status_ptr_t "wait_status_ptr_t___ip" =
+    RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -539,6 +532,13 @@ instance ( ty ~ RIP.Ptr Wait
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"wait_status_ptr_t___up")
+
+instance HasCField.HasCField Wait_status_ptr_t "wait_status_ptr_t___up" where
+
+  type CFieldType Wait_status_ptr_t "wait_status_ptr_t___up" =
+    RIP.Ptr Wait
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union wait@
 
@@ -576,6 +576,13 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
 
@@ -586,13 +593,6 @@ instance HasCField.HasCField T1 "unwrapT1" where
   type CFieldType T1 "unwrapT1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
 
 {-| __C declaration:__ @short_a@
 
@@ -623,6 +623,14 @@ newtype Short_a = Short_a
     )
 
 instance ( ty ~ RIP.CShort
+         ) => RIP.CompatHasField.HasField "unwrapShort_a" Short_a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Short_a {unwrapShort_a = y1}, RIP.getField @"unwrapShort_a" x0)
+
+instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapShort_a" (RIP.Ptr Short_a) (RIP.Ptr ty) where
 
   getField =
@@ -633,11 +641,3 @@ instance HasCField.HasCField Short_a "unwrapShort_a" where
   type CFieldType Short_a "unwrapShort_a" = RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.CompatHasField.HasField "unwrapShort_a" Short_a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Short_a {unwrapShort_a = y1}, RIP.getField @"unwrapShort_a" x0)

--- a/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/bindingspec.yaml
@@ -44,7 +44,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -52,6 +51,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -73,11 +74,12 @@ hstypes:
       - my_packed_struct_i
       - my_packed_struct_s
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -91,11 +93,12 @@ hstypes:
       - my_unpacked_struct_c
       - my_unpacked_struct_i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -108,11 +111,12 @@ hstypes:
       fields:
       - s_f
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -125,11 +129,12 @@ hstypes:
       fields:
       - s2_f
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -145,7 +150,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -153,6 +157,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -175,7 +181,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -183,6 +188,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -206,7 +213,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/type_attributes/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_f_2 -> writeRaw (Proxy @"s_f") ptr_0 s_f_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_f"
-    where type CFieldType S "s_f" = ConstantArray 3 CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CShort) =>
-         HasField "s_f" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_f")
 instance (~) ty (ConstantArray 3 CShort) => HasField "s_f" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_f = y_1},
                               getField @"s_f" x_0)
+instance (~) ty (ConstantArray 3 CShort) =>
+         HasField "s_f" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_f")
+instance HasCField S "s_f"
+    where type CFieldType S "s_f" = ConstantArray 3 CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @more_aligned_int@
 
     __defined at:__ @attributes\/type_attributes.h 9:13@
@@ -57,16 +57,16 @@ newtype More_aligned_int
                       Storable,
                       WriteRaw)
 instance (~) ty CInt =>
+         HasField "unwrapMore_aligned_int" More_aligned_int ty
+    where hasField = \x_0 -> (\y_1 -> More_aligned_int{unwrapMore_aligned_int = y_1},
+                              getField @"unwrapMore_aligned_int" x_0)
+instance (~) ty CInt =>
          HasField "unwrapMore_aligned_int" (Ptr More_aligned_int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMore_aligned_int")
 instance HasCField More_aligned_int "unwrapMore_aligned_int"
     where type CFieldType More_aligned_int
                           "unwrapMore_aligned_int" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapMore_aligned_int" More_aligned_int ty
-    where hasField = \x_0 -> (\y_1 -> More_aligned_int{unwrapMore_aligned_int = y_1},
-                              getField @"unwrapMore_aligned_int" x_0)
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @attributes\/type_attributes.h 11:8@
@@ -91,15 +91,15 @@ instance WriteRaw S2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S2 s2_f_2 -> writeRaw (Proxy @"s2_f") ptr_0 s2_f_2
 deriving via (EquivStorable S2) instance Storable S2
-instance HasCField S2 "s2_f"
-    where type CFieldType S2 "s2_f" = ConstantArray 3 CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CShort) =>
-         HasField "s2_f" (Ptr S2) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_f")
 instance (~) ty (ConstantArray 3 CShort) => HasField "s2_f" S2 ty
     where hasField = \x_0 -> (\y_1 -> S2{s2_f = y_1},
                               getField @"s2_f" x_0)
+instance (~) ty (ConstantArray 3 CShort) =>
+         HasField "s2_f" (Ptr S2) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_f")
+instance HasCField S2 "s2_f"
+    where type CFieldType S2 "s2_f" = ConstantArray 3 CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct my_unpacked_struct@
 
     __defined at:__ @attributes\/type_attributes.h 13:8@
@@ -132,30 +132,30 @@ instance WriteRaw My_unpacked_struct
                                        My_unpacked_struct my_unpacked_struct_c_2
                                                           my_unpacked_struct_i_3 -> writeRaw (Proxy @"my_unpacked_struct_c") ptr_0 my_unpacked_struct_c_2 >> writeRaw (Proxy @"my_unpacked_struct_i") ptr_0 my_unpacked_struct_i_3
 deriving via (EquivStorable My_unpacked_struct) instance Storable My_unpacked_struct
-instance HasCField My_unpacked_struct "my_unpacked_struct_c"
-    where type CFieldType My_unpacked_struct
-                          "my_unpacked_struct_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "my_unpacked_struct_c" (Ptr My_unpacked_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"my_unpacked_struct_c")
 instance (~) ty CChar =>
          HasField "my_unpacked_struct_c" My_unpacked_struct ty
     where hasField = \x_0 -> (\y_1 -> My_unpacked_struct{my_unpacked_struct_c = y_1,
                                                          my_unpacked_struct_i = getField @"my_unpacked_struct_i" x_0},
                               getField @"my_unpacked_struct_c" x_0)
-instance HasCField My_unpacked_struct "my_unpacked_struct_i"
+instance (~) ty CChar =>
+         HasField "my_unpacked_struct_c" (Ptr My_unpacked_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"my_unpacked_struct_c")
+instance HasCField My_unpacked_struct "my_unpacked_struct_c"
     where type CFieldType My_unpacked_struct
-                          "my_unpacked_struct_i" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "my_unpacked_struct_i" (Ptr My_unpacked_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"my_unpacked_struct_i")
+                          "my_unpacked_struct_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "my_unpacked_struct_i" My_unpacked_struct ty
     where hasField = \x_0 -> (\y_1 -> My_unpacked_struct{my_unpacked_struct_i = y_1,
                                                          my_unpacked_struct_c = getField @"my_unpacked_struct_c" x_0},
                               getField @"my_unpacked_struct_i" x_0)
+instance (~) ty CInt =>
+         HasField "my_unpacked_struct_i" (Ptr My_unpacked_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"my_unpacked_struct_i")
+instance HasCField My_unpacked_struct "my_unpacked_struct_i"
+    where type CFieldType My_unpacked_struct
+                          "my_unpacked_struct_i" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct my_packed_struct@
 
     __defined at:__ @attributes\/type_attributes.h 19:37@
@@ -196,43 +196,43 @@ instance WriteRaw My_packed_struct
                                                         my_packed_struct_i_3
                                                         my_packed_struct_s_4 -> writeRaw (Proxy @"my_packed_struct_c") ptr_0 my_packed_struct_c_2 >> (writeRaw (Proxy @"my_packed_struct_i") ptr_0 my_packed_struct_i_3 >> writeRaw (Proxy @"my_packed_struct_s") ptr_0 my_packed_struct_s_4)
 deriving via (EquivStorable My_packed_struct) instance Storable My_packed_struct
-instance HasCField My_packed_struct "my_packed_struct_c"
-    where type CFieldType My_packed_struct "my_packed_struct_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "my_packed_struct_c" (Ptr My_packed_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"my_packed_struct_c")
 instance (~) ty CChar =>
          HasField "my_packed_struct_c" My_packed_struct ty
     where hasField = \x_0 -> (\y_1 -> My_packed_struct{my_packed_struct_c = y_1,
                                                        my_packed_struct_i = getField @"my_packed_struct_i" x_0,
                                                        my_packed_struct_s = getField @"my_packed_struct_s" x_0},
                               getField @"my_packed_struct_c" x_0)
-instance HasCField My_packed_struct "my_packed_struct_i"
-    where type CFieldType My_packed_struct "my_packed_struct_i" = CInt
-          offset# = \_ -> \_ -> 1
-instance (~) ty CInt =>
-         HasField "my_packed_struct_i" (Ptr My_packed_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"my_packed_struct_i")
+instance (~) ty CChar =>
+         HasField "my_packed_struct_c" (Ptr My_packed_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"my_packed_struct_c")
+instance HasCField My_packed_struct "my_packed_struct_c"
+    where type CFieldType My_packed_struct "my_packed_struct_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "my_packed_struct_i" My_packed_struct ty
     where hasField = \x_0 -> (\y_1 -> My_packed_struct{my_packed_struct_i = y_1,
                                                        my_packed_struct_c = getField @"my_packed_struct_c" x_0,
                                                        my_packed_struct_s = getField @"my_packed_struct_s" x_0},
                               getField @"my_packed_struct_i" x_0)
-instance HasCField My_packed_struct "my_packed_struct_s"
-    where type CFieldType My_packed_struct
-                          "my_packed_struct_s" = My_unpacked_struct
-          offset# = \_ -> \_ -> 5
-instance (~) ty My_unpacked_struct =>
-         HasField "my_packed_struct_s" (Ptr My_packed_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"my_packed_struct_s")
+instance (~) ty CInt =>
+         HasField "my_packed_struct_i" (Ptr My_packed_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"my_packed_struct_i")
+instance HasCField My_packed_struct "my_packed_struct_i"
+    where type CFieldType My_packed_struct "my_packed_struct_i" = CInt
+          offset# = \_ -> \_ -> 1
 instance (~) ty My_unpacked_struct =>
          HasField "my_packed_struct_s" My_packed_struct ty
     where hasField = \x_0 -> (\y_1 -> My_packed_struct{my_packed_struct_s = y_1,
                                                        my_packed_struct_c = getField @"my_packed_struct_c" x_0,
                                                        my_packed_struct_i = getField @"my_packed_struct_i" x_0},
                               getField @"my_packed_struct_s" x_0)
+instance (~) ty My_unpacked_struct =>
+         HasField "my_packed_struct_s" (Ptr My_packed_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"my_packed_struct_s")
+instance HasCField My_packed_struct "my_packed_struct_s"
+    where type CFieldType My_packed_struct
+                          "my_packed_struct_s" = My_unpacked_struct
+          offset# = \_ -> \_ -> 5
 {-| __C declaration:__ @union wait_status_ptr_t@
 
     __defined at:__ @attributes\/type_attributes.h 26:9@
@@ -317,20 +317,20 @@ set_wait_status_ptr_t___up :: Ptr Wait -> Wait_status_ptr_t
 
 -}
 set_wait_status_ptr_t___up = setUnionPayload
+instance (~) ty (Ptr CInt) =>
+         HasField "wait_status_ptr_t___ip" (Ptr Wait_status_ptr_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"wait_status_ptr_t___ip")
 instance HasCField Wait_status_ptr_t "wait_status_ptr_t___ip"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___ip" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "wait_status_ptr_t___ip" (Ptr Wait_status_ptr_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"wait_status_ptr_t___ip")
+instance (~) ty (Ptr Wait) =>
+         HasField "wait_status_ptr_t___up" (Ptr Wait_status_ptr_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"wait_status_ptr_t___up")
 instance HasCField Wait_status_ptr_t "wait_status_ptr_t___up"
     where type CFieldType Wait_status_ptr_t
                           "wait_status_ptr_t___up" = Ptr Wait
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Wait) =>
-         HasField "wait_status_ptr_t___up" (Ptr Wait_status_ptr_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"wait_status_ptr_t___up")
 {-| __C declaration:__ @union wait@
 
     __defined at:__ @attributes\/type_attributes.h 29:9@
@@ -362,14 +362,14 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT1" T1 ty
+    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
+                              getField @"unwrapT1" x_0)
 instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT1" T1 ty
-    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
-                              getField @"unwrapT1" x_0)
 {-| __C declaration:__ @short_a@
 
     __defined at:__ @attributes\/type_attributes.h 34:46@
@@ -394,12 +394,12 @@ newtype Short_a
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CShort => HasField "unwrapShort_a" Short_a ty
+    where hasField = \x_0 -> (\y_1 -> Short_a{unwrapShort_a = y_1},
+                              getField @"unwrapShort_a" x_0)
 instance (~) ty CShort =>
          HasField "unwrapShort_a" (Ptr Short_a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapShort_a")
 instance HasCField Short_a "unwrapShort_a"
     where type CFieldType Short_a "unwrapShort_a" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort => HasField "unwrapShort_a" Short_a ty
-    where hasField = \x_0 -> (\y_1 -> Short_a{unwrapShort_a = y_1},
-                              getField @"unwrapShort_a" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/Example.hs
@@ -69,15 +69,15 @@ set_u_x ::
   -> U
 set_u_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u_x")
+
 instance HasCField.HasCField U "u_x" where
 
   type CFieldType U "u_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u_x")
 
 {-| __C declaration:__ @struct S@
 
@@ -120,17 +120,17 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_y" where
+instance (ty ~ U) => RIP.CompatHasField.HasField "s_y" S ty where
 
-  type CFieldType S "s_y" = U
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S {s_y = y1}, RIP.getField @"s_y" x0)
 
 instance (ty ~ U) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y")
 
-instance (ty ~ U) => RIP.CompatHasField.HasField "s_y" S ty where
+instance HasCField.HasCField S "s_y" where
 
-  hasField =
-    \x0 -> (\y1 -> S {s_y = y1}, RIP.getField @"s_y" x0)
+  type CFieldType S "s_y" = U
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/bindingspec.yaml
@@ -17,10 +17,11 @@ hstypes:
       fields:
       - s_y
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -34,7 +35,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/edge-cases/nested_types/th.txt
@@ -44,11 +44,11 @@ set_u_x :: CInt -> U
 
 -}
 set_u_x = setUnionPayload
+instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
+    where getField = fromPtr (Proxy @"u_x")
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
-    where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @struct S@
 
     __defined at:__ @attributes\/visibility\/edge-cases\/nested_types.h 2:49@
@@ -73,11 +73,11 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_y_2 -> writeRaw (Proxy @"s_y") ptr_0 s_y_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_y"
-    where type CFieldType S "s_y" = U
-          offset# = \_ -> \_ -> 0
-instance (~) ty U => HasField "s_y" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y")
 instance (~) ty U => HasField "s_y" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_y = y_1},
                               getField @"s_y" x_0)
+instance (~) ty U => HasField "s_y" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y")
+instance HasCField S "s_y"
+    where type CFieldType S "s_y" = U
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/Example.hs
@@ -212,21 +212,21 @@ instance Marshal.WriteRaw S5 where
 
 deriving via Marshal.EquivStorable S5 instance RIP.Storable S5
 
-instance HasCField.HasCField S5 "s5_x" where
-
-  type CFieldType S5 "s5_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_x" (RIP.Ptr S5) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s5_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s5_x" S5 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S5 {s5_x = y1}, RIP.getField @"s5_x" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s5_x" (RIP.Ptr S5) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s5_x")
+
+instance HasCField.HasCField S5 "s5_x" where
+
+  type CFieldType S5 "s5_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S6@
 
@@ -269,21 +269,21 @@ instance Marshal.WriteRaw S6 where
 
 deriving via Marshal.EquivStorable S6 instance RIP.Storable S6
 
-instance HasCField.HasCField S6 "s6_x" where
-
-  type CFieldType S6 "s6_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_x" (RIP.Ptr S6) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s6_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s6_x" S6 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S6 {s6_x = y1}, RIP.getField @"s6_x" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s6_x" (RIP.Ptr S6) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s6_x")
+
+instance HasCField.HasCField S6 "s6_x" where
+
+  type CFieldType S6 "s6_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S7@
 
@@ -326,21 +326,21 @@ instance Marshal.WriteRaw S7 where
 
 deriving via Marshal.EquivStorable S7 instance RIP.Storable S7
 
-instance HasCField.HasCField S7 "s7_x" where
-
-  type CFieldType S7 "s7_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s7_x" (RIP.Ptr S7) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s7_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s7_x" S7 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S7 {s7_x = y1}, RIP.getField @"s7_x" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s7_x" (RIP.Ptr S7) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s7_x")
+
+instance HasCField.HasCField S7 "s7_x" where
+
+  type CFieldType S7 "s7_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S8@
 
@@ -383,21 +383,21 @@ instance Marshal.WriteRaw S8 where
 
 deriving via Marshal.EquivStorable S8 instance RIP.Storable S8
 
-instance HasCField.HasCField S8 "s8_x" where
-
-  type CFieldType S8 "s8_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s8_x" (RIP.Ptr S8) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s8_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s8_x" S8 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S8 {s8_x = y1}, RIP.getField @"s8_x" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s8_x" (RIP.Ptr S8) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s8_x")
+
+instance HasCField.HasCField S8 "s8_x" where
+
+  type CFieldType S8 "s8_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S9@
 
@@ -440,21 +440,21 @@ instance Marshal.WriteRaw S9 where
 
 deriving via Marshal.EquivStorable S9 instance RIP.Storable S9
 
-instance HasCField.HasCField S9 "s9_x" where
-
-  type CFieldType S9 "s9_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s9_x" (RIP.Ptr S9) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s9_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s9_x" S9 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S9 {s9_x = y1}, RIP.getField @"s9_x" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s9_x" (RIP.Ptr S9) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s9_x")
+
+instance HasCField.HasCField S9 "s9_x" where
+
+  type CFieldType S9 "s9_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S10@
 
@@ -497,22 +497,22 @@ instance Marshal.WriteRaw S10 where
 
 deriving via Marshal.EquivStorable S10 instance RIP.Storable S10
 
-instance HasCField.HasCField S10 "s10_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s10_x" S10 ty where
 
-  type CFieldType S10 "s10_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S10 {s10_x = y1}, RIP.getField @"s10_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s10_x" (RIP.Ptr S10) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s10_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s10_x" S10 ty where
+instance HasCField.HasCField S10 "s10_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S10 {s10_x = y1}, RIP.getField @"s10_x" x0)
+  type CFieldType S10 "s10_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S11@
 
@@ -555,22 +555,22 @@ instance Marshal.WriteRaw S11 where
 
 deriving via Marshal.EquivStorable S11 instance RIP.Storable S11
 
-instance HasCField.HasCField S11 "s11_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s11_x" S11 ty where
 
-  type CFieldType S11 "s11_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S11 {s11_x = y1}, RIP.getField @"s11_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s11_x" (RIP.Ptr S11) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s11_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s11_x" S11 ty where
+instance HasCField.HasCField S11 "s11_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S11 {s11_x = y1}, RIP.getField @"s11_x" x0)
+  type CFieldType S11 "s11_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S12@
 
@@ -613,22 +613,22 @@ instance Marshal.WriteRaw S12 where
 
 deriving via Marshal.EquivStorable S12 instance RIP.Storable S12
 
-instance HasCField.HasCField S12 "s12_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s12_x" S12 ty where
 
-  type CFieldType S12 "s12_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S12 {s12_x = y1}, RIP.getField @"s12_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s12_x" (RIP.Ptr S12) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s12_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s12_x" S12 ty where
+instance HasCField.HasCField S12 "s12_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S12 {s12_x = y1}, RIP.getField @"s12_x" x0)
+  type CFieldType S12 "s12_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S13@
 
@@ -671,22 +671,22 @@ instance Marshal.WriteRaw S13 where
 
 deriving via Marshal.EquivStorable S13 instance RIP.Storable S13
 
-instance HasCField.HasCField S13 "s13_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s13_x" S13 ty where
 
-  type CFieldType S13 "s13_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S13 {s13_x = y1}, RIP.getField @"s13_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s13_x" (RIP.Ptr S13) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s13_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s13_x" S13 ty where
+instance HasCField.HasCField S13 "s13_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S13 {s13_x = y1}, RIP.getField @"s13_x" x0)
+  type CFieldType S13 "s13_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S14@
 
@@ -729,22 +729,22 @@ instance Marshal.WriteRaw S14 where
 
 deriving via Marshal.EquivStorable S14 instance RIP.Storable S14
 
-instance HasCField.HasCField S14 "s14_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s14_x" S14 ty where
 
-  type CFieldType S14 "s14_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S14 {s14_x = y1}, RIP.getField @"s14_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s14_x" (RIP.Ptr S14) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s14_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s14_x" S14 ty where
+instance HasCField.HasCField S14 "s14_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S14 {s14_x = y1}, RIP.getField @"s14_x" x0)
+  type CFieldType S14 "s14_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S15@
 
@@ -787,22 +787,22 @@ instance Marshal.WriteRaw S15 where
 
 deriving via Marshal.EquivStorable S15 instance RIP.Storable S15
 
-instance HasCField.HasCField S15 "s15_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s15_x" S15 ty where
 
-  type CFieldType S15 "s15_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S15 {s15_x = y1}, RIP.getField @"s15_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s15_x" (RIP.Ptr S15) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s15_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s15_x" S15 ty where
+instance HasCField.HasCField S15 "s15_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S15 {s15_x = y1}, RIP.getField @"s15_x" x0)
+  type CFieldType S15 "s15_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S16@
 
@@ -845,22 +845,22 @@ instance Marshal.WriteRaw S16 where
 
 deriving via Marshal.EquivStorable S16 instance RIP.Storable S16
 
-instance HasCField.HasCField S16 "s16_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s16_x" S16 ty where
 
-  type CFieldType S16 "s16_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S16 {s16_x = y1}, RIP.getField @"s16_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s16_x" (RIP.Ptr S16) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s16_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s16_x" S16 ty where
+instance HasCField.HasCField S16 "s16_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S16 {s16_x = y1}, RIP.getField @"s16_x" x0)
+  type CFieldType S16 "s16_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S17@
 
@@ -903,22 +903,22 @@ instance Marshal.WriteRaw S17 where
 
 deriving via Marshal.EquivStorable S17 instance RIP.Storable S17
 
-instance HasCField.HasCField S17 "s17_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s17_x" S17 ty where
 
-  type CFieldType S17 "s17_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S17 {s17_x = y1}, RIP.getField @"s17_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s17_x" (RIP.Ptr S17) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s17_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s17_x" S17 ty where
+instance HasCField.HasCField S17 "s17_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S17 {s17_x = y1}, RIP.getField @"s17_x" x0)
+  type CFieldType S17 "s17_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S18@
 
@@ -961,22 +961,22 @@ instance Marshal.WriteRaw S18 where
 
 deriving via Marshal.EquivStorable S18 instance RIP.Storable S18
 
-instance HasCField.HasCField S18 "s18_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s18_x" S18 ty where
 
-  type CFieldType S18 "s18_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S18 {s18_x = y1}, RIP.getField @"s18_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s18_x" (RIP.Ptr S18) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s18_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s18_x" S18 ty where
+instance HasCField.HasCField S18 "s18_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S18 {s18_x = y1}, RIP.getField @"s18_x" x0)
+  type CFieldType S18 "s18_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S19@
 
@@ -1019,22 +1019,22 @@ instance Marshal.WriteRaw S19 where
 
 deriving via Marshal.EquivStorable S19 instance RIP.Storable S19
 
-instance HasCField.HasCField S19 "s19_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s19_x" S19 ty where
 
-  type CFieldType S19 "s19_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> S19 {s19_x = y1}, RIP.getField @"s19_x" x0)
 
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "s19_x" (RIP.Ptr S19) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s19_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s19_x" S19 ty where
+instance HasCField.HasCField S19 "s19_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> S19 {s19_x = y1}, RIP.getField @"s19_x" x0)
+  type CFieldType S19 "s19_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union U0@
 
@@ -1120,15 +1120,15 @@ set_u5_x ::
   -> U5
 set_u5_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u5_x" (RIP.Ptr U5) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u5_x")
+
 instance HasCField.HasCField U5 "u5_x" where
 
   type CFieldType U5 "u5_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u5_x" (RIP.Ptr U5) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u5_x")
 
 {-| __C declaration:__ @union U6@
 
@@ -1174,15 +1174,15 @@ set_u6_x ::
   -> U6
 set_u6_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u6_x" (RIP.Ptr U6) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u6_x")
+
 instance HasCField.HasCField U6 "u6_x" where
 
   type CFieldType U6 "u6_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u6_x" (RIP.Ptr U6) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u6_x")
 
 {-| __C declaration:__ @union U7@
 
@@ -1228,15 +1228,15 @@ set_u7_x ::
   -> U7
 set_u7_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u7_x" (RIP.Ptr U7) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u7_x")
+
 instance HasCField.HasCField U7 "u7_x" where
 
   type CFieldType U7 "u7_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u7_x" (RIP.Ptr U7) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u7_x")
 
 {-| __C declaration:__ @union U8@
 
@@ -1282,15 +1282,15 @@ set_u8_x ::
   -> U8
 set_u8_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u8_x" (RIP.Ptr U8) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u8_x")
+
 instance HasCField.HasCField U8 "u8_x" where
 
   type CFieldType U8 "u8_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u8_x" (RIP.Ptr U8) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u8_x")
 
 {-| __C declaration:__ @union U9@
 
@@ -1336,15 +1336,15 @@ set_u9_x ::
   -> U9
 set_u9_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u9_x" (RIP.Ptr U9) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u9_x")
+
 instance HasCField.HasCField U9 "u9_x" where
 
   type CFieldType U9 "u9_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u9_x" (RIP.Ptr U9) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u9_x")
 
 {-| __C declaration:__ @union U10@
 
@@ -1390,16 +1390,16 @@ set_u10_x ::
   -> U10
 set_u10_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u10_x" (RIP.Ptr U10) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u10_x")
+
 instance HasCField.HasCField U10 "u10_x" where
 
   type CFieldType U10 "u10_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u10_x" (RIP.Ptr U10) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u10_x")
 
 {-| __C declaration:__ @union U11@
 
@@ -1445,16 +1445,16 @@ set_u11_x ::
   -> U11
 set_u11_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u11_x" (RIP.Ptr U11) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u11_x")
+
 instance HasCField.HasCField U11 "u11_x" where
 
   type CFieldType U11 "u11_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u11_x" (RIP.Ptr U11) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u11_x")
 
 {-| __C declaration:__ @union U12@
 
@@ -1500,16 +1500,16 @@ set_u12_x ::
   -> U12
 set_u12_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u12_x" (RIP.Ptr U12) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u12_x")
+
 instance HasCField.HasCField U12 "u12_x" where
 
   type CFieldType U12 "u12_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u12_x" (RIP.Ptr U12) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u12_x")
 
 {-| __C declaration:__ @union U13@
 
@@ -1555,16 +1555,16 @@ set_u13_x ::
   -> U13
 set_u13_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u13_x" (RIP.Ptr U13) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u13_x")
+
 instance HasCField.HasCField U13 "u13_x" where
 
   type CFieldType U13 "u13_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u13_x" (RIP.Ptr U13) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u13_x")
 
 {-| __C declaration:__ @union U14@
 
@@ -1610,16 +1610,16 @@ set_u14_x ::
   -> U14
 set_u14_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u14_x" (RIP.Ptr U14) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u14_x")
+
 instance HasCField.HasCField U14 "u14_x" where
 
   type CFieldType U14 "u14_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u14_x" (RIP.Ptr U14) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u14_x")
 
 {-| __C declaration:__ @union U15@
 
@@ -1665,16 +1665,16 @@ set_u15_x ::
   -> U15
 set_u15_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u15_x" (RIP.Ptr U15) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u15_x")
+
 instance HasCField.HasCField U15 "u15_x" where
 
   type CFieldType U15 "u15_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u15_x" (RIP.Ptr U15) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u15_x")
 
 {-| __C declaration:__ @union U16@
 
@@ -1720,16 +1720,16 @@ set_u16_x ::
   -> U16
 set_u16_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u16_x" (RIP.Ptr U16) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u16_x")
+
 instance HasCField.HasCField U16 "u16_x" where
 
   type CFieldType U16 "u16_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u16_x" (RIP.Ptr U16) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u16_x")
 
 {-| __C declaration:__ @union U17@
 
@@ -1775,16 +1775,16 @@ set_u17_x ::
   -> U17
 set_u17_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u17_x" (RIP.Ptr U17) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u17_x")
+
 instance HasCField.HasCField U17 "u17_x" where
 
   type CFieldType U17 "u17_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u17_x" (RIP.Ptr U17) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u17_x")
 
 {-| __C declaration:__ @union U18@
 
@@ -1830,16 +1830,16 @@ set_u18_x ::
   -> U18
 set_u18_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u18_x" (RIP.Ptr U18) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u18_x")
+
 instance HasCField.HasCField U18 "u18_x" where
 
   type CFieldType U18 "u18_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u18_x" (RIP.Ptr U18) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u18_x")
 
 {-| __C declaration:__ @union U19@
 
@@ -1885,16 +1885,16 @@ set_u19_x ::
   -> U19
 set_u19_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "u19_x" (RIP.Ptr U19) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u19_x")
+
 instance HasCField.HasCField U19 "u19_x" where
 
   type CFieldType U19 "u19_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "u19_x" (RIP.Ptr U19) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u19_x")
 
 {-| __C declaration:__ @enum E0@
 
@@ -2013,6 +2013,13 @@ instance Read E5 where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE5" E5 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E5 {unwrapE5 = y1}, RIP.getField @"unwrapE5" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE5" (RIP.Ptr E5) (RIP.Ptr ty) where
 
@@ -2023,13 +2030,6 @@ instance HasCField.HasCField E5 "unwrapE5" where
   type CFieldType E5 "unwrapE5" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE5" E5 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E5 {unwrapE5 = y1}, RIP.getField @"unwrapE5" x0)
 
 {-| __C declaration:__ @x5@
 
@@ -2117,6 +2117,13 @@ instance Read E6 where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE6" E6 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E6 {unwrapE6 = y1}, RIP.getField @"unwrapE6" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE6" (RIP.Ptr E6) (RIP.Ptr ty) where
 
@@ -2127,13 +2134,6 @@ instance HasCField.HasCField E6 "unwrapE6" where
   type CFieldType E6 "unwrapE6" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE6" E6 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E6 {unwrapE6 = y1}, RIP.getField @"unwrapE6" x0)
 
 {-| __C declaration:__ @x6@
 
@@ -2221,6 +2221,13 @@ instance Read E7 where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE7" E7 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E7 {unwrapE7 = y1}, RIP.getField @"unwrapE7" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE7" (RIP.Ptr E7) (RIP.Ptr ty) where
 
@@ -2231,13 +2238,6 @@ instance HasCField.HasCField E7 "unwrapE7" where
   type CFieldType E7 "unwrapE7" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE7" E7 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E7 {unwrapE7 = y1}, RIP.getField @"unwrapE7" x0)
 
 {-| __C declaration:__ @x7@
 
@@ -2325,6 +2325,13 @@ instance Read E8 where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE8" E8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E8 {unwrapE8 = y1}, RIP.getField @"unwrapE8" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE8" (RIP.Ptr E8) (RIP.Ptr ty) where
 
@@ -2335,13 +2342,6 @@ instance HasCField.HasCField E8 "unwrapE8" where
   type CFieldType E8 "unwrapE8" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE8" E8 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E8 {unwrapE8 = y1}, RIP.getField @"unwrapE8" x0)
 
 {-| __C declaration:__ @x8@
 
@@ -2429,6 +2429,13 @@ instance Read E9 where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE9" E9 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E9 {unwrapE9 = y1}, RIP.getField @"unwrapE9" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE9" (RIP.Ptr E9) (RIP.Ptr ty) where
 
@@ -2439,13 +2446,6 @@ instance HasCField.HasCField E9 "unwrapE9" where
   type CFieldType E9 "unwrapE9" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE9" E9 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E9 {unwrapE9 = y1}, RIP.getField @"unwrapE9" x0)
 
 {-| __C declaration:__ @x9@
 
@@ -2534,6 +2534,14 @@ instance Read E10 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE10" E10 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E10 {unwrapE10 = y1}, RIP.getField @"unwrapE10" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE10" (RIP.Ptr E10) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE10")
@@ -2543,14 +2551,6 @@ instance HasCField.HasCField E10 "unwrapE10" where
   type CFieldType E10 "unwrapE10" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE10" E10 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E10 {unwrapE10 = y1}, RIP.getField @"unwrapE10" x0)
 
 {-| __C declaration:__ @x10@
 
@@ -2639,6 +2639,14 @@ instance Read E11 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE11" E11 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E11 {unwrapE11 = y1}, RIP.getField @"unwrapE11" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE11" (RIP.Ptr E11) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE11")
@@ -2648,14 +2656,6 @@ instance HasCField.HasCField E11 "unwrapE11" where
   type CFieldType E11 "unwrapE11" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE11" E11 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E11 {unwrapE11 = y1}, RIP.getField @"unwrapE11" x0)
 
 {-| __C declaration:__ @x11@
 
@@ -2744,6 +2744,14 @@ instance Read E12 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE12" E12 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E12 {unwrapE12 = y1}, RIP.getField @"unwrapE12" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE12" (RIP.Ptr E12) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE12")
@@ -2753,14 +2761,6 @@ instance HasCField.HasCField E12 "unwrapE12" where
   type CFieldType E12 "unwrapE12" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE12" E12 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E12 {unwrapE12 = y1}, RIP.getField @"unwrapE12" x0)
 
 {-| __C declaration:__ @x12@
 
@@ -2849,6 +2849,14 @@ instance Read E13 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE13" E13 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E13 {unwrapE13 = y1}, RIP.getField @"unwrapE13" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE13" (RIP.Ptr E13) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE13")
@@ -2858,14 +2866,6 @@ instance HasCField.HasCField E13 "unwrapE13" where
   type CFieldType E13 "unwrapE13" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE13" E13 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E13 {unwrapE13 = y1}, RIP.getField @"unwrapE13" x0)
 
 {-| __C declaration:__ @x13@
 
@@ -2954,6 +2954,14 @@ instance Read E14 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE14" E14 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E14 {unwrapE14 = y1}, RIP.getField @"unwrapE14" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE14" (RIP.Ptr E14) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE14")
@@ -2963,14 +2971,6 @@ instance HasCField.HasCField E14 "unwrapE14" where
   type CFieldType E14 "unwrapE14" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE14" E14 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E14 {unwrapE14 = y1}, RIP.getField @"unwrapE14" x0)
 
 {-| __C declaration:__ @x14@
 
@@ -3059,6 +3059,14 @@ instance Read E15 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE15" E15 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E15 {unwrapE15 = y1}, RIP.getField @"unwrapE15" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE15" (RIP.Ptr E15) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE15")
@@ -3068,14 +3076,6 @@ instance HasCField.HasCField E15 "unwrapE15" where
   type CFieldType E15 "unwrapE15" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE15" E15 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E15 {unwrapE15 = y1}, RIP.getField @"unwrapE15" x0)
 
 {-| __C declaration:__ @x15@
 
@@ -3164,6 +3164,14 @@ instance Read E16 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE16" E16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E16 {unwrapE16 = y1}, RIP.getField @"unwrapE16" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE16" (RIP.Ptr E16) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE16")
@@ -3173,14 +3181,6 @@ instance HasCField.HasCField E16 "unwrapE16" where
   type CFieldType E16 "unwrapE16" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE16" E16 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E16 {unwrapE16 = y1}, RIP.getField @"unwrapE16" x0)
 
 {-| __C declaration:__ @x16@
 
@@ -3269,6 +3269,14 @@ instance Read E17 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE17" E17 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E17 {unwrapE17 = y1}, RIP.getField @"unwrapE17" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE17" (RIP.Ptr E17) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE17")
@@ -3278,14 +3286,6 @@ instance HasCField.HasCField E17 "unwrapE17" where
   type CFieldType E17 "unwrapE17" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE17" E17 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E17 {unwrapE17 = y1}, RIP.getField @"unwrapE17" x0)
 
 {-| __C declaration:__ @x17@
 
@@ -3374,6 +3374,14 @@ instance Read E18 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE18" E18 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E18 {unwrapE18 = y1}, RIP.getField @"unwrapE18" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE18" (RIP.Ptr E18) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE18")
@@ -3383,14 +3391,6 @@ instance HasCField.HasCField E18 "unwrapE18" where
   type CFieldType E18 "unwrapE18" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE18" E18 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E18 {unwrapE18 = y1}, RIP.getField @"unwrapE18" x0)
 
 {-| __C declaration:__ @x18@
 
@@ -3479,6 +3479,14 @@ instance Read E19 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapE19" E19 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         E19 {unwrapE19 = y1}, RIP.getField @"unwrapE19" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE19" (RIP.Ptr E19) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE19")
@@ -3488,14 +3496,6 @@ instance HasCField.HasCField E19 "unwrapE19" where
   type CFieldType E19 "unwrapE19" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapE19" E19 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         E19 {unwrapE19 = y1}, RIP.getField @"unwrapE19" x0)
 
 {-| __C declaration:__ @x19@
 

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/bindingspec.yaml
@@ -196,12 +196,13 @@ hstypes:
       - unwrapE10
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -219,12 +220,13 @@ hstypes:
       - unwrapE11
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -242,12 +244,13 @@ hstypes:
       - unwrapE12
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -265,12 +268,13 @@ hstypes:
       - unwrapE13
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -288,12 +292,13 @@ hstypes:
       - unwrapE14
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -311,12 +316,13 @@ hstypes:
       - unwrapE15
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -334,12 +340,13 @@ hstypes:
       - unwrapE16
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -357,12 +364,13 @@ hstypes:
       - unwrapE17
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -380,12 +388,13 @@ hstypes:
       - unwrapE18
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -403,12 +412,13 @@ hstypes:
       - unwrapE19
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -432,12 +442,13 @@ hstypes:
       - unwrapE5
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -455,12 +466,13 @@ hstypes:
       - unwrapE6
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -478,12 +490,13 @@ hstypes:
       - unwrapE7
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -501,12 +514,13 @@ hstypes:
       - unwrapE8
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -524,12 +538,13 @@ hstypes:
       - unwrapE9
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -550,11 +565,12 @@ hstypes:
       fields:
       - s10_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -567,11 +583,12 @@ hstypes:
       fields:
       - s11_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -584,11 +601,12 @@ hstypes:
       fields:
       - s12_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -601,11 +619,12 @@ hstypes:
       fields:
       - s13_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -618,11 +637,12 @@ hstypes:
       fields:
       - s14_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -635,11 +655,12 @@ hstypes:
       fields:
       - s15_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -652,11 +673,12 @@ hstypes:
       fields:
       - s16_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -669,11 +691,12 @@ hstypes:
       fields:
       - s17_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -686,11 +709,12 @@ hstypes:
       fields:
       - s18_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -703,11 +727,12 @@ hstypes:
       fields:
       - s19_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -726,11 +751,12 @@ hstypes:
       fields:
       - s5_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -743,11 +769,12 @@ hstypes:
       fields:
       - s6_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -760,11 +787,12 @@ hstypes:
       fields:
       - s7_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -777,11 +805,12 @@ hstypes:
       fields:
       - s8_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -794,11 +823,12 @@ hstypes:
       fields:
       - s9_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -817,7 +847,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -831,7 +861,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -845,7 +875,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -859,7 +889,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -873,7 +903,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -887,7 +917,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -901,7 +931,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -915,7 +945,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -929,7 +959,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -943,7 +973,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -963,7 +993,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -977,7 +1007,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -991,7 +1021,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -1005,7 +1035,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -1019,7 +1049,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/th.txt
@@ -58,14 +58,14 @@ instance WriteRaw S5
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S5 s5_x_2 -> writeRaw (Proxy @"s5_x") ptr_0 s5_x_2
 deriving via (EquivStorable S5) instance Storable S5
-instance HasCField S5 "s5_x"
-    where type CFieldType S5 "s5_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s5_x" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"s5_x")
 instance (~) ty CInt => HasField "s5_x" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{s5_x = y_1},
                               getField @"s5_x" x_0)
+instance (~) ty CInt => HasField "s5_x" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"s5_x")
+instance HasCField S5 "s5_x"
+    where type CFieldType S5 "s5_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S6@
 
     __defined at:__ @attributes\/visibility\/types.h 21:51@
@@ -90,14 +90,14 @@ instance WriteRaw S6
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S6 s6_x_2 -> writeRaw (Proxy @"s6_x") ptr_0 s6_x_2
 deriving via (EquivStorable S6) instance Storable S6
-instance HasCField S6 "s6_x"
-    where type CFieldType S6 "s6_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s6_x" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"s6_x")
 instance (~) ty CInt => HasField "s6_x" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{s6_x = y_1},
                               getField @"s6_x" x_0)
+instance (~) ty CInt => HasField "s6_x" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"s6_x")
+instance HasCField S6 "s6_x"
+    where type CFieldType S6 "s6_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S7@
 
     __defined at:__ @attributes\/visibility\/types.h 22:51@
@@ -122,14 +122,14 @@ instance WriteRaw S7
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S7 s7_x_2 -> writeRaw (Proxy @"s7_x") ptr_0 s7_x_2
 deriving via (EquivStorable S7) instance Storable S7
-instance HasCField S7 "s7_x"
-    where type CFieldType S7 "s7_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s7_x" (Ptr S7) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7_x")
 instance (~) ty CInt => HasField "s7_x" S7 ty
     where hasField = \x_0 -> (\y_1 -> S7{s7_x = y_1},
                               getField @"s7_x" x_0)
+instance (~) ty CInt => HasField "s7_x" (Ptr S7) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7_x")
+instance HasCField S7 "s7_x"
+    where type CFieldType S7 "s7_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S8@
 
     __defined at:__ @attributes\/visibility\/types.h 23:51@
@@ -154,14 +154,14 @@ instance WriteRaw S8
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S8 s8_x_2 -> writeRaw (Proxy @"s8_x") ptr_0 s8_x_2
 deriving via (EquivStorable S8) instance Storable S8
-instance HasCField S8 "s8_x"
-    where type CFieldType S8 "s8_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s8_x" (Ptr S8) (Ptr ty)
-    where getField = fromPtr (Proxy @"s8_x")
 instance (~) ty CInt => HasField "s8_x" S8 ty
     where hasField = \x_0 -> (\y_1 -> S8{s8_x = y_1},
                               getField @"s8_x" x_0)
+instance (~) ty CInt => HasField "s8_x" (Ptr S8) (Ptr ty)
+    where getField = fromPtr (Proxy @"s8_x")
+instance HasCField S8 "s8_x"
+    where type CFieldType S8 "s8_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S9@
 
     __defined at:__ @attributes\/visibility\/types.h 24:51@
@@ -186,14 +186,14 @@ instance WriteRaw S9
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S9 s9_x_2 -> writeRaw (Proxy @"s9_x") ptr_0 s9_x_2
 deriving via (EquivStorable S9) instance Storable S9
-instance HasCField S9 "s9_x"
-    where type CFieldType S9 "s9_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s9_x" (Ptr S9) (Ptr ty)
-    where getField = fromPtr (Proxy @"s9_x")
 instance (~) ty CInt => HasField "s9_x" S9 ty
     where hasField = \x_0 -> (\y_1 -> S9{s9_x = y_1},
                               getField @"s9_x" x_0)
+instance (~) ty CInt => HasField "s9_x" (Ptr S9) (Ptr ty)
+    where getField = fromPtr (Proxy @"s9_x")
+instance HasCField S9 "s9_x"
+    where type CFieldType S9 "s9_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S10@
 
     __defined at:__ @attributes\/visibility\/types.h 33:51@
@@ -218,14 +218,14 @@ instance WriteRaw S10
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S10 s10_x_2 -> writeRaw (Proxy @"s10_x") ptr_0 s10_x_2
 deriving via (EquivStorable S10) instance Storable S10
-instance HasCField S10 "s10_x"
-    where type CFieldType S10 "s10_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s10_x" (Ptr S10) (Ptr ty)
-    where getField = fromPtr (Proxy @"s10_x")
 instance (~) ty CInt => HasField "s10_x" S10 ty
     where hasField = \x_0 -> (\y_1 -> S10{s10_x = y_1},
                               getField @"s10_x" x_0)
+instance (~) ty CInt => HasField "s10_x" (Ptr S10) (Ptr ty)
+    where getField = fromPtr (Proxy @"s10_x")
+instance HasCField S10 "s10_x"
+    where type CFieldType S10 "s10_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S11@
 
     __defined at:__ @attributes\/visibility\/types.h 34:51@
@@ -250,14 +250,14 @@ instance WriteRaw S11
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S11 s11_x_2 -> writeRaw (Proxy @"s11_x") ptr_0 s11_x_2
 deriving via (EquivStorable S11) instance Storable S11
-instance HasCField S11 "s11_x"
-    where type CFieldType S11 "s11_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s11_x" (Ptr S11) (Ptr ty)
-    where getField = fromPtr (Proxy @"s11_x")
 instance (~) ty CInt => HasField "s11_x" S11 ty
     where hasField = \x_0 -> (\y_1 -> S11{s11_x = y_1},
                               getField @"s11_x" x_0)
+instance (~) ty CInt => HasField "s11_x" (Ptr S11) (Ptr ty)
+    where getField = fromPtr (Proxy @"s11_x")
+instance HasCField S11 "s11_x"
+    where type CFieldType S11 "s11_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S12@
 
     __defined at:__ @attributes\/visibility\/types.h 35:51@
@@ -282,14 +282,14 @@ instance WriteRaw S12
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S12 s12_x_2 -> writeRaw (Proxy @"s12_x") ptr_0 s12_x_2
 deriving via (EquivStorable S12) instance Storable S12
-instance HasCField S12 "s12_x"
-    where type CFieldType S12 "s12_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s12_x" (Ptr S12) (Ptr ty)
-    where getField = fromPtr (Proxy @"s12_x")
 instance (~) ty CInt => HasField "s12_x" S12 ty
     where hasField = \x_0 -> (\y_1 -> S12{s12_x = y_1},
                               getField @"s12_x" x_0)
+instance (~) ty CInt => HasField "s12_x" (Ptr S12) (Ptr ty)
+    where getField = fromPtr (Proxy @"s12_x")
+instance HasCField S12 "s12_x"
+    where type CFieldType S12 "s12_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S13@
 
     __defined at:__ @attributes\/visibility\/types.h 36:51@
@@ -314,14 +314,14 @@ instance WriteRaw S13
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S13 s13_x_2 -> writeRaw (Proxy @"s13_x") ptr_0 s13_x_2
 deriving via (EquivStorable S13) instance Storable S13
-instance HasCField S13 "s13_x"
-    where type CFieldType S13 "s13_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s13_x" (Ptr S13) (Ptr ty)
-    where getField = fromPtr (Proxy @"s13_x")
 instance (~) ty CInt => HasField "s13_x" S13 ty
     where hasField = \x_0 -> (\y_1 -> S13{s13_x = y_1},
                               getField @"s13_x" x_0)
+instance (~) ty CInt => HasField "s13_x" (Ptr S13) (Ptr ty)
+    where getField = fromPtr (Proxy @"s13_x")
+instance HasCField S13 "s13_x"
+    where type CFieldType S13 "s13_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S14@
 
     __defined at:__ @attributes\/visibility\/types.h 37:51@
@@ -346,14 +346,14 @@ instance WriteRaw S14
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S14 s14_x_2 -> writeRaw (Proxy @"s14_x") ptr_0 s14_x_2
 deriving via (EquivStorable S14) instance Storable S14
-instance HasCField S14 "s14_x"
-    where type CFieldType S14 "s14_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s14_x" (Ptr S14) (Ptr ty)
-    where getField = fromPtr (Proxy @"s14_x")
 instance (~) ty CInt => HasField "s14_x" S14 ty
     where hasField = \x_0 -> (\y_1 -> S14{s14_x = y_1},
                               getField @"s14_x" x_0)
+instance (~) ty CInt => HasField "s14_x" (Ptr S14) (Ptr ty)
+    where getField = fromPtr (Proxy @"s14_x")
+instance HasCField S14 "s14_x"
+    where type CFieldType S14 "s14_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S15@
 
     __defined at:__ @attributes\/visibility\/types.h 46:51@
@@ -378,14 +378,14 @@ instance WriteRaw S15
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S15 s15_x_2 -> writeRaw (Proxy @"s15_x") ptr_0 s15_x_2
 deriving via (EquivStorable S15) instance Storable S15
-instance HasCField S15 "s15_x"
-    where type CFieldType S15 "s15_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s15_x" (Ptr S15) (Ptr ty)
-    where getField = fromPtr (Proxy @"s15_x")
 instance (~) ty CInt => HasField "s15_x" S15 ty
     where hasField = \x_0 -> (\y_1 -> S15{s15_x = y_1},
                               getField @"s15_x" x_0)
+instance (~) ty CInt => HasField "s15_x" (Ptr S15) (Ptr ty)
+    where getField = fromPtr (Proxy @"s15_x")
+instance HasCField S15 "s15_x"
+    where type CFieldType S15 "s15_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S16@
 
     __defined at:__ @attributes\/visibility\/types.h 47:51@
@@ -410,14 +410,14 @@ instance WriteRaw S16
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S16 s16_x_2 -> writeRaw (Proxy @"s16_x") ptr_0 s16_x_2
 deriving via (EquivStorable S16) instance Storable S16
-instance HasCField S16 "s16_x"
-    where type CFieldType S16 "s16_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s16_x" (Ptr S16) (Ptr ty)
-    where getField = fromPtr (Proxy @"s16_x")
 instance (~) ty CInt => HasField "s16_x" S16 ty
     where hasField = \x_0 -> (\y_1 -> S16{s16_x = y_1},
                               getField @"s16_x" x_0)
+instance (~) ty CInt => HasField "s16_x" (Ptr S16) (Ptr ty)
+    where getField = fromPtr (Proxy @"s16_x")
+instance HasCField S16 "s16_x"
+    where type CFieldType S16 "s16_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S17@
 
     __defined at:__ @attributes\/visibility\/types.h 48:51@
@@ -442,14 +442,14 @@ instance WriteRaw S17
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S17 s17_x_2 -> writeRaw (Proxy @"s17_x") ptr_0 s17_x_2
 deriving via (EquivStorable S17) instance Storable S17
-instance HasCField S17 "s17_x"
-    where type CFieldType S17 "s17_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s17_x" (Ptr S17) (Ptr ty)
-    where getField = fromPtr (Proxy @"s17_x")
 instance (~) ty CInt => HasField "s17_x" S17 ty
     where hasField = \x_0 -> (\y_1 -> S17{s17_x = y_1},
                               getField @"s17_x" x_0)
+instance (~) ty CInt => HasField "s17_x" (Ptr S17) (Ptr ty)
+    where getField = fromPtr (Proxy @"s17_x")
+instance HasCField S17 "s17_x"
+    where type CFieldType S17 "s17_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S18@
 
     __defined at:__ @attributes\/visibility\/types.h 49:51@
@@ -474,14 +474,14 @@ instance WriteRaw S18
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S18 s18_x_2 -> writeRaw (Proxy @"s18_x") ptr_0 s18_x_2
 deriving via (EquivStorable S18) instance Storable S18
-instance HasCField S18 "s18_x"
-    where type CFieldType S18 "s18_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s18_x" (Ptr S18) (Ptr ty)
-    where getField = fromPtr (Proxy @"s18_x")
 instance (~) ty CInt => HasField "s18_x" S18 ty
     where hasField = \x_0 -> (\y_1 -> S18{s18_x = y_1},
                               getField @"s18_x" x_0)
+instance (~) ty CInt => HasField "s18_x" (Ptr S18) (Ptr ty)
+    where getField = fromPtr (Proxy @"s18_x")
+instance HasCField S18 "s18_x"
+    where type CFieldType S18 "s18_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S19@
 
     __defined at:__ @attributes\/visibility\/types.h 50:51@
@@ -506,14 +506,14 @@ instance WriteRaw S19
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S19 s19_x_2 -> writeRaw (Proxy @"s19_x") ptr_0 s19_x_2
 deriving via (EquivStorable S19) instance Storable S19
-instance HasCField S19 "s19_x"
-    where type CFieldType S19 "s19_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s19_x" (Ptr S19) (Ptr ty)
-    where getField = fromPtr (Proxy @"s19_x")
 instance (~) ty CInt => HasField "s19_x" S19 ty
     where hasField = \x_0 -> (\y_1 -> S19{s19_x = y_1},
                               getField @"s19_x" x_0)
+instance (~) ty CInt => HasField "s19_x" (Ptr S19) (Ptr ty)
+    where getField = fromPtr (Proxy @"s19_x")
+instance HasCField S19 "s19_x"
+    where type CFieldType S19 "s19_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union U0@
 
     __defined at:__ @attributes\/visibility\/types.h 53:50@
@@ -594,11 +594,11 @@ set_u5_x :: CInt -> U5
 
 -}
 set_u5_x = setUnionPayload
+instance (~) ty CInt => HasField "u5_x" (Ptr U5) (Ptr ty)
+    where getField = fromPtr (Proxy @"u5_x")
 instance HasCField U5 "u5_x"
     where type CFieldType U5 "u5_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u5_x" (Ptr U5) (Ptr ty)
-    where getField = fromPtr (Proxy @"u5_x")
 {-| __C declaration:__ @union U6@
 
     __defined at:__ @attributes\/visibility\/types.h 61:50@
@@ -644,11 +644,11 @@ set_u6_x :: CInt -> U6
 
 -}
 set_u6_x = setUnionPayload
+instance (~) ty CInt => HasField "u6_x" (Ptr U6) (Ptr ty)
+    where getField = fromPtr (Proxy @"u6_x")
 instance HasCField U6 "u6_x"
     where type CFieldType U6 "u6_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u6_x" (Ptr U6) (Ptr ty)
-    where getField = fromPtr (Proxy @"u6_x")
 {-| __C declaration:__ @union U7@
 
     __defined at:__ @attributes\/visibility\/types.h 62:50@
@@ -694,11 +694,11 @@ set_u7_x :: CInt -> U7
 
 -}
 set_u7_x = setUnionPayload
+instance (~) ty CInt => HasField "u7_x" (Ptr U7) (Ptr ty)
+    where getField = fromPtr (Proxy @"u7_x")
 instance HasCField U7 "u7_x"
     where type CFieldType U7 "u7_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u7_x" (Ptr U7) (Ptr ty)
-    where getField = fromPtr (Proxy @"u7_x")
 {-| __C declaration:__ @union U8@
 
     __defined at:__ @attributes\/visibility\/types.h 63:50@
@@ -744,11 +744,11 @@ set_u8_x :: CInt -> U8
 
 -}
 set_u8_x = setUnionPayload
+instance (~) ty CInt => HasField "u8_x" (Ptr U8) (Ptr ty)
+    where getField = fromPtr (Proxy @"u8_x")
 instance HasCField U8 "u8_x"
     where type CFieldType U8 "u8_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u8_x" (Ptr U8) (Ptr ty)
-    where getField = fromPtr (Proxy @"u8_x")
 {-| __C declaration:__ @union U9@
 
     __defined at:__ @attributes\/visibility\/types.h 64:50@
@@ -794,11 +794,11 @@ set_u9_x :: CInt -> U9
 
 -}
 set_u9_x = setUnionPayload
+instance (~) ty CInt => HasField "u9_x" (Ptr U9) (Ptr ty)
+    where getField = fromPtr (Proxy @"u9_x")
 instance HasCField U9 "u9_x"
     where type CFieldType U9 "u9_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u9_x" (Ptr U9) (Ptr ty)
-    where getField = fromPtr (Proxy @"u9_x")
 {-| __C declaration:__ @union U10@
 
     __defined at:__ @attributes\/visibility\/types.h 73:50@
@@ -844,11 +844,11 @@ set_u10_x :: CInt -> U10
 
 -}
 set_u10_x = setUnionPayload
+instance (~) ty CInt => HasField "u10_x" (Ptr U10) (Ptr ty)
+    where getField = fromPtr (Proxy @"u10_x")
 instance HasCField U10 "u10_x"
     where type CFieldType U10 "u10_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u10_x" (Ptr U10) (Ptr ty)
-    where getField = fromPtr (Proxy @"u10_x")
 {-| __C declaration:__ @union U11@
 
     __defined at:__ @attributes\/visibility\/types.h 74:50@
@@ -894,11 +894,11 @@ set_u11_x :: CInt -> U11
 
 -}
 set_u11_x = setUnionPayload
+instance (~) ty CInt => HasField "u11_x" (Ptr U11) (Ptr ty)
+    where getField = fromPtr (Proxy @"u11_x")
 instance HasCField U11 "u11_x"
     where type CFieldType U11 "u11_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u11_x" (Ptr U11) (Ptr ty)
-    where getField = fromPtr (Proxy @"u11_x")
 {-| __C declaration:__ @union U12@
 
     __defined at:__ @attributes\/visibility\/types.h 75:50@
@@ -944,11 +944,11 @@ set_u12_x :: CInt -> U12
 
 -}
 set_u12_x = setUnionPayload
+instance (~) ty CInt => HasField "u12_x" (Ptr U12) (Ptr ty)
+    where getField = fromPtr (Proxy @"u12_x")
 instance HasCField U12 "u12_x"
     where type CFieldType U12 "u12_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u12_x" (Ptr U12) (Ptr ty)
-    where getField = fromPtr (Proxy @"u12_x")
 {-| __C declaration:__ @union U13@
 
     __defined at:__ @attributes\/visibility\/types.h 76:50@
@@ -994,11 +994,11 @@ set_u13_x :: CInt -> U13
 
 -}
 set_u13_x = setUnionPayload
+instance (~) ty CInt => HasField "u13_x" (Ptr U13) (Ptr ty)
+    where getField = fromPtr (Proxy @"u13_x")
 instance HasCField U13 "u13_x"
     where type CFieldType U13 "u13_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u13_x" (Ptr U13) (Ptr ty)
-    where getField = fromPtr (Proxy @"u13_x")
 {-| __C declaration:__ @union U14@
 
     __defined at:__ @attributes\/visibility\/types.h 77:50@
@@ -1044,11 +1044,11 @@ set_u14_x :: CInt -> U14
 
 -}
 set_u14_x = setUnionPayload
+instance (~) ty CInt => HasField "u14_x" (Ptr U14) (Ptr ty)
+    where getField = fromPtr (Proxy @"u14_x")
 instance HasCField U14 "u14_x"
     where type CFieldType U14 "u14_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u14_x" (Ptr U14) (Ptr ty)
-    where getField = fromPtr (Proxy @"u14_x")
 {-| __C declaration:__ @union U15@
 
     __defined at:__ @attributes\/visibility\/types.h 86:50@
@@ -1094,11 +1094,11 @@ set_u15_x :: CInt -> U15
 
 -}
 set_u15_x = setUnionPayload
+instance (~) ty CInt => HasField "u15_x" (Ptr U15) (Ptr ty)
+    where getField = fromPtr (Proxy @"u15_x")
 instance HasCField U15 "u15_x"
     where type CFieldType U15 "u15_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u15_x" (Ptr U15) (Ptr ty)
-    where getField = fromPtr (Proxy @"u15_x")
 {-| __C declaration:__ @union U16@
 
     __defined at:__ @attributes\/visibility\/types.h 87:50@
@@ -1144,11 +1144,11 @@ set_u16_x :: CInt -> U16
 
 -}
 set_u16_x = setUnionPayload
+instance (~) ty CInt => HasField "u16_x" (Ptr U16) (Ptr ty)
+    where getField = fromPtr (Proxy @"u16_x")
 instance HasCField U16 "u16_x"
     where type CFieldType U16 "u16_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u16_x" (Ptr U16) (Ptr ty)
-    where getField = fromPtr (Proxy @"u16_x")
 {-| __C declaration:__ @union U17@
 
     __defined at:__ @attributes\/visibility\/types.h 88:50@
@@ -1194,11 +1194,11 @@ set_u17_x :: CInt -> U17
 
 -}
 set_u17_x = setUnionPayload
+instance (~) ty CInt => HasField "u17_x" (Ptr U17) (Ptr ty)
+    where getField = fromPtr (Proxy @"u17_x")
 instance HasCField U17 "u17_x"
     where type CFieldType U17 "u17_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u17_x" (Ptr U17) (Ptr ty)
-    where getField = fromPtr (Proxy @"u17_x")
 {-| __C declaration:__ @union U18@
 
     __defined at:__ @attributes\/visibility\/types.h 89:50@
@@ -1244,11 +1244,11 @@ set_u18_x :: CInt -> U18
 
 -}
 set_u18_x = setUnionPayload
+instance (~) ty CInt => HasField "u18_x" (Ptr U18) (Ptr ty)
+    where getField = fromPtr (Proxy @"u18_x")
 instance HasCField U18 "u18_x"
     where type CFieldType U18 "u18_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u18_x" (Ptr U18) (Ptr ty)
-    where getField = fromPtr (Proxy @"u18_x")
 {-| __C declaration:__ @union U19@
 
     __defined at:__ @attributes\/visibility\/types.h 90:50@
@@ -1294,11 +1294,11 @@ set_u19_x :: CInt -> U19
 
 -}
 set_u19_x = setUnionPayload
+instance (~) ty CInt => HasField "u19_x" (Ptr U19) (Ptr ty)
+    where getField = fromPtr (Proxy @"u19_x")
 instance HasCField U19 "u19_x"
     where type CFieldType U19 "u19_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u19_x" (Ptr U19) (Ptr ty)
-    where getField = fromPtr (Proxy @"u19_x")
 {-| __C declaration:__ @enum E0@
 
     __defined at:__ @attributes\/visibility\/types.h 93:49@
@@ -1372,14 +1372,14 @@ instance Read E5
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE5" E5 ty
+    where hasField = \x_0 -> (\y_1 -> E5{unwrapE5 = y_1},
+                              getField @"unwrapE5" x_0)
 instance (~) ty CUInt => HasField "unwrapE5" (Ptr E5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE5")
 instance HasCField E5 "unwrapE5"
     where type CFieldType E5 "unwrapE5" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE5" E5 ty
-    where hasField = \x_0 -> (\y_1 -> E5{unwrapE5 = y_1},
-                              getField @"unwrapE5" x_0)
 {-| __C declaration:__ @x5@
 
     __defined at:__ @attributes\/visibility\/types.h 100:54@
@@ -1426,14 +1426,14 @@ instance Read E6
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE6" E6 ty
+    where hasField = \x_0 -> (\y_1 -> E6{unwrapE6 = y_1},
+                              getField @"unwrapE6" x_0)
 instance (~) ty CUInt => HasField "unwrapE6" (Ptr E6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE6")
 instance HasCField E6 "unwrapE6"
     where type CFieldType E6 "unwrapE6" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE6" E6 ty
-    where hasField = \x_0 -> (\y_1 -> E6{unwrapE6 = y_1},
-                              getField @"unwrapE6" x_0)
 {-| __C declaration:__ @x6@
 
     __defined at:__ @attributes\/visibility\/types.h 101:54@
@@ -1480,14 +1480,14 @@ instance Read E7
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE7" E7 ty
+    where hasField = \x_0 -> (\y_1 -> E7{unwrapE7 = y_1},
+                              getField @"unwrapE7" x_0)
 instance (~) ty CUInt => HasField "unwrapE7" (Ptr E7) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE7")
 instance HasCField E7 "unwrapE7"
     where type CFieldType E7 "unwrapE7" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE7" E7 ty
-    where hasField = \x_0 -> (\y_1 -> E7{unwrapE7 = y_1},
-                              getField @"unwrapE7" x_0)
 {-| __C declaration:__ @x7@
 
     __defined at:__ @attributes\/visibility\/types.h 102:54@
@@ -1534,14 +1534,14 @@ instance Read E8
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE8" E8 ty
+    where hasField = \x_0 -> (\y_1 -> E8{unwrapE8 = y_1},
+                              getField @"unwrapE8" x_0)
 instance (~) ty CUInt => HasField "unwrapE8" (Ptr E8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE8")
 instance HasCField E8 "unwrapE8"
     where type CFieldType E8 "unwrapE8" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE8" E8 ty
-    where hasField = \x_0 -> (\y_1 -> E8{unwrapE8 = y_1},
-                              getField @"unwrapE8" x_0)
 {-| __C declaration:__ @x8@
 
     __defined at:__ @attributes\/visibility\/types.h 103:54@
@@ -1588,14 +1588,14 @@ instance Read E9
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE9" E9 ty
+    where hasField = \x_0 -> (\y_1 -> E9{unwrapE9 = y_1},
+                              getField @"unwrapE9" x_0)
 instance (~) ty CUInt => HasField "unwrapE9" (Ptr E9) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE9")
 instance HasCField E9 "unwrapE9"
     where type CFieldType E9 "unwrapE9" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE9" E9 ty
-    where hasField = \x_0 -> (\y_1 -> E9{unwrapE9 = y_1},
-                              getField @"unwrapE9" x_0)
 {-| __C declaration:__ @x9@
 
     __defined at:__ @attributes\/visibility\/types.h 104:54@
@@ -1643,14 +1643,14 @@ instance Read E10
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE10" E10 ty
+    where hasField = \x_0 -> (\y_1 -> E10{unwrapE10 = y_1},
+                              getField @"unwrapE10" x_0)
 instance (~) ty CUInt => HasField "unwrapE10" (Ptr E10) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE10")
 instance HasCField E10 "unwrapE10"
     where type CFieldType E10 "unwrapE10" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE10" E10 ty
-    where hasField = \x_0 -> (\y_1 -> E10{unwrapE10 = y_1},
-                              getField @"unwrapE10" x_0)
 {-| __C declaration:__ @x10@
 
     __defined at:__ @attributes\/visibility\/types.h 113:55@
@@ -1698,14 +1698,14 @@ instance Read E11
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE11" E11 ty
+    where hasField = \x_0 -> (\y_1 -> E11{unwrapE11 = y_1},
+                              getField @"unwrapE11" x_0)
 instance (~) ty CUInt => HasField "unwrapE11" (Ptr E11) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE11")
 instance HasCField E11 "unwrapE11"
     where type CFieldType E11 "unwrapE11" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE11" E11 ty
-    where hasField = \x_0 -> (\y_1 -> E11{unwrapE11 = y_1},
-                              getField @"unwrapE11" x_0)
 {-| __C declaration:__ @x11@
 
     __defined at:__ @attributes\/visibility\/types.h 114:55@
@@ -1753,14 +1753,14 @@ instance Read E12
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE12" E12 ty
+    where hasField = \x_0 -> (\y_1 -> E12{unwrapE12 = y_1},
+                              getField @"unwrapE12" x_0)
 instance (~) ty CUInt => HasField "unwrapE12" (Ptr E12) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE12")
 instance HasCField E12 "unwrapE12"
     where type CFieldType E12 "unwrapE12" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE12" E12 ty
-    where hasField = \x_0 -> (\y_1 -> E12{unwrapE12 = y_1},
-                              getField @"unwrapE12" x_0)
 {-| __C declaration:__ @x12@
 
     __defined at:__ @attributes\/visibility\/types.h 115:55@
@@ -1808,14 +1808,14 @@ instance Read E13
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE13" E13 ty
+    where hasField = \x_0 -> (\y_1 -> E13{unwrapE13 = y_1},
+                              getField @"unwrapE13" x_0)
 instance (~) ty CUInt => HasField "unwrapE13" (Ptr E13) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE13")
 instance HasCField E13 "unwrapE13"
     where type CFieldType E13 "unwrapE13" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE13" E13 ty
-    where hasField = \x_0 -> (\y_1 -> E13{unwrapE13 = y_1},
-                              getField @"unwrapE13" x_0)
 {-| __C declaration:__ @x13@
 
     __defined at:__ @attributes\/visibility\/types.h 116:55@
@@ -1863,14 +1863,14 @@ instance Read E14
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE14" E14 ty
+    where hasField = \x_0 -> (\y_1 -> E14{unwrapE14 = y_1},
+                              getField @"unwrapE14" x_0)
 instance (~) ty CUInt => HasField "unwrapE14" (Ptr E14) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE14")
 instance HasCField E14 "unwrapE14"
     where type CFieldType E14 "unwrapE14" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE14" E14 ty
-    where hasField = \x_0 -> (\y_1 -> E14{unwrapE14 = y_1},
-                              getField @"unwrapE14" x_0)
 {-| __C declaration:__ @x14@
 
     __defined at:__ @attributes\/visibility\/types.h 117:55@
@@ -1918,14 +1918,14 @@ instance Read E15
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE15" E15 ty
+    where hasField = \x_0 -> (\y_1 -> E15{unwrapE15 = y_1},
+                              getField @"unwrapE15" x_0)
 instance (~) ty CUInt => HasField "unwrapE15" (Ptr E15) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE15")
 instance HasCField E15 "unwrapE15"
     where type CFieldType E15 "unwrapE15" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE15" E15 ty
-    where hasField = \x_0 -> (\y_1 -> E15{unwrapE15 = y_1},
-                              getField @"unwrapE15" x_0)
 {-| __C declaration:__ @x15@
 
     __defined at:__ @attributes\/visibility\/types.h 126:55@
@@ -1973,14 +1973,14 @@ instance Read E16
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE16" E16 ty
+    where hasField = \x_0 -> (\y_1 -> E16{unwrapE16 = y_1},
+                              getField @"unwrapE16" x_0)
 instance (~) ty CUInt => HasField "unwrapE16" (Ptr E16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE16")
 instance HasCField E16 "unwrapE16"
     where type CFieldType E16 "unwrapE16" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE16" E16 ty
-    where hasField = \x_0 -> (\y_1 -> E16{unwrapE16 = y_1},
-                              getField @"unwrapE16" x_0)
 {-| __C declaration:__ @x16@
 
     __defined at:__ @attributes\/visibility\/types.h 127:55@
@@ -2028,14 +2028,14 @@ instance Read E17
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE17" E17 ty
+    where hasField = \x_0 -> (\y_1 -> E17{unwrapE17 = y_1},
+                              getField @"unwrapE17" x_0)
 instance (~) ty CUInt => HasField "unwrapE17" (Ptr E17) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE17")
 instance HasCField E17 "unwrapE17"
     where type CFieldType E17 "unwrapE17" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE17" E17 ty
-    where hasField = \x_0 -> (\y_1 -> E17{unwrapE17 = y_1},
-                              getField @"unwrapE17" x_0)
 {-| __C declaration:__ @x17@
 
     __defined at:__ @attributes\/visibility\/types.h 128:55@
@@ -2083,14 +2083,14 @@ instance Read E18
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE18" E18 ty
+    where hasField = \x_0 -> (\y_1 -> E18{unwrapE18 = y_1},
+                              getField @"unwrapE18" x_0)
 instance (~) ty CUInt => HasField "unwrapE18" (Ptr E18) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE18")
 instance HasCField E18 "unwrapE18"
     where type CFieldType E18 "unwrapE18" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE18" E18 ty
-    where hasField = \x_0 -> (\y_1 -> E18{unwrapE18 = y_1},
-                              getField @"unwrapE18" x_0)
 {-| __C declaration:__ @x18@
 
     __defined at:__ @attributes\/visibility\/types.h 129:55@
@@ -2138,14 +2138,14 @@ instance Read E19
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE19" E19 ty
+    where hasField = \x_0 -> (\y_1 -> E19{unwrapE19 = y_1},
+                              getField @"unwrapE19" x_0)
 instance (~) ty CUInt => HasField "unwrapE19" (Ptr E19) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE19")
 instance HasCField E19 "unwrapE19"
     where type CFieldType E19 "unwrapE19" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE19" E19 ty
-    where hasField = \x_0 -> (\y_1 -> E19{unwrapE19 = y_1},
-                              getField @"unwrapE19" x_0)
 {-| __C declaration:__ @x19@
 
     __defined at:__ @attributes\/visibility\/types.h 130:55@

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/Example.hs
@@ -39,6 +39,14 @@ newtype MyArray = MyArray
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyArray" MyArray ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyArray {unwrapMyArray = y1}, RIP.getField @"unwrapMyArray" x0)
+
+instance ( ty ~ IA.IncompleteArray RIP.CInt
          ) => RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr ty) where
 
   getField =
@@ -50,14 +58,6 @@ instance HasCField.HasCField MyArray "unwrapMyArray" where
     IA.IncompleteArray RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyArray" MyArray ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyArray {unwrapMyArray = y1}, RIP.getField @"unwrapMyArray" x0)
 
 {-| __C declaration:__ @macro A@
 
@@ -71,6 +71,12 @@ newtype A = A
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
+instance (ty ~ MyArray) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyArray) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -80,12 +86,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyArray
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyArray) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -99,6 +99,12 @@ newtype B = B
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -108,12 +114,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -126,6 +126,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -135,9 +141,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: B
@@ -37,11 +38,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: E
@@ -51,10 +53,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyArray
   representation:
     newtype:
@@ -62,10 +65,11 @@ hstypes:
       fields:
       - unwrapMyArray
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array/th.txt
@@ -131,16 +131,16 @@ newtype MyArray
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray CInt) =>
+         HasField "unwrapMyArray" MyArray ty
+    where hasField = \x_0 -> (\y_1 -> MyArray{unwrapMyArray = y_1},
+                              getField @"unwrapMyArray" x_0)
+instance (~) ty (IncompleteArray CInt) =>
          HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray
                           "unwrapMyArray" = IncompleteArray CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray CInt) =>
-         HasField "unwrapMyArray" MyArray ty
-    where hasField = \x_0 -> (\y_1 -> MyArray{unwrapMyArray = y_1},
-                              getField @"unwrapMyArray" x_0)
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array.h 9:9@
@@ -151,14 +151,14 @@ newtype A
     = A {unwrapA :: MyArray}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty MyArray => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
           offset# = \_ -> \_ -> 0
-instance (~) ty MyArray => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array.h 10:9@
@@ -169,14 +169,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array.h 31:9@
@@ -184,14 +184,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/array.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacroar_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_2a6ef3a515232132" hs_bindgen_2a6ef3a515232132_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/Example.hs
@@ -46,6 +46,14 @@ newtype MyArray = MyArray
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyArray" MyArray ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyArray {unwrapMyArray = y1}, RIP.getField @"unwrapMyArray" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapMyArray" (RIP.Ptr MyArray) (RIP.Ptr ty) where
 
   getField =
@@ -57,14 +65,6 @@ instance HasCField.HasCField MyArray "unwrapMyArray" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyArray" MyArray ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyArray {unwrapMyArray = y1}, RIP.getField @"unwrapMyArray" x0)
 
 {-| __C declaration:__ @macro A@
 
@@ -84,6 +84,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyArray) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyArray) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -93,12 +99,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyArray
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyArray) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -118,6 +118,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -127,12 +133,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -145,6 +145,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -154,9 +160,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -41,11 +42,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -59,10 +61,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyArray
   representation:
     newtype:
@@ -70,11 +73,12 @@ hstypes:
       fields:
       - unwrapMyArray
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/array_known_size/th.txt
@@ -131,16 +131,16 @@ newtype MyArray
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 3 CInt) =>
+         HasField "unwrapMyArray" MyArray ty
+    where hasField = \x_0 -> (\y_1 -> MyArray{unwrapMyArray = y_1},
+                              getField @"unwrapMyArray" x_0)
+instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapMyArray" (Ptr MyArray) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyArray")
 instance HasCField MyArray "unwrapMyArray"
     where type CFieldType MyArray "unwrapMyArray" = ConstantArray 3
                                                                   CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapMyArray" MyArray ty
-    where hasField = \x_0 -> (\y_1 -> MyArray{unwrapMyArray = y_1},
-                              getField @"unwrapMyArray" x_0)
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array_known_size.h 9:9@
@@ -151,14 +151,14 @@ newtype A
     = A {unwrapA :: MyArray}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty MyArray => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyArray => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyArray
           offset# = \_ -> \_ -> 0
-instance (~) ty MyArray => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array_known_size.h 10:9@
@@ -169,14 +169,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/array_known_size.h 31:9@
@@ -184,14 +184,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/array_known_size.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacroar_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_2a6ef3a515232132" hs_bindgen_2a6ef3a515232132_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/Example.hs
@@ -110,6 +110,14 @@ instance Read MyEnum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
 
   getField =
@@ -120,14 +128,6 @@ instance HasCField.HasCField MyEnum "unwrapMyEnum" where
   type CFieldType MyEnum "unwrapMyEnum" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
 
 {-| __C declaration:__ @x@
 
@@ -157,6 +157,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyEnum) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyEnum) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -166,12 +172,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyEnum
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyEnum) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -192,6 +192,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -201,12 +207,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -219,6 +219,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -228,9 +234,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
@@ -23,12 +23,13 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -44,12 +45,13 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -65,10 +67,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyEnum
   representation:
     newtype:
@@ -77,12 +80,13 @@ hstypes:
       - unwrapMyEnum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/th.txt
@@ -158,15 +158,15 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
+    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
+                              getField @"unwrapMyEnum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
-    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
-                              getField @"unwrapMyEnum" x_0)
 {-| __C declaration:__ @x@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/enum.h 5:14@
@@ -190,14 +190,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty MyEnum => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
           offset# = \_ -> \_ -> 0
-instance (~) ty MyEnum => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/enum.h 10:9@
@@ -213,14 +213,14 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/enum.h 31:9@
@@ -228,14 +228,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/enum.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacroen_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_d49a011eb7da5969" hs_bindgen_d49a011eb7da5969_base ::
     Word32

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/Example.hs
@@ -71,6 +71,15 @@ instance RIP.FromFunPtr MyFunction where
   fromFunPtr = hs_bindgen_bb71f7e730356103
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapMyFunction" MyFunction ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> MyFunction {unwrapMyFunction = y1}
+      , RIP.getField @"unwrapMyFunction" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapMyFunction" (RIP.Ptr MyFunction) (RIP.Ptr ty) where
 
   getField =
@@ -82,15 +91,6 @@ instance HasCField.HasCField MyFunction "unwrapMyFunction" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapMyFunction" MyFunction ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> MyFunction {unwrapMyFunction = y1}
-      , RIP.getField @"unwrapMyFunction" x0
-      )
 
 {-| __C declaration:__ @macro A@
 
@@ -104,6 +104,12 @@ newtype A = A
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ MyFunction) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ MyFunction
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -114,12 +120,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyFunction
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyFunction) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -133,6 +133,12 @@ newtype B = B
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -142,12 +148,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -160,6 +160,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -169,9 +175,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: B
   representation:
     newtype:
@@ -35,11 +36,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: E
   representation:
     newtype:
@@ -47,10 +49,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyFunction
   representation:
     newtype:
@@ -58,10 +61,11 @@ hstypes:
       fields:
       - unwrapMyFunction
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function/th.txt
@@ -278,16 +278,16 @@ instance ToFunPtr MyFunction
 instance FromFunPtr MyFunction
     where fromFunPtr = hs_bindgen_bb71f7e730356103
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapMyFunction" MyFunction ty
+    where hasField = \x_0 -> (\y_1 -> MyFunction{unwrapMyFunction = y_1},
+                              getField @"unwrapMyFunction" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapMyFunction" (Ptr MyFunction) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyFunction")
 instance HasCField MyFunction "unwrapMyFunction"
     where type CFieldType MyFunction "unwrapMyFunction" = CInt ->
                                                           IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapMyFunction" MyFunction ty
-    where hasField = \x_0 -> (\y_1 -> MyFunction{unwrapMyFunction = y_1},
-                              getField @"unwrapMyFunction" x_0)
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function.h 9:9@
@@ -298,14 +298,14 @@ newtype A
     = A {unwrapA :: MyFunction}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty MyFunction => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyFunction => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunction
           offset# = \_ -> \_ -> 0
-instance (~) ty MyFunction => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function.h 10:9@
@@ -316,14 +316,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function.h 31:9@
@@ -331,14 +331,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/function.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacrofu_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_40e15e86e5db36ce" hs_bindgen_40e15e86e5db36ce_base ::
     FunPtr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/Example.hs
@@ -75,6 +75,16 @@ instance RIP.FromFunPtr MyFunctionPointer_Aux where
   fromFunPtr = hs_bindgen_5738272f94a589e2
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapMyFunctionPointer_Aux" MyFunctionPointer_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MyFunctionPointer_Aux {unwrapMyFunctionPointer_Aux = y1}
+      , RIP.getField @"unwrapMyFunctionPointer_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapMyFunctionPointer_Aux" (RIP.Ptr MyFunctionPointer_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -86,16 +96,6 @@ instance HasCField.HasCField MyFunctionPointer_Aux "unwrapMyFunctionPointer_Aux"
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapMyFunctionPointer_Aux" MyFunctionPointer_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MyFunctionPointer_Aux {unwrapMyFunctionPointer_Aux = y1}
-      , RIP.getField @"unwrapMyFunctionPointer_Aux" x0
-      )
 
 {-| __C declaration:__ @MyFunctionPointer@
 
@@ -116,6 +116,16 @@ newtype MyFunctionPointer = MyFunctionPointer
     )
 
 instance ( ty ~ RIP.FunPtr MyFunctionPointer_Aux
+         ) => RIP.CompatHasField.HasField "unwrapMyFunctionPointer" MyFunctionPointer ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MyFunctionPointer {unwrapMyFunctionPointer = y1}
+      , RIP.getField @"unwrapMyFunctionPointer" x0
+      )
+
+instance ( ty ~ RIP.FunPtr MyFunctionPointer_Aux
          ) => RIP.HasField "unwrapMyFunctionPointer" (RIP.Ptr MyFunctionPointer) (RIP.Ptr ty) where
 
   getField =
@@ -127,16 +137,6 @@ instance HasCField.HasCField MyFunctionPointer "unwrapMyFunctionPointer" where
     RIP.FunPtr MyFunctionPointer_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr MyFunctionPointer_Aux
-         ) => RIP.CompatHasField.HasField "unwrapMyFunctionPointer" MyFunctionPointer ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MyFunctionPointer {unwrapMyFunctionPointer = y1}
-      , RIP.getField @"unwrapMyFunctionPointer" x0
-      )
 
 {-| __C declaration:__ @macro A@
 
@@ -157,6 +157,13 @@ newtype A = A
     )
 
 instance ( ty ~ MyFunctionPointer
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ MyFunctionPointer
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -166,13 +173,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyFunctionPointer
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyFunctionPointer
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -192,6 +192,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -201,12 +207,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -219,6 +219,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -228,9 +234,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/bindingspec.yaml
@@ -23,12 +23,13 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -42,12 +43,13 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -61,10 +63,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyFunctionPointer
   representation:
     newtype:
@@ -72,12 +75,13 @@ hstypes:
       fields:
       - unwrapMyFunctionPointer
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/function_pointer/th.txt
@@ -157,6 +157,10 @@ instance ToFunPtr MyFunctionPointer_Aux
 instance FromFunPtr MyFunctionPointer_Aux
     where fromFunPtr = hs_bindgen_5738272f94a589e2
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapMyFunctionPointer_Aux" MyFunctionPointer_Aux ty
+    where hasField = \x_0 -> (\y_1 -> MyFunctionPointer_Aux{unwrapMyFunctionPointer_Aux = y_1},
+                              getField @"unwrapMyFunctionPointer_Aux" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapMyFunctionPointer_Aux"
                   (Ptr MyFunctionPointer_Aux)
                   (Ptr ty)
@@ -166,10 +170,6 @@ instance HasCField MyFunctionPointer_Aux
     where type CFieldType MyFunctionPointer_Aux
                           "unwrapMyFunctionPointer_Aux" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapMyFunctionPointer_Aux" MyFunctionPointer_Aux ty
-    where hasField = \x_0 -> (\y_1 -> MyFunctionPointer_Aux{unwrapMyFunctionPointer_Aux = y_1},
-                              getField @"unwrapMyFunctionPointer_Aux" x_0)
 {-| __C declaration:__ @MyFunctionPointer@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function_pointer.h 5:15@
@@ -185,16 +185,16 @@ newtype MyFunctionPointer
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr MyFunctionPointer_Aux) =>
+         HasField "unwrapMyFunctionPointer" MyFunctionPointer ty
+    where hasField = \x_0 -> (\y_1 -> MyFunctionPointer{unwrapMyFunctionPointer = y_1},
+                              getField @"unwrapMyFunctionPointer" x_0)
+instance (~) ty (FunPtr MyFunctionPointer_Aux) =>
          HasField "unwrapMyFunctionPointer" (Ptr MyFunctionPointer) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyFunctionPointer")
 instance HasCField MyFunctionPointer "unwrapMyFunctionPointer"
     where type CFieldType MyFunctionPointer
                           "unwrapMyFunctionPointer" = FunPtr MyFunctionPointer_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr MyFunctionPointer_Aux) =>
-         HasField "unwrapMyFunctionPointer" MyFunctionPointer ty
-    where hasField = \x_0 -> (\y_1 -> MyFunctionPointer{unwrapMyFunctionPointer = y_1},
-                              getField @"unwrapMyFunctionPointer" x_0)
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function_pointer.h 9:9@
@@ -209,15 +209,15 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty MyFunctionPointer => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyFunctionPointer =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyFunctionPointer
           offset# = \_ -> \_ -> 0
-instance (~) ty MyFunctionPointer => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function_pointer.h 10:9@
@@ -232,14 +232,14 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/function_pointer.h 31:9@
@@ -247,14 +247,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/function_pointer.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacrofu_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_40e15e86e5db36ce" hs_bindgen_40e15e86e5db36ce_base ::
     FunPtr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/Example.hs
@@ -68,18 +68,6 @@ instance Marshal.WriteRaw MyStruct where
 
 deriving via Marshal.EquivStorable MyStruct instance RIP.Storable MyStruct
 
-instance HasCField.HasCField MyStruct "myStruct_x" where
-
-  type CFieldType MyStruct "myStruct_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"myStruct_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "myStruct_x" MyStruct ty where
 
@@ -87,6 +75,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          MyStruct {myStruct_x = y1}, RIP.getField @"myStruct_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"myStruct_x")
+
+instance HasCField.HasCField MyStruct "myStruct_x" where
+
+  type CFieldType MyStruct "myStruct_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @macro A@
 
@@ -105,6 +105,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyStruct) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ MyStruct
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -115,12 +121,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyStruct
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyStruct) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -139,6 +139,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -148,12 +154,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -166,6 +166,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -175,9 +181,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -40,11 +41,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -57,10 +59,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyStruct
   representation:
     record:
@@ -68,11 +71,12 @@ hstypes:
       fields:
       - myStruct_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/struct/th.txt
@@ -144,15 +144,15 @@ instance WriteRaw MyStruct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        MyStruct myStruct_x_2 -> writeRaw (Proxy @"myStruct_x") ptr_0 myStruct_x_2
 deriving via (EquivStorable MyStruct) instance Storable MyStruct
-instance HasCField MyStruct "myStruct_x"
-    where type CFieldType MyStruct "myStruct_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"myStruct_x")
 instance (~) ty CInt => HasField "myStruct_x" MyStruct ty
     where hasField = \x_0 -> (\y_1 -> MyStruct{myStruct_x = y_1},
                               getField @"myStruct_x" x_0)
+instance (~) ty CInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"myStruct_x")
+instance HasCField MyStruct "myStruct_x"
+    where type CFieldType MyStruct "myStruct_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/struct.h 11:9@
@@ -163,14 +163,14 @@ newtype A
     = A {unwrapA :: MyStruct}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty MyStruct => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
           offset# = \_ -> \_ -> 0
-instance (~) ty MyStruct => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/struct.h 12:9@
@@ -181,14 +181,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/struct.h 35:9@
@@ -196,14 +196,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/struct.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacrost_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_f2a9c7d0ba1aaa3b" hs_bindgen_f2a9c7d0ba1aaa3b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/Example.hs
@@ -73,16 +73,16 @@ set_myUnion_x ::
   -> MyUnion
 set_myUnion_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
+
 instance HasCField.HasCField MyUnion "myUnion_x" where
 
   type CFieldType MyUnion "myUnion_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
 
 {-| __C declaration:__ @macro A@
 
@@ -101,6 +101,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyUnion) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyUnion) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -110,12 +116,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyUnion
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyUnion) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro B@
 
@@ -134,6 +134,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -143,12 +149,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @macro E@
 
@@ -161,6 +161,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -170,9 +176,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/bindingspec.yaml
@@ -23,10 +23,11 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -38,10 +39,11 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -53,10 +55,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyUnion
   representation:
     newtype:
@@ -66,7 +69,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/union/th.txt
@@ -167,11 +167,11 @@ set_myUnion_x :: CInt -> MyUnion
 
 -}
 set_myUnion_x = setUnionPayload
+instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+    where getField = fromPtr (Proxy @"myUnion_x")
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
-    where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @macro A@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/union.h 9:9@
@@ -182,14 +182,14 @@ newtype A
     = A {unwrapA :: MyUnion}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty MyUnion => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
           offset# = \_ -> \_ -> 0
-instance (~) ty MyUnion => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro B@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/union.h 10:9@
@@ -200,14 +200,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @macro E@
 
     __defined at:__ @binding-specs\/fun_arg\/macro\/union.h 31:9@
@@ -215,14 +215,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/macro\/union.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argmacroun_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_5da9ad143faecbca" hs_bindgen_5da9ad143faecbca_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/Example.hs
@@ -38,6 +38,13 @@ newtype A = A
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ IA.IncompleteArray RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -48,13 +55,6 @@ instance HasCField.HasCField A "unwrapA" where
     IA.IncompleteArray RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -68,6 +68,12 @@ newtype B = B
   deriving stock (Eq, RIP.Generic, Show)
   deriving newtype (IsA.IsArray)
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -77,12 +83,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -95,6 +95,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -104,9 +110,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: B
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: E
@@ -48,7 +50,8 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array/th.txt
@@ -130,15 +130,15 @@ newtype A
     = A {unwrapA :: (IncompleteArray CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty (IncompleteArray CInt) => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty (IncompleteArray CInt) =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = IncompleteArray CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray CInt) => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/array.h 7:11@
@@ -149,14 +149,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/array.h 19:11@
@@ -164,14 +164,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/typedef\/array.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/Example.hs
@@ -45,6 +45,13 @@ newtype A = A
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -55,13 +62,6 @@ instance HasCField.HasCField A "unwrapA" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -81,6 +81,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -90,12 +96,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -108,6 +108,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -117,9 +123,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -38,11 +39,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -56,7 +58,8 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/array_known_size/th.txt
@@ -130,15 +130,15 @@ newtype A
     = A {unwrapA :: (ConstantArray 3 CInt)}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = ConstantArray 3 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h 7:11@
@@ -149,14 +149,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h 19:11@
@@ -164,14 +164,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/typedef\/array_known_size.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/Example.hs
@@ -110,6 +110,14 @@ instance Read MyEnum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
 
   getField =
@@ -120,14 +128,6 @@ instance HasCField.HasCField MyEnum "unwrapMyEnum" where
   type CFieldType MyEnum "unwrapMyEnum" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
 
 {-| __C declaration:__ @x@
 
@@ -157,6 +157,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyEnum) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyEnum) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -166,12 +172,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyEnum
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyEnum) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -192,6 +192,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -201,12 +207,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -220,6 +220,12 @@ newtype E = E
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -229,9 +235,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
@@ -23,12 +23,13 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -44,12 +45,13 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -65,11 +67,12 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyEnum
   representation:
     newtype:
@@ -78,12 +81,13 @@ hstypes:
       - unwrapMyEnum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/th.txt
@@ -158,15 +158,15 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
+    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
+                              getField @"unwrapMyEnum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
-    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
-                              getField @"unwrapMyEnum" x_0)
 {-| __C declaration:__ @x@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/enum.h 4:14@
@@ -190,14 +190,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty MyEnum => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyEnum => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyEnum
           offset# = \_ -> \_ -> 0
-instance (~) ty MyEnum => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/enum.h 8:11@
@@ -213,14 +213,14 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/enum.h 21:11@
@@ -231,14 +231,14 @@ newtype E
     = E {unwrapE :: M.C}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     Word32

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/Example.hs
@@ -70,6 +70,13 @@ instance RIP.FromFunPtr A where
   fromFunPtr = hs_bindgen_0cf9a6d50f563441
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -79,13 +86,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -99,6 +99,12 @@ newtype B = B
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -108,12 +114,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -126,6 +126,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -135,9 +141,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/bindingspec.yaml
@@ -20,12 +20,13 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr
 - hsname: B
   representation:
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: E
   representation:
     newtype:
@@ -46,7 +48,8 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function/th.txt
@@ -283,15 +283,15 @@ instance ToFunPtr A
     where toFunPtr = hs_bindgen_0c7d4776a632d026
 instance FromFunPtr A
     where fromFunPtr = hs_bindgen_0cf9a6d50f563441
+instance (~) ty (CInt -> IO CInt) => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/function.h 7:11@
@@ -302,14 +302,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/function.h 19:11@
@@ -317,14 +317,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/typedef\/function.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     FunPtr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/Example.hs
@@ -74,6 +74,14 @@ instance RIP.FromFunPtr A_Aux where
   fromFunPtr = hs_bindgen_cdb12400c6863f15
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapA_Aux" A_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         A_Aux {unwrapA_Aux = y1}, RIP.getField @"unwrapA_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapA_Aux" (RIP.Ptr A_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -85,14 +93,6 @@ instance HasCField.HasCField A_Aux "unwrapA_Aux" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapA_Aux" A_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         A_Aux {unwrapA_Aux = y1}, RIP.getField @"unwrapA_Aux" x0)
 
 {-| __C declaration:__ @A@
 
@@ -113,6 +113,13 @@ newtype A = A
     )
 
 instance ( ty ~ RIP.FunPtr A_Aux
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ RIP.FunPtr A_Aux
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -122,13 +129,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.FunPtr A_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr A_Aux
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -148,6 +148,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -157,12 +163,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -176,6 +176,12 @@ newtype E = E
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -185,9 +191,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/bindingspec.yaml
@@ -20,12 +20,13 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -39,12 +40,13 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -58,8 +60,9 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/function_pointer/th.txt
@@ -160,15 +160,15 @@ instance ToFunPtr A_Aux
 instance FromFunPtr A_Aux
     where fromFunPtr = hs_bindgen_cdb12400c6863f15
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapA_Aux" A_Aux ty
+    where hasField = \x_0 -> (\y_1 -> A_Aux{unwrapA_Aux = y_1},
+                              getField @"unwrapA_Aux" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapA_Aux" (Ptr A_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_Aux")
 instance HasCField A_Aux "unwrapA_Aux"
     where type CFieldType A_Aux "unwrapA_Aux" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapA_Aux" A_Aux ty
-    where hasField = \x_0 -> (\y_1 -> A_Aux{unwrapA_Aux = y_1},
-                              getField @"unwrapA_Aux" x_0)
 {-| __C declaration:__ @A@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h 6:15@
@@ -183,15 +183,15 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr A_Aux) => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty (FunPtr A_Aux) =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = FunPtr A_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr A_Aux) => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h 7:11@
@@ -206,14 +206,14 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/function_pointer.h 19:11@
@@ -224,14 +224,14 @@ newtype E
     = E {unwrapE :: M.C}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     FunPtr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/Example.hs
@@ -68,18 +68,6 @@ instance Marshal.WriteRaw MyStruct where
 
 deriving via Marshal.EquivStorable MyStruct instance RIP.Storable MyStruct
 
-instance HasCField.HasCField MyStruct "myStruct_x" where
-
-  type CFieldType MyStruct "myStruct_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"myStruct_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "myStruct_x" MyStruct ty where
 
@@ -87,6 +75,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          MyStruct {myStruct_x = y1}, RIP.getField @"myStruct_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"myStruct_x")
+
+instance HasCField.HasCField MyStruct "myStruct_x" where
+
+  type CFieldType MyStruct "myStruct_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @A@
 
@@ -105,6 +105,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyStruct) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ MyStruct
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -115,12 +121,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyStruct
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyStruct) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -139,6 +139,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -148,12 +154,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -166,6 +166,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -175,9 +181,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -40,11 +41,12 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -57,10 +59,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyStruct
   representation:
     record:
@@ -68,11 +71,12 @@ hstypes:
       fields:
       - myStruct_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/struct/th.txt
@@ -144,15 +144,15 @@ instance WriteRaw MyStruct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        MyStruct myStruct_x_2 -> writeRaw (Proxy @"myStruct_x") ptr_0 myStruct_x_2
 deriving via (EquivStorable MyStruct) instance Storable MyStruct
-instance HasCField MyStruct "myStruct_x"
-    where type CFieldType MyStruct "myStruct_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"myStruct_x")
 instance (~) ty CInt => HasField "myStruct_x" MyStruct ty
     where hasField = \x_0 -> (\y_1 -> MyStruct{myStruct_x = y_1},
                               getField @"myStruct_x" x_0)
+instance (~) ty CInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"myStruct_x")
+instance HasCField MyStruct "myStruct_x"
+    where type CFieldType MyStruct "myStruct_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @A@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/struct.h 7:25@
@@ -163,14 +163,14 @@ newtype A
     = A {unwrapA :: MyStruct}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty MyStruct => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyStruct => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyStruct
           offset# = \_ -> \_ -> 0
-instance (~) ty MyStruct => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/struct.h 8:11@
@@ -181,14 +181,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/struct.h 21:11@
@@ -196,14 +196,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/typedef\/struct.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/Example.hs
@@ -73,16 +73,16 @@ set_myUnion_x ::
   -> MyUnion
 set_myUnion_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
+
 instance HasCField.HasCField MyUnion "myUnion_x" where
 
   type CFieldType MyUnion "myUnion_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "myUnion_x" (RIP.Ptr MyUnion) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"myUnion_x")
 
 {-| __C declaration:__ @A@
 
@@ -101,6 +101,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MyUnion) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance (ty ~ MyUnion) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -110,12 +116,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = MyUnion
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyUnion) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -134,6 +134,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -143,12 +149,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @E@
 
@@ -161,6 +161,12 @@ newtype E = E
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance (ty ~ M.C) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapE")
@@ -170,9 +176,3 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = M.C
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.C) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/bindingspec.yaml
@@ -23,10 +23,11 @@ hstypes:
       fields:
       - unwrapA
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -38,10 +39,11 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -53,10 +55,11 @@ hstypes:
       fields:
       - unwrapE
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: MyUnion
   representation:
     newtype:
@@ -66,7 +69,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/union/th.txt
@@ -167,11 +167,11 @@ set_myUnion_x :: CInt -> MyUnion
 
 -}
 set_myUnion_x = setUnionPayload
+instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
+    where getField = fromPtr (Proxy @"myUnion_x")
 instance HasCField MyUnion "myUnion_x"
     where type CFieldType MyUnion "myUnion_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "myUnion_x" (Ptr MyUnion) (Ptr ty)
-    where getField = fromPtr (Proxy @"myUnion_x")
 {-| __C declaration:__ @A@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/union.h 7:23@
@@ -182,14 +182,14 @@ newtype A
     = A {unwrapA :: MyUnion}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty MyUnion => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty MyUnion => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = MyUnion
           offset# = \_ -> \_ -> 0
-instance (~) ty MyUnion => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/union.h 8:11@
@@ -200,14 +200,14 @@ newtype B
     = B {unwrapB :: A}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @E@
 
     __defined at:__ @binding-specs\/fun_arg\/typedef\/union.h 21:11@
@@ -215,14 +215,14 @@ instance (~) ty A => HasField "unwrapB" B ty
     __exported by:__ @binding-specs\/fun_arg\/typedef\/union.h@
 -}
 newtype E = E {unwrapE :: M.C} deriving stock Generic
+instance (~) ty M.C => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty M.C => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = M.C
           offset# = \_ -> \_ -> 0
-instance (~) ty M.C => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 -- __unique:__ @test_bindingspecsfun_argtypedef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_99bb90e6d7637d2c" hs_bindgen_99bb90e6d7637d2c_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/Example.hs
@@ -72,17 +72,6 @@ instance Marshal.WriteRaw Hoge where
 
 deriving via Marshal.EquivStorable Hoge instance RIP.Storable Hoge
 
-instance HasCField.HasCField Hoge "hoge_x" where
-
-  type CFieldType Hoge "hoge_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_x" Hoge ty where
 
   hasField =
@@ -92,16 +81,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_x" Hoge ty where
       , RIP.getField @"hoge_x" x0
       )
 
-instance HasCField.HasCField Hoge "hoge_y" where
-
-  type CFieldType Hoge "hoge_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
+
+instance HasCField.HasCField Hoge "hoge_x" where
+
+  type CFieldType Hoge "hoge_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_y" Hoge ty where
 
@@ -111,3 +100,14 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_y" Hoge ty where
           Hoge {hoge_y = y1, hoge_x = RIP.getField @"hoge_x" x0}
       , RIP.getField @"hoge_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")
+
+instance HasCField.HasCField Hoge "hoge_y" where
+
+  type CFieldType Hoge "hoge_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - hoge_x
       - hoge_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_both/th.txt
@@ -31,21 +31,21 @@ instance WriteRaw Hoge
                                        Hoge hoge_x_2
                                             hoge_y_3 -> writeRaw (Proxy @"hoge_x") ptr_0 hoge_x_2 >> writeRaw (Proxy @"hoge_y") ptr_0 hoge_y_3
 deriving via (EquivStorable Hoge) instance Storable Hoge
-instance HasCField Hoge "hoge_x"
-    where type CFieldType Hoge "hoge_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
-    where getField = fromPtr (Proxy @"hoge_x")
 instance (~) ty CInt => HasField "hoge_x" Hoge ty
     where hasField = \x_0 -> (\y_1 -> Hoge{hoge_x = y_1,
                                            hoge_y = getField @"hoge_y" x_0},
                               getField @"hoge_x" x_0)
-instance HasCField Hoge "hoge_y"
-    where type CFieldType Hoge "hoge_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
-    where getField = fromPtr (Proxy @"hoge_y")
+instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+    where getField = fromPtr (Proxy @"hoge_x")
+instance HasCField Hoge "hoge_x"
+    where type CFieldType Hoge "hoge_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "hoge_y" Hoge ty
     where hasField = \x_0 -> (\y_1 -> Hoge{hoge_y = y_1,
                                            hoge_x = getField @"hoge_x" x_0},
                               getField @"hoge_y" x_0)
+instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+    where getField = fromPtr (Proxy @"hoge_y")
+instance HasCField Hoge "hoge_y"
+    where type CFieldType Hoge "hoge_y" = CInt
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/Example.hs
@@ -72,17 +72,6 @@ instance Marshal.WriteRaw Hoge where
 
 deriving via Marshal.EquivStorable Hoge instance RIP.Storable Hoge
 
-instance HasCField.HasCField Hoge "hoge_x" where
-
-  type CFieldType Hoge "hoge_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_x" Hoge ty where
 
   hasField =
@@ -92,16 +81,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_x" Hoge ty where
       , RIP.getField @"hoge_x" x0
       )
 
-instance HasCField.HasCField Hoge "hoge_y" where
-
-  type CFieldType Hoge "hoge_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+         ) => RIP.HasField "hoge_x" (RIP.Ptr Hoge) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"hoge_x")
+
+instance HasCField.HasCField Hoge "hoge_x" where
+
+  type CFieldType Hoge "hoge_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_y" Hoge ty where
 
@@ -111,3 +100,14 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "hoge_y" Hoge ty where
           Hoge {hoge_y = y1, hoge_x = RIP.getField @"hoge_x" x0}
       , RIP.getField @"hoge_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "hoge_y" (RIP.Ptr Hoge) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"hoge_y")
+
+instance HasCField.HasCField Hoge "hoge_y" where
+
+  type CFieldType Hoge "hoge_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - hoge_x
       - hoge_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_struct/th.txt
@@ -31,21 +31,21 @@ instance WriteRaw Hoge
                                        Hoge hoge_x_2
                                             hoge_y_3 -> writeRaw (Proxy @"hoge_x") ptr_0 hoge_x_2 >> writeRaw (Proxy @"hoge_y") ptr_0 hoge_y_3
 deriving via (EquivStorable Hoge) instance Storable Hoge
-instance HasCField Hoge "hoge_x"
-    where type CFieldType Hoge "hoge_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
-    where getField = fromPtr (Proxy @"hoge_x")
 instance (~) ty CInt => HasField "hoge_x" Hoge ty
     where hasField = \x_0 -> (\y_1 -> Hoge{hoge_x = y_1,
                                            hoge_y = getField @"hoge_y" x_0},
                               getField @"hoge_x" x_0)
-instance HasCField Hoge "hoge_y"
-    where type CFieldType Hoge "hoge_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
-    where getField = fromPtr (Proxy @"hoge_y")
+instance (~) ty CInt => HasField "hoge_x" (Ptr Hoge) (Ptr ty)
+    where getField = fromPtr (Proxy @"hoge_x")
+instance HasCField Hoge "hoge_x"
+    where type CFieldType Hoge "hoge_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "hoge_y" Hoge ty
     where hasField = \x_0 -> (\y_1 -> Hoge{hoge_y = y_1,
                                            hoge_x = getField @"hoge_x" x_0},
                               getField @"hoge_y" x_0)
+instance (~) ty CInt => HasField "hoge_y" (Ptr Hoge) (Ptr ty)
+    where getField = fromPtr (Proxy @"hoge_y")
+instance HasCField Hoge "hoge_y"
+    where type CFieldType Hoge "hoge_y" = CInt
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/Example.hs
@@ -72,17 +72,6 @@ instance Marshal.WriteRaw Piyo where
 
 deriving via Marshal.EquivStorable Piyo instance RIP.Storable Piyo
 
-instance HasCField.HasCField Piyo "piyo_x" where
-
-  type CFieldType Piyo "piyo_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "piyo_x" (RIP.Ptr Piyo) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"piyo_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "piyo_x" Piyo ty where
 
   hasField =
@@ -92,16 +81,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "piyo_x" Piyo ty where
       , RIP.getField @"piyo_x" x0
       )
 
-instance HasCField.HasCField Piyo "piyo_y" where
-
-  type CFieldType Piyo "piyo_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "piyo_y" (RIP.Ptr Piyo) (RIP.Ptr ty) where
+         ) => RIP.HasField "piyo_x" (RIP.Ptr Piyo) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"piyo_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"piyo_x")
+
+instance HasCField.HasCField Piyo "piyo_x" where
+
+  type CFieldType Piyo "piyo_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "piyo_y" Piyo ty where
 
@@ -111,3 +100,14 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "piyo_y" Piyo ty where
           Piyo {piyo_y = y1, piyo_x = RIP.getField @"piyo_x" x0}
       , RIP.getField @"piyo_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "piyo_y" (RIP.Ptr Piyo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"piyo_y")
+
+instance HasCField.HasCField Piyo "piyo_y" where
+
+  type CFieldType Piyo "piyo_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - piyo_x
       - piyo_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/squash_typedef/th.txt
@@ -31,21 +31,21 @@ instance WriteRaw Piyo
                                        Piyo piyo_x_2
                                             piyo_y_3 -> writeRaw (Proxy @"piyo_x") ptr_0 piyo_x_2 >> writeRaw (Proxy @"piyo_y") ptr_0 piyo_y_3
 deriving via (EquivStorable Piyo) instance Storable Piyo
-instance HasCField Piyo "piyo_x"
-    where type CFieldType Piyo "piyo_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "piyo_x" (Ptr Piyo) (Ptr ty)
-    where getField = fromPtr (Proxy @"piyo_x")
 instance (~) ty CInt => HasField "piyo_x" Piyo ty
     where hasField = \x_0 -> (\y_1 -> Piyo{piyo_x = y_1,
                                            piyo_y = getField @"piyo_y" x_0},
                               getField @"piyo_x" x_0)
-instance HasCField Piyo "piyo_y"
-    where type CFieldType Piyo "piyo_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "piyo_y" (Ptr Piyo) (Ptr ty)
-    where getField = fromPtr (Proxy @"piyo_y")
+instance (~) ty CInt => HasField "piyo_x" (Ptr Piyo) (Ptr ty)
+    where getField = fromPtr (Proxy @"piyo_x")
+instance HasCField Piyo "piyo_x"
+    where type CFieldType Piyo "piyo_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "piyo_y" Piyo ty
     where hasField = \x_0 -> (\y_1 -> Piyo{piyo_y = y_1,
                                            piyo_x = getField @"piyo_x" x_0},
                               getField @"piyo_y" x_0)
+instance (~) ty CInt => HasField "piyo_y" (Ptr Piyo) (Ptr ty)
+    where getField = fromPtr (Proxy @"piyo_y")
+instance HasCField Piyo "piyo_y"
+    where type CFieldType Piyo "piyo_y" = CInt
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/Example.hs
@@ -51,6 +51,14 @@ newtype MySym = MySym
     )
 
 instance ( ty ~ RIP.CChar
+         ) => RIP.CompatHasField.HasField "unwrapMySym" MySym ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MySym {unwrapMySym = y1}, RIP.getField @"unwrapMySym" x0)
+
+instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapMySym" (RIP.Ptr MySym) (RIP.Ptr ty) where
 
   getField =
@@ -61,11 +69,3 @@ instance HasCField.HasCField MySym "unwrapMySym" where
   type CFieldType MySym "unwrapMySym" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.CompatHasField.HasField "unwrapMySym" MySym ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MySym {unwrapMySym = y1}, RIP.getField @"unwrapMySym" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/name/type/th.txt
@@ -23,12 +23,12 @@ newtype MySym
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapMySym" MySym ty
+    where hasField = \x_0 -> (\y_1 -> MySym{unwrapMySym = y_1},
+                              getField @"unwrapMySym" x_0)
 instance (~) ty CChar =>
          HasField "unwrapMySym" (Ptr MySym) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMySym")
 instance HasCField MySym "unwrapMySym"
     where type CFieldType MySym "unwrapMySym" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapMySym" MySym ty
-    where hasField = \x_0 -> (\y_1 -> MySym{unwrapMySym = y_1},
-                              getField @"unwrapMySym" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/Example.hs
@@ -51,6 +51,14 @@ newtype Sym = Sym
     )
 
 instance ( ty ~ RIP.CChar
+         ) => RIP.CompatHasField.HasField "unwrapSym" Sym ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Sym {unwrapSym = y1}, RIP.getField @"unwrapSym" x0)
+
+instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapSym" (RIP.Ptr Sym) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapSym")
@@ -60,11 +68,3 @@ instance HasCField.HasCField Sym "unwrapSym" where
   type CFieldType Sym "unwrapSym" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.CompatHasField.HasField "unwrapSym" Sym ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Sym {unwrapSym = y1}, RIP.getField @"unwrapSym" x0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/omit_type/th.txt
@@ -23,11 +23,11 @@ newtype Sym
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapSym" Sym ty
+    where hasField = \x_0 -> (\y_1 -> Sym{unwrapSym = y_1},
+                              getField @"unwrapSym" x_0)
 instance (~) ty CChar => HasField "unwrapSym" (Ptr Sym) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSym")
 instance HasCField Sym "unwrapSym"
     where type CFieldType Sym "unwrapSym" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapSym" Sym ty
-    where hasField = \x_0 -> (\y_1 -> Sym{unwrapSym = y_1},
-                              getField @"unwrapSym" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/Example.hs
@@ -51,6 +51,15 @@ newtype Stdlib_CBool = Stdlib_CBool
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
+      , RIP.getField @"unwrapStdlib_CBool" x0
+      )
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
 
   getField =
@@ -62,12 +71,3 @@ instance HasCField.HasCField Stdlib_CBool "unwrapStdlib_CBool" where
     RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
-      , RIP.getField @"unwrapStdlib_CBool" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/bool/th.txt
@@ -24,12 +24,12 @@ newtype Stdlib_CBool
                       Storable,
                       WriteRaw)
 instance (~) ty CBool =>
+         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
+                              getField @"unwrapStdlib_CBool" x_0)
+instance (~) ty CBool =>
          HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
-                              getField @"unwrapStdlib_CBool" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/Example.hs
@@ -82,6 +82,15 @@ newtype Stdlib_CBool = Stdlib_CBool
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
+      , RIP.getField @"unwrapStdlib_CBool" x0
+      )
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
 
   getField =
@@ -93,15 +102,6 @@ instance HasCField.HasCField Stdlib_CBool "unwrapStdlib_CBool" where
     RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
-      , RIP.getField @"unwrapStdlib_CBool" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int8@
 
@@ -132,6 +132,15 @@ newtype Stdlib_Int8 = Stdlib_Int8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int8
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int8" Stdlib_Int8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int8 {unwrapStdlib_Int8 = y1}
+      , RIP.getField @"unwrapStdlib_Int8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int8
          ) => RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr ty) where
 
   getField =
@@ -143,15 +152,6 @@ instance HasCField.HasCField Stdlib_Int8 "unwrapStdlib_Int8" where
     HsBindgen.Runtime.LibC.Int8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int8" Stdlib_Int8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int8 {unwrapStdlib_Int8 = y1}
-      , RIP.getField @"unwrapStdlib_Int8" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int16@
 
@@ -182,6 +182,15 @@ newtype Stdlib_Int16 = Stdlib_Int16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int16
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int16" Stdlib_Int16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int16 {unwrapStdlib_Int16 = y1}
+      , RIP.getField @"unwrapStdlib_Int16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int16
          ) => RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr ty) where
 
   getField =
@@ -193,15 +202,6 @@ instance HasCField.HasCField Stdlib_Int16 "unwrapStdlib_Int16" where
     HsBindgen.Runtime.LibC.Int16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int16" Stdlib_Int16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int16 {unwrapStdlib_Int16 = y1}
-      , RIP.getField @"unwrapStdlib_Int16" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int32@
 
@@ -232,6 +232,15 @@ newtype Stdlib_Int32 = Stdlib_Int32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int32" Stdlib_Int32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int32 {unwrapStdlib_Int32 = y1}
+      , RIP.getField @"unwrapStdlib_Int32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr ty) where
 
   getField =
@@ -243,15 +252,6 @@ instance HasCField.HasCField Stdlib_Int32 "unwrapStdlib_Int32" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int32" Stdlib_Int32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int32 {unwrapStdlib_Int32 = y1}
-      , RIP.getField @"unwrapStdlib_Int32" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int64@
 
@@ -282,6 +282,15 @@ newtype Stdlib_Int64 = Stdlib_Int64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int64
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int64" Stdlib_Int64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int64 {unwrapStdlib_Int64 = y1}
+      , RIP.getField @"unwrapStdlib_Int64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int64
          ) => RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr ty) where
 
   getField =
@@ -293,15 +302,6 @@ instance HasCField.HasCField Stdlib_Int64 "unwrapStdlib_Int64" where
     HsBindgen.Runtime.LibC.Int64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int64" Stdlib_Int64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int64 {unwrapStdlib_Int64 = y1}
-      , RIP.getField @"unwrapStdlib_Int64" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word8@
 
@@ -332,6 +332,15 @@ newtype Stdlib_Word8 = Stdlib_Word8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word8" Stdlib_Word8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word8 {unwrapStdlib_Word8 = y1}
+      , RIP.getField @"unwrapStdlib_Word8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr ty) where
 
   getField =
@@ -343,15 +352,6 @@ instance HasCField.HasCField Stdlib_Word8 "unwrapStdlib_Word8" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word8" Stdlib_Word8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word8 {unwrapStdlib_Word8 = y1}
-      , RIP.getField @"unwrapStdlib_Word8" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word16@
 
@@ -382,6 +382,15 @@ newtype Stdlib_Word16 = Stdlib_Word16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word16" Stdlib_Word16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word16 {unwrapStdlib_Word16 = y1}
+      , RIP.getField @"unwrapStdlib_Word16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr ty) where
 
   getField =
@@ -393,15 +402,6 @@ instance HasCField.HasCField Stdlib_Word16 "unwrapStdlib_Word16" where
     HsBindgen.Runtime.LibC.Word16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word16" Stdlib_Word16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word16 {unwrapStdlib_Word16 = y1}
-      , RIP.getField @"unwrapStdlib_Word16" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word32@
 
@@ -432,6 +432,15 @@ newtype Stdlib_Word32 = Stdlib_Word32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word32" Stdlib_Word32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word32 {unwrapStdlib_Word32 = y1}
+      , RIP.getField @"unwrapStdlib_Word32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr ty) where
 
   getField =
@@ -443,15 +452,6 @@ instance HasCField.HasCField Stdlib_Word32 "unwrapStdlib_Word32" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word32" Stdlib_Word32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word32 {unwrapStdlib_Word32 = y1}
-      , RIP.getField @"unwrapStdlib_Word32" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word64@
 
@@ -482,6 +482,15 @@ newtype Stdlib_Word64 = Stdlib_Word64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word64" Stdlib_Word64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word64 {unwrapStdlib_Word64 = y1}
+      , RIP.getField @"unwrapStdlib_Word64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr ty) where
 
   getField =
@@ -493,15 +502,6 @@ instance HasCField.HasCField Stdlib_Word64 "unwrapStdlib_Word64" where
     HsBindgen.Runtime.LibC.Word64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word64" Stdlib_Word64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word64 {unwrapStdlib_Word64 = y1}
-      , RIP.getField @"unwrapStdlib_Word64" x0
-      )
 
 {-| __C declaration:__ @stdlib_CIntMax@
 
@@ -532,6 +532,15 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CIntMax {unwrapStdlib_CIntMax = y1}
+      , RIP.getField @"unwrapStdlib_CIntMax" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
          ) => RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr ty) where
 
   getField =
@@ -543,15 +552,6 @@ instance HasCField.HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax" where
     HsBindgen.Runtime.LibC.CIntMax
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CIntMax {unwrapStdlib_CIntMax = y1}
-      , RIP.getField @"unwrapStdlib_CIntMax" x0
-      )
 
 {-| __C declaration:__ @stdlib_CUIntMax@
 
@@ -582,6 +582,15 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CUIntMax {unwrapStdlib_CUIntMax = y1}
+      , RIP.getField @"unwrapStdlib_CUIntMax" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
          ) => RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr ty) where
 
   getField =
@@ -593,15 +602,6 @@ instance HasCField.HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax" where
     HsBindgen.Runtime.LibC.CUIntMax
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CUIntMax {unwrapStdlib_CUIntMax = y1}
-      , RIP.getField @"unwrapStdlib_CUIntMax" x0
-      )
 
 {-| __C declaration:__ @stdlib_CIntPtr@
 
@@ -632,6 +632,15 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CIntPtr {unwrapStdlib_CIntPtr = y1}
+      , RIP.getField @"unwrapStdlib_CIntPtr" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
          ) => RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr ty) where
 
   getField =
@@ -643,15 +652,6 @@ instance HasCField.HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr" where
     HsBindgen.Runtime.LibC.CIntPtr
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CIntPtr {unwrapStdlib_CIntPtr = y1}
-      , RIP.getField @"unwrapStdlib_CIntPtr" x0
-      )
 
 {-| __C declaration:__ @stdlib_CUIntPtr@
 
@@ -682,6 +682,15 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CUIntPtr {unwrapStdlib_CUIntPtr = y1}
+      , RIP.getField @"unwrapStdlib_CUIntPtr" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
          ) => RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr ty) where
 
   getField =
@@ -694,15 +703,6 @@ instance HasCField.HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CUIntPtr {unwrapStdlib_CUIntPtr = y1}
-      , RIP.getField @"unwrapStdlib_CUIntPtr" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFenvT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 35:19@
@@ -713,6 +713,15 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   { unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFenvT {unwrapStdlib_CFenvT = y1}
+      , RIP.getField @"unwrapStdlib_CFenvT" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
          ) => RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr ty) where
@@ -727,15 +736,6 @@ instance HasCField.HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFenvT {unwrapStdlib_CFenvT = y1}
-      , RIP.getField @"unwrapStdlib_CFenvT" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFexceptT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 36:19@
@@ -746,6 +746,16 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   { unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CFexceptT {unwrapStdlib_CFexceptT = y1}
+      , RIP.getField @"unwrapStdlib_CFexceptT" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
          ) => RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr ty) where
@@ -759,16 +769,6 @@ instance HasCField.HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT" where
     HsBindgen.Runtime.LibC.CFexceptT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CFexceptT {unwrapStdlib_CFexceptT = y1}
-      , RIP.getField @"unwrapStdlib_CFexceptT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CSize@
 
@@ -799,6 +799,15 @@ newtype Stdlib_CSize = Stdlib_CSize
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSize" Stdlib_CSize ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CSize {unwrapStdlib_CSize = y1}
+      , RIP.getField @"unwrapStdlib_CSize" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr ty) where
 
   getField =
@@ -810,15 +819,6 @@ instance HasCField.HasCField Stdlib_CSize "unwrapStdlib_CSize" where
     HsBindgen.Runtime.LibC.CSize
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSize" Stdlib_CSize ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CSize {unwrapStdlib_CSize = y1}
-      , RIP.getField @"unwrapStdlib_CSize" x0
-      )
 
 {-| __C declaration:__ @stdlib_CPtrdiff@
 
@@ -849,6 +849,15 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CPtrdiff {unwrapStdlib_CPtrdiff = y1}
+      , RIP.getField @"unwrapStdlib_CPtrdiff" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
          ) => RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr ty) where
 
   getField =
@@ -860,15 +869,6 @@ instance HasCField.HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff" where
     HsBindgen.Runtime.LibC.CPtrdiff
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CPtrdiff {unwrapStdlib_CPtrdiff = y1}
-      , RIP.getField @"unwrapStdlib_CPtrdiff" x0
-      )
 
 {-| __C declaration:__ @stdlib_CJmpBuf@
 
@@ -882,6 +882,15 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   deriving stock (RIP.Generic)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf = y1}
+      , RIP.getField @"unwrapStdlib_CJmpBuf" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
          ) => RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr ty) where
 
   getField =
@@ -893,15 +902,6 @@ instance HasCField.HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf" where
     HsBindgen.Runtime.LibC.CJmpBuf
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf = y1}
-      , RIP.getField @"unwrapStdlib_CJmpBuf" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWchar@
 
@@ -932,6 +932,15 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWchar {unwrapStdlib_CWchar = y1}
+      , RIP.getField @"unwrapStdlib_CWchar" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
          ) => RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr ty) where
 
   getField =
@@ -943,15 +952,6 @@ instance HasCField.HasCField Stdlib_CWchar "unwrapStdlib_CWchar" where
     HsBindgen.Runtime.LibC.CWchar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWchar {unwrapStdlib_CWchar = y1}
-      , RIP.getField @"unwrapStdlib_CWchar" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWintT@
 
@@ -982,6 +982,15 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWintT {unwrapStdlib_CWintT = y1}
+      , RIP.getField @"unwrapStdlib_CWintT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
          ) => RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr ty) where
 
   getField =
@@ -993,15 +1002,6 @@ instance HasCField.HasCField Stdlib_CWintT "unwrapStdlib_CWintT" where
     HsBindgen.Runtime.LibC.CWintT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWintT {unwrapStdlib_CWintT = y1}
-      , RIP.getField @"unwrapStdlib_CWintT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CMbstateT@
 
@@ -1015,6 +1015,16 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   deriving stock (RIP.Generic)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CMbstateT {unwrapStdlib_CMbstateT = y1}
+      , RIP.getField @"unwrapStdlib_CMbstateT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
          ) => RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr ty) where
 
   getField =
@@ -1026,16 +1036,6 @@ instance HasCField.HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT" where
     HsBindgen.Runtime.LibC.CMbstateT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CMbstateT {unwrapStdlib_CMbstateT = y1}
-      , RIP.getField @"unwrapStdlib_CMbstateT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWctransT@
 
@@ -1057,6 +1057,16 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CWctransT {unwrapStdlib_CWctransT = y1}
+      , RIP.getField @"unwrapStdlib_CWctransT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
          ) => RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr ty) where
 
   getField =
@@ -1068,16 +1078,6 @@ instance HasCField.HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT" where
     HsBindgen.Runtime.LibC.CWctransT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CWctransT {unwrapStdlib_CWctransT = y1}
-      , RIP.getField @"unwrapStdlib_CWctransT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWctypeT@
 
@@ -1099,6 +1099,15 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWctypeT {unwrapStdlib_CWctypeT = y1}
+      , RIP.getField @"unwrapStdlib_CWctypeT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
          ) => RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr ty) where
 
   getField =
@@ -1110,15 +1119,6 @@ instance HasCField.HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT" where
     HsBindgen.Runtime.LibC.CWctypeT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWctypeT {unwrapStdlib_CWctypeT = y1}
-      , RIP.getField @"unwrapStdlib_CWctypeT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CChar16T@
 
@@ -1149,6 +1149,15 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CChar16T {unwrapStdlib_CChar16T = y1}
+      , RIP.getField @"unwrapStdlib_CChar16T" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
          ) => RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr ty) where
 
   getField =
@@ -1160,15 +1169,6 @@ instance HasCField.HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T" where
     HsBindgen.Runtime.LibC.CChar16T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CChar16T {unwrapStdlib_CChar16T = y1}
-      , RIP.getField @"unwrapStdlib_CChar16T" x0
-      )
 
 {-| __C declaration:__ @stdlib_CChar32T@
 
@@ -1199,6 +1199,15 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CChar32T {unwrapStdlib_CChar32T = y1}
+      , RIP.getField @"unwrapStdlib_CChar32T" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
          ) => RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr ty) where
 
   getField =
@@ -1210,15 +1219,6 @@ instance HasCField.HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T" where
     HsBindgen.Runtime.LibC.CChar32T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CChar32T {unwrapStdlib_CChar32T = y1}
-      , RIP.getField @"unwrapStdlib_CChar32T" x0
-      )
 
 {-| __C declaration:__ @stdlib_CTime@
 
@@ -1242,6 +1242,15 @@ newtype Stdlib_CTime = Stdlib_CTime
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CTime
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTime" Stdlib_CTime ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CTime {unwrapStdlib_CTime = y1}
+      , RIP.getField @"unwrapStdlib_CTime" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CTime
          ) => RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr ty) where
 
   getField =
@@ -1253,15 +1262,6 @@ instance HasCField.HasCField Stdlib_CTime "unwrapStdlib_CTime" where
     HsBindgen.Runtime.LibC.CTime
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CTime
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTime" Stdlib_CTime ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CTime {unwrapStdlib_CTime = y1}
-      , RIP.getField @"unwrapStdlib_CTime" x0
-      )
 
 {-| __C declaration:__ @stdlib_CClock@
 
@@ -1285,6 +1285,15 @@ newtype Stdlib_CClock = Stdlib_CClock
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CClock
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CClock" Stdlib_CClock ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CClock {unwrapStdlib_CClock = y1}
+      , RIP.getField @"unwrapStdlib_CClock" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CClock
          ) => RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr ty) where
 
   getField =
@@ -1296,15 +1305,6 @@ instance HasCField.HasCField Stdlib_CClock "unwrapStdlib_CClock" where
     HsBindgen.Runtime.LibC.CClock
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CClock
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CClock" Stdlib_CClock ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CClock {unwrapStdlib_CClock = y1}
-      , RIP.getField @"unwrapStdlib_CClock" x0
-      )
 
 {-| __C declaration:__ @stdlib_CTm@
 
@@ -1319,6 +1319,15 @@ newtype Stdlib_CTm = Stdlib_CTm
   deriving newtype (Marshal.ReadRaw, Marshal.StaticSize)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CTm
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTm" Stdlib_CTm ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CTm {unwrapStdlib_CTm = y1}
+      , RIP.getField @"unwrapStdlib_CTm" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CTm
          ) => RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr ty) where
 
   getField =
@@ -1331,15 +1340,6 @@ instance HasCField.HasCField Stdlib_CTm "unwrapStdlib_CTm" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTm
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTm" Stdlib_CTm ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CTm {unwrapStdlib_CTm = y1}
-      , RIP.getField @"unwrapStdlib_CTm" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFile@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 60:16@
@@ -1350,6 +1350,15 @@ newtype Stdlib_CFile = Stdlib_CFile
   { unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFile
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFile" Stdlib_CFile ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFile {unwrapStdlib_CFile = y1}
+      , RIP.getField @"unwrapStdlib_CFile" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFile
          ) => RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr ty) where
@@ -1364,15 +1373,6 @@ instance HasCField.HasCField Stdlib_CFile "unwrapStdlib_CFile" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFile
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFile" Stdlib_CFile ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFile {unwrapStdlib_CFile = y1}
-      , RIP.getField @"unwrapStdlib_CFile" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFpos@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 61:16@
@@ -1383,6 +1383,15 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   { unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFpos {unwrapStdlib_CFpos = y1}
+      , RIP.getField @"unwrapStdlib_CFpos" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
          ) => RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr ty) where
@@ -1396,15 +1405,6 @@ instance HasCField.HasCField Stdlib_CFpos "unwrapStdlib_CFpos" where
     HsBindgen.Runtime.LibC.CFpos
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFpos {unwrapStdlib_CFpos = y1}
-      , RIP.getField @"unwrapStdlib_CFpos" x0
-      )
 
 {-| __C declaration:__ @stdlib_CSigAtomic@
 
@@ -1435,6 +1435,16 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CSigAtomic {unwrapStdlib_CSigAtomic = y1}
+      , RIP.getField @"unwrapStdlib_CSigAtomic" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
          ) => RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr ty) where
 
   getField =
@@ -1446,13 +1456,3 @@ instance HasCField.HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic" where
     HsBindgen.Runtime.LibC.CSigAtomic
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CSigAtomic {unwrapStdlib_CSigAtomic = y1}
-      , RIP.getField @"unwrapStdlib_CSigAtomic" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/bindingspec.yaml
@@ -107,7 +107,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -115,6 +114,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -137,7 +138,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -145,6 +145,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -167,7 +169,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -175,6 +176,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -194,13 +197,14 @@ hstypes:
       fields:
       - unwrapStdlib_CClock
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Read
@@ -217,10 +221,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFenvT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFexceptT
   representation:
     newtype:
@@ -228,10 +233,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFexceptT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFile
   representation:
     newtype:
@@ -239,10 +245,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFile
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFpos
   representation:
     newtype:
@@ -250,10 +257,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFpos
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CIntMax
   representation:
     newtype:
@@ -264,7 +272,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -272,6 +279,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -294,7 +303,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -302,6 +310,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -321,10 +331,11 @@ hstypes:
       fields:
       - unwrapStdlib_CJmpBuf
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CMbstateT
   representation:
     newtype:
@@ -332,10 +343,11 @@ hstypes:
       fields:
       - unwrapStdlib_CMbstateT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CPtrdiff
   representation:
     newtype:
@@ -346,7 +358,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -354,6 +365,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -376,7 +389,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -384,6 +396,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -406,7 +420,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -414,6 +427,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -433,13 +448,14 @@ hstypes:
       fields:
       - unwrapStdlib_CTime
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Read
@@ -456,11 +472,12 @@ hstypes:
       fields:
       - unwrapStdlib_CTm
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -474,7 +491,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -482,6 +498,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -504,7 +522,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -512,6 +529,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -534,7 +553,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -542,6 +560,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -561,12 +581,13 @@ hstypes:
       fields:
       - unwrapStdlib_CWctransT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Prim
   - ReadRaw
   - Show
@@ -580,12 +601,13 @@ hstypes:
       fields:
       - unwrapStdlib_CWctypeT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Prim
   - ReadRaw
   - Show
@@ -602,7 +624,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -610,6 +631,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -632,7 +655,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -640,6 +662,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -662,7 +686,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -670,6 +693,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -692,7 +717,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -700,6 +724,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -722,7 +748,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -730,6 +755,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -752,7 +779,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -760,6 +786,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -782,7 +810,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -790,6 +817,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -812,7 +841,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -820,6 +848,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -842,7 +872,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -850,6 +879,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c11-parse-all/th.txt
@@ -41,15 +41,15 @@ newtype Stdlib_CBool
                       Storable,
                       WriteRaw)
 instance (~) ty CBool =>
+         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
+                              getField @"unwrapStdlib_CBool" x_0)
+instance (~) ty CBool =>
          HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
-                              getField @"unwrapStdlib_CBool" x_0)
 {-| __C declaration:__ @stdlib_Int8@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 21:19@
@@ -75,16 +75,16 @@ newtype Stdlib_Int8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapStdlib_Int8" Stdlib_Int8 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int8{unwrapStdlib_Int8 = y_1},
+                              getField @"unwrapStdlib_Int8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
          HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
                           "unwrapStdlib_Int8" = HsBindgen.Runtime.LibC.Int8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapStdlib_Int8" Stdlib_Int8 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int8{unwrapStdlib_Int8 = y_1},
-                              getField @"unwrapStdlib_Int8" x_0)
 {-| __C declaration:__ @stdlib_Int16@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 22:19@
@@ -110,16 +110,16 @@ newtype Stdlib_Int16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapStdlib_Int16" Stdlib_Int16 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int16{unwrapStdlib_Int16 = y_1},
+                              getField @"unwrapStdlib_Int16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
          HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
                           "unwrapStdlib_Int16" = HsBindgen.Runtime.LibC.Int16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapStdlib_Int16" Stdlib_Int16 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int16{unwrapStdlib_Int16 = y_1},
-                              getField @"unwrapStdlib_Int16" x_0)
 {-| __C declaration:__ @stdlib_Int32@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 23:19@
@@ -145,16 +145,16 @@ newtype Stdlib_Int32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapStdlib_Int32" Stdlib_Int32 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int32{unwrapStdlib_Int32 = y_1},
+                              getField @"unwrapStdlib_Int32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
                           "unwrapStdlib_Int32" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapStdlib_Int32" Stdlib_Int32 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int32{unwrapStdlib_Int32 = y_1},
-                              getField @"unwrapStdlib_Int32" x_0)
 {-| __C declaration:__ @stdlib_Int64@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 24:19@
@@ -180,16 +180,16 @@ newtype Stdlib_Int64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapStdlib_Int64" Stdlib_Int64 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int64{unwrapStdlib_Int64 = y_1},
+                              getField @"unwrapStdlib_Int64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
          HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
                           "unwrapStdlib_Int64" = HsBindgen.Runtime.LibC.Int64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapStdlib_Int64" Stdlib_Int64 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int64{unwrapStdlib_Int64 = y_1},
-                              getField @"unwrapStdlib_Int64" x_0)
 {-| __C declaration:__ @stdlib_Word8@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 25:19@
@@ -215,16 +215,16 @@ newtype Stdlib_Word8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapStdlib_Word8" Stdlib_Word8 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word8{unwrapStdlib_Word8 = y_1},
+                              getField @"unwrapStdlib_Word8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
                           "unwrapStdlib_Word8" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapStdlib_Word8" Stdlib_Word8 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word8{unwrapStdlib_Word8 = y_1},
-                              getField @"unwrapStdlib_Word8" x_0)
 {-| __C declaration:__ @stdlib_Word16@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 26:19@
@@ -250,16 +250,16 @@ newtype Stdlib_Word16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapStdlib_Word16" Stdlib_Word16 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word16{unwrapStdlib_Word16 = y_1},
+                              getField @"unwrapStdlib_Word16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
                           "unwrapStdlib_Word16" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapStdlib_Word16" Stdlib_Word16 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word16{unwrapStdlib_Word16 = y_1},
-                              getField @"unwrapStdlib_Word16" x_0)
 {-| __C declaration:__ @stdlib_Word32@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 27:19@
@@ -285,16 +285,16 @@ newtype Stdlib_Word32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapStdlib_Word32" Stdlib_Word32 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word32{unwrapStdlib_Word32 = y_1},
+                              getField @"unwrapStdlib_Word32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
                           "unwrapStdlib_Word32" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapStdlib_Word32" Stdlib_Word32 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word32{unwrapStdlib_Word32 = y_1},
-                              getField @"unwrapStdlib_Word32" x_0)
 {-| __C declaration:__ @stdlib_Word64@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 28:19@
@@ -320,16 +320,16 @@ newtype Stdlib_Word64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapStdlib_Word64" Stdlib_Word64 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word64{unwrapStdlib_Word64 = y_1},
+                              getField @"unwrapStdlib_Word64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
                           "unwrapStdlib_Word64" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapStdlib_Word64" Stdlib_Word64 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word64{unwrapStdlib_Word64 = y_1},
-                              getField @"unwrapStdlib_Word64" x_0)
 {-| __C declaration:__ @stdlib_CIntMax@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 29:19@
@@ -355,16 +355,16 @@ newtype Stdlib_CIntMax
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
+         HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntMax{unwrapStdlib_CIntMax = y_1},
+                              getField @"unwrapStdlib_CIntMax" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
          HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
                           "unwrapStdlib_CIntMax" = HsBindgen.Runtime.LibC.CIntMax
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
-         HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntMax{unwrapStdlib_CIntMax = y_1},
-                              getField @"unwrapStdlib_CIntMax" x_0)
 {-| __C declaration:__ @stdlib_CUIntMax@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 30:19@
@@ -390,16 +390,16 @@ newtype Stdlib_CUIntMax
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
+         HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntMax{unwrapStdlib_CUIntMax = y_1},
+                              getField @"unwrapStdlib_CUIntMax" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
          HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
                           "unwrapStdlib_CUIntMax" = HsBindgen.Runtime.LibC.CUIntMax
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
-         HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntMax{unwrapStdlib_CUIntMax = y_1},
-                              getField @"unwrapStdlib_CUIntMax" x_0)
 {-| __C declaration:__ @stdlib_CIntPtr@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 31:19@
@@ -425,16 +425,16 @@ newtype Stdlib_CIntPtr
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
+         HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntPtr{unwrapStdlib_CIntPtr = y_1},
+                              getField @"unwrapStdlib_CIntPtr" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
          HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
                           "unwrapStdlib_CIntPtr" = HsBindgen.Runtime.LibC.CIntPtr
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
-         HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntPtr{unwrapStdlib_CIntPtr = y_1},
-                              getField @"unwrapStdlib_CIntPtr" x_0)
 {-| __C declaration:__ @stdlib_CUIntPtr@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 32:19@
@@ -460,16 +460,16 @@ newtype Stdlib_CUIntPtr
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
+         HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntPtr{unwrapStdlib_CUIntPtr = y_1},
+                              getField @"unwrapStdlib_CUIntPtr" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
          HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
                           "unwrapStdlib_CUIntPtr" = HsBindgen.Runtime.LibC.CUIntPtr
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
-         HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntPtr{unwrapStdlib_CUIntPtr = y_1},
-                              getField @"unwrapStdlib_CUIntPtr" x_0)
 {-| __C declaration:__ @stdlib_CFenvT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 35:19@
@@ -480,16 +480,16 @@ newtype Stdlib_CFenvT
     = Stdlib_CFenvT {unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
+         HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFenvT{unwrapStdlib_CFenvT = y_1},
+                              getField @"unwrapStdlib_CFenvT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
          HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
                           "unwrapStdlib_CFenvT" = HsBindgen.Runtime.LibC.CFenvT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
-         HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFenvT{unwrapStdlib_CFenvT = y_1},
-                              getField @"unwrapStdlib_CFenvT" x_0)
 {-| __C declaration:__ @stdlib_CFexceptT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 36:19@
@@ -500,16 +500,16 @@ newtype Stdlib_CFexceptT
     = Stdlib_CFexceptT {unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
+         HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFexceptT{unwrapStdlib_CFexceptT = y_1},
+                              getField @"unwrapStdlib_CFexceptT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
          HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
                           "unwrapStdlib_CFexceptT" = HsBindgen.Runtime.LibC.CFexceptT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
-         HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFexceptT{unwrapStdlib_CFexceptT = y_1},
-                              getField @"unwrapStdlib_CFexceptT" x_0)
 {-| __C declaration:__ @stdlib_CSize@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 39:19@
@@ -535,16 +535,16 @@ newtype Stdlib_CSize
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapStdlib_CSize" Stdlib_CSize ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CSize{unwrapStdlib_CSize = y_1},
+                              getField @"unwrapStdlib_CSize" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
                           "unwrapStdlib_CSize" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapStdlib_CSize" Stdlib_CSize ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CSize{unwrapStdlib_CSize = y_1},
-                              getField @"unwrapStdlib_CSize" x_0)
 {-| __C declaration:__ @stdlib_CPtrdiff@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 40:19@
@@ -570,16 +570,16 @@ newtype Stdlib_CPtrdiff
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
+         HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CPtrdiff{unwrapStdlib_CPtrdiff = y_1},
+                              getField @"unwrapStdlib_CPtrdiff" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
          HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
                           "unwrapStdlib_CPtrdiff" = HsBindgen.Runtime.LibC.CPtrdiff
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CPtrdiff{unwrapStdlib_CPtrdiff = y_1},
-                              getField @"unwrapStdlib_CPtrdiff" x_0)
 {-| __C declaration:__ @stdlib_CJmpBuf@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 43:17@
@@ -590,16 +590,16 @@ newtype Stdlib_CJmpBuf
     = Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf :: HsBindgen.Runtime.LibC.CJmpBuf}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
+         HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CJmpBuf{unwrapStdlib_CJmpBuf = y_1},
+                              getField @"unwrapStdlib_CJmpBuf" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
          HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
                           "unwrapStdlib_CJmpBuf" = HsBindgen.Runtime.LibC.CJmpBuf
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
-         HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CJmpBuf{unwrapStdlib_CJmpBuf = y_1},
-                              getField @"unwrapStdlib_CJmpBuf" x_0)
 {-| __C declaration:__ @stdlib_CWchar@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 46:19@
@@ -625,16 +625,16 @@ newtype Stdlib_CWchar
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
+         HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWchar{unwrapStdlib_CWchar = y_1},
+                              getField @"unwrapStdlib_CWchar" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
          HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
                           "unwrapStdlib_CWchar" = HsBindgen.Runtime.LibC.CWchar
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
-         HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWchar{unwrapStdlib_CWchar = y_1},
-                              getField @"unwrapStdlib_CWchar" x_0)
 {-| __C declaration:__ @stdlib_CWintT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 47:19@
@@ -660,16 +660,16 @@ newtype Stdlib_CWintT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
+         HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWintT{unwrapStdlib_CWintT = y_1},
+                              getField @"unwrapStdlib_CWintT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
          HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
                           "unwrapStdlib_CWintT" = HsBindgen.Runtime.LibC.CWintT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
-         HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWintT{unwrapStdlib_CWintT = y_1},
-                              getField @"unwrapStdlib_CWintT" x_0)
 {-| __C declaration:__ @stdlib_CMbstateT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 48:19@
@@ -680,16 +680,16 @@ newtype Stdlib_CMbstateT
     = Stdlib_CMbstateT {unwrapStdlib_CMbstateT :: HsBindgen.Runtime.LibC.CMbstateT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
+         HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CMbstateT{unwrapStdlib_CMbstateT = y_1},
+                              getField @"unwrapStdlib_CMbstateT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
          HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
                           "unwrapStdlib_CMbstateT" = HsBindgen.Runtime.LibC.CMbstateT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
-         HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CMbstateT{unwrapStdlib_CMbstateT = y_1},
-                              getField @"unwrapStdlib_CMbstateT" x_0)
 {-| __C declaration:__ @stdlib_CWctransT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 49:19@
@@ -706,16 +706,16 @@ newtype Stdlib_CWctransT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
+         HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctransT{unwrapStdlib_CWctransT = y_1},
+                              getField @"unwrapStdlib_CWctransT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
          HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
                           "unwrapStdlib_CWctransT" = HsBindgen.Runtime.LibC.CWctransT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
-         HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctransT{unwrapStdlib_CWctransT = y_1},
-                              getField @"unwrapStdlib_CWctransT" x_0)
 {-| __C declaration:__ @stdlib_CWctypeT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 50:19@
@@ -732,16 +732,16 @@ newtype Stdlib_CWctypeT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
+         HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctypeT{unwrapStdlib_CWctypeT = y_1},
+                              getField @"unwrapStdlib_CWctypeT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
          HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
                           "unwrapStdlib_CWctypeT" = HsBindgen.Runtime.LibC.CWctypeT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
-         HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctypeT{unwrapStdlib_CWctypeT = y_1},
-                              getField @"unwrapStdlib_CWctypeT" x_0)
 {-| __C declaration:__ @stdlib_CChar16T@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 51:19@
@@ -767,16 +767,16 @@ newtype Stdlib_CChar16T
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
+         HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar16T{unwrapStdlib_CChar16T = y_1},
+                              getField @"unwrapStdlib_CChar16T" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
          HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
                           "unwrapStdlib_CChar16T" = HsBindgen.Runtime.LibC.CChar16T
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
-         HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar16T{unwrapStdlib_CChar16T = y_1},
-                              getField @"unwrapStdlib_CChar16T" x_0)
 {-| __C declaration:__ @stdlib_CChar32T@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 52:19@
@@ -802,16 +802,16 @@ newtype Stdlib_CChar32T
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
+         HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar32T{unwrapStdlib_CChar32T = y_1},
+                              getField @"unwrapStdlib_CChar32T" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
          HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
                           "unwrapStdlib_CChar32T" = HsBindgen.Runtime.LibC.CChar32T
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
-         HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar32T{unwrapStdlib_CChar32T = y_1},
-                              getField @"unwrapStdlib_CChar32T" x_0)
 {-| __C declaration:__ @stdlib_CTime@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 55:19@
@@ -830,16 +830,16 @@ newtype Stdlib_CTime
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CTime =>
+         HasField "unwrapStdlib_CTime" Stdlib_CTime ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CTime{unwrapStdlib_CTime = y_1},
+                              getField @"unwrapStdlib_CTime" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CTime =>
          HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
                           "unwrapStdlib_CTime" = HsBindgen.Runtime.LibC.CTime
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CTime =>
-         HasField "unwrapStdlib_CTime" Stdlib_CTime ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CTime{unwrapStdlib_CTime = y_1},
-                              getField @"unwrapStdlib_CTime" x_0)
 {-| __C declaration:__ @stdlib_CClock@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 56:19@
@@ -858,16 +858,16 @@ newtype Stdlib_CClock
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CClock =>
+         HasField "unwrapStdlib_CClock" Stdlib_CClock ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CClock{unwrapStdlib_CClock = y_1},
+                              getField @"unwrapStdlib_CClock" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CClock =>
          HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
                           "unwrapStdlib_CClock" = HsBindgen.Runtime.LibC.CClock
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CClock =>
-         HasField "unwrapStdlib_CClock" Stdlib_CClock ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CClock{unwrapStdlib_CClock = y_1},
-                              getField @"unwrapStdlib_CClock" x_0)
 {-| __C declaration:__ @stdlib_CTm@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 57:19@
@@ -879,16 +879,16 @@ newtype Stdlib_CTm
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize)
 instance (~) ty HsBindgen.Runtime.LibC.CTm =>
+         HasField "unwrapStdlib_CTm" Stdlib_CTm ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CTm{unwrapStdlib_CTm = y_1},
+                              getField @"unwrapStdlib_CTm" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CTm =>
          HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
                           "unwrapStdlib_CTm" = HsBindgen.Runtime.LibC.CTm
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CTm =>
-         HasField "unwrapStdlib_CTm" Stdlib_CTm ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CTm{unwrapStdlib_CTm = y_1},
-                              getField @"unwrapStdlib_CTm" x_0)
 {-| __C declaration:__ @stdlib_CFile@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 60:16@
@@ -899,16 +899,16 @@ newtype Stdlib_CFile
     = Stdlib_CFile {unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFile =>
+         HasField "unwrapStdlib_CFile" Stdlib_CFile ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFile{unwrapStdlib_CFile = y_1},
+                              getField @"unwrapStdlib_CFile" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFile =>
          HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
                           "unwrapStdlib_CFile" = HsBindgen.Runtime.LibC.CFile
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFile =>
-         HasField "unwrapStdlib_CFile" Stdlib_CFile ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFile{unwrapStdlib_CFile = y_1},
-                              getField @"unwrapStdlib_CFile" x_0)
 {-| __C declaration:__ @stdlib_CFpos@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 61:16@
@@ -919,16 +919,16 @@ newtype Stdlib_CFpos
     = Stdlib_CFpos {unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
+         HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFpos{unwrapStdlib_CFpos = y_1},
+                              getField @"unwrapStdlib_CFpos" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
          HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
                           "unwrapStdlib_CFpos" = HsBindgen.Runtime.LibC.CFpos
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
-         HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFpos{unwrapStdlib_CFpos = y_1},
-                              getField @"unwrapStdlib_CFpos" x_0)
 {-| __C declaration:__ @stdlib_CSigAtomic@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 64:22@
@@ -954,13 +954,13 @@ newtype Stdlib_CSigAtomic
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
+         HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CSigAtomic{unwrapStdlib_CSigAtomic = y_1},
+                              getField @"unwrapStdlib_CSigAtomic" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
          HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic
                           "unwrapStdlib_CSigAtomic" = HsBindgen.Runtime.LibC.CSigAtomic
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
-         HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CSigAtomic{unwrapStdlib_CSigAtomic = y_1},
-                              getField @"unwrapStdlib_CSigAtomic" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/Example.hs
@@ -82,6 +82,15 @@ newtype Stdlib_CBool = Stdlib_CBool
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
+      , RIP.getField @"unwrapStdlib_CBool" x0
+      )
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapStdlib_CBool" (RIP.Ptr Stdlib_CBool) (RIP.Ptr ty) where
 
   getField =
@@ -93,15 +102,6 @@ instance HasCField.HasCField Stdlib_CBool "unwrapStdlib_CBool" where
     RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CBool" Stdlib_CBool ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CBool {unwrapStdlib_CBool = y1}
-      , RIP.getField @"unwrapStdlib_CBool" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int8@
 
@@ -132,6 +132,15 @@ newtype Stdlib_Int8 = Stdlib_Int8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int8
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int8" Stdlib_Int8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int8 {unwrapStdlib_Int8 = y1}
+      , RIP.getField @"unwrapStdlib_Int8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int8
          ) => RIP.HasField "unwrapStdlib_Int8" (RIP.Ptr Stdlib_Int8) (RIP.Ptr ty) where
 
   getField =
@@ -143,15 +152,6 @@ instance HasCField.HasCField Stdlib_Int8 "unwrapStdlib_Int8" where
     HsBindgen.Runtime.LibC.Int8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int8" Stdlib_Int8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int8 {unwrapStdlib_Int8 = y1}
-      , RIP.getField @"unwrapStdlib_Int8" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int16@
 
@@ -182,6 +182,15 @@ newtype Stdlib_Int16 = Stdlib_Int16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int16
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int16" Stdlib_Int16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int16 {unwrapStdlib_Int16 = y1}
+      , RIP.getField @"unwrapStdlib_Int16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int16
          ) => RIP.HasField "unwrapStdlib_Int16" (RIP.Ptr Stdlib_Int16) (RIP.Ptr ty) where
 
   getField =
@@ -193,15 +202,6 @@ instance HasCField.HasCField Stdlib_Int16 "unwrapStdlib_Int16" where
     HsBindgen.Runtime.LibC.Int16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int16" Stdlib_Int16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int16 {unwrapStdlib_Int16 = y1}
-      , RIP.getField @"unwrapStdlib_Int16" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int32@
 
@@ -232,6 +232,15 @@ newtype Stdlib_Int32 = Stdlib_Int32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int32" Stdlib_Int32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int32 {unwrapStdlib_Int32 = y1}
+      , RIP.getField @"unwrapStdlib_Int32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapStdlib_Int32" (RIP.Ptr Stdlib_Int32) (RIP.Ptr ty) where
 
   getField =
@@ -243,15 +252,6 @@ instance HasCField.HasCField Stdlib_Int32 "unwrapStdlib_Int32" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int32" Stdlib_Int32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int32 {unwrapStdlib_Int32 = y1}
-      , RIP.getField @"unwrapStdlib_Int32" x0
-      )
 
 {-| __C declaration:__ @stdlib_Int64@
 
@@ -282,6 +282,15 @@ newtype Stdlib_Int64 = Stdlib_Int64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int64
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int64" Stdlib_Int64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Int64 {unwrapStdlib_Int64 = y1}
+      , RIP.getField @"unwrapStdlib_Int64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int64
          ) => RIP.HasField "unwrapStdlib_Int64" (RIP.Ptr Stdlib_Int64) (RIP.Ptr ty) where
 
   getField =
@@ -293,15 +302,6 @@ instance HasCField.HasCField Stdlib_Int64 "unwrapStdlib_Int64" where
     HsBindgen.Runtime.LibC.Int64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Int64" Stdlib_Int64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Int64 {unwrapStdlib_Int64 = y1}
-      , RIP.getField @"unwrapStdlib_Int64" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word8@
 
@@ -332,6 +332,15 @@ newtype Stdlib_Word8 = Stdlib_Word8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word8" Stdlib_Word8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word8 {unwrapStdlib_Word8 = y1}
+      , RIP.getField @"unwrapStdlib_Word8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapStdlib_Word8" (RIP.Ptr Stdlib_Word8) (RIP.Ptr ty) where
 
   getField =
@@ -343,15 +352,6 @@ instance HasCField.HasCField Stdlib_Word8 "unwrapStdlib_Word8" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word8" Stdlib_Word8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word8 {unwrapStdlib_Word8 = y1}
-      , RIP.getField @"unwrapStdlib_Word8" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word16@
 
@@ -382,6 +382,15 @@ newtype Stdlib_Word16 = Stdlib_Word16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word16" Stdlib_Word16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word16 {unwrapStdlib_Word16 = y1}
+      , RIP.getField @"unwrapStdlib_Word16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.HasField "unwrapStdlib_Word16" (RIP.Ptr Stdlib_Word16) (RIP.Ptr ty) where
 
   getField =
@@ -393,15 +402,6 @@ instance HasCField.HasCField Stdlib_Word16 "unwrapStdlib_Word16" where
     HsBindgen.Runtime.LibC.Word16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word16" Stdlib_Word16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word16 {unwrapStdlib_Word16 = y1}
-      , RIP.getField @"unwrapStdlib_Word16" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word32@
 
@@ -432,6 +432,15 @@ newtype Stdlib_Word32 = Stdlib_Word32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word32" Stdlib_Word32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word32 {unwrapStdlib_Word32 = y1}
+      , RIP.getField @"unwrapStdlib_Word32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapStdlib_Word32" (RIP.Ptr Stdlib_Word32) (RIP.Ptr ty) where
 
   getField =
@@ -443,15 +452,6 @@ instance HasCField.HasCField Stdlib_Word32 "unwrapStdlib_Word32" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word32" Stdlib_Word32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word32 {unwrapStdlib_Word32 = y1}
-      , RIP.getField @"unwrapStdlib_Word32" x0
-      )
 
 {-| __C declaration:__ @stdlib_Word64@
 
@@ -482,6 +482,15 @@ newtype Stdlib_Word64 = Stdlib_Word64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word64" Stdlib_Word64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_Word64 {unwrapStdlib_Word64 = y1}
+      , RIP.getField @"unwrapStdlib_Word64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.HasField "unwrapStdlib_Word64" (RIP.Ptr Stdlib_Word64) (RIP.Ptr ty) where
 
   getField =
@@ -493,15 +502,6 @@ instance HasCField.HasCField Stdlib_Word64 "unwrapStdlib_Word64" where
     HsBindgen.Runtime.LibC.Word64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_Word64" Stdlib_Word64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_Word64 {unwrapStdlib_Word64 = y1}
-      , RIP.getField @"unwrapStdlib_Word64" x0
-      )
 
 {-| __C declaration:__ @stdlib_CIntMax@
 
@@ -532,6 +532,15 @@ newtype Stdlib_CIntMax = Stdlib_CIntMax
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CIntMax {unwrapStdlib_CIntMax = y1}
+      , RIP.getField @"unwrapStdlib_CIntMax" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
          ) => RIP.HasField "unwrapStdlib_CIntMax" (RIP.Ptr Stdlib_CIntMax) (RIP.Ptr ty) where
 
   getField =
@@ -543,15 +552,6 @@ instance HasCField.HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax" where
     HsBindgen.Runtime.LibC.CIntMax
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntMax
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CIntMax {unwrapStdlib_CIntMax = y1}
-      , RIP.getField @"unwrapStdlib_CIntMax" x0
-      )
 
 {-| __C declaration:__ @stdlib_CUIntMax@
 
@@ -582,6 +582,15 @@ newtype Stdlib_CUIntMax = Stdlib_CUIntMax
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CUIntMax {unwrapStdlib_CUIntMax = y1}
+      , RIP.getField @"unwrapStdlib_CUIntMax" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
          ) => RIP.HasField "unwrapStdlib_CUIntMax" (RIP.Ptr Stdlib_CUIntMax) (RIP.Ptr ty) where
 
   getField =
@@ -593,15 +602,6 @@ instance HasCField.HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax" where
     HsBindgen.Runtime.LibC.CUIntMax
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntMax
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CUIntMax {unwrapStdlib_CUIntMax = y1}
-      , RIP.getField @"unwrapStdlib_CUIntMax" x0
-      )
 
 {-| __C declaration:__ @stdlib_CIntPtr@
 
@@ -632,6 +632,15 @@ newtype Stdlib_CIntPtr = Stdlib_CIntPtr
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CIntPtr {unwrapStdlib_CIntPtr = y1}
+      , RIP.getField @"unwrapStdlib_CIntPtr" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
          ) => RIP.HasField "unwrapStdlib_CIntPtr" (RIP.Ptr Stdlib_CIntPtr) (RIP.Ptr ty) where
 
   getField =
@@ -643,15 +652,6 @@ instance HasCField.HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr" where
     HsBindgen.Runtime.LibC.CIntPtr
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CIntPtr
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CIntPtr {unwrapStdlib_CIntPtr = y1}
-      , RIP.getField @"unwrapStdlib_CIntPtr" x0
-      )
 
 {-| __C declaration:__ @stdlib_CUIntPtr@
 
@@ -682,6 +682,15 @@ newtype Stdlib_CUIntPtr = Stdlib_CUIntPtr
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CUIntPtr {unwrapStdlib_CUIntPtr = y1}
+      , RIP.getField @"unwrapStdlib_CUIntPtr" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
          ) => RIP.HasField "unwrapStdlib_CUIntPtr" (RIP.Ptr Stdlib_CUIntPtr) (RIP.Ptr ty) where
 
   getField =
@@ -694,15 +703,6 @@ instance HasCField.HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CUIntPtr
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CUIntPtr {unwrapStdlib_CUIntPtr = y1}
-      , RIP.getField @"unwrapStdlib_CUIntPtr" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFenvT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 35:19@
@@ -713,6 +713,15 @@ newtype Stdlib_CFenvT = Stdlib_CFenvT
   { unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFenvT {unwrapStdlib_CFenvT = y1}
+      , RIP.getField @"unwrapStdlib_CFenvT" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
          ) => RIP.HasField "unwrapStdlib_CFenvT" (RIP.Ptr Stdlib_CFenvT) (RIP.Ptr ty) where
@@ -727,15 +736,6 @@ instance HasCField.HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFenvT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFenvT {unwrapStdlib_CFenvT = y1}
-      , RIP.getField @"unwrapStdlib_CFenvT" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFexceptT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 36:19@
@@ -746,6 +746,16 @@ newtype Stdlib_CFexceptT = Stdlib_CFexceptT
   { unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CFexceptT {unwrapStdlib_CFexceptT = y1}
+      , RIP.getField @"unwrapStdlib_CFexceptT" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
          ) => RIP.HasField "unwrapStdlib_CFexceptT" (RIP.Ptr Stdlib_CFexceptT) (RIP.Ptr ty) where
@@ -759,16 +769,6 @@ instance HasCField.HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT" where
     HsBindgen.Runtime.LibC.CFexceptT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CFexceptT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CFexceptT {unwrapStdlib_CFexceptT = y1}
-      , RIP.getField @"unwrapStdlib_CFexceptT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CSize@
 
@@ -799,6 +799,15 @@ newtype Stdlib_CSize = Stdlib_CSize
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSize" Stdlib_CSize ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CSize {unwrapStdlib_CSize = y1}
+      , RIP.getField @"unwrapStdlib_CSize" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.HasField "unwrapStdlib_CSize" (RIP.Ptr Stdlib_CSize) (RIP.Ptr ty) where
 
   getField =
@@ -810,15 +819,6 @@ instance HasCField.HasCField Stdlib_CSize "unwrapStdlib_CSize" where
     HsBindgen.Runtime.LibC.CSize
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSize" Stdlib_CSize ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CSize {unwrapStdlib_CSize = y1}
-      , RIP.getField @"unwrapStdlib_CSize" x0
-      )
 
 {-| __C declaration:__ @stdlib_CPtrdiff@
 
@@ -849,6 +849,15 @@ newtype Stdlib_CPtrdiff = Stdlib_CPtrdiff
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CPtrdiff {unwrapStdlib_CPtrdiff = y1}
+      , RIP.getField @"unwrapStdlib_CPtrdiff" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
          ) => RIP.HasField "unwrapStdlib_CPtrdiff" (RIP.Ptr Stdlib_CPtrdiff) (RIP.Ptr ty) where
 
   getField =
@@ -860,15 +869,6 @@ instance HasCField.HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff" where
     HsBindgen.Runtime.LibC.CPtrdiff
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CPtrdiff {unwrapStdlib_CPtrdiff = y1}
-      , RIP.getField @"unwrapStdlib_CPtrdiff" x0
-      )
 
 {-| __C declaration:__ @stdlib_CJmpBuf@
 
@@ -882,6 +882,15 @@ newtype Stdlib_CJmpBuf = Stdlib_CJmpBuf
   deriving stock (RIP.Generic)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf = y1}
+      , RIP.getField @"unwrapStdlib_CJmpBuf" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
          ) => RIP.HasField "unwrapStdlib_CJmpBuf" (RIP.Ptr Stdlib_CJmpBuf) (RIP.Ptr ty) where
 
   getField =
@@ -893,15 +902,6 @@ instance HasCField.HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf" where
     HsBindgen.Runtime.LibC.CJmpBuf
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CJmpBuf
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf = y1}
-      , RIP.getField @"unwrapStdlib_CJmpBuf" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWchar@
 
@@ -932,6 +932,15 @@ newtype Stdlib_CWchar = Stdlib_CWchar
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWchar {unwrapStdlib_CWchar = y1}
+      , RIP.getField @"unwrapStdlib_CWchar" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
          ) => RIP.HasField "unwrapStdlib_CWchar" (RIP.Ptr Stdlib_CWchar) (RIP.Ptr ty) where
 
   getField =
@@ -943,15 +952,6 @@ instance HasCField.HasCField Stdlib_CWchar "unwrapStdlib_CWchar" where
     HsBindgen.Runtime.LibC.CWchar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWchar
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWchar {unwrapStdlib_CWchar = y1}
-      , RIP.getField @"unwrapStdlib_CWchar" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWintT@
 
@@ -982,6 +982,15 @@ newtype Stdlib_CWintT = Stdlib_CWintT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWintT {unwrapStdlib_CWintT = y1}
+      , RIP.getField @"unwrapStdlib_CWintT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
          ) => RIP.HasField "unwrapStdlib_CWintT" (RIP.Ptr Stdlib_CWintT) (RIP.Ptr ty) where
 
   getField =
@@ -993,15 +1002,6 @@ instance HasCField.HasCField Stdlib_CWintT "unwrapStdlib_CWintT" where
     HsBindgen.Runtime.LibC.CWintT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWintT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWintT {unwrapStdlib_CWintT = y1}
-      , RIP.getField @"unwrapStdlib_CWintT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CMbstateT@
 
@@ -1015,6 +1015,16 @@ newtype Stdlib_CMbstateT = Stdlib_CMbstateT
   deriving stock (RIP.Generic)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CMbstateT {unwrapStdlib_CMbstateT = y1}
+      , RIP.getField @"unwrapStdlib_CMbstateT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
          ) => RIP.HasField "unwrapStdlib_CMbstateT" (RIP.Ptr Stdlib_CMbstateT) (RIP.Ptr ty) where
 
   getField =
@@ -1026,16 +1036,6 @@ instance HasCField.HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT" where
     HsBindgen.Runtime.LibC.CMbstateT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CMbstateT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CMbstateT {unwrapStdlib_CMbstateT = y1}
-      , RIP.getField @"unwrapStdlib_CMbstateT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWctransT@
 
@@ -1057,6 +1057,16 @@ newtype Stdlib_CWctransT = Stdlib_CWctransT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CWctransT {unwrapStdlib_CWctransT = y1}
+      , RIP.getField @"unwrapStdlib_CWctransT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
          ) => RIP.HasField "unwrapStdlib_CWctransT" (RIP.Ptr Stdlib_CWctransT) (RIP.Ptr ty) where
 
   getField =
@@ -1068,16 +1078,6 @@ instance HasCField.HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT" where
     HsBindgen.Runtime.LibC.CWctransT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctransT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CWctransT {unwrapStdlib_CWctransT = y1}
-      , RIP.getField @"unwrapStdlib_CWctransT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CWctypeT@
 
@@ -1099,6 +1099,15 @@ newtype Stdlib_CWctypeT = Stdlib_CWctypeT
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CWctypeT {unwrapStdlib_CWctypeT = y1}
+      , RIP.getField @"unwrapStdlib_CWctypeT" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
          ) => RIP.HasField "unwrapStdlib_CWctypeT" (RIP.Ptr Stdlib_CWctypeT) (RIP.Ptr ty) where
 
   getField =
@@ -1110,15 +1119,6 @@ instance HasCField.HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT" where
     HsBindgen.Runtime.LibC.CWctypeT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CWctypeT
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CWctypeT {unwrapStdlib_CWctypeT = y1}
-      , RIP.getField @"unwrapStdlib_CWctypeT" x0
-      )
 
 {-| __C declaration:__ @stdlib_CChar16T@
 
@@ -1149,6 +1149,15 @@ newtype Stdlib_CChar16T = Stdlib_CChar16T
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CChar16T {unwrapStdlib_CChar16T = y1}
+      , RIP.getField @"unwrapStdlib_CChar16T" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
          ) => RIP.HasField "unwrapStdlib_CChar16T" (RIP.Ptr Stdlib_CChar16T) (RIP.Ptr ty) where
 
   getField =
@@ -1160,15 +1169,6 @@ instance HasCField.HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T" where
     HsBindgen.Runtime.LibC.CChar16T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar16T
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CChar16T {unwrapStdlib_CChar16T = y1}
-      , RIP.getField @"unwrapStdlib_CChar16T" x0
-      )
 
 {-| __C declaration:__ @stdlib_CChar32T@
 
@@ -1199,6 +1199,15 @@ newtype Stdlib_CChar32T = Stdlib_CChar32T
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CChar32T {unwrapStdlib_CChar32T = y1}
+      , RIP.getField @"unwrapStdlib_CChar32T" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
          ) => RIP.HasField "unwrapStdlib_CChar32T" (RIP.Ptr Stdlib_CChar32T) (RIP.Ptr ty) where
 
   getField =
@@ -1210,15 +1219,6 @@ instance HasCField.HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T" where
     HsBindgen.Runtime.LibC.CChar32T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CChar32T
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CChar32T {unwrapStdlib_CChar32T = y1}
-      , RIP.getField @"unwrapStdlib_CChar32T" x0
-      )
 
 {-| __C declaration:__ @stdlib_CTime@
 
@@ -1242,6 +1242,15 @@ newtype Stdlib_CTime = Stdlib_CTime
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CTime
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTime" Stdlib_CTime ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CTime {unwrapStdlib_CTime = y1}
+      , RIP.getField @"unwrapStdlib_CTime" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CTime
          ) => RIP.HasField "unwrapStdlib_CTime" (RIP.Ptr Stdlib_CTime) (RIP.Ptr ty) where
 
   getField =
@@ -1253,15 +1262,6 @@ instance HasCField.HasCField Stdlib_CTime "unwrapStdlib_CTime" where
     HsBindgen.Runtime.LibC.CTime
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CTime
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTime" Stdlib_CTime ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CTime {unwrapStdlib_CTime = y1}
-      , RIP.getField @"unwrapStdlib_CTime" x0
-      )
 
 {-| __C declaration:__ @stdlib_CClock@
 
@@ -1285,6 +1285,15 @@ newtype Stdlib_CClock = Stdlib_CClock
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CClock
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CClock" Stdlib_CClock ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CClock {unwrapStdlib_CClock = y1}
+      , RIP.getField @"unwrapStdlib_CClock" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CClock
          ) => RIP.HasField "unwrapStdlib_CClock" (RIP.Ptr Stdlib_CClock) (RIP.Ptr ty) where
 
   getField =
@@ -1296,15 +1305,6 @@ instance HasCField.HasCField Stdlib_CClock "unwrapStdlib_CClock" where
     HsBindgen.Runtime.LibC.CClock
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CClock
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CClock" Stdlib_CClock ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CClock {unwrapStdlib_CClock = y1}
-      , RIP.getField @"unwrapStdlib_CClock" x0
-      )
 
 {-| __C declaration:__ @stdlib_CTm@
 
@@ -1319,6 +1319,15 @@ newtype Stdlib_CTm = Stdlib_CTm
   deriving newtype (Marshal.ReadRaw, Marshal.StaticSize)
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CTm
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTm" Stdlib_CTm ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CTm {unwrapStdlib_CTm = y1}
+      , RIP.getField @"unwrapStdlib_CTm" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CTm
          ) => RIP.HasField "unwrapStdlib_CTm" (RIP.Ptr Stdlib_CTm) (RIP.Ptr ty) where
 
   getField =
@@ -1331,15 +1340,6 @@ instance HasCField.HasCField Stdlib_CTm "unwrapStdlib_CTm" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CTm
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CTm" Stdlib_CTm ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CTm {unwrapStdlib_CTm = y1}
-      , RIP.getField @"unwrapStdlib_CTm" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFile@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 60:16@
@@ -1350,6 +1350,15 @@ newtype Stdlib_CFile = Stdlib_CFile
   { unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFile
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFile" Stdlib_CFile ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFile {unwrapStdlib_CFile = y1}
+      , RIP.getField @"unwrapStdlib_CFile" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFile
          ) => RIP.HasField "unwrapStdlib_CFile" (RIP.Ptr Stdlib_CFile) (RIP.Ptr ty) where
@@ -1364,15 +1373,6 @@ instance HasCField.HasCField Stdlib_CFile "unwrapStdlib_CFile" where
 
   offset# = \_ -> \_ -> 0
 
-instance ( ty ~ HsBindgen.Runtime.LibC.CFile
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFile" Stdlib_CFile ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFile {unwrapStdlib_CFile = y1}
-      , RIP.getField @"unwrapStdlib_CFile" x0
-      )
-
 {-| __C declaration:__ @stdlib_CFpos@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 61:16@
@@ -1383,6 +1383,15 @@ newtype Stdlib_CFpos = Stdlib_CFpos
   { unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos
   }
   deriving stock (RIP.Generic)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Stdlib_CFpos {unwrapStdlib_CFpos = y1}
+      , RIP.getField @"unwrapStdlib_CFpos" x0
+      )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
          ) => RIP.HasField "unwrapStdlib_CFpos" (RIP.Ptr Stdlib_CFpos) (RIP.Ptr ty) where
@@ -1396,15 +1405,6 @@ instance HasCField.HasCField Stdlib_CFpos "unwrapStdlib_CFpos" where
     HsBindgen.Runtime.LibC.CFpos
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CFpos
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Stdlib_CFpos {unwrapStdlib_CFpos = y1}
-      , RIP.getField @"unwrapStdlib_CFpos" x0
-      )
 
 {-| __C declaration:__ @stdlib_CSigAtomic@
 
@@ -1435,6 +1435,16 @@ newtype Stdlib_CSigAtomic = Stdlib_CSigAtomic
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
+         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Stdlib_CSigAtomic {unwrapStdlib_CSigAtomic = y1}
+      , RIP.getField @"unwrapStdlib_CSigAtomic" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
          ) => RIP.HasField "unwrapStdlib_CSigAtomic" (RIP.Ptr Stdlib_CSigAtomic) (RIP.Ptr ty) where
 
   getField =
@@ -1446,13 +1456,3 @@ instance HasCField.HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic" where
     HsBindgen.Runtime.LibC.CSigAtomic
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSigAtomic
-         ) => RIP.CompatHasField.HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Stdlib_CSigAtomic {unwrapStdlib_CSigAtomic = y1}
-      , RIP.getField @"unwrapStdlib_CSigAtomic" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/bindingspec.yaml
@@ -107,7 +107,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -115,6 +114,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -137,7 +138,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -145,6 +145,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -167,7 +169,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -175,6 +176,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -194,13 +197,14 @@ hstypes:
       fields:
       - unwrapStdlib_CClock
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Read
@@ -217,10 +221,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFenvT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFexceptT
   representation:
     newtype:
@@ -228,10 +233,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFexceptT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFile
   representation:
     newtype:
@@ -239,10 +245,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFile
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CFpos
   representation:
     newtype:
@@ -250,10 +257,11 @@ hstypes:
       fields:
       - unwrapStdlib_CFpos
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CIntMax
   representation:
     newtype:
@@ -264,7 +272,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -272,6 +279,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -294,7 +303,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -302,6 +310,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -321,10 +331,11 @@ hstypes:
       fields:
       - unwrapStdlib_CJmpBuf
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CMbstateT
   representation:
     newtype:
@@ -332,10 +343,11 @@ hstypes:
       fields:
       - unwrapStdlib_CMbstateT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Stdlib_CPtrdiff
   representation:
     newtype:
@@ -346,7 +358,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -354,6 +365,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -376,7 +389,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -384,6 +396,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -406,7 +420,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -414,6 +427,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -433,13 +448,14 @@ hstypes:
       fields:
       - unwrapStdlib_CTime
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Read
@@ -456,11 +472,12 @@ hstypes:
       fields:
       - unwrapStdlib_CTm
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -474,7 +491,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -482,6 +498,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -504,7 +522,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -512,6 +529,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -534,7 +553,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -542,6 +560,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -561,12 +581,13 @@ hstypes:
       fields:
       - unwrapStdlib_CWctransT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Prim
   - ReadRaw
   - Show
@@ -580,12 +601,13 @@ hstypes:
       fields:
       - unwrapStdlib_CWctypeT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Prim
   - ReadRaw
   - Show
@@ -602,7 +624,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -610,6 +631,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -632,7 +655,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -640,6 +662,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -662,7 +686,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -670,6 +693,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -692,7 +717,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -700,6 +724,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -722,7 +748,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -730,6 +755,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -752,7 +779,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -760,6 +786,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -782,7 +810,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -790,6 +817,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -812,7 +841,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -820,6 +848,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -842,7 +872,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -850,6 +879,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/stdlib/instances.1.c23-parse-all/th.txt
@@ -41,15 +41,15 @@ newtype Stdlib_CBool
                       Storable,
                       WriteRaw)
 instance (~) ty CBool =>
+         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
+                              getField @"unwrapStdlib_CBool" x_0)
+instance (~) ty CBool =>
          HasField "unwrapStdlib_CBool" (Ptr Stdlib_CBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CBool")
 instance HasCField Stdlib_CBool "unwrapStdlib_CBool"
     where type CFieldType Stdlib_CBool "unwrapStdlib_CBool" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "unwrapStdlib_CBool" Stdlib_CBool ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CBool{unwrapStdlib_CBool = y_1},
-                              getField @"unwrapStdlib_CBool" x_0)
 {-| __C declaration:__ @stdlib_Int8@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 21:19@
@@ -75,16 +75,16 @@ newtype Stdlib_Int8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapStdlib_Int8" Stdlib_Int8 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int8{unwrapStdlib_Int8 = y_1},
+                              getField @"unwrapStdlib_Int8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
          HasField "unwrapStdlib_Int8" (Ptr Stdlib_Int8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int8")
 instance HasCField Stdlib_Int8 "unwrapStdlib_Int8"
     where type CFieldType Stdlib_Int8
                           "unwrapStdlib_Int8" = HsBindgen.Runtime.LibC.Int8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapStdlib_Int8" Stdlib_Int8 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int8{unwrapStdlib_Int8 = y_1},
-                              getField @"unwrapStdlib_Int8" x_0)
 {-| __C declaration:__ @stdlib_Int16@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 22:19@
@@ -110,16 +110,16 @@ newtype Stdlib_Int16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapStdlib_Int16" Stdlib_Int16 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int16{unwrapStdlib_Int16 = y_1},
+                              getField @"unwrapStdlib_Int16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
          HasField "unwrapStdlib_Int16" (Ptr Stdlib_Int16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int16")
 instance HasCField Stdlib_Int16 "unwrapStdlib_Int16"
     where type CFieldType Stdlib_Int16
                           "unwrapStdlib_Int16" = HsBindgen.Runtime.LibC.Int16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapStdlib_Int16" Stdlib_Int16 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int16{unwrapStdlib_Int16 = y_1},
-                              getField @"unwrapStdlib_Int16" x_0)
 {-| __C declaration:__ @stdlib_Int32@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 23:19@
@@ -145,16 +145,16 @@ newtype Stdlib_Int32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapStdlib_Int32" Stdlib_Int32 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int32{unwrapStdlib_Int32 = y_1},
+                              getField @"unwrapStdlib_Int32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapStdlib_Int32" (Ptr Stdlib_Int32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int32")
 instance HasCField Stdlib_Int32 "unwrapStdlib_Int32"
     where type CFieldType Stdlib_Int32
                           "unwrapStdlib_Int32" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapStdlib_Int32" Stdlib_Int32 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int32{unwrapStdlib_Int32 = y_1},
-                              getField @"unwrapStdlib_Int32" x_0)
 {-| __C declaration:__ @stdlib_Int64@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 24:19@
@@ -180,16 +180,16 @@ newtype Stdlib_Int64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapStdlib_Int64" Stdlib_Int64 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Int64{unwrapStdlib_Int64 = y_1},
+                              getField @"unwrapStdlib_Int64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
          HasField "unwrapStdlib_Int64" (Ptr Stdlib_Int64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Int64")
 instance HasCField Stdlib_Int64 "unwrapStdlib_Int64"
     where type CFieldType Stdlib_Int64
                           "unwrapStdlib_Int64" = HsBindgen.Runtime.LibC.Int64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapStdlib_Int64" Stdlib_Int64 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Int64{unwrapStdlib_Int64 = y_1},
-                              getField @"unwrapStdlib_Int64" x_0)
 {-| __C declaration:__ @stdlib_Word8@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 25:19@
@@ -215,16 +215,16 @@ newtype Stdlib_Word8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapStdlib_Word8" Stdlib_Word8 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word8{unwrapStdlib_Word8 = y_1},
+                              getField @"unwrapStdlib_Word8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapStdlib_Word8" (Ptr Stdlib_Word8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word8")
 instance HasCField Stdlib_Word8 "unwrapStdlib_Word8"
     where type CFieldType Stdlib_Word8
                           "unwrapStdlib_Word8" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapStdlib_Word8" Stdlib_Word8 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word8{unwrapStdlib_Word8 = y_1},
-                              getField @"unwrapStdlib_Word8" x_0)
 {-| __C declaration:__ @stdlib_Word16@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 26:19@
@@ -250,16 +250,16 @@ newtype Stdlib_Word16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapStdlib_Word16" Stdlib_Word16 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word16{unwrapStdlib_Word16 = y_1},
+                              getField @"unwrapStdlib_Word16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "unwrapStdlib_Word16" (Ptr Stdlib_Word16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word16")
 instance HasCField Stdlib_Word16 "unwrapStdlib_Word16"
     where type CFieldType Stdlib_Word16
                           "unwrapStdlib_Word16" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapStdlib_Word16" Stdlib_Word16 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word16{unwrapStdlib_Word16 = y_1},
-                              getField @"unwrapStdlib_Word16" x_0)
 {-| __C declaration:__ @stdlib_Word32@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 27:19@
@@ -285,16 +285,16 @@ newtype Stdlib_Word32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapStdlib_Word32" Stdlib_Word32 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word32{unwrapStdlib_Word32 = y_1},
+                              getField @"unwrapStdlib_Word32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapStdlib_Word32" (Ptr Stdlib_Word32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word32")
 instance HasCField Stdlib_Word32 "unwrapStdlib_Word32"
     where type CFieldType Stdlib_Word32
                           "unwrapStdlib_Word32" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapStdlib_Word32" Stdlib_Word32 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word32{unwrapStdlib_Word32 = y_1},
-                              getField @"unwrapStdlib_Word32" x_0)
 {-| __C declaration:__ @stdlib_Word64@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 28:19@
@@ -320,16 +320,16 @@ newtype Stdlib_Word64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapStdlib_Word64" Stdlib_Word64 ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_Word64{unwrapStdlib_Word64 = y_1},
+                              getField @"unwrapStdlib_Word64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "unwrapStdlib_Word64" (Ptr Stdlib_Word64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_Word64")
 instance HasCField Stdlib_Word64 "unwrapStdlib_Word64"
     where type CFieldType Stdlib_Word64
                           "unwrapStdlib_Word64" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapStdlib_Word64" Stdlib_Word64 ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_Word64{unwrapStdlib_Word64 = y_1},
-                              getField @"unwrapStdlib_Word64" x_0)
 {-| __C declaration:__ @stdlib_CIntMax@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 29:19@
@@ -355,16 +355,16 @@ newtype Stdlib_CIntMax
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
+         HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntMax{unwrapStdlib_CIntMax = y_1},
+                              getField @"unwrapStdlib_CIntMax" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
          HasField "unwrapStdlib_CIntMax" (Ptr Stdlib_CIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntMax")
 instance HasCField Stdlib_CIntMax "unwrapStdlib_CIntMax"
     where type CFieldType Stdlib_CIntMax
                           "unwrapStdlib_CIntMax" = HsBindgen.Runtime.LibC.CIntMax
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CIntMax =>
-         HasField "unwrapStdlib_CIntMax" Stdlib_CIntMax ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntMax{unwrapStdlib_CIntMax = y_1},
-                              getField @"unwrapStdlib_CIntMax" x_0)
 {-| __C declaration:__ @stdlib_CUIntMax@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 30:19@
@@ -390,16 +390,16 @@ newtype Stdlib_CUIntMax
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
+         HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntMax{unwrapStdlib_CUIntMax = y_1},
+                              getField @"unwrapStdlib_CUIntMax" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
          HasField "unwrapStdlib_CUIntMax" (Ptr Stdlib_CUIntMax) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntMax")
 instance HasCField Stdlib_CUIntMax "unwrapStdlib_CUIntMax"
     where type CFieldType Stdlib_CUIntMax
                           "unwrapStdlib_CUIntMax" = HsBindgen.Runtime.LibC.CUIntMax
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CUIntMax =>
-         HasField "unwrapStdlib_CUIntMax" Stdlib_CUIntMax ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntMax{unwrapStdlib_CUIntMax = y_1},
-                              getField @"unwrapStdlib_CUIntMax" x_0)
 {-| __C declaration:__ @stdlib_CIntPtr@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 31:19@
@@ -425,16 +425,16 @@ newtype Stdlib_CIntPtr
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
+         HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntPtr{unwrapStdlib_CIntPtr = y_1},
+                              getField @"unwrapStdlib_CIntPtr" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
          HasField "unwrapStdlib_CIntPtr" (Ptr Stdlib_CIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CIntPtr")
 instance HasCField Stdlib_CIntPtr "unwrapStdlib_CIntPtr"
     where type CFieldType Stdlib_CIntPtr
                           "unwrapStdlib_CIntPtr" = HsBindgen.Runtime.LibC.CIntPtr
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CIntPtr =>
-         HasField "unwrapStdlib_CIntPtr" Stdlib_CIntPtr ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CIntPtr{unwrapStdlib_CIntPtr = y_1},
-                              getField @"unwrapStdlib_CIntPtr" x_0)
 {-| __C declaration:__ @stdlib_CUIntPtr@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 32:19@
@@ -460,16 +460,16 @@ newtype Stdlib_CUIntPtr
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
+         HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntPtr{unwrapStdlib_CUIntPtr = y_1},
+                              getField @"unwrapStdlib_CUIntPtr" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
          HasField "unwrapStdlib_CUIntPtr" (Ptr Stdlib_CUIntPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CUIntPtr")
 instance HasCField Stdlib_CUIntPtr "unwrapStdlib_CUIntPtr"
     where type CFieldType Stdlib_CUIntPtr
                           "unwrapStdlib_CUIntPtr" = HsBindgen.Runtime.LibC.CUIntPtr
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CUIntPtr =>
-         HasField "unwrapStdlib_CUIntPtr" Stdlib_CUIntPtr ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CUIntPtr{unwrapStdlib_CUIntPtr = y_1},
-                              getField @"unwrapStdlib_CUIntPtr" x_0)
 {-| __C declaration:__ @stdlib_CFenvT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 35:19@
@@ -480,16 +480,16 @@ newtype Stdlib_CFenvT
     = Stdlib_CFenvT {unwrapStdlib_CFenvT :: HsBindgen.Runtime.LibC.CFenvT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
+         HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFenvT{unwrapStdlib_CFenvT = y_1},
+                              getField @"unwrapStdlib_CFenvT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
          HasField "unwrapStdlib_CFenvT" (Ptr Stdlib_CFenvT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFenvT")
 instance HasCField Stdlib_CFenvT "unwrapStdlib_CFenvT"
     where type CFieldType Stdlib_CFenvT
                           "unwrapStdlib_CFenvT" = HsBindgen.Runtime.LibC.CFenvT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFenvT =>
-         HasField "unwrapStdlib_CFenvT" Stdlib_CFenvT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFenvT{unwrapStdlib_CFenvT = y_1},
-                              getField @"unwrapStdlib_CFenvT" x_0)
 {-| __C declaration:__ @stdlib_CFexceptT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 36:19@
@@ -500,16 +500,16 @@ newtype Stdlib_CFexceptT
     = Stdlib_CFexceptT {unwrapStdlib_CFexceptT :: HsBindgen.Runtime.LibC.CFexceptT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
+         HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFexceptT{unwrapStdlib_CFexceptT = y_1},
+                              getField @"unwrapStdlib_CFexceptT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
          HasField "unwrapStdlib_CFexceptT" (Ptr Stdlib_CFexceptT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFexceptT")
 instance HasCField Stdlib_CFexceptT "unwrapStdlib_CFexceptT"
     where type CFieldType Stdlib_CFexceptT
                           "unwrapStdlib_CFexceptT" = HsBindgen.Runtime.LibC.CFexceptT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFexceptT =>
-         HasField "unwrapStdlib_CFexceptT" Stdlib_CFexceptT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFexceptT{unwrapStdlib_CFexceptT = y_1},
-                              getField @"unwrapStdlib_CFexceptT" x_0)
 {-| __C declaration:__ @stdlib_CSize@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 39:19@
@@ -535,16 +535,16 @@ newtype Stdlib_CSize
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapStdlib_CSize" Stdlib_CSize ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CSize{unwrapStdlib_CSize = y_1},
+                              getField @"unwrapStdlib_CSize" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "unwrapStdlib_CSize" (Ptr Stdlib_CSize) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSize")
 instance HasCField Stdlib_CSize "unwrapStdlib_CSize"
     where type CFieldType Stdlib_CSize
                           "unwrapStdlib_CSize" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapStdlib_CSize" Stdlib_CSize ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CSize{unwrapStdlib_CSize = y_1},
-                              getField @"unwrapStdlib_CSize" x_0)
 {-| __C declaration:__ @stdlib_CPtrdiff@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 40:19@
@@ -570,16 +570,16 @@ newtype Stdlib_CPtrdiff
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
+         HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CPtrdiff{unwrapStdlib_CPtrdiff = y_1},
+                              getField @"unwrapStdlib_CPtrdiff" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
          HasField "unwrapStdlib_CPtrdiff" (Ptr Stdlib_CPtrdiff) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CPtrdiff")
 instance HasCField Stdlib_CPtrdiff "unwrapStdlib_CPtrdiff"
     where type CFieldType Stdlib_CPtrdiff
                           "unwrapStdlib_CPtrdiff" = HsBindgen.Runtime.LibC.CPtrdiff
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapStdlib_CPtrdiff" Stdlib_CPtrdiff ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CPtrdiff{unwrapStdlib_CPtrdiff = y_1},
-                              getField @"unwrapStdlib_CPtrdiff" x_0)
 {-| __C declaration:__ @stdlib_CJmpBuf@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 43:17@
@@ -590,16 +590,16 @@ newtype Stdlib_CJmpBuf
     = Stdlib_CJmpBuf {unwrapStdlib_CJmpBuf :: HsBindgen.Runtime.LibC.CJmpBuf}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
+         HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CJmpBuf{unwrapStdlib_CJmpBuf = y_1},
+                              getField @"unwrapStdlib_CJmpBuf" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
          HasField "unwrapStdlib_CJmpBuf" (Ptr Stdlib_CJmpBuf) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CJmpBuf")
 instance HasCField Stdlib_CJmpBuf "unwrapStdlib_CJmpBuf"
     where type CFieldType Stdlib_CJmpBuf
                           "unwrapStdlib_CJmpBuf" = HsBindgen.Runtime.LibC.CJmpBuf
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CJmpBuf =>
-         HasField "unwrapStdlib_CJmpBuf" Stdlib_CJmpBuf ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CJmpBuf{unwrapStdlib_CJmpBuf = y_1},
-                              getField @"unwrapStdlib_CJmpBuf" x_0)
 {-| __C declaration:__ @stdlib_CWchar@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 46:19@
@@ -625,16 +625,16 @@ newtype Stdlib_CWchar
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
+         HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWchar{unwrapStdlib_CWchar = y_1},
+                              getField @"unwrapStdlib_CWchar" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
          HasField "unwrapStdlib_CWchar" (Ptr Stdlib_CWchar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWchar")
 instance HasCField Stdlib_CWchar "unwrapStdlib_CWchar"
     where type CFieldType Stdlib_CWchar
                           "unwrapStdlib_CWchar" = HsBindgen.Runtime.LibC.CWchar
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWchar =>
-         HasField "unwrapStdlib_CWchar" Stdlib_CWchar ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWchar{unwrapStdlib_CWchar = y_1},
-                              getField @"unwrapStdlib_CWchar" x_0)
 {-| __C declaration:__ @stdlib_CWintT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 47:19@
@@ -660,16 +660,16 @@ newtype Stdlib_CWintT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
+         HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWintT{unwrapStdlib_CWintT = y_1},
+                              getField @"unwrapStdlib_CWintT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
          HasField "unwrapStdlib_CWintT" (Ptr Stdlib_CWintT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWintT")
 instance HasCField Stdlib_CWintT "unwrapStdlib_CWintT"
     where type CFieldType Stdlib_CWintT
                           "unwrapStdlib_CWintT" = HsBindgen.Runtime.LibC.CWintT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWintT =>
-         HasField "unwrapStdlib_CWintT" Stdlib_CWintT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWintT{unwrapStdlib_CWintT = y_1},
-                              getField @"unwrapStdlib_CWintT" x_0)
 {-| __C declaration:__ @stdlib_CMbstateT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 48:19@
@@ -680,16 +680,16 @@ newtype Stdlib_CMbstateT
     = Stdlib_CMbstateT {unwrapStdlib_CMbstateT :: HsBindgen.Runtime.LibC.CMbstateT}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
+         HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CMbstateT{unwrapStdlib_CMbstateT = y_1},
+                              getField @"unwrapStdlib_CMbstateT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
          HasField "unwrapStdlib_CMbstateT" (Ptr Stdlib_CMbstateT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CMbstateT")
 instance HasCField Stdlib_CMbstateT "unwrapStdlib_CMbstateT"
     where type CFieldType Stdlib_CMbstateT
                           "unwrapStdlib_CMbstateT" = HsBindgen.Runtime.LibC.CMbstateT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CMbstateT =>
-         HasField "unwrapStdlib_CMbstateT" Stdlib_CMbstateT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CMbstateT{unwrapStdlib_CMbstateT = y_1},
-                              getField @"unwrapStdlib_CMbstateT" x_0)
 {-| __C declaration:__ @stdlib_CWctransT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 49:19@
@@ -706,16 +706,16 @@ newtype Stdlib_CWctransT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
+         HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctransT{unwrapStdlib_CWctransT = y_1},
+                              getField @"unwrapStdlib_CWctransT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
          HasField "unwrapStdlib_CWctransT" (Ptr Stdlib_CWctransT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctransT")
 instance HasCField Stdlib_CWctransT "unwrapStdlib_CWctransT"
     where type CFieldType Stdlib_CWctransT
                           "unwrapStdlib_CWctransT" = HsBindgen.Runtime.LibC.CWctransT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWctransT =>
-         HasField "unwrapStdlib_CWctransT" Stdlib_CWctransT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctransT{unwrapStdlib_CWctransT = y_1},
-                              getField @"unwrapStdlib_CWctransT" x_0)
 {-| __C declaration:__ @stdlib_CWctypeT@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 50:19@
@@ -732,16 +732,16 @@ newtype Stdlib_CWctypeT
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
+         HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctypeT{unwrapStdlib_CWctypeT = y_1},
+                              getField @"unwrapStdlib_CWctypeT" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
          HasField "unwrapStdlib_CWctypeT" (Ptr Stdlib_CWctypeT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CWctypeT")
 instance HasCField Stdlib_CWctypeT "unwrapStdlib_CWctypeT"
     where type CFieldType Stdlib_CWctypeT
                           "unwrapStdlib_CWctypeT" = HsBindgen.Runtime.LibC.CWctypeT
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CWctypeT =>
-         HasField "unwrapStdlib_CWctypeT" Stdlib_CWctypeT ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CWctypeT{unwrapStdlib_CWctypeT = y_1},
-                              getField @"unwrapStdlib_CWctypeT" x_0)
 {-| __C declaration:__ @stdlib_CChar16T@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 51:19@
@@ -767,16 +767,16 @@ newtype Stdlib_CChar16T
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
+         HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar16T{unwrapStdlib_CChar16T = y_1},
+                              getField @"unwrapStdlib_CChar16T" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
          HasField "unwrapStdlib_CChar16T" (Ptr Stdlib_CChar16T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar16T")
 instance HasCField Stdlib_CChar16T "unwrapStdlib_CChar16T"
     where type CFieldType Stdlib_CChar16T
                           "unwrapStdlib_CChar16T" = HsBindgen.Runtime.LibC.CChar16T
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CChar16T =>
-         HasField "unwrapStdlib_CChar16T" Stdlib_CChar16T ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar16T{unwrapStdlib_CChar16T = y_1},
-                              getField @"unwrapStdlib_CChar16T" x_0)
 {-| __C declaration:__ @stdlib_CChar32T@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 52:19@
@@ -802,16 +802,16 @@ newtype Stdlib_CChar32T
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
+         HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar32T{unwrapStdlib_CChar32T = y_1},
+                              getField @"unwrapStdlib_CChar32T" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
          HasField "unwrapStdlib_CChar32T" (Ptr Stdlib_CChar32T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CChar32T")
 instance HasCField Stdlib_CChar32T "unwrapStdlib_CChar32T"
     where type CFieldType Stdlib_CChar32T
                           "unwrapStdlib_CChar32T" = HsBindgen.Runtime.LibC.CChar32T
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CChar32T =>
-         HasField "unwrapStdlib_CChar32T" Stdlib_CChar32T ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CChar32T{unwrapStdlib_CChar32T = y_1},
-                              getField @"unwrapStdlib_CChar32T" x_0)
 {-| __C declaration:__ @stdlib_CTime@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 55:19@
@@ -830,16 +830,16 @@ newtype Stdlib_CTime
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CTime =>
+         HasField "unwrapStdlib_CTime" Stdlib_CTime ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CTime{unwrapStdlib_CTime = y_1},
+                              getField @"unwrapStdlib_CTime" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CTime =>
          HasField "unwrapStdlib_CTime" (Ptr Stdlib_CTime) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTime")
 instance HasCField Stdlib_CTime "unwrapStdlib_CTime"
     where type CFieldType Stdlib_CTime
                           "unwrapStdlib_CTime" = HsBindgen.Runtime.LibC.CTime
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CTime =>
-         HasField "unwrapStdlib_CTime" Stdlib_CTime ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CTime{unwrapStdlib_CTime = y_1},
-                              getField @"unwrapStdlib_CTime" x_0)
 {-| __C declaration:__ @stdlib_CClock@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 56:19@
@@ -858,16 +858,16 @@ newtype Stdlib_CClock
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CClock =>
+         HasField "unwrapStdlib_CClock" Stdlib_CClock ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CClock{unwrapStdlib_CClock = y_1},
+                              getField @"unwrapStdlib_CClock" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CClock =>
          HasField "unwrapStdlib_CClock" (Ptr Stdlib_CClock) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CClock")
 instance HasCField Stdlib_CClock "unwrapStdlib_CClock"
     where type CFieldType Stdlib_CClock
                           "unwrapStdlib_CClock" = HsBindgen.Runtime.LibC.CClock
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CClock =>
-         HasField "unwrapStdlib_CClock" Stdlib_CClock ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CClock{unwrapStdlib_CClock = y_1},
-                              getField @"unwrapStdlib_CClock" x_0)
 {-| __C declaration:__ @stdlib_CTm@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 57:19@
@@ -879,16 +879,16 @@ newtype Stdlib_CTm
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize)
 instance (~) ty HsBindgen.Runtime.LibC.CTm =>
+         HasField "unwrapStdlib_CTm" Stdlib_CTm ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CTm{unwrapStdlib_CTm = y_1},
+                              getField @"unwrapStdlib_CTm" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CTm =>
          HasField "unwrapStdlib_CTm" (Ptr Stdlib_CTm) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CTm")
 instance HasCField Stdlib_CTm "unwrapStdlib_CTm"
     where type CFieldType Stdlib_CTm
                           "unwrapStdlib_CTm" = HsBindgen.Runtime.LibC.CTm
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CTm =>
-         HasField "unwrapStdlib_CTm" Stdlib_CTm ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CTm{unwrapStdlib_CTm = y_1},
-                              getField @"unwrapStdlib_CTm" x_0)
 {-| __C declaration:__ @stdlib_CFile@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 60:16@
@@ -899,16 +899,16 @@ newtype Stdlib_CFile
     = Stdlib_CFile {unwrapStdlib_CFile :: HsBindgen.Runtime.LibC.CFile}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFile =>
+         HasField "unwrapStdlib_CFile" Stdlib_CFile ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFile{unwrapStdlib_CFile = y_1},
+                              getField @"unwrapStdlib_CFile" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFile =>
          HasField "unwrapStdlib_CFile" (Ptr Stdlib_CFile) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFile")
 instance HasCField Stdlib_CFile "unwrapStdlib_CFile"
     where type CFieldType Stdlib_CFile
                           "unwrapStdlib_CFile" = HsBindgen.Runtime.LibC.CFile
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFile =>
-         HasField "unwrapStdlib_CFile" Stdlib_CFile ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFile{unwrapStdlib_CFile = y_1},
-                              getField @"unwrapStdlib_CFile" x_0)
 {-| __C declaration:__ @stdlib_CFpos@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 61:16@
@@ -919,16 +919,16 @@ newtype Stdlib_CFpos
     = Stdlib_CFpos {unwrapStdlib_CFpos :: HsBindgen.Runtime.LibC.CFpos}
     deriving stock Generic
 instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
+         HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CFpos{unwrapStdlib_CFpos = y_1},
+                              getField @"unwrapStdlib_CFpos" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
          HasField "unwrapStdlib_CFpos" (Ptr Stdlib_CFpos) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CFpos")
 instance HasCField Stdlib_CFpos "unwrapStdlib_CFpos"
     where type CFieldType Stdlib_CFpos
                           "unwrapStdlib_CFpos" = HsBindgen.Runtime.LibC.CFpos
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CFpos =>
-         HasField "unwrapStdlib_CFpos" Stdlib_CFpos ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CFpos{unwrapStdlib_CFpos = y_1},
-                              getField @"unwrapStdlib_CFpos" x_0)
 {-| __C declaration:__ @stdlib_CSigAtomic@
 
     __defined at:__ @binding-specs\/stdlib\/instances.h 64:22@
@@ -954,13 +954,13 @@ newtype Stdlib_CSigAtomic
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
+         HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty
+    where hasField = \x_0 -> (\y_1 -> Stdlib_CSigAtomic{unwrapStdlib_CSigAtomic = y_1},
+                              getField @"unwrapStdlib_CSigAtomic" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
          HasField "unwrapStdlib_CSigAtomic" (Ptr Stdlib_CSigAtomic) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStdlib_CSigAtomic")
 instance HasCField Stdlib_CSigAtomic "unwrapStdlib_CSigAtomic"
     where type CFieldType Stdlib_CSigAtomic
                           "unwrapStdlib_CSigAtomic" = HsBindgen.Runtime.LibC.CSigAtomic
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSigAtomic =>
-         HasField "unwrapStdlib_CSigAtomic" Stdlib_CSigAtomic ty
-    where hasField = \x_0 -> (\y_1 -> Stdlib_CSigAtomic{unwrapStdlib_CSigAtomic = y_1},
-                              getField @"unwrapStdlib_CSigAtomic" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/Example.hs
@@ -152,6 +152,14 @@ newtype An_pchar = An_pchar
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.CChar
+         ) => RIP.CompatHasField.HasField "unwrap" An_pchar ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         An_pchar {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ PtrConst.PtrConst RIP.CChar
          ) => RIP.HasField "unwrap" (RIP.Ptr An_pchar) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -162,14 +170,6 @@ instance HasCField.HasCField An_pchar "unwrap" where
     PtrConst.PtrConst RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.CChar
-         ) => RIP.CompatHasField.HasField "unwrap" An_pchar ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         An_pchar {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct MyCoolStruct@
 
@@ -212,19 +212,6 @@ instance Marshal.WriteRaw MyCoolStruct where
 
 deriving via Marshal.EquivStorable MyCoolStruct instance RIP.Storable MyCoolStruct
 
-instance HasCField.HasCField MyCoolStruct "listOfNames" where
-
-  type CFieldType MyCoolStruct "listOfNames" =
-    CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
-         ) => RIP.HasField "listOfNames" (RIP.Ptr MyCoolStruct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"listOfNames")
-
 instance ( ty ~ CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
          ) => RIP.CompatHasField.HasField "listOfNames" MyCoolStruct ty where
 
@@ -232,6 +219,19 @@ instance ( ty ~ CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
     \x0 ->
       (\y1 ->
          MyCoolStruct {listOfNames = y1}, RIP.getField @"listOfNames" x0)
+
+instance ( ty ~ CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
+         ) => RIP.HasField "listOfNames" (RIP.Ptr MyCoolStruct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"listOfNames")
+
+instance HasCField.HasCField MyCoolStruct "listOfNames" where
+
+  type CFieldType MyCoolStruct "listOfNames" =
+    CA.ConstantArray 8 (CA.ConstantArray 255 RIP.CChar)
+
+  offset# = \_ -> \_ -> 0
 
 {-| Auxiliary type used by 'Foo'
 
@@ -282,6 +282,14 @@ instance RIP.FromFunPtr Foo_Aux where
   fromFunPtr = hs_bindgen_223d08172bb37c01
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrap" Foo_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo_Aux {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrap" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -292,14 +300,6 @@ instance HasCField.HasCField Foo_Aux "unwrap" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrap" Foo_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Foo_Aux {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @foo@
 
@@ -320,6 +320,13 @@ newtype Foo = Foo
     )
 
 instance ( ty ~ RIP.FunPtr Foo_Aux
+         ) => RIP.CompatHasField.HasField "unwrap" Foo ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> Foo {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.FunPtr Foo_Aux
          ) => RIP.HasField "unwrap" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -329,13 +336,6 @@ instance HasCField.HasCField Foo "unwrap" where
   type CFieldType Foo "unwrap" = RIP.FunPtr Foo_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Foo_Aux
-         ) => RIP.CompatHasField.HasField "unwrap" Foo ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> Foo {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct foo_t@
 
@@ -378,19 +378,6 @@ instance Marshal.WriteRaw Foo_t where
 
 deriving via Marshal.EquivStorable Foo_t instance RIP.Storable Foo_t
 
-instance HasCField.HasCField Foo_t "foo_member" where
-
-  type CFieldType Foo_t "foo_member" =
-    RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.HasField "foo_member" (RIP.Ptr Foo_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"foo_member")
-
 instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
          ) => RIP.CompatHasField.HasField "foo_member" Foo_t ty where
 
@@ -398,6 +385,19 @@ instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
     \x0 ->
       (\y1 ->
          Foo_t {foo_member = y1}, RIP.getField @"foo_member" x0)
+
+instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.HasField "foo_member" (RIP.Ptr Foo_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"foo_member")
+
+instance HasCField.HasCField Foo_t "foo_member" where
+
+  type CFieldType Foo_t "foo_member" =
+    RIP.FunPtr (RIP.CInt -> IO RIP.CInt)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct Foo_10_@
 
@@ -486,6 +486,14 @@ instance Read Bar_10 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrap" Bar_10 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bar_10 {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Bar_10) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -495,14 +503,6 @@ instance HasCField.HasCField Bar_10 "unwrap" where
   type CFieldType Bar_10 "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrap" Bar_10 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bar_10 {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @BAR@
 
@@ -553,20 +553,20 @@ instance Marshal.WriteRaw St where
 
 deriving via Marshal.EquivStorable St instance RIP.Storable St
 
-instance HasCField.HasCField St "i" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "i" St ty where
 
-  type CFieldType St "i" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> St {i = y1}, RIP.getField @"i" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "i" (RIP.Ptr St) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"i")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "i" St ty where
+instance HasCField.HasCField St "i" where
 
-  hasField =
-    \x0 -> (\y1 -> St {i = y1}, RIP.getField @"i" x0)
+  type CFieldType St "i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @enum e@
 
@@ -645,6 +645,12 @@ instance Read E where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrap" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrap = y1}, RIP.getField @"unwrap" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr E) (RIP.Ptr ty) where
 
@@ -655,12 +661,6 @@ instance HasCField.HasCField E "unwrap" where
   type CFieldType E "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrap" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @CONST@
 
@@ -715,15 +715,15 @@ set_u_c ::
   -> U
 set_u_c = RIP.setUnionPayload
 
+instance (ty ~ RIP.CChar) => RIP.HasField "c" (RIP.Ptr U) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"c")
+
 instance HasCField.HasCField U "c" where
 
   type CFieldType U "c" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "c" (RIP.Ptr U) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"c")
 
 {-| __C declaration:__ @struct MyTypeImpl@
 
@@ -752,6 +752,14 @@ newtype MyType = MyType
     )
 
 instance ( ty ~ RIP.Ptr MyTypeImpl
+         ) => RIP.CompatHasField.HasField "unwrap" MyType ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyType {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.Ptr MyTypeImpl
          ) => RIP.HasField "unwrap" (RIP.Ptr MyType) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -761,14 +769,6 @@ instance HasCField.HasCField MyType "unwrap" where
   type CFieldType MyType "unwrap" = RIP.Ptr MyTypeImpl
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr MyTypeImpl
-         ) => RIP.CompatHasField.HasField "unwrap" MyType ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyType {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct MyStruct@
 
@@ -811,23 +811,23 @@ instance Marshal.WriteRaw MyStructType where
 
 deriving via Marshal.EquivStorable MyStructType instance RIP.Storable MyStructType
 
-instance HasCField.HasCField MyStructType "x" where
-
-  type CFieldType MyStructType "x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "x" (RIP.Ptr MyStructType) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "x" MyStructType ty where
 
   hasField =
     \x0 ->
       (\y1 -> MyStructType {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr MyStructType) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField MyStructType "x" where
+
+  type CFieldType MyStructType "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct MyStructEmpty@
 
@@ -880,19 +880,6 @@ instance Marshal.WriteRaw Ordinary_float_struct where
 
 deriving via Marshal.EquivStorable Ordinary_float_struct instance RIP.Storable Ordinary_float_struct
 
-instance HasCField.HasCField Ordinary_float_struct "ordinary_float_member" where
-
-  type CFieldType Ordinary_float_struct "ordinary_float_member" =
-    RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "ordinary_float_member" (RIP.Ptr Ordinary_float_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_float_member")
-
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "ordinary_float_member" Ordinary_float_struct ty where
 
@@ -902,6 +889,19 @@ instance ( ty ~ RIP.CFloat
           Ordinary_float_struct {ordinary_float_member = y1}
       , RIP.getField @"ordinary_float_member" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "ordinary_float_member" (RIP.Ptr Ordinary_float_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_float_member")
+
+instance HasCField.HasCField Ordinary_float_struct "ordinary_float_member" where
+
+  type CFieldType Ordinary_float_struct "ordinary_float_member" =
+    RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_double_struct@
 
@@ -944,19 +944,6 @@ instance Marshal.WriteRaw Ordinary_double_struct where
 
 deriving via Marshal.EquivStorable Ordinary_double_struct instance RIP.Storable Ordinary_double_struct
 
-instance HasCField.HasCField Ordinary_double_struct "ordinary_double_member" where
-
-  type CFieldType Ordinary_double_struct "ordinary_double_member" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "ordinary_double_member" (RIP.Ptr Ordinary_double_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_double_member")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "ordinary_double_member" Ordinary_double_struct ty where
 
@@ -966,6 +953,19 @@ instance ( ty ~ RIP.CDouble
           Ordinary_double_struct {ordinary_double_member = y1}
       , RIP.getField @"ordinary_double_member" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "ordinary_double_member" (RIP.Ptr Ordinary_double_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_double_member")
+
+instance HasCField.HasCField Ordinary_double_struct "ordinary_double_member" where
+
+  type CFieldType Ordinary_double_struct "ordinary_double_member" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_char_struct@
 
@@ -1008,19 +1008,6 @@ instance Marshal.WriteRaw Ordinary_signed_char_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_char_struct instance RIP.Storable Ordinary_signed_char_struct
 
-instance HasCField.HasCField Ordinary_signed_char_struct "ordinary_signed_char_member" where
-
-  type CFieldType Ordinary_signed_char_struct "ordinary_signed_char_member" =
-    RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_member" (RIP.Ptr Ordinary_signed_char_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_member")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "ordinary_signed_char_member" Ordinary_signed_char_struct ty where
 
@@ -1030,6 +1017,19 @@ instance ( ty ~ RIP.CChar
           Ordinary_signed_char_struct {ordinary_signed_char_member = y1}
       , RIP.getField @"ordinary_signed_char_member" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "ordinary_signed_char_member" (RIP.Ptr Ordinary_signed_char_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_member")
+
+instance HasCField.HasCField Ordinary_signed_char_struct "ordinary_signed_char_member" where
+
+  type CFieldType Ordinary_signed_char_struct "ordinary_signed_char_member" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_char_struct@
 
@@ -1072,19 +1072,6 @@ instance Marshal.WriteRaw Explicit_signed_char_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_char_struct instance RIP.Storable Explicit_signed_char_struct
 
-instance HasCField.HasCField Explicit_signed_char_struct "explicit_signed_char_member" where
-
-  type CFieldType Explicit_signed_char_struct "explicit_signed_char_member" =
-    RIP.CSChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_member" (RIP.Ptr Explicit_signed_char_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_member")
-
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "explicit_signed_char_member" Explicit_signed_char_struct ty where
 
@@ -1094,6 +1081,19 @@ instance ( ty ~ RIP.CSChar
           Explicit_signed_char_struct {explicit_signed_char_member = y1}
       , RIP.getField @"explicit_signed_char_member" x0
       )
+
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "explicit_signed_char_member" (RIP.Ptr Explicit_signed_char_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_member")
+
+instance HasCField.HasCField Explicit_signed_char_struct "explicit_signed_char_member" where
+
+  type CFieldType Explicit_signed_char_struct "explicit_signed_char_member" =
+    RIP.CSChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_char_struct@
 
@@ -1136,19 +1136,6 @@ instance Marshal.WriteRaw Unsigned_char_struct where
 
 deriving via Marshal.EquivStorable Unsigned_char_struct instance RIP.Storable Unsigned_char_struct
 
-instance HasCField.HasCField Unsigned_char_struct "unsigned_char_member" where
-
-  type CFieldType Unsigned_char_struct "unsigned_char_member" =
-    RIP.CUChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "unsigned_char_member" (RIP.Ptr Unsigned_char_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_char_member")
-
 instance ( ty ~ RIP.CUChar
          ) => RIP.CompatHasField.HasField "unsigned_char_member" Unsigned_char_struct ty where
 
@@ -1158,6 +1145,19 @@ instance ( ty ~ RIP.CUChar
           Unsigned_char_struct {unsigned_char_member = y1}
       , RIP.getField @"unsigned_char_member" x0
       )
+
+instance ( ty ~ RIP.CUChar
+         ) => RIP.HasField "unsigned_char_member" (RIP.Ptr Unsigned_char_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_char_member")
+
+instance HasCField.HasCField Unsigned_char_struct "unsigned_char_member" where
+
+  type CFieldType Unsigned_char_struct "unsigned_char_member" =
+    RIP.CUChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_short_struct@
 
@@ -1200,19 +1200,6 @@ instance Marshal.WriteRaw Ordinary_signed_short_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_short_struct instance RIP.Storable Ordinary_signed_short_struct
 
-instance HasCField.HasCField Ordinary_signed_short_struct "ordinary_signed_short_member" where
-
-  type CFieldType Ordinary_signed_short_struct "ordinary_signed_short_member" =
-    RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_member" (RIP.Ptr Ordinary_signed_short_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_member")
-
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "ordinary_signed_short_member" Ordinary_signed_short_struct ty where
 
@@ -1222,6 +1209,19 @@ instance ( ty ~ RIP.CShort
           Ordinary_signed_short_struct {ordinary_signed_short_member = y1}
       , RIP.getField @"ordinary_signed_short_member" x0
       )
+
+instance ( ty ~ RIP.CShort
+         ) => RIP.HasField "ordinary_signed_short_member" (RIP.Ptr Ordinary_signed_short_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_member")
+
+instance HasCField.HasCField Ordinary_signed_short_struct "ordinary_signed_short_member" where
+
+  type CFieldType Ordinary_signed_short_struct "ordinary_signed_short_member" =
+    RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_short_struct@
 
@@ -1264,19 +1264,6 @@ instance Marshal.WriteRaw Explicit_signed_short_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_short_struct instance RIP.Storable Explicit_signed_short_struct
 
-instance HasCField.HasCField Explicit_signed_short_struct "explicit_signed_short_member" where
-
-  type CFieldType Explicit_signed_short_struct "explicit_signed_short_member" =
-    RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_member" (RIP.Ptr Explicit_signed_short_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_member")
-
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "explicit_signed_short_member" Explicit_signed_short_struct ty where
 
@@ -1286,6 +1273,19 @@ instance ( ty ~ RIP.CShort
           Explicit_signed_short_struct {explicit_signed_short_member = y1}
       , RIP.getField @"explicit_signed_short_member" x0
       )
+
+instance ( ty ~ RIP.CShort
+         ) => RIP.HasField "explicit_signed_short_member" (RIP.Ptr Explicit_signed_short_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_member")
+
+instance HasCField.HasCField Explicit_signed_short_struct "explicit_signed_short_member" where
+
+  type CFieldType Explicit_signed_short_struct "explicit_signed_short_member" =
+    RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_short_struct@
 
@@ -1328,19 +1328,6 @@ instance Marshal.WriteRaw Unsigned_short_struct where
 
 deriving via Marshal.EquivStorable Unsigned_short_struct instance RIP.Storable Unsigned_short_struct
 
-instance HasCField.HasCField Unsigned_short_struct "unsigned_short_member" where
-
-  type CFieldType Unsigned_short_struct "unsigned_short_member" =
-    RIP.CUShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "unsigned_short_member" (RIP.Ptr Unsigned_short_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_short_member")
-
 instance ( ty ~ RIP.CUShort
          ) => RIP.CompatHasField.HasField "unsigned_short_member" Unsigned_short_struct ty where
 
@@ -1350,6 +1337,19 @@ instance ( ty ~ RIP.CUShort
           Unsigned_short_struct {unsigned_short_member = y1}
       , RIP.getField @"unsigned_short_member" x0
       )
+
+instance ( ty ~ RIP.CUShort
+         ) => RIP.HasField "unsigned_short_member" (RIP.Ptr Unsigned_short_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_short_member")
+
+instance HasCField.HasCField Unsigned_short_struct "unsigned_short_member" where
+
+  type CFieldType Unsigned_short_struct "unsigned_short_member" =
+    RIP.CUShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_int_struct@
 
@@ -1392,19 +1392,6 @@ instance Marshal.WriteRaw Ordinary_signed_int_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_int_struct instance RIP.Storable Ordinary_signed_int_struct
 
-instance HasCField.HasCField Ordinary_signed_int_struct "ordinary_signed_int_member" where
-
-  type CFieldType Ordinary_signed_int_struct "ordinary_signed_int_member" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_member" (RIP.Ptr Ordinary_signed_int_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_member")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "ordinary_signed_int_member" Ordinary_signed_int_struct ty where
 
@@ -1414,6 +1401,19 @@ instance ( ty ~ RIP.CInt
           Ordinary_signed_int_struct {ordinary_signed_int_member = y1}
       , RIP.getField @"ordinary_signed_int_member" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "ordinary_signed_int_member" (RIP.Ptr Ordinary_signed_int_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_member")
+
+instance HasCField.HasCField Ordinary_signed_int_struct "ordinary_signed_int_member" where
+
+  type CFieldType Ordinary_signed_int_struct "ordinary_signed_int_member" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_int_struct@
 
@@ -1456,19 +1456,6 @@ instance Marshal.WriteRaw Explicit_signed_int_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_int_struct instance RIP.Storable Explicit_signed_int_struct
 
-instance HasCField.HasCField Explicit_signed_int_struct "explicit_signed_int_member" where
-
-  type CFieldType Explicit_signed_int_struct "explicit_signed_int_member" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_member" (RIP.Ptr Explicit_signed_int_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_member")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "explicit_signed_int_member" Explicit_signed_int_struct ty where
 
@@ -1478,6 +1465,19 @@ instance ( ty ~ RIP.CInt
           Explicit_signed_int_struct {explicit_signed_int_member = y1}
       , RIP.getField @"explicit_signed_int_member" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "explicit_signed_int_member" (RIP.Ptr Explicit_signed_int_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_member")
+
+instance HasCField.HasCField Explicit_signed_int_struct "explicit_signed_int_member" where
+
+  type CFieldType Explicit_signed_int_struct "explicit_signed_int_member" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_int_struct@
 
@@ -1520,19 +1520,6 @@ instance Marshal.WriteRaw Unsigned_int_struct where
 
 deriving via Marshal.EquivStorable Unsigned_int_struct instance RIP.Storable Unsigned_int_struct
 
-instance HasCField.HasCField Unsigned_int_struct "unsigned_int_member" where
-
-  type CFieldType Unsigned_int_struct "unsigned_int_member" =
-    RIP.CUInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "unsigned_int_member" (RIP.Ptr Unsigned_int_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_int_member")
-
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "unsigned_int_member" Unsigned_int_struct ty where
 
@@ -1542,6 +1529,19 @@ instance ( ty ~ RIP.CUInt
           Unsigned_int_struct {unsigned_int_member = y1}
       , RIP.getField @"unsigned_int_member" x0
       )
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.HasField "unsigned_int_member" (RIP.Ptr Unsigned_int_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_int_member")
+
+instance HasCField.HasCField Unsigned_int_struct "unsigned_int_member" where
+
+  type CFieldType Unsigned_int_struct "unsigned_int_member" =
+    RIP.CUInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_struct@
 
@@ -1584,19 +1584,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_struct instance RIP.Storable Ordinary_signed_long_struct
 
-instance HasCField.HasCField Ordinary_signed_long_struct "ordinary_signed_long_member" where
-
-  type CFieldType Ordinary_signed_long_struct "ordinary_signed_long_member" =
-    RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_member" (RIP.Ptr Ordinary_signed_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_member")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_member" Ordinary_signed_long_struct ty where
 
@@ -1606,6 +1593,19 @@ instance ( ty ~ RIP.CLong
           Ordinary_signed_long_struct {ordinary_signed_long_member = y1}
       , RIP.getField @"ordinary_signed_long_member" x0
       )
+
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "ordinary_signed_long_member" (RIP.Ptr Ordinary_signed_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_member")
+
+instance HasCField.HasCField Ordinary_signed_long_struct "ordinary_signed_long_member" where
+
+  type CFieldType Ordinary_signed_long_struct "ordinary_signed_long_member" =
+    RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_struct@
 
@@ -1648,19 +1648,6 @@ instance Marshal.WriteRaw Explicit_signed_long_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_struct instance RIP.Storable Explicit_signed_long_struct
 
-instance HasCField.HasCField Explicit_signed_long_struct "explicit_signed_long_member" where
-
-  type CFieldType Explicit_signed_long_struct "explicit_signed_long_member" =
-    RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_member" (RIP.Ptr Explicit_signed_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_member")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_member" Explicit_signed_long_struct ty where
 
@@ -1670,6 +1657,19 @@ instance ( ty ~ RIP.CLong
           Explicit_signed_long_struct {explicit_signed_long_member = y1}
       , RIP.getField @"explicit_signed_long_member" x0
       )
+
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "explicit_signed_long_member" (RIP.Ptr Explicit_signed_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_member")
+
+instance HasCField.HasCField Explicit_signed_long_struct "explicit_signed_long_member" where
+
+  type CFieldType Explicit_signed_long_struct "explicit_signed_long_member" =
+    RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_struct@
 
@@ -1712,19 +1712,6 @@ instance Marshal.WriteRaw Unsigned_long_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_struct instance RIP.Storable Unsigned_long_struct
 
-instance HasCField.HasCField Unsigned_long_struct "unsigned_long_member" where
-
-  type CFieldType Unsigned_long_struct "unsigned_long_member" =
-    RIP.CULong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "unsigned_long_member" (RIP.Ptr Unsigned_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_member")
-
 instance ( ty ~ RIP.CULong
          ) => RIP.CompatHasField.HasField "unsigned_long_member" Unsigned_long_struct ty where
 
@@ -1734,6 +1721,19 @@ instance ( ty ~ RIP.CULong
           Unsigned_long_struct {unsigned_long_member = y1}
       , RIP.getField @"unsigned_long_member" x0
       )
+
+instance ( ty ~ RIP.CULong
+         ) => RIP.HasField "unsigned_long_member" (RIP.Ptr Unsigned_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_member")
+
+instance HasCField.HasCField Unsigned_long_struct "unsigned_long_member" where
+
+  type CFieldType Unsigned_long_struct "unsigned_long_member" =
+    RIP.CULong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_long_struct@
 
@@ -1776,19 +1776,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_long_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_long_struct instance RIP.Storable Ordinary_signed_long_long_struct
 
-instance HasCField.HasCField Ordinary_signed_long_long_struct "ordinary_signed_long_long_member" where
-
-  type CFieldType Ordinary_signed_long_long_struct "ordinary_signed_long_long_member" =
-    RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_member" (RIP.Ptr Ordinary_signed_long_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_member")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_long_member" Ordinary_signed_long_long_struct ty where
 
@@ -1798,6 +1785,19 @@ instance ( ty ~ RIP.CLLong
           Ordinary_signed_long_long_struct {ordinary_signed_long_long_member = y1}
       , RIP.getField @"ordinary_signed_long_long_member" x0
       )
+
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "ordinary_signed_long_long_member" (RIP.Ptr Ordinary_signed_long_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_member")
+
+instance HasCField.HasCField Ordinary_signed_long_long_struct "ordinary_signed_long_long_member" where
+
+  type CFieldType Ordinary_signed_long_long_struct "ordinary_signed_long_long_member" =
+    RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_long_struct@
 
@@ -1840,19 +1840,6 @@ instance Marshal.WriteRaw Explicit_signed_long_long_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_long_struct instance RIP.Storable Explicit_signed_long_long_struct
 
-instance HasCField.HasCField Explicit_signed_long_long_struct "explicit_signed_long_long_member" where
-
-  type CFieldType Explicit_signed_long_long_struct "explicit_signed_long_long_member" =
-    RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_member" (RIP.Ptr Explicit_signed_long_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_member")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_long_member" Explicit_signed_long_long_struct ty where
 
@@ -1862,6 +1849,19 @@ instance ( ty ~ RIP.CLLong
           Explicit_signed_long_long_struct {explicit_signed_long_long_member = y1}
       , RIP.getField @"explicit_signed_long_long_member" x0
       )
+
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "explicit_signed_long_long_member" (RIP.Ptr Explicit_signed_long_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_member")
+
+instance HasCField.HasCField Explicit_signed_long_long_struct "explicit_signed_long_long_member" where
+
+  type CFieldType Explicit_signed_long_long_struct "explicit_signed_long_long_member" =
+    RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_long_struct@
 
@@ -1904,19 +1904,6 @@ instance Marshal.WriteRaw Unsigned_long_long_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_long_struct instance RIP.Storable Unsigned_long_long_struct
 
-instance HasCField.HasCField Unsigned_long_long_struct "unsigned_long_long_member" where
-
-  type CFieldType Unsigned_long_long_struct "unsigned_long_long_member" =
-    RIP.CULLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_member" (RIP.Ptr Unsigned_long_long_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_member")
-
 instance ( ty ~ RIP.CULLong
          ) => RIP.CompatHasField.HasField "unsigned_long_long_member" Unsigned_long_long_struct ty where
 
@@ -1926,6 +1913,19 @@ instance ( ty ~ RIP.CULLong
           Unsigned_long_long_struct {unsigned_long_long_member = y1}
       , RIP.getField @"unsigned_long_long_member" x0
       )
+
+instance ( ty ~ RIP.CULLong
+         ) => RIP.HasField "unsigned_long_long_member" (RIP.Ptr Unsigned_long_long_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_member")
+
+instance HasCField.HasCField Unsigned_long_long_struct "unsigned_long_long_member" where
+
+  type CFieldType Unsigned_long_long_struct "unsigned_long_long_member" =
+    RIP.CULLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| Structs: pointers
 
@@ -1972,19 +1972,6 @@ instance Marshal.WriteRaw Ordinary_void_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_void_pointer_struct instance RIP.Storable Ordinary_void_pointer_struct
 
-instance HasCField.HasCField Ordinary_void_pointer_struct "ordinary_void_pointer_member" where
-
-  type CFieldType Ordinary_void_pointer_struct "ordinary_void_pointer_member" =
-    RIP.Ptr RIP.Void
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "ordinary_void_pointer_member" (RIP.Ptr Ordinary_void_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.Void
          ) => RIP.CompatHasField.HasField "ordinary_void_pointer_member" Ordinary_void_pointer_struct ty where
 
@@ -1994,6 +1981,19 @@ instance ( ty ~ RIP.Ptr RIP.Void
           Ordinary_void_pointer_struct {ordinary_void_pointer_member = y1}
       , RIP.getField @"ordinary_void_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.Void
+         ) => RIP.HasField "ordinary_void_pointer_member" (RIP.Ptr Ordinary_void_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_member")
+
+instance HasCField.HasCField Ordinary_void_pointer_struct "ordinary_void_pointer_member" where
+
+  type CFieldType Ordinary_void_pointer_struct "ordinary_void_pointer_member" =
+    RIP.Ptr RIP.Void
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_float_pointer_struct@
 
@@ -2036,19 +2036,6 @@ instance Marshal.WriteRaw Ordinary_float_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_float_pointer_struct instance RIP.Storable Ordinary_float_pointer_struct
 
-instance HasCField.HasCField Ordinary_float_pointer_struct "ordinary_float_pointer_member" where
-
-  type CFieldType Ordinary_float_pointer_struct "ordinary_float_pointer_member" =
-    RIP.Ptr RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CFloat
-         ) => RIP.HasField "ordinary_float_pointer_member" (RIP.Ptr Ordinary_float_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CFloat
          ) => RIP.CompatHasField.HasField "ordinary_float_pointer_member" Ordinary_float_pointer_struct ty where
 
@@ -2058,6 +2045,19 @@ instance ( ty ~ RIP.Ptr RIP.CFloat
           Ordinary_float_pointer_struct {ordinary_float_pointer_member = y1}
       , RIP.getField @"ordinary_float_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CFloat
+         ) => RIP.HasField "ordinary_float_pointer_member" (RIP.Ptr Ordinary_float_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_member")
+
+instance HasCField.HasCField Ordinary_float_pointer_struct "ordinary_float_pointer_member" where
+
+  type CFieldType Ordinary_float_pointer_struct "ordinary_float_pointer_member" =
+    RIP.Ptr RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_double_pointer_struct@
 
@@ -2100,19 +2100,6 @@ instance Marshal.WriteRaw Ordinary_double_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_double_pointer_struct instance RIP.Storable Ordinary_double_pointer_struct
 
-instance HasCField.HasCField Ordinary_double_pointer_struct "ordinary_double_pointer_member" where
-
-  type CFieldType Ordinary_double_pointer_struct "ordinary_double_pointer_member" =
-    RIP.Ptr RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CDouble
-         ) => RIP.HasField "ordinary_double_pointer_member" (RIP.Ptr Ordinary_double_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CDouble
          ) => RIP.CompatHasField.HasField "ordinary_double_pointer_member" Ordinary_double_pointer_struct ty where
 
@@ -2122,6 +2109,19 @@ instance ( ty ~ RIP.Ptr RIP.CDouble
           Ordinary_double_pointer_struct {ordinary_double_pointer_member = y1}
       , RIP.getField @"ordinary_double_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CDouble
+         ) => RIP.HasField "ordinary_double_pointer_member" (RIP.Ptr Ordinary_double_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_member")
+
+instance HasCField.HasCField Ordinary_double_pointer_struct "ordinary_double_pointer_member" where
+
+  type CFieldType Ordinary_double_pointer_struct "ordinary_double_pointer_member" =
+    RIP.Ptr RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_struct@
 
@@ -2164,19 +2164,6 @@ instance Marshal.WriteRaw Ordinary_signed_char_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_char_pointer_struct instance RIP.Storable Ordinary_signed_char_pointer_struct
 
-instance HasCField.HasCField Ordinary_signed_char_pointer_struct "ordinary_signed_char_pointer_member" where
-
-  type CFieldType Ordinary_signed_char_pointer_struct "ordinary_signed_char_pointer_member" =
-    RIP.Ptr RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_pointer_member" (RIP.Ptr Ordinary_signed_char_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CChar
          ) => RIP.CompatHasField.HasField "ordinary_signed_char_pointer_member" Ordinary_signed_char_pointer_struct ty where
 
@@ -2186,6 +2173,19 @@ instance ( ty ~ RIP.Ptr RIP.CChar
           Ordinary_signed_char_pointer_struct {ordinary_signed_char_pointer_member = y1}
       , RIP.getField @"ordinary_signed_char_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CChar
+         ) => RIP.HasField "ordinary_signed_char_pointer_member" (RIP.Ptr Ordinary_signed_char_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_member")
+
+instance HasCField.HasCField Ordinary_signed_char_pointer_struct "ordinary_signed_char_pointer_member" where
+
+  type CFieldType Ordinary_signed_char_pointer_struct "ordinary_signed_char_pointer_member" =
+    RIP.Ptr RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_char_pointer_struct@
 
@@ -2228,19 +2228,6 @@ instance Marshal.WriteRaw Explicit_signed_char_pointer_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_char_pointer_struct instance RIP.Storable Explicit_signed_char_pointer_struct
 
-instance HasCField.HasCField Explicit_signed_char_pointer_struct "explicit_signed_char_pointer_member" where
-
-  type CFieldType Explicit_signed_char_pointer_struct "explicit_signed_char_pointer_member" =
-    RIP.Ptr RIP.CSChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_pointer_member" (RIP.Ptr Explicit_signed_char_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CSChar
          ) => RIP.CompatHasField.HasField "explicit_signed_char_pointer_member" Explicit_signed_char_pointer_struct ty where
 
@@ -2250,6 +2237,19 @@ instance ( ty ~ RIP.Ptr RIP.CSChar
           Explicit_signed_char_pointer_struct {explicit_signed_char_pointer_member = y1}
       , RIP.getField @"explicit_signed_char_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CSChar
+         ) => RIP.HasField "explicit_signed_char_pointer_member" (RIP.Ptr Explicit_signed_char_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_member")
+
+instance HasCField.HasCField Explicit_signed_char_pointer_struct "explicit_signed_char_pointer_member" where
+
+  type CFieldType Explicit_signed_char_pointer_struct "explicit_signed_char_pointer_member" =
+    RIP.Ptr RIP.CSChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_char_pointer_struct@
 
@@ -2292,19 +2292,6 @@ instance Marshal.WriteRaw Unsigned_char_pointer_struct where
 
 deriving via Marshal.EquivStorable Unsigned_char_pointer_struct instance RIP.Storable Unsigned_char_pointer_struct
 
-instance HasCField.HasCField Unsigned_char_pointer_struct "unsigned_char_pointer_member" where
-
-  type CFieldType Unsigned_char_pointer_struct "unsigned_char_pointer_member" =
-    RIP.Ptr RIP.CUChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CUChar
-         ) => RIP.HasField "unsigned_char_pointer_member" (RIP.Ptr Unsigned_char_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CUChar
          ) => RIP.CompatHasField.HasField "unsigned_char_pointer_member" Unsigned_char_pointer_struct ty where
 
@@ -2314,6 +2301,19 @@ instance ( ty ~ RIP.Ptr RIP.CUChar
           Unsigned_char_pointer_struct {unsigned_char_pointer_member = y1}
       , RIP.getField @"unsigned_char_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CUChar
+         ) => RIP.HasField "unsigned_char_pointer_member" (RIP.Ptr Unsigned_char_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_member")
+
+instance HasCField.HasCField Unsigned_char_pointer_struct "unsigned_char_pointer_member" where
+
+  type CFieldType Unsigned_char_pointer_struct "unsigned_char_pointer_member" =
+    RIP.Ptr RIP.CUChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_struct@
 
@@ -2356,19 +2356,6 @@ instance Marshal.WriteRaw Ordinary_signed_short_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_short_pointer_struct instance RIP.Storable Ordinary_signed_short_pointer_struct
 
-instance HasCField.HasCField Ordinary_signed_short_pointer_struct "ordinary_signed_short_pointer_member" where
-
-  type CFieldType Ordinary_signed_short_pointer_struct "ordinary_signed_short_pointer_member" =
-    RIP.Ptr RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_pointer_member" (RIP.Ptr Ordinary_signed_short_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CShort
          ) => RIP.CompatHasField.HasField "ordinary_signed_short_pointer_member" Ordinary_signed_short_pointer_struct ty where
 
@@ -2378,6 +2365,19 @@ instance ( ty ~ RIP.Ptr RIP.CShort
           Ordinary_signed_short_pointer_struct {ordinary_signed_short_pointer_member = y1}
       , RIP.getField @"ordinary_signed_short_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CShort
+         ) => RIP.HasField "ordinary_signed_short_pointer_member" (RIP.Ptr Ordinary_signed_short_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_member")
+
+instance HasCField.HasCField Ordinary_signed_short_pointer_struct "ordinary_signed_short_pointer_member" where
+
+  type CFieldType Ordinary_signed_short_pointer_struct "ordinary_signed_short_pointer_member" =
+    RIP.Ptr RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_short_pointer_struct@
 
@@ -2420,19 +2420,6 @@ instance Marshal.WriteRaw Explicit_signed_short_pointer_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_short_pointer_struct instance RIP.Storable Explicit_signed_short_pointer_struct
 
-instance HasCField.HasCField Explicit_signed_short_pointer_struct "explicit_signed_short_pointer_member" where
-
-  type CFieldType Explicit_signed_short_pointer_struct "explicit_signed_short_pointer_member" =
-    RIP.Ptr RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_pointer_member" (RIP.Ptr Explicit_signed_short_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CShort
          ) => RIP.CompatHasField.HasField "explicit_signed_short_pointer_member" Explicit_signed_short_pointer_struct ty where
 
@@ -2442,6 +2429,19 @@ instance ( ty ~ RIP.Ptr RIP.CShort
           Explicit_signed_short_pointer_struct {explicit_signed_short_pointer_member = y1}
       , RIP.getField @"explicit_signed_short_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CShort
+         ) => RIP.HasField "explicit_signed_short_pointer_member" (RIP.Ptr Explicit_signed_short_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_member")
+
+instance HasCField.HasCField Explicit_signed_short_pointer_struct "explicit_signed_short_pointer_member" where
+
+  type CFieldType Explicit_signed_short_pointer_struct "explicit_signed_short_pointer_member" =
+    RIP.Ptr RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_short_pointer_struct@
 
@@ -2484,19 +2484,6 @@ instance Marshal.WriteRaw Unsigned_short_pointer_struct where
 
 deriving via Marshal.EquivStorable Unsigned_short_pointer_struct instance RIP.Storable Unsigned_short_pointer_struct
 
-instance HasCField.HasCField Unsigned_short_pointer_struct "unsigned_short_pointer_member" where
-
-  type CFieldType Unsigned_short_pointer_struct "unsigned_short_pointer_member" =
-    RIP.Ptr RIP.CUShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CUShort
-         ) => RIP.HasField "unsigned_short_pointer_member" (RIP.Ptr Unsigned_short_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CUShort
          ) => RIP.CompatHasField.HasField "unsigned_short_pointer_member" Unsigned_short_pointer_struct ty where
 
@@ -2506,6 +2493,19 @@ instance ( ty ~ RIP.Ptr RIP.CUShort
           Unsigned_short_pointer_struct {unsigned_short_pointer_member = y1}
       , RIP.getField @"unsigned_short_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CUShort
+         ) => RIP.HasField "unsigned_short_pointer_member" (RIP.Ptr Unsigned_short_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_member")
+
+instance HasCField.HasCField Unsigned_short_pointer_struct "unsigned_short_pointer_member" where
+
+  type CFieldType Unsigned_short_pointer_struct "unsigned_short_pointer_member" =
+    RIP.Ptr RIP.CUShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_struct@
 
@@ -2548,19 +2548,6 @@ instance Marshal.WriteRaw Ordinary_signed_int_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_int_pointer_struct instance RIP.Storable Ordinary_signed_int_pointer_struct
 
-instance HasCField.HasCField Ordinary_signed_int_pointer_struct "ordinary_signed_int_pointer_member" where
-
-  type CFieldType Ordinary_signed_int_pointer_struct "ordinary_signed_int_pointer_member" =
-    RIP.Ptr RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_pointer_member" (RIP.Ptr Ordinary_signed_int_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.CompatHasField.HasField "ordinary_signed_int_pointer_member" Ordinary_signed_int_pointer_struct ty where
 
@@ -2570,6 +2557,19 @@ instance ( ty ~ RIP.Ptr RIP.CInt
           Ordinary_signed_int_pointer_struct {ordinary_signed_int_pointer_member = y1}
       , RIP.getField @"ordinary_signed_int_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "ordinary_signed_int_pointer_member" (RIP.Ptr Ordinary_signed_int_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_member")
+
+instance HasCField.HasCField Ordinary_signed_int_pointer_struct "ordinary_signed_int_pointer_member" where
+
+  type CFieldType Ordinary_signed_int_pointer_struct "ordinary_signed_int_pointer_member" =
+    RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_int_pointer_struct@
 
@@ -2612,19 +2612,6 @@ instance Marshal.WriteRaw Explicit_signed_int_pointer_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_int_pointer_struct instance RIP.Storable Explicit_signed_int_pointer_struct
 
-instance HasCField.HasCField Explicit_signed_int_pointer_struct "explicit_signed_int_pointer_member" where
-
-  type CFieldType Explicit_signed_int_pointer_struct "explicit_signed_int_pointer_member" =
-    RIP.Ptr RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_pointer_member" (RIP.Ptr Explicit_signed_int_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.CompatHasField.HasField "explicit_signed_int_pointer_member" Explicit_signed_int_pointer_struct ty where
 
@@ -2634,6 +2621,19 @@ instance ( ty ~ RIP.Ptr RIP.CInt
           Explicit_signed_int_pointer_struct {explicit_signed_int_pointer_member = y1}
       , RIP.getField @"explicit_signed_int_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "explicit_signed_int_pointer_member" (RIP.Ptr Explicit_signed_int_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_member")
+
+instance HasCField.HasCField Explicit_signed_int_pointer_struct "explicit_signed_int_pointer_member" where
+
+  type CFieldType Explicit_signed_int_pointer_struct "explicit_signed_int_pointer_member" =
+    RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_int_pointer_struct@
 
@@ -2676,19 +2676,6 @@ instance Marshal.WriteRaw Unsigned_int_pointer_struct where
 
 deriving via Marshal.EquivStorable Unsigned_int_pointer_struct instance RIP.Storable Unsigned_int_pointer_struct
 
-instance HasCField.HasCField Unsigned_int_pointer_struct "unsigned_int_pointer_member" where
-
-  type CFieldType Unsigned_int_pointer_struct "unsigned_int_pointer_member" =
-    RIP.Ptr RIP.CUInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CUInt
-         ) => RIP.HasField "unsigned_int_pointer_member" (RIP.Ptr Unsigned_int_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CUInt
          ) => RIP.CompatHasField.HasField "unsigned_int_pointer_member" Unsigned_int_pointer_struct ty where
 
@@ -2698,6 +2685,19 @@ instance ( ty ~ RIP.Ptr RIP.CUInt
           Unsigned_int_pointer_struct {unsigned_int_pointer_member = y1}
       , RIP.getField @"unsigned_int_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CUInt
+         ) => RIP.HasField "unsigned_int_pointer_member" (RIP.Ptr Unsigned_int_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_member")
+
+instance HasCField.HasCField Unsigned_int_pointer_struct "unsigned_int_pointer_member" where
+
+  type CFieldType Unsigned_int_pointer_struct "unsigned_int_pointer_member" =
+    RIP.Ptr RIP.CUInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_struct@
 
@@ -2740,19 +2740,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_pointer_struct instance RIP.Storable Ordinary_signed_long_pointer_struct
 
-instance HasCField.HasCField Ordinary_signed_long_pointer_struct "ordinary_signed_long_pointer_member" where
-
-  type CFieldType Ordinary_signed_long_pointer_struct "ordinary_signed_long_pointer_member" =
-    RIP.Ptr RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_pointer_member" (RIP.Ptr Ordinary_signed_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_pointer_member" Ordinary_signed_long_pointer_struct ty where
 
@@ -2762,6 +2749,19 @@ instance ( ty ~ RIP.Ptr RIP.CLong
           Ordinary_signed_long_pointer_struct {ordinary_signed_long_pointer_member = y1}
       , RIP.getField @"ordinary_signed_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CLong
+         ) => RIP.HasField "ordinary_signed_long_pointer_member" (RIP.Ptr Ordinary_signed_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_member")
+
+instance HasCField.HasCField Ordinary_signed_long_pointer_struct "ordinary_signed_long_pointer_member" where
+
+  type CFieldType Ordinary_signed_long_pointer_struct "ordinary_signed_long_pointer_member" =
+    RIP.Ptr RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_pointer_struct@
 
@@ -2804,19 +2804,6 @@ instance Marshal.WriteRaw Explicit_signed_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_pointer_struct instance RIP.Storable Explicit_signed_long_pointer_struct
 
-instance HasCField.HasCField Explicit_signed_long_pointer_struct "explicit_signed_long_pointer_member" where
-
-  type CFieldType Explicit_signed_long_pointer_struct "explicit_signed_long_pointer_member" =
-    RIP.Ptr RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_pointer_member" (RIP.Ptr Explicit_signed_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_pointer_member" Explicit_signed_long_pointer_struct ty where
 
@@ -2826,6 +2813,19 @@ instance ( ty ~ RIP.Ptr RIP.CLong
           Explicit_signed_long_pointer_struct {explicit_signed_long_pointer_member = y1}
       , RIP.getField @"explicit_signed_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CLong
+         ) => RIP.HasField "explicit_signed_long_pointer_member" (RIP.Ptr Explicit_signed_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_member")
+
+instance HasCField.HasCField Explicit_signed_long_pointer_struct "explicit_signed_long_pointer_member" where
+
+  type CFieldType Explicit_signed_long_pointer_struct "explicit_signed_long_pointer_member" =
+    RIP.Ptr RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_pointer_struct@
 
@@ -2868,19 +2868,6 @@ instance Marshal.WriteRaw Unsigned_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_pointer_struct instance RIP.Storable Unsigned_long_pointer_struct
 
-instance HasCField.HasCField Unsigned_long_pointer_struct "unsigned_long_pointer_member" where
-
-  type CFieldType Unsigned_long_pointer_struct "unsigned_long_pointer_member" =
-    RIP.Ptr RIP.CULong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CULong
-         ) => RIP.HasField "unsigned_long_pointer_member" (RIP.Ptr Unsigned_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CULong
          ) => RIP.CompatHasField.HasField "unsigned_long_pointer_member" Unsigned_long_pointer_struct ty where
 
@@ -2890,6 +2877,19 @@ instance ( ty ~ RIP.Ptr RIP.CULong
           Unsigned_long_pointer_struct {unsigned_long_pointer_member = y1}
       , RIP.getField @"unsigned_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CULong
+         ) => RIP.HasField "unsigned_long_pointer_member" (RIP.Ptr Unsigned_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_member")
+
+instance HasCField.HasCField Unsigned_long_pointer_struct "unsigned_long_pointer_member" where
+
+  type CFieldType Unsigned_long_pointer_struct "unsigned_long_pointer_member" =
+    RIP.Ptr RIP.CULong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_struct@
 
@@ -2933,19 +2933,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_long_pointer_struct instance RIP.Storable Ordinary_signed_long_long_pointer_struct
 
-instance HasCField.HasCField Ordinary_signed_long_long_pointer_struct "ordinary_signed_long_long_pointer_member" where
-
-  type CFieldType Ordinary_signed_long_long_pointer_struct "ordinary_signed_long_long_pointer_member" =
-    RIP.Ptr RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_pointer_member" (RIP.Ptr Ordinary_signed_long_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CLLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_long_pointer_member" Ordinary_signed_long_long_pointer_struct ty where
 
@@ -2955,6 +2942,19 @@ instance ( ty ~ RIP.Ptr RIP.CLLong
           Ordinary_signed_long_long_pointer_struct {ordinary_signed_long_long_pointer_member = y1}
       , RIP.getField @"ordinary_signed_long_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CLLong
+         ) => RIP.HasField "ordinary_signed_long_long_pointer_member" (RIP.Ptr Ordinary_signed_long_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_member")
+
+instance HasCField.HasCField Ordinary_signed_long_long_pointer_struct "ordinary_signed_long_long_pointer_member" where
+
+  type CFieldType Ordinary_signed_long_long_pointer_struct "ordinary_signed_long_long_pointer_member" =
+    RIP.Ptr RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_struct@
 
@@ -2998,19 +2998,6 @@ instance Marshal.WriteRaw Explicit_signed_long_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_long_pointer_struct instance RIP.Storable Explicit_signed_long_long_pointer_struct
 
-instance HasCField.HasCField Explicit_signed_long_long_pointer_struct "explicit_signed_long_long_pointer_member" where
-
-  type CFieldType Explicit_signed_long_long_pointer_struct "explicit_signed_long_long_pointer_member" =
-    RIP.Ptr RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_pointer_member" (RIP.Ptr Explicit_signed_long_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CLLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_long_pointer_member" Explicit_signed_long_long_pointer_struct ty where
 
@@ -3020,6 +3007,19 @@ instance ( ty ~ RIP.Ptr RIP.CLLong
           Explicit_signed_long_long_pointer_struct {explicit_signed_long_long_pointer_member = y1}
       , RIP.getField @"explicit_signed_long_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CLLong
+         ) => RIP.HasField "explicit_signed_long_long_pointer_member" (RIP.Ptr Explicit_signed_long_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_member")
+
+instance HasCField.HasCField Explicit_signed_long_long_pointer_struct "explicit_signed_long_long_pointer_member" where
+
+  type CFieldType Explicit_signed_long_long_pointer_struct "explicit_signed_long_long_pointer_member" =
+    RIP.Ptr RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_long_pointer_struct@
 
@@ -3062,19 +3062,6 @@ instance Marshal.WriteRaw Unsigned_long_long_pointer_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_long_pointer_struct instance RIP.Storable Unsigned_long_long_pointer_struct
 
-instance HasCField.HasCField Unsigned_long_long_pointer_struct "unsigned_long_long_pointer_member" where
-
-  type CFieldType Unsigned_long_long_pointer_struct "unsigned_long_long_pointer_member" =
-    RIP.Ptr RIP.CULLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_pointer_member" (RIP.Ptr Unsigned_long_long_pointer_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_member")
-
 instance ( ty ~ RIP.Ptr RIP.CULLong
          ) => RIP.CompatHasField.HasField "unsigned_long_long_pointer_member" Unsigned_long_long_pointer_struct ty where
 
@@ -3084,6 +3071,19 @@ instance ( ty ~ RIP.Ptr RIP.CULLong
           Unsigned_long_long_pointer_struct {unsigned_long_long_pointer_member = y1}
       , RIP.getField @"unsigned_long_long_pointer_member" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CULLong
+         ) => RIP.HasField "unsigned_long_long_pointer_member" (RIP.Ptr Unsigned_long_long_pointer_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_member")
+
+instance HasCField.HasCField Unsigned_long_long_pointer_struct "unsigned_long_long_pointer_member" where
+
+  type CFieldType Unsigned_long_long_pointer_struct "unsigned_long_long_pointer_member" =
+    RIP.Ptr RIP.CULLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| Structs: arrays
 
@@ -3128,19 +3128,6 @@ instance Marshal.WriteRaw Ordinary_float_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_float_array_struct instance RIP.Storable Ordinary_float_array_struct
 
-instance HasCField.HasCField Ordinary_float_array_struct "ordinary_float_array_member" where
-
-  type CFieldType Ordinary_float_array_struct "ordinary_float_array_member" =
-    CA.ConstantArray 10 RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CFloat
-         ) => RIP.HasField "ordinary_float_array_member" (RIP.Ptr Ordinary_float_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_float_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CFloat
          ) => RIP.CompatHasField.HasField "ordinary_float_array_member" Ordinary_float_array_struct ty where
 
@@ -3150,6 +3137,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CFloat
           Ordinary_float_array_struct {ordinary_float_array_member = y1}
       , RIP.getField @"ordinary_float_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CFloat
+         ) => RIP.HasField "ordinary_float_array_member" (RIP.Ptr Ordinary_float_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_float_array_member")
+
+instance HasCField.HasCField Ordinary_float_array_struct "ordinary_float_array_member" where
+
+  type CFieldType Ordinary_float_array_struct "ordinary_float_array_member" =
+    CA.ConstantArray 10 RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_double_array_struct@
 
@@ -3192,19 +3192,6 @@ instance Marshal.WriteRaw Ordinary_double_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_double_array_struct instance RIP.Storable Ordinary_double_array_struct
 
-instance HasCField.HasCField Ordinary_double_array_struct "ordinary_double_array_member" where
-
-  type CFieldType Ordinary_double_array_struct "ordinary_double_array_member" =
-    CA.ConstantArray 10 RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CDouble
-         ) => RIP.HasField "ordinary_double_array_member" (RIP.Ptr Ordinary_double_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_double_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CDouble
          ) => RIP.CompatHasField.HasField "ordinary_double_array_member" Ordinary_double_array_struct ty where
 
@@ -3214,6 +3201,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CDouble
           Ordinary_double_array_struct {ordinary_double_array_member = y1}
       , RIP.getField @"ordinary_double_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CDouble
+         ) => RIP.HasField "ordinary_double_array_member" (RIP.Ptr Ordinary_double_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_double_array_member")
+
+instance HasCField.HasCField Ordinary_double_array_struct "ordinary_double_array_member" where
+
+  type CFieldType Ordinary_double_array_struct "ordinary_double_array_member" =
+    CA.ConstantArray 10 RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_char_array_struct@
 
@@ -3256,19 +3256,6 @@ instance Marshal.WriteRaw Ordinary_signed_char_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_char_array_struct instance RIP.Storable Ordinary_signed_char_array_struct
 
-instance HasCField.HasCField Ordinary_signed_char_array_struct "ordinary_signed_char_array_member" where
-
-  type CFieldType Ordinary_signed_char_array_struct "ordinary_signed_char_array_member" =
-    CA.ConstantArray 10 RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CChar
-         ) => RIP.HasField "ordinary_signed_char_array_member" (RIP.Ptr Ordinary_signed_char_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CChar
          ) => RIP.CompatHasField.HasField "ordinary_signed_char_array_member" Ordinary_signed_char_array_struct ty where
 
@@ -3278,6 +3265,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CChar
           Ordinary_signed_char_array_struct {ordinary_signed_char_array_member = y1}
       , RIP.getField @"ordinary_signed_char_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CChar
+         ) => RIP.HasField "ordinary_signed_char_array_member" (RIP.Ptr Ordinary_signed_char_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_array_member")
+
+instance HasCField.HasCField Ordinary_signed_char_array_struct "ordinary_signed_char_array_member" where
+
+  type CFieldType Ordinary_signed_char_array_struct "ordinary_signed_char_array_member" =
+    CA.ConstantArray 10 RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_char_array_struct@
 
@@ -3320,19 +3320,6 @@ instance Marshal.WriteRaw Explicit_signed_char_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_char_array_struct instance RIP.Storable Explicit_signed_char_array_struct
 
-instance HasCField.HasCField Explicit_signed_char_array_struct "explicit_signed_char_array_member" where
-
-  type CFieldType Explicit_signed_char_array_struct "explicit_signed_char_array_member" =
-    CA.ConstantArray 10 RIP.CSChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CSChar
-         ) => RIP.HasField "explicit_signed_char_array_member" (RIP.Ptr Explicit_signed_char_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CSChar
          ) => RIP.CompatHasField.HasField "explicit_signed_char_array_member" Explicit_signed_char_array_struct ty where
 
@@ -3342,6 +3329,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CSChar
           Explicit_signed_char_array_struct {explicit_signed_char_array_member = y1}
       , RIP.getField @"explicit_signed_char_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CSChar
+         ) => RIP.HasField "explicit_signed_char_array_member" (RIP.Ptr Explicit_signed_char_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_array_member")
+
+instance HasCField.HasCField Explicit_signed_char_array_struct "explicit_signed_char_array_member" where
+
+  type CFieldType Explicit_signed_char_array_struct "explicit_signed_char_array_member" =
+    CA.ConstantArray 10 RIP.CSChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_char_array_struct@
 
@@ -3384,19 +3384,6 @@ instance Marshal.WriteRaw Unsigned_char_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_char_array_struct instance RIP.Storable Unsigned_char_array_struct
 
-instance HasCField.HasCField Unsigned_char_array_struct "unsigned_char_array_member" where
-
-  type CFieldType Unsigned_char_array_struct "unsigned_char_array_member" =
-    CA.ConstantArray 10 RIP.CUChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CUChar
-         ) => RIP.HasField "unsigned_char_array_member" (RIP.Ptr Unsigned_char_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_char_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CUChar
          ) => RIP.CompatHasField.HasField "unsigned_char_array_member" Unsigned_char_array_struct ty where
 
@@ -3406,6 +3393,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CUChar
           Unsigned_char_array_struct {unsigned_char_array_member = y1}
       , RIP.getField @"unsigned_char_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CUChar
+         ) => RIP.HasField "unsigned_char_array_member" (RIP.Ptr Unsigned_char_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_char_array_member")
+
+instance HasCField.HasCField Unsigned_char_array_struct "unsigned_char_array_member" where
+
+  type CFieldType Unsigned_char_array_struct "unsigned_char_array_member" =
+    CA.ConstantArray 10 RIP.CUChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_short_array_struct@
 
@@ -3448,19 +3448,6 @@ instance Marshal.WriteRaw Ordinary_signed_short_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_short_array_struct instance RIP.Storable Ordinary_signed_short_array_struct
 
-instance HasCField.HasCField Ordinary_signed_short_array_struct "ordinary_signed_short_array_member" where
-
-  type CFieldType Ordinary_signed_short_array_struct "ordinary_signed_short_array_member" =
-    CA.ConstantArray 10 RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CShort
-         ) => RIP.HasField "ordinary_signed_short_array_member" (RIP.Ptr Ordinary_signed_short_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CShort
          ) => RIP.CompatHasField.HasField "ordinary_signed_short_array_member" Ordinary_signed_short_array_struct ty where
 
@@ -3470,6 +3457,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CShort
           Ordinary_signed_short_array_struct {ordinary_signed_short_array_member = y1}
       , RIP.getField @"ordinary_signed_short_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CShort
+         ) => RIP.HasField "ordinary_signed_short_array_member" (RIP.Ptr Ordinary_signed_short_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_array_member")
+
+instance HasCField.HasCField Ordinary_signed_short_array_struct "ordinary_signed_short_array_member" where
+
+  type CFieldType Ordinary_signed_short_array_struct "ordinary_signed_short_array_member" =
+    CA.ConstantArray 10 RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_short_array_struct@
 
@@ -3512,19 +3512,6 @@ instance Marshal.WriteRaw Explicit_signed_short_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_short_array_struct instance RIP.Storable Explicit_signed_short_array_struct
 
-instance HasCField.HasCField Explicit_signed_short_array_struct "explicit_signed_short_array_member" where
-
-  type CFieldType Explicit_signed_short_array_struct "explicit_signed_short_array_member" =
-    CA.ConstantArray 10 RIP.CShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CShort
-         ) => RIP.HasField "explicit_signed_short_array_member" (RIP.Ptr Explicit_signed_short_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CShort
          ) => RIP.CompatHasField.HasField "explicit_signed_short_array_member" Explicit_signed_short_array_struct ty where
 
@@ -3534,6 +3521,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CShort
           Explicit_signed_short_array_struct {explicit_signed_short_array_member = y1}
       , RIP.getField @"explicit_signed_short_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CShort
+         ) => RIP.HasField "explicit_signed_short_array_member" (RIP.Ptr Explicit_signed_short_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_array_member")
+
+instance HasCField.HasCField Explicit_signed_short_array_struct "explicit_signed_short_array_member" where
+
+  type CFieldType Explicit_signed_short_array_struct "explicit_signed_short_array_member" =
+    CA.ConstantArray 10 RIP.CShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_short_array_struct@
 
@@ -3576,19 +3576,6 @@ instance Marshal.WriteRaw Unsigned_short_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_short_array_struct instance RIP.Storable Unsigned_short_array_struct
 
-instance HasCField.HasCField Unsigned_short_array_struct "unsigned_short_array_member" where
-
-  type CFieldType Unsigned_short_array_struct "unsigned_short_array_member" =
-    CA.ConstantArray 10 RIP.CUShort
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CUShort
-         ) => RIP.HasField "unsigned_short_array_member" (RIP.Ptr Unsigned_short_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_short_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CUShort
          ) => RIP.CompatHasField.HasField "unsigned_short_array_member" Unsigned_short_array_struct ty where
 
@@ -3598,6 +3585,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CUShort
           Unsigned_short_array_struct {unsigned_short_array_member = y1}
       , RIP.getField @"unsigned_short_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CUShort
+         ) => RIP.HasField "unsigned_short_array_member" (RIP.Ptr Unsigned_short_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_short_array_member")
+
+instance HasCField.HasCField Unsigned_short_array_struct "unsigned_short_array_member" where
+
+  type CFieldType Unsigned_short_array_struct "unsigned_short_array_member" =
+    CA.ConstantArray 10 RIP.CUShort
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_int_array_struct@
 
@@ -3640,19 +3640,6 @@ instance Marshal.WriteRaw Ordinary_signed_int_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_int_array_struct instance RIP.Storable Ordinary_signed_int_array_struct
 
-instance HasCField.HasCField Ordinary_signed_int_array_struct "ordinary_signed_int_array_member" where
-
-  type CFieldType Ordinary_signed_int_array_struct "ordinary_signed_int_array_member" =
-    CA.ConstantArray 10 RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CInt
-         ) => RIP.HasField "ordinary_signed_int_array_member" (RIP.Ptr Ordinary_signed_int_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CInt
          ) => RIP.CompatHasField.HasField "ordinary_signed_int_array_member" Ordinary_signed_int_array_struct ty where
 
@@ -3662,6 +3649,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CInt
           Ordinary_signed_int_array_struct {ordinary_signed_int_array_member = y1}
       , RIP.getField @"ordinary_signed_int_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CInt
+         ) => RIP.HasField "ordinary_signed_int_array_member" (RIP.Ptr Ordinary_signed_int_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_array_member")
+
+instance HasCField.HasCField Ordinary_signed_int_array_struct "ordinary_signed_int_array_member" where
+
+  type CFieldType Ordinary_signed_int_array_struct "ordinary_signed_int_array_member" =
+    CA.ConstantArray 10 RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_int_array_struct@
 
@@ -3704,19 +3704,6 @@ instance Marshal.WriteRaw Explicit_signed_int_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_int_array_struct instance RIP.Storable Explicit_signed_int_array_struct
 
-instance HasCField.HasCField Explicit_signed_int_array_struct "explicit_signed_int_array_member" where
-
-  type CFieldType Explicit_signed_int_array_struct "explicit_signed_int_array_member" =
-    CA.ConstantArray 10 RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CInt
-         ) => RIP.HasField "explicit_signed_int_array_member" (RIP.Ptr Explicit_signed_int_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CInt
          ) => RIP.CompatHasField.HasField "explicit_signed_int_array_member" Explicit_signed_int_array_struct ty where
 
@@ -3726,6 +3713,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CInt
           Explicit_signed_int_array_struct {explicit_signed_int_array_member = y1}
       , RIP.getField @"explicit_signed_int_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CInt
+         ) => RIP.HasField "explicit_signed_int_array_member" (RIP.Ptr Explicit_signed_int_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_array_member")
+
+instance HasCField.HasCField Explicit_signed_int_array_struct "explicit_signed_int_array_member" where
+
+  type CFieldType Explicit_signed_int_array_struct "explicit_signed_int_array_member" =
+    CA.ConstantArray 10 RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_int_array_struct@
 
@@ -3768,19 +3768,6 @@ instance Marshal.WriteRaw Unsigned_int_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_int_array_struct instance RIP.Storable Unsigned_int_array_struct
 
-instance HasCField.HasCField Unsigned_int_array_struct "unsigned_int_array_member" where
-
-  type CFieldType Unsigned_int_array_struct "unsigned_int_array_member" =
-    CA.ConstantArray 10 RIP.CUInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CUInt
-         ) => RIP.HasField "unsigned_int_array_member" (RIP.Ptr Unsigned_int_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_int_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CUInt
          ) => RIP.CompatHasField.HasField "unsigned_int_array_member" Unsigned_int_array_struct ty where
 
@@ -3790,6 +3777,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CUInt
           Unsigned_int_array_struct {unsigned_int_array_member = y1}
       , RIP.getField @"unsigned_int_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CUInt
+         ) => RIP.HasField "unsigned_int_array_member" (RIP.Ptr Unsigned_int_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_int_array_member")
+
+instance HasCField.HasCField Unsigned_int_array_struct "unsigned_int_array_member" where
+
+  type CFieldType Unsigned_int_array_struct "unsigned_int_array_member" =
+    CA.ConstantArray 10 RIP.CUInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_array_struct@
 
@@ -3832,19 +3832,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_array_struct instance RIP.Storable Ordinary_signed_long_array_struct
 
-instance HasCField.HasCField Ordinary_signed_long_array_struct "ordinary_signed_long_array_member" where
-
-  type CFieldType Ordinary_signed_long_array_struct "ordinary_signed_long_array_member" =
-    CA.ConstantArray 10 RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CLong
-         ) => RIP.HasField "ordinary_signed_long_array_member" (RIP.Ptr Ordinary_signed_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_array_member" Ordinary_signed_long_array_struct ty where
 
@@ -3854,6 +3841,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CLong
           Ordinary_signed_long_array_struct {ordinary_signed_long_array_member = y1}
       , RIP.getField @"ordinary_signed_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CLong
+         ) => RIP.HasField "ordinary_signed_long_array_member" (RIP.Ptr Ordinary_signed_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_array_member")
+
+instance HasCField.HasCField Ordinary_signed_long_array_struct "ordinary_signed_long_array_member" where
+
+  type CFieldType Ordinary_signed_long_array_struct "ordinary_signed_long_array_member" =
+    CA.ConstantArray 10 RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_array_struct@
 
@@ -3896,19 +3896,6 @@ instance Marshal.WriteRaw Explicit_signed_long_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_array_struct instance RIP.Storable Explicit_signed_long_array_struct
 
-instance HasCField.HasCField Explicit_signed_long_array_struct "explicit_signed_long_array_member" where
-
-  type CFieldType Explicit_signed_long_array_struct "explicit_signed_long_array_member" =
-    CA.ConstantArray 10 RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CLong
-         ) => RIP.HasField "explicit_signed_long_array_member" (RIP.Ptr Explicit_signed_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_array_member" Explicit_signed_long_array_struct ty where
 
@@ -3918,6 +3905,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CLong
           Explicit_signed_long_array_struct {explicit_signed_long_array_member = y1}
       , RIP.getField @"explicit_signed_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CLong
+         ) => RIP.HasField "explicit_signed_long_array_member" (RIP.Ptr Explicit_signed_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_array_member")
+
+instance HasCField.HasCField Explicit_signed_long_array_struct "explicit_signed_long_array_member" where
+
+  type CFieldType Explicit_signed_long_array_struct "explicit_signed_long_array_member" =
+    CA.ConstantArray 10 RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_array_struct@
 
@@ -3960,19 +3960,6 @@ instance Marshal.WriteRaw Unsigned_long_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_array_struct instance RIP.Storable Unsigned_long_array_struct
 
-instance HasCField.HasCField Unsigned_long_array_struct "unsigned_long_array_member" where
-
-  type CFieldType Unsigned_long_array_struct "unsigned_long_array_member" =
-    CA.ConstantArray 10 RIP.CULong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CULong
-         ) => RIP.HasField "unsigned_long_array_member" (RIP.Ptr Unsigned_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CULong
          ) => RIP.CompatHasField.HasField "unsigned_long_array_member" Unsigned_long_array_struct ty where
 
@@ -3982,6 +3969,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CULong
           Unsigned_long_array_struct {unsigned_long_array_member = y1}
       , RIP.getField @"unsigned_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CULong
+         ) => RIP.HasField "unsigned_long_array_member" (RIP.Ptr Unsigned_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_array_member")
+
+instance HasCField.HasCField Unsigned_long_array_struct "unsigned_long_array_member" where
+
+  type CFieldType Unsigned_long_array_struct "unsigned_long_array_member" =
+    CA.ConstantArray 10 RIP.CULong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_long_array_struct@
 
@@ -4025,19 +4025,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_long_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_long_array_struct instance RIP.Storable Ordinary_signed_long_long_array_struct
 
-instance HasCField.HasCField Ordinary_signed_long_long_array_struct "ordinary_signed_long_long_array_member" where
-
-  type CFieldType Ordinary_signed_long_long_array_struct "ordinary_signed_long_long_array_member" =
-    CA.ConstantArray 10 RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
-         ) => RIP.HasField "ordinary_signed_long_long_array_member" (RIP.Ptr Ordinary_signed_long_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_long_array_member" Ordinary_signed_long_long_array_struct ty where
 
@@ -4047,6 +4034,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
           Ordinary_signed_long_long_array_struct {ordinary_signed_long_long_array_member = y1}
       , RIP.getField @"ordinary_signed_long_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
+         ) => RIP.HasField "ordinary_signed_long_long_array_member" (RIP.Ptr Ordinary_signed_long_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_array_member")
+
+instance HasCField.HasCField Ordinary_signed_long_long_array_struct "ordinary_signed_long_long_array_member" where
+
+  type CFieldType Ordinary_signed_long_long_array_struct "ordinary_signed_long_long_array_member" =
+    CA.ConstantArray 10 RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_long_array_struct@
 
@@ -4090,19 +4090,6 @@ instance Marshal.WriteRaw Explicit_signed_long_long_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_long_array_struct instance RIP.Storable Explicit_signed_long_long_array_struct
 
-instance HasCField.HasCField Explicit_signed_long_long_array_struct "explicit_signed_long_long_array_member" where
-
-  type CFieldType Explicit_signed_long_long_array_struct "explicit_signed_long_long_array_member" =
-    CA.ConstantArray 10 RIP.CLLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
-         ) => RIP.HasField "explicit_signed_long_long_array_member" (RIP.Ptr Explicit_signed_long_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
          ) => RIP.CompatHasField.HasField "explicit_signed_long_long_array_member" Explicit_signed_long_long_array_struct ty where
 
@@ -4112,6 +4099,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
           Explicit_signed_long_long_array_struct {explicit_signed_long_long_array_member = y1}
       , RIP.getField @"explicit_signed_long_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CLLong
+         ) => RIP.HasField "explicit_signed_long_long_array_member" (RIP.Ptr Explicit_signed_long_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_array_member")
+
+instance HasCField.HasCField Explicit_signed_long_long_array_struct "explicit_signed_long_long_array_member" where
+
+  type CFieldType Explicit_signed_long_long_array_struct "explicit_signed_long_long_array_member" =
+    CA.ConstantArray 10 RIP.CLLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_long_array_struct@
 
@@ -4154,19 +4154,6 @@ instance Marshal.WriteRaw Unsigned_long_long_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_long_array_struct instance RIP.Storable Unsigned_long_long_array_struct
 
-instance HasCField.HasCField Unsigned_long_long_array_struct "unsigned_long_long_array_member" where
-
-  type CFieldType Unsigned_long_long_array_struct "unsigned_long_long_array_member" =
-    CA.ConstantArray 10 RIP.CULLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 RIP.CULLong
-         ) => RIP.HasField "unsigned_long_long_array_member" (RIP.Ptr Unsigned_long_long_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 RIP.CULLong
          ) => RIP.CompatHasField.HasField "unsigned_long_long_array_member" Unsigned_long_long_array_struct ty where
 
@@ -4176,6 +4163,19 @@ instance ( ty ~ CA.ConstantArray 10 RIP.CULLong
           Unsigned_long_long_array_struct {unsigned_long_long_array_member = y1}
       , RIP.getField @"unsigned_long_long_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 RIP.CULLong
+         ) => RIP.HasField "unsigned_long_long_array_member" (RIP.Ptr Unsigned_long_long_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_array_member")
+
+instance HasCField.HasCField Unsigned_long_long_array_struct "unsigned_long_long_array_member" where
+
+  type CFieldType Unsigned_long_long_array_struct "unsigned_long_long_array_member" =
+    CA.ConstantArray 10 RIP.CULLong
+
+  offset# = \_ -> \_ -> 0
 
 {-| Structs: arrays of pointers
 
@@ -4222,19 +4222,6 @@ instance Marshal.WriteRaw Ordinary_void_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_void_pointer_array_struct instance RIP.Storable Ordinary_void_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_void_pointer_array_struct "ordinary_void_pointer_array_member" where
-
-  type CFieldType Ordinary_void_pointer_array_struct "ordinary_void_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.Void)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.Void)
-         ) => RIP.HasField "ordinary_void_pointer_array_member" (RIP.Ptr Ordinary_void_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.Void)
          ) => RIP.CompatHasField.HasField "ordinary_void_pointer_array_member" Ordinary_void_pointer_array_struct ty where
 
@@ -4244,6 +4231,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.Void)
           Ordinary_void_pointer_array_struct {ordinary_void_pointer_array_member = y1}
       , RIP.getField @"ordinary_void_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.Void)
+         ) => RIP.HasField "ordinary_void_pointer_array_member" (RIP.Ptr Ordinary_void_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_void_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_void_pointer_array_struct "ordinary_void_pointer_array_member" where
+
+  type CFieldType Ordinary_void_pointer_array_struct "ordinary_void_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.Void)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_float_pointer_array_struct@
 
@@ -4286,19 +4286,6 @@ instance Marshal.WriteRaw Ordinary_float_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_float_pointer_array_struct instance RIP.Storable Ordinary_float_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_float_pointer_array_struct "ordinary_float_pointer_array_member" where
-
-  type CFieldType Ordinary_float_pointer_array_struct "ordinary_float_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
-         ) => RIP.HasField "ordinary_float_pointer_array_member" (RIP.Ptr Ordinary_float_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
          ) => RIP.CompatHasField.HasField "ordinary_float_pointer_array_member" Ordinary_float_pointer_array_struct ty where
 
@@ -4308,6 +4295,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
           Ordinary_float_pointer_array_struct {ordinary_float_pointer_array_member = y1}
       , RIP.getField @"ordinary_float_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
+         ) => RIP.HasField "ordinary_float_pointer_array_member" (RIP.Ptr Ordinary_float_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_float_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_float_pointer_array_struct "ordinary_float_pointer_array_member" where
+
+  type CFieldType Ordinary_float_pointer_array_struct "ordinary_float_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CFloat)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_double_pointer_array_struct@
 
@@ -4350,19 +4350,6 @@ instance Marshal.WriteRaw Ordinary_double_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_double_pointer_array_struct instance RIP.Storable Ordinary_double_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_double_pointer_array_struct "ordinary_double_pointer_array_member" where
-
-  type CFieldType Ordinary_double_pointer_array_struct "ordinary_double_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
-         ) => RIP.HasField "ordinary_double_pointer_array_member" (RIP.Ptr Ordinary_double_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
          ) => RIP.CompatHasField.HasField "ordinary_double_pointer_array_member" Ordinary_double_pointer_array_struct ty where
 
@@ -4372,6 +4359,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
           Ordinary_double_pointer_array_struct {ordinary_double_pointer_array_member = y1}
       , RIP.getField @"ordinary_double_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
+         ) => RIP.HasField "ordinary_double_pointer_array_member" (RIP.Ptr Ordinary_double_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_double_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_double_pointer_array_struct "ordinary_double_pointer_array_member" where
+
+  type CFieldType Ordinary_double_pointer_array_struct "ordinary_double_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CDouble)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_array_struct@
 
@@ -4415,19 +4415,6 @@ instance Marshal.WriteRaw Ordinary_signed_char_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_char_pointer_array_struct instance RIP.Storable Ordinary_signed_char_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_signed_char_pointer_array_struct "ordinary_signed_char_pointer_array_member" where
-
-  type CFieldType Ordinary_signed_char_pointer_array_struct "ordinary_signed_char_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
-         ) => RIP.HasField "ordinary_signed_char_pointer_array_member" (RIP.Ptr Ordinary_signed_char_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
          ) => RIP.CompatHasField.HasField "ordinary_signed_char_pointer_array_member" Ordinary_signed_char_pointer_array_struct ty where
 
@@ -4437,6 +4424,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
           Ordinary_signed_char_pointer_array_struct {ordinary_signed_char_pointer_array_member = y1}
       , RIP.getField @"ordinary_signed_char_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
+         ) => RIP.HasField "ordinary_signed_char_pointer_array_member" (RIP.Ptr Ordinary_signed_char_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_char_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_signed_char_pointer_array_struct "ordinary_signed_char_pointer_array_member" where
+
+  type CFieldType Ordinary_signed_char_pointer_array_struct "ordinary_signed_char_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CChar)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_char_pointer_array_struct@
 
@@ -4480,19 +4480,6 @@ instance Marshal.WriteRaw Explicit_signed_char_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_char_pointer_array_struct instance RIP.Storable Explicit_signed_char_pointer_array_struct
 
-instance HasCField.HasCField Explicit_signed_char_pointer_array_struct "explicit_signed_char_pointer_array_member" where
-
-  type CFieldType Explicit_signed_char_pointer_array_struct "explicit_signed_char_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
-         ) => RIP.HasField "explicit_signed_char_pointer_array_member" (RIP.Ptr Explicit_signed_char_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
          ) => RIP.CompatHasField.HasField "explicit_signed_char_pointer_array_member" Explicit_signed_char_pointer_array_struct ty where
 
@@ -4502,6 +4489,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
           Explicit_signed_char_pointer_array_struct {explicit_signed_char_pointer_array_member = y1}
       , RIP.getField @"explicit_signed_char_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
+         ) => RIP.HasField "explicit_signed_char_pointer_array_member" (RIP.Ptr Explicit_signed_char_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_char_pointer_array_member")
+
+instance HasCField.HasCField Explicit_signed_char_pointer_array_struct "explicit_signed_char_pointer_array_member" where
+
+  type CFieldType Explicit_signed_char_pointer_array_struct "explicit_signed_char_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CSChar)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_char_pointer_array_struct@
 
@@ -4544,19 +4544,6 @@ instance Marshal.WriteRaw Unsigned_char_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_char_pointer_array_struct instance RIP.Storable Unsigned_char_pointer_array_struct
 
-instance HasCField.HasCField Unsigned_char_pointer_array_struct "unsigned_char_pointer_array_member" where
-
-  type CFieldType Unsigned_char_pointer_array_struct "unsigned_char_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
-         ) => RIP.HasField "unsigned_char_pointer_array_member" (RIP.Ptr Unsigned_char_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
          ) => RIP.CompatHasField.HasField "unsigned_char_pointer_array_member" Unsigned_char_pointer_array_struct ty where
 
@@ -4566,6 +4553,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
           Unsigned_char_pointer_array_struct {unsigned_char_pointer_array_member = y1}
       , RIP.getField @"unsigned_char_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
+         ) => RIP.HasField "unsigned_char_pointer_array_member" (RIP.Ptr Unsigned_char_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_char_pointer_array_member")
+
+instance HasCField.HasCField Unsigned_char_pointer_array_struct "unsigned_char_pointer_array_member" where
+
+  type CFieldType Unsigned_char_pointer_array_struct "unsigned_char_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CUChar)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_array_struct@
 
@@ -4609,19 +4609,6 @@ instance Marshal.WriteRaw Ordinary_signed_short_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_short_pointer_array_struct instance RIP.Storable Ordinary_signed_short_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_signed_short_pointer_array_struct "ordinary_signed_short_pointer_array_member" where
-
-  type CFieldType Ordinary_signed_short_pointer_array_struct "ordinary_signed_short_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-         ) => RIP.HasField "ordinary_signed_short_pointer_array_member" (RIP.Ptr Ordinary_signed_short_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
          ) => RIP.CompatHasField.HasField "ordinary_signed_short_pointer_array_member" Ordinary_signed_short_pointer_array_struct ty where
 
@@ -4631,6 +4618,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
           Ordinary_signed_short_pointer_array_struct {ordinary_signed_short_pointer_array_member = y1}
       , RIP.getField @"ordinary_signed_short_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
+         ) => RIP.HasField "ordinary_signed_short_pointer_array_member" (RIP.Ptr Ordinary_signed_short_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_short_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_signed_short_pointer_array_struct "ordinary_signed_short_pointer_array_member" where
+
+  type CFieldType Ordinary_signed_short_pointer_array_struct "ordinary_signed_short_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_short_pointer_array_struct@
 
@@ -4674,19 +4674,6 @@ instance Marshal.WriteRaw Explicit_signed_short_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_short_pointer_array_struct instance RIP.Storable Explicit_signed_short_pointer_array_struct
 
-instance HasCField.HasCField Explicit_signed_short_pointer_array_struct "explicit_signed_short_pointer_array_member" where
-
-  type CFieldType Explicit_signed_short_pointer_array_struct "explicit_signed_short_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
-         ) => RIP.HasField "explicit_signed_short_pointer_array_member" (RIP.Ptr Explicit_signed_short_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
          ) => RIP.CompatHasField.HasField "explicit_signed_short_pointer_array_member" Explicit_signed_short_pointer_array_struct ty where
 
@@ -4696,6 +4683,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
           Explicit_signed_short_pointer_array_struct {explicit_signed_short_pointer_array_member = y1}
       , RIP.getField @"explicit_signed_short_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
+         ) => RIP.HasField "explicit_signed_short_pointer_array_member" (RIP.Ptr Explicit_signed_short_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_short_pointer_array_member")
+
+instance HasCField.HasCField Explicit_signed_short_pointer_array_struct "explicit_signed_short_pointer_array_member" where
+
+  type CFieldType Explicit_signed_short_pointer_array_struct "explicit_signed_short_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CShort)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_short_pointer_array_struct@
 
@@ -4738,19 +4738,6 @@ instance Marshal.WriteRaw Unsigned_short_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_short_pointer_array_struct instance RIP.Storable Unsigned_short_pointer_array_struct
 
-instance HasCField.HasCField Unsigned_short_pointer_array_struct "unsigned_short_pointer_array_member" where
-
-  type CFieldType Unsigned_short_pointer_array_struct "unsigned_short_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
-         ) => RIP.HasField "unsigned_short_pointer_array_member" (RIP.Ptr Unsigned_short_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
          ) => RIP.CompatHasField.HasField "unsigned_short_pointer_array_member" Unsigned_short_pointer_array_struct ty where
 
@@ -4760,6 +4747,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
           Unsigned_short_pointer_array_struct {unsigned_short_pointer_array_member = y1}
       , RIP.getField @"unsigned_short_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
+         ) => RIP.HasField "unsigned_short_pointer_array_member" (RIP.Ptr Unsigned_short_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_short_pointer_array_member")
+
+instance HasCField.HasCField Unsigned_short_pointer_array_struct "unsigned_short_pointer_array_member" where
+
+  type CFieldType Unsigned_short_pointer_array_struct "unsigned_short_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CUShort)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_array_struct@
 
@@ -4803,19 +4803,6 @@ instance Marshal.WriteRaw Ordinary_signed_int_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_int_pointer_array_struct instance RIP.Storable Ordinary_signed_int_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_signed_int_pointer_array_struct "ordinary_signed_int_pointer_array_member" where
-
-  type CFieldType Ordinary_signed_int_pointer_array_struct "ordinary_signed_int_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-         ) => RIP.HasField "ordinary_signed_int_pointer_array_member" (RIP.Ptr Ordinary_signed_int_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
          ) => RIP.CompatHasField.HasField "ordinary_signed_int_pointer_array_member" Ordinary_signed_int_pointer_array_struct ty where
 
@@ -4825,6 +4812,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
           Ordinary_signed_int_pointer_array_struct {ordinary_signed_int_pointer_array_member = y1}
       , RIP.getField @"ordinary_signed_int_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
+         ) => RIP.HasField "ordinary_signed_int_pointer_array_member" (RIP.Ptr Ordinary_signed_int_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_int_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_signed_int_pointer_array_struct "ordinary_signed_int_pointer_array_member" where
+
+  type CFieldType Ordinary_signed_int_pointer_array_struct "ordinary_signed_int_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_int_pointer_array_struct@
 
@@ -4868,19 +4868,6 @@ instance Marshal.WriteRaw Explicit_signed_int_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_int_pointer_array_struct instance RIP.Storable Explicit_signed_int_pointer_array_struct
 
-instance HasCField.HasCField Explicit_signed_int_pointer_array_struct "explicit_signed_int_pointer_array_member" where
-
-  type CFieldType Explicit_signed_int_pointer_array_struct "explicit_signed_int_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
-         ) => RIP.HasField "explicit_signed_int_pointer_array_member" (RIP.Ptr Explicit_signed_int_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
          ) => RIP.CompatHasField.HasField "explicit_signed_int_pointer_array_member" Explicit_signed_int_pointer_array_struct ty where
 
@@ -4890,6 +4877,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
           Explicit_signed_int_pointer_array_struct {explicit_signed_int_pointer_array_member = y1}
       , RIP.getField @"explicit_signed_int_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
+         ) => RIP.HasField "explicit_signed_int_pointer_array_member" (RIP.Ptr Explicit_signed_int_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_int_pointer_array_member")
+
+instance HasCField.HasCField Explicit_signed_int_pointer_array_struct "explicit_signed_int_pointer_array_member" where
+
+  type CFieldType Explicit_signed_int_pointer_array_struct "explicit_signed_int_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CInt)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_int_pointer_array_struct@
 
@@ -4932,19 +4932,6 @@ instance Marshal.WriteRaw Unsigned_int_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_int_pointer_array_struct instance RIP.Storable Unsigned_int_pointer_array_struct
 
-instance HasCField.HasCField Unsigned_int_pointer_array_struct "unsigned_int_pointer_array_member" where
-
-  type CFieldType Unsigned_int_pointer_array_struct "unsigned_int_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
-         ) => RIP.HasField "unsigned_int_pointer_array_member" (RIP.Ptr Unsigned_int_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
          ) => RIP.CompatHasField.HasField "unsigned_int_pointer_array_member" Unsigned_int_pointer_array_struct ty where
 
@@ -4954,6 +4941,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
           Unsigned_int_pointer_array_struct {unsigned_int_pointer_array_member = y1}
       , RIP.getField @"unsigned_int_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
+         ) => RIP.HasField "unsigned_int_pointer_array_member" (RIP.Ptr Unsigned_int_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_int_pointer_array_member")
+
+instance HasCField.HasCField Unsigned_int_pointer_array_struct "unsigned_int_pointer_array_member" where
+
+  type CFieldType Unsigned_int_pointer_array_struct "unsigned_int_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CUInt)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_array_struct@
 
@@ -4997,19 +4997,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_pointer_array_struct instance RIP.Storable Ordinary_signed_long_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_signed_long_pointer_array_struct "ordinary_signed_long_pointer_array_member" where
-
-  type CFieldType Ordinary_signed_long_pointer_array_struct "ordinary_signed_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-         ) => RIP.HasField "ordinary_signed_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_pointer_array_member" Ordinary_signed_long_pointer_array_struct ty where
 
@@ -5019,6 +5006,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
           Ordinary_signed_long_pointer_array_struct {ordinary_signed_long_pointer_array_member = y1}
       , RIP.getField @"ordinary_signed_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
+         ) => RIP.HasField "ordinary_signed_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_signed_long_pointer_array_struct "ordinary_signed_long_pointer_array_member" where
+
+  type CFieldType Ordinary_signed_long_pointer_array_struct "ordinary_signed_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_pointer_array_struct@
 
@@ -5062,19 +5062,6 @@ instance Marshal.WriteRaw Explicit_signed_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_pointer_array_struct instance RIP.Storable Explicit_signed_long_pointer_array_struct
 
-instance HasCField.HasCField Explicit_signed_long_pointer_array_struct "explicit_signed_long_pointer_array_member" where
-
-  type CFieldType Explicit_signed_long_pointer_array_struct "explicit_signed_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
-         ) => RIP.HasField "explicit_signed_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
          ) => RIP.CompatHasField.HasField "explicit_signed_long_pointer_array_member" Explicit_signed_long_pointer_array_struct ty where
 
@@ -5084,6 +5071,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
           Explicit_signed_long_pointer_array_struct {explicit_signed_long_pointer_array_member = y1}
       , RIP.getField @"explicit_signed_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
+         ) => RIP.HasField "explicit_signed_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_pointer_array_member")
+
+instance HasCField.HasCField Explicit_signed_long_pointer_array_struct "explicit_signed_long_pointer_array_member" where
+
+  type CFieldType Explicit_signed_long_pointer_array_struct "explicit_signed_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CLong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_pointer_array_struct@
 
@@ -5126,19 +5126,6 @@ instance Marshal.WriteRaw Unsigned_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_pointer_array_struct instance RIP.Storable Unsigned_long_pointer_array_struct
 
-instance HasCField.HasCField Unsigned_long_pointer_array_struct "unsigned_long_pointer_array_member" where
-
-  type CFieldType Unsigned_long_pointer_array_struct "unsigned_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
-         ) => RIP.HasField "unsigned_long_pointer_array_member" (RIP.Ptr Unsigned_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
          ) => RIP.CompatHasField.HasField "unsigned_long_pointer_array_member" Unsigned_long_pointer_array_struct ty where
 
@@ -5148,6 +5135,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
           Unsigned_long_pointer_array_struct {unsigned_long_pointer_array_member = y1}
       , RIP.getField @"unsigned_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
+         ) => RIP.HasField "unsigned_long_pointer_array_member" (RIP.Ptr Unsigned_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_pointer_array_member")
+
+instance HasCField.HasCField Unsigned_long_pointer_array_struct "unsigned_long_pointer_array_member" where
+
+  type CFieldType Unsigned_long_pointer_array_struct "unsigned_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CULong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_array_struct@
 
@@ -5191,19 +5191,6 @@ instance Marshal.WriteRaw Ordinary_signed_long_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Ordinary_signed_long_long_pointer_array_struct instance RIP.Storable Ordinary_signed_long_long_pointer_array_struct
 
-instance HasCField.HasCField Ordinary_signed_long_long_pointer_array_struct "ordinary_signed_long_long_pointer_array_member" where
-
-  type CFieldType Ordinary_signed_long_long_pointer_array_struct "ordinary_signed_long_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-         ) => RIP.HasField "ordinary_signed_long_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
          ) => RIP.CompatHasField.HasField "ordinary_signed_long_long_pointer_array_member" Ordinary_signed_long_long_pointer_array_struct ty where
 
@@ -5213,6 +5200,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
           Ordinary_signed_long_long_pointer_array_struct {ordinary_signed_long_long_pointer_array_member = y1}
       , RIP.getField @"ordinary_signed_long_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
+         ) => RIP.HasField "ordinary_signed_long_long_pointer_array_member" (RIP.Ptr Ordinary_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ordinary_signed_long_long_pointer_array_member")
+
+instance HasCField.HasCField Ordinary_signed_long_long_pointer_array_struct "ordinary_signed_long_long_pointer_array_member" where
+
+  type CFieldType Ordinary_signed_long_long_pointer_array_struct "ordinary_signed_long_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_array_struct@
 
@@ -5256,19 +5256,6 @@ instance Marshal.WriteRaw Explicit_signed_long_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Explicit_signed_long_long_pointer_array_struct instance RIP.Storable Explicit_signed_long_long_pointer_array_struct
 
-instance HasCField.HasCField Explicit_signed_long_long_pointer_array_struct "explicit_signed_long_long_pointer_array_member" where
-
-  type CFieldType Explicit_signed_long_long_pointer_array_struct "explicit_signed_long_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
-         ) => RIP.HasField "explicit_signed_long_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
          ) => RIP.CompatHasField.HasField "explicit_signed_long_long_pointer_array_member" Explicit_signed_long_long_pointer_array_struct ty where
 
@@ -5278,6 +5265,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
           Explicit_signed_long_long_pointer_array_struct {explicit_signed_long_long_pointer_array_member = y1}
       , RIP.getField @"explicit_signed_long_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
+         ) => RIP.HasField "explicit_signed_long_long_pointer_array_member" (RIP.Ptr Explicit_signed_long_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"explicit_signed_long_long_pointer_array_member")
+
+instance HasCField.HasCField Explicit_signed_long_long_pointer_array_struct "explicit_signed_long_long_pointer_array_member" where
+
+  type CFieldType Explicit_signed_long_long_pointer_array_struct "explicit_signed_long_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CLLong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct unsigned_long_long_pointer_array_struct@
 
@@ -5321,19 +5321,6 @@ instance Marshal.WriteRaw Unsigned_long_long_pointer_array_struct where
 
 deriving via Marshal.EquivStorable Unsigned_long_long_pointer_array_struct instance RIP.Storable Unsigned_long_long_pointer_array_struct
 
-instance HasCField.HasCField Unsigned_long_long_pointer_array_struct "unsigned_long_long_pointer_array_member" where
-
-  type CFieldType Unsigned_long_long_pointer_array_struct "unsigned_long_long_pointer_array_member" =
-    CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
-         ) => RIP.HasField "unsigned_long_long_pointer_array_member" (RIP.Ptr Unsigned_long_long_pointer_array_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_array_member")
-
 instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
          ) => RIP.CompatHasField.HasField "unsigned_long_long_pointer_array_member" Unsigned_long_long_pointer_array_struct ty where
 
@@ -5343,6 +5330,19 @@ instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
           Unsigned_long_long_pointer_array_struct {unsigned_long_long_pointer_array_member = y1}
       , RIP.getField @"unsigned_long_long_pointer_array_member" x0
       )
+
+instance ( ty ~ CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
+         ) => RIP.HasField "unsigned_long_long_pointer_array_member" (RIP.Ptr Unsigned_long_long_pointer_array_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unsigned_long_long_pointer_array_member")
+
+instance HasCField.HasCField Unsigned_long_long_pointer_array_struct "unsigned_long_long_pointer_array_member" where
+
+  type CFieldType Unsigned_long_long_pointer_array_struct "unsigned_long_long_pointer_array_member" =
+    CA.ConstantArray 10 (RIP.Ptr RIP.CULLong)
+
+  offset# = \_ -> \_ -> 0
 
 {-| Sanity checks
 
@@ -5376,6 +5376,13 @@ newtype An_int = An_int
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrap" An_int ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         An_int {unwrap = y1}, RIP.getField @"unwrap" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrap" (RIP.Ptr An_int) (RIP.Ptr ty) where
 
@@ -5386,13 +5393,6 @@ instance HasCField.HasCField An_int "unwrap" where
   type CFieldType An_int "unwrap" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrap" An_int ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         An_int {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct \@cal_table_table@
 
@@ -5444,17 +5444,6 @@ instance Marshal.WriteRaw Cal_table_table where
 
 deriving via Marshal.EquivStorable Cal_table_table instance RIP.Storable Cal_table_table
 
-instance HasCField.HasCField Cal_table_table "raw" where
-
-  type CFieldType Cal_table_table "raw" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "raw" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"raw")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "raw" Cal_table_table ty where
 
@@ -5465,16 +5454,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"raw" x0
       )
 
-instance HasCField.HasCField Cal_table_table "val" where
-
-  type CFieldType Cal_table_table "val" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "val" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
+         ) => RIP.HasField "raw" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"val")
+  getField = HasCField.fromPtr (RIP.Proxy @"raw")
+
+instance HasCField.HasCField Cal_table_table "raw" where
+
+  type CFieldType Cal_table_table "raw" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "val" Cal_table_table ty where
@@ -5485,6 +5474,17 @@ instance ( ty ~ RIP.CInt
           Cal_table_table {val = y1, raw = RIP.getField @"raw" x0}
       , RIP.getField @"val" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "val" (RIP.Ptr Cal_table_table) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"val")
+
+instance HasCField.HasCField Cal_table_table "val" where
+
+  type CFieldType Cal_table_table "val" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| Issues without test cases in the original test suite
 
@@ -5540,17 +5540,6 @@ instance Marshal.WriteRaw Cal_table where
 
 deriving via Marshal.EquivStorable Cal_table instance RIP.Storable Cal_table
 
-instance HasCField.HasCField Cal_table "size" where
-
-  type CFieldType Cal_table "size" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "size" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"size")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "size" Cal_table ty where
 
@@ -5561,17 +5550,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"size" x0
       )
 
-instance HasCField.HasCField Cal_table "table" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "size" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
 
-  type CFieldType Cal_table "table" =
-    CA.ConstantArray 32 Cal_table_table
+  getField = HasCField.fromPtr (RIP.Proxy @"size")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField Cal_table "size" where
 
-instance ( ty ~ CA.ConstantArray 32 Cal_table_table
-         ) => RIP.HasField "table" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
+  type CFieldType Cal_table "size" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"table")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ CA.ConstantArray 32 Cal_table_table
          ) => RIP.CompatHasField.HasField "table" Cal_table ty where
@@ -5582,6 +5570,18 @@ instance ( ty ~ CA.ConstantArray 32 Cal_table_table
           Cal_table {table = y1, size = RIP.getField @"size" x0}
       , RIP.getField @"table" x0
       )
+
+instance ( ty ~ CA.ConstantArray 32 Cal_table_table
+         ) => RIP.HasField "table" (RIP.Ptr Cal_table) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"table")
+
+instance HasCField.HasCField Cal_table "table" where
+
+  type CFieldType Cal_table "table" =
+    CA.ConstantArray 32 Cal_table_table
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union \@Elf32_External_Dyn_d_un@
 
@@ -5656,6 +5656,11 @@ set_elf32_External_Dyn_d_un_d_ptr ::
 set_elf32_External_Dyn_d_un_d_ptr =
   RIP.setUnionPayload
 
+instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
+         ) => RIP.HasField "d_val" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"d_val")
+
 instance HasCField.HasCField Elf32_External_Dyn_d_un "d_val" where
 
   type CFieldType Elf32_External_Dyn_d_un "d_val" =
@@ -5664,9 +5669,9 @@ instance HasCField.HasCField Elf32_External_Dyn_d_un "d_val" where
   offset# = \_ -> \_ -> 0
 
 instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_val" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
+         ) => RIP.HasField "d_ptr" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"d_val")
+  getField = HasCField.fromPtr (RIP.Proxy @"d_ptr")
 
 instance HasCField.HasCField Elf32_External_Dyn_d_un "d_ptr" where
 
@@ -5674,11 +5679,6 @@ instance HasCField.HasCField Elf32_External_Dyn_d_un "d_ptr" where
     CA.ConstantArray 4 RIP.CUChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_ptr" (RIP.Ptr Elf32_External_Dyn_d_un) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"d_ptr")
 
 {-| __C declaration:__ @struct Elf32_External_Dyn@
 
@@ -5730,18 +5730,6 @@ instance Marshal.WriteRaw Elf32_External_Dyn where
 
 deriving via Marshal.EquivStorable Elf32_External_Dyn instance RIP.Storable Elf32_External_Dyn
 
-instance HasCField.HasCField Elf32_External_Dyn "d_tag" where
-
-  type CFieldType Elf32_External_Dyn "d_tag" =
-    CA.ConstantArray 4 RIP.CUChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
-         ) => RIP.HasField "d_tag" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"d_tag")
-
 instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
          ) => RIP.CompatHasField.HasField "d_tag" Elf32_External_Dyn ty where
 
@@ -5752,17 +5740,17 @@ instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
       , RIP.getField @"d_tag" x0
       )
 
-instance HasCField.HasCField Elf32_External_Dyn "d_un" where
+instance ( ty ~ CA.ConstantArray 4 RIP.CUChar
+         ) => RIP.HasField "d_tag" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
 
-  type CFieldType Elf32_External_Dyn "d_un" =
-    Elf32_External_Dyn_d_un
+  getField = HasCField.fromPtr (RIP.Proxy @"d_tag")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField Elf32_External_Dyn "d_tag" where
 
-instance ( ty ~ Elf32_External_Dyn_d_un
-         ) => RIP.HasField "d_un" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
+  type CFieldType Elf32_External_Dyn "d_tag" =
+    CA.ConstantArray 4 RIP.CUChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"d_un")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Elf32_External_Dyn_d_un
          ) => RIP.CompatHasField.HasField "d_un" Elf32_External_Dyn ty where
@@ -5773,6 +5761,18 @@ instance ( ty ~ Elf32_External_Dyn_d_un
           Elf32_External_Dyn {d_un = y1, d_tag = RIP.getField @"d_tag" x0}
       , RIP.getField @"d_un" x0
       )
+
+instance ( ty ~ Elf32_External_Dyn_d_un
+         ) => RIP.HasField "d_un" (RIP.Ptr Elf32_External_Dyn) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"d_un")
+
+instance HasCField.HasCField Elf32_External_Dyn "d_un" where
+
+  type CFieldType Elf32_External_Dyn "d_un" =
+    Elf32_External_Dyn_d_un
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @bug_24@
 
@@ -5793,6 +5793,14 @@ newtype Bug_24 = Bug_24
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrap" Bug_24 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bug_24 {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Bug_24) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -5802,14 +5810,6 @@ instance HasCField.HasCField Bug_24 "unwrap" where
   type CFieldType Bug_24 "unwrap" = RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrap" Bug_24 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bug_24 {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @bug_24_2@
 
@@ -5830,6 +5830,14 @@ newtype Bug_24_2 = Bug_24_2
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrap" Bug_24_2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bug_24_2 {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ PtrConst.PtrConst RIP.CInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Bug_24_2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -5840,14 +5848,6 @@ instance HasCField.HasCField Bug_24_2 "unwrap" where
     PtrConst.PtrConst RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrap" Bug_24_2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bug_24_2 {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @MyArray_27@
 
@@ -5868,6 +5868,14 @@ newtype MyArray_27 = MyArray_27
     )
 
 instance ( ty ~ CA.ConstantArray 20 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrap" MyArray_27 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyArray_27 {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ CA.ConstantArray 20 RIP.CInt
          ) => RIP.HasField "unwrap" (RIP.Ptr MyArray_27) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -5878,14 +5886,6 @@ instance HasCField.HasCField MyArray_27 "unwrap" where
     CA.ConstantArray 20 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 20 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrap" MyArray_27 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyArray_27 {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct MyStruct_27@
 
@@ -5928,20 +5928,20 @@ instance Marshal.WriteRaw MyStruct_27 where
 
 deriving via Marshal.EquivStorable MyStruct_27 instance RIP.Storable MyStruct_27
 
-instance HasCField.HasCField MyStruct_27 "x" where
-
-  type CFieldType MyStruct_27 "x" = MyArray_27
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyArray_27
-         ) => RIP.HasField "x" (RIP.Ptr MyStruct_27) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"x")
-
 instance ( ty ~ MyArray_27
          ) => RIP.CompatHasField.HasField "x" MyStruct_27 ty where
 
   hasField =
     \x0 ->
       (\y1 -> MyStruct_27 {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ MyArray_27
+         ) => RIP.HasField "x" (RIP.Ptr MyStruct_27) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField MyStruct_27 "x" where
+
+  type CFieldType MyStruct_27 "x" = MyArray_27
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/bindingspec.yaml
@@ -311,7 +311,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -319,6 +318,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -338,12 +339,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -358,12 +360,13 @@ hstypes:
       - unwrap
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -380,12 +383,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -399,12 +403,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -419,11 +424,12 @@ hstypes:
       - size
       - table
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -437,11 +443,12 @@ hstypes:
       - raw
       - val
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -455,12 +462,13 @@ hstypes:
       - unwrap
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -478,10 +486,11 @@ hstypes:
       - d_tag
       - d_un
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -495,7 +504,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -507,11 +516,12 @@ hstypes:
       fields:
       - explicit_signed_char_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -524,11 +534,12 @@ hstypes:
       fields:
       - explicit_signed_char_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -541,11 +552,12 @@ hstypes:
       fields:
       - explicit_signed_char_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -558,11 +570,12 @@ hstypes:
       fields:
       - explicit_signed_char_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -575,11 +588,12 @@ hstypes:
       fields:
       - explicit_signed_int_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -592,11 +606,12 @@ hstypes:
       fields:
       - explicit_signed_int_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -609,11 +624,12 @@ hstypes:
       fields:
       - explicit_signed_int_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -626,11 +642,12 @@ hstypes:
       fields:
       - explicit_signed_int_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -643,11 +660,12 @@ hstypes:
       fields:
       - explicit_signed_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -660,11 +678,12 @@ hstypes:
       fields:
       - explicit_signed_long_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -677,11 +696,12 @@ hstypes:
       fields:
       - explicit_signed_long_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -694,11 +714,12 @@ hstypes:
       fields:
       - explicit_signed_long_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -711,11 +732,12 @@ hstypes:
       fields:
       - explicit_signed_long_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -728,11 +750,12 @@ hstypes:
       fields:
       - explicit_signed_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -745,11 +768,12 @@ hstypes:
       fields:
       - explicit_signed_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -762,11 +786,12 @@ hstypes:
       fields:
       - explicit_signed_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -779,11 +804,12 @@ hstypes:
       fields:
       - explicit_signed_short_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -796,11 +822,12 @@ hstypes:
       fields:
       - explicit_signed_short_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -813,11 +840,12 @@ hstypes:
       fields:
       - explicit_signed_short_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -830,11 +858,12 @@ hstypes:
       fields:
       - explicit_signed_short_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -847,12 +876,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -868,11 +898,12 @@ hstypes:
       fields:
       - foo_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -885,11 +916,12 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -903,11 +935,12 @@ hstypes:
       fields:
       - listOfNames
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -922,11 +955,12 @@ hstypes:
       fields:
       - x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -939,11 +973,12 @@ hstypes:
       fields:
       - x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -956,12 +991,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -977,11 +1013,12 @@ hstypes:
       fields:
       - ordinary_double_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -994,11 +1031,12 @@ hstypes:
       fields:
       - ordinary_double_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1011,11 +1049,12 @@ hstypes:
       fields:
       - ordinary_double_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1028,11 +1067,12 @@ hstypes:
       fields:
       - ordinary_double_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1045,11 +1085,12 @@ hstypes:
       fields:
       - ordinary_float_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1062,11 +1103,12 @@ hstypes:
       fields:
       - ordinary_float_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1079,11 +1121,12 @@ hstypes:
       fields:
       - ordinary_float_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1096,11 +1139,12 @@ hstypes:
       fields:
       - ordinary_float_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1113,11 +1157,12 @@ hstypes:
       fields:
       - ordinary_signed_char_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1130,11 +1175,12 @@ hstypes:
       fields:
       - ordinary_signed_char_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1147,11 +1193,12 @@ hstypes:
       fields:
       - ordinary_signed_char_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1164,11 +1211,12 @@ hstypes:
       fields:
       - ordinary_signed_char_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1181,11 +1229,12 @@ hstypes:
       fields:
       - ordinary_signed_int_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1198,11 +1247,12 @@ hstypes:
       fields:
       - ordinary_signed_int_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1215,11 +1265,12 @@ hstypes:
       fields:
       - ordinary_signed_int_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1232,11 +1283,12 @@ hstypes:
       fields:
       - ordinary_signed_int_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1249,11 +1301,12 @@ hstypes:
       fields:
       - ordinary_signed_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1266,11 +1319,12 @@ hstypes:
       fields:
       - ordinary_signed_long_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1283,11 +1337,12 @@ hstypes:
       fields:
       - ordinary_signed_long_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1300,11 +1355,12 @@ hstypes:
       fields:
       - ordinary_signed_long_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1317,11 +1373,12 @@ hstypes:
       fields:
       - ordinary_signed_long_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1334,11 +1391,12 @@ hstypes:
       fields:
       - ordinary_signed_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1351,11 +1409,12 @@ hstypes:
       fields:
       - ordinary_signed_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1368,11 +1427,12 @@ hstypes:
       fields:
       - ordinary_signed_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1385,11 +1445,12 @@ hstypes:
       fields:
       - ordinary_signed_short_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1402,11 +1463,12 @@ hstypes:
       fields:
       - ordinary_signed_short_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1419,11 +1481,12 @@ hstypes:
       fields:
       - ordinary_signed_short_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1436,11 +1499,12 @@ hstypes:
       fields:
       - ordinary_signed_short_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1453,11 +1517,12 @@ hstypes:
       fields:
       - ordinary_void_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1470,11 +1535,12 @@ hstypes:
       fields:
       - ordinary_void_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1487,11 +1553,12 @@ hstypes:
       fields:
       - i
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1506,7 +1573,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -1518,11 +1585,12 @@ hstypes:
       fields:
       - unsigned_char_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1535,11 +1603,12 @@ hstypes:
       fields:
       - unsigned_char_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1552,11 +1621,12 @@ hstypes:
       fields:
       - unsigned_char_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1569,11 +1639,12 @@ hstypes:
       fields:
       - unsigned_char_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1586,11 +1657,12 @@ hstypes:
       fields:
       - unsigned_int_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1603,11 +1675,12 @@ hstypes:
       fields:
       - unsigned_int_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1620,11 +1693,12 @@ hstypes:
       fields:
       - unsigned_int_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1637,11 +1711,12 @@ hstypes:
       fields:
       - unsigned_int_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1654,11 +1729,12 @@ hstypes:
       fields:
       - unsigned_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1671,11 +1747,12 @@ hstypes:
       fields:
       - unsigned_long_long_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1688,11 +1765,12 @@ hstypes:
       fields:
       - unsigned_long_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1705,11 +1783,12 @@ hstypes:
       fields:
       - unsigned_long_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1722,11 +1801,12 @@ hstypes:
       fields:
       - unsigned_long_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1739,11 +1819,12 @@ hstypes:
       fields:
       - unsigned_long_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1756,11 +1837,12 @@ hstypes:
       fields:
       - unsigned_long_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1773,11 +1855,12 @@ hstypes:
       fields:
       - unsigned_long_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1790,11 +1873,12 @@ hstypes:
       fields:
       - unsigned_short_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1807,11 +1891,12 @@ hstypes:
       fields:
       - unsigned_short_pointer_array_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1824,11 +1909,12 @@ hstypes:
       fields:
       - unsigned_short_pointer_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -1841,11 +1927,12 @@ hstypes:
       fields:
       - unsigned_short_member
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/th.txt
@@ -530,15 +530,15 @@ newtype An_pchar
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (PtrConst CChar) => HasField "unwrap" An_pchar ty
+    where hasField = \x_0 -> (\y_1 -> An_pchar{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (PtrConst CChar) =>
          HasField "unwrap" (Ptr An_pchar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField An_pchar "unwrap"
     where type CFieldType An_pchar "unwrap" = PtrConst CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst CChar) => HasField "unwrap" An_pchar ty
-    where hasField = \x_0 -> (\y_1 -> An_pchar{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct MyCoolStruct@
 
     __defined at:__ @comprehensive\/c2hsc.h 15:9@
@@ -564,17 +564,17 @@ instance WriteRaw MyCoolStruct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        MyCoolStruct listOfNames_2 -> writeRaw (Proxy @"listOfNames") ptr_0 listOfNames_2
 deriving via (EquivStorable MyCoolStruct) instance Storable MyCoolStruct
-instance HasCField MyCoolStruct "listOfNames"
-    where type CFieldType MyCoolStruct "listOfNames" = ConstantArray 8
-                                                                     (ConstantArray 255 CChar)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 8 (ConstantArray 255 CChar)) =>
-         HasField "listOfNames" (Ptr MyCoolStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"listOfNames")
 instance (~) ty (ConstantArray 8 (ConstantArray 255 CChar)) =>
          HasField "listOfNames" MyCoolStruct ty
     where hasField = \x_0 -> (\y_1 -> MyCoolStruct{listOfNames = y_1},
                               getField @"listOfNames" x_0)
+instance (~) ty (ConstantArray 8 (ConstantArray 255 CChar)) =>
+         HasField "listOfNames" (Ptr MyCoolStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"listOfNames")
+instance HasCField MyCoolStruct "listOfNames"
+    where type CFieldType MyCoolStruct "listOfNames" = ConstantArray 8
+                                                                     (ConstantArray 255 CChar)
+          offset# = \_ -> \_ -> 0
 {-| Auxiliary type used by 'Foo'
 
     __C declaration:__ @foo@
@@ -608,15 +608,15 @@ instance ToFunPtr Foo_Aux
     where toFunPtr = hs_bindgen_b5a7b5e83ffee6b4
 instance FromFunPtr Foo_Aux
     where fromFunPtr = hs_bindgen_223d08172bb37c01
+instance (~) ty (CInt -> IO CInt) => HasField "unwrap" Foo_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Foo_Aux{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrap" (Ptr Foo_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Foo_Aux "unwrap"
     where type CFieldType Foo_Aux "unwrap" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) => HasField "unwrap" Foo_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Foo_Aux{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @foo@
 
     __defined at:__ @comprehensive\/c2hsc.h 20:15@
@@ -631,15 +631,15 @@ newtype Foo
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr Foo_Aux) => HasField "unwrap" Foo ty
+    where hasField = \x_0 -> (\y_1 -> Foo{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (FunPtr Foo_Aux) =>
          HasField "unwrap" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Foo "unwrap"
     where type CFieldType Foo "unwrap" = FunPtr Foo_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Foo_Aux) => HasField "unwrap" Foo ty
-    where hasField = \x_0 -> (\y_1 -> Foo{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct foo_t@
 
     __defined at:__ @comprehensive\/c2hsc.h 31:8@
@@ -664,16 +664,16 @@ instance WriteRaw Foo_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Foo_t foo_member_2 -> writeRaw (Proxy @"foo_member") ptr_0 foo_member_2
 deriving via (EquivStorable Foo_t) instance Storable Foo_t
-instance HasCField Foo_t "foo_member"
-    where type CFieldType Foo_t "foo_member" = FunPtr (CInt -> IO CInt)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (CInt -> IO CInt)) =>
-         HasField "foo_member" (Ptr Foo_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_member")
 instance (~) ty (FunPtr (CInt -> IO CInt)) =>
          HasField "foo_member" Foo_t ty
     where hasField = \x_0 -> (\y_1 -> Foo_t{foo_member = y_1},
                               getField @"foo_member" x_0)
+instance (~) ty (FunPtr (CInt -> IO CInt)) =>
+         HasField "foo_member" (Ptr Foo_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_member")
+instance HasCField Foo_t "foo_member"
+    where type CFieldType Foo_t "foo_member" = FunPtr (CInt -> IO CInt)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct Foo_10_@
 
     __defined at:__ @comprehensive\/c2hsc.h 44:16@
@@ -720,14 +720,14 @@ instance Read Bar_10
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrap" Bar_10 ty
+    where hasField = \x_0 -> (\y_1 -> Bar_10{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr Bar_10) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bar_10 "unwrap"
     where type CFieldType Bar_10 "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" Bar_10 ty
-    where hasField = \x_0 -> (\y_1 -> Bar_10{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @BAR@
 
     __defined at:__ @comprehensive\/c2hsc.h 45:24@
@@ -760,13 +760,13 @@ instance WriteRaw St
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        St i_2 -> writeRaw (Proxy @"i") ptr_0 i_2
 deriving via (EquivStorable St) instance Storable St
+instance (~) ty CInt => HasField "i" St ty
+    where hasField = \x_0 -> (\y_1 -> St{i = y_1}, getField @"i" x_0)
+instance (~) ty CInt => HasField "i" (Ptr St) (Ptr ty)
+    where getField = fromPtr (Proxy @"i")
 instance HasCField St "i"
     where type CFieldType St "i" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "i" (Ptr St) (Ptr ty)
-    where getField = fromPtr (Proxy @"i")
-instance (~) ty CInt => HasField "i" St ty
-    where hasField = \x_0 -> (\y_1 -> St{i = y_1}, getField @"i" x_0)
 {-| __C declaration:__ @enum e@
 
     __defined at:__ @comprehensive\/c2hsc.h 52:6@
@@ -806,14 +806,14 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrap" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField E "unwrap"
     where type CFieldType E "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @CONST@
 
     __defined at:__ @comprehensive\/c2hsc.h 53:3@
@@ -867,11 +867,11 @@ set_u_c :: CChar -> U
 
 -}
 set_u_c = setUnionPayload
+instance (~) ty CChar => HasField "c" (Ptr U) (Ptr ty)
+    where getField = fromPtr (Proxy @"c")
 instance HasCField U "c"
     where type CFieldType U "c" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "c" (Ptr U) (Ptr ty)
-    where getField = fromPtr (Proxy @"c")
 {-| __C declaration:__ @struct MyTypeImpl@
 
     __defined at:__ @comprehensive\/c2hsc.h 61:8@
@@ -893,15 +893,15 @@ newtype MyType
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr MyTypeImpl) => HasField "unwrap" MyType ty
+    where hasField = \x_0 -> (\y_1 -> MyType{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (Ptr MyTypeImpl) =>
          HasField "unwrap" (Ptr MyType) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField MyType "unwrap"
     where type CFieldType MyType "unwrap" = Ptr MyTypeImpl
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr MyTypeImpl) => HasField "unwrap" MyType ty
-    where hasField = \x_0 -> (\y_1 -> MyType{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct MyStruct@
 
     __defined at:__ @comprehensive\/c2hsc.h 64:16@
@@ -926,14 +926,14 @@ instance WriteRaw MyStructType
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        MyStructType x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
 deriving via (EquivStorable MyStructType) instance Storable MyStructType
-instance HasCField MyStructType "x"
-    where type CFieldType MyStructType "x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x" (Ptr MyStructType) (Ptr ty)
-    where getField = fromPtr (Proxy @"x")
 instance (~) ty CInt => HasField "x" MyStructType ty
     where hasField = \x_0 -> (\y_1 -> MyStructType{x = y_1},
                               getField @"x" x_0)
+instance (~) ty CInt => HasField "x" (Ptr MyStructType) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField MyStructType "x"
+    where type CFieldType MyStructType "x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct MyStructEmpty@
 
     __defined at:__ @comprehensive\/c2hsc.h 68:16@
@@ -967,19 +967,19 @@ instance WriteRaw Ordinary_float_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_float_struct ordinary_float_member_2 -> writeRaw (Proxy @"ordinary_float_member") ptr_0 ordinary_float_member_2
 deriving via (EquivStorable Ordinary_float_struct) instance Storable Ordinary_float_struct
-instance HasCField Ordinary_float_struct "ordinary_float_member"
-    where type CFieldType Ordinary_float_struct
-                          "ordinary_float_member" = CFloat
-          offset# = \_ -> \_ -> 0
+instance (~) ty CFloat =>
+         HasField "ordinary_float_member" Ordinary_float_struct ty
+    where hasField = \x_0 -> (\y_1 -> Ordinary_float_struct{ordinary_float_member = y_1},
+                              getField @"ordinary_float_member" x_0)
 instance (~) ty CFloat =>
          HasField "ordinary_float_member"
                   (Ptr Ordinary_float_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"ordinary_float_member")
-instance (~) ty CFloat =>
-         HasField "ordinary_float_member" Ordinary_float_struct ty
-    where hasField = \x_0 -> (\y_1 -> Ordinary_float_struct{ordinary_float_member = y_1},
-                              getField @"ordinary_float_member" x_0)
+instance HasCField Ordinary_float_struct "ordinary_float_member"
+    where type CFieldType Ordinary_float_struct
+                          "ordinary_float_member" = CFloat
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_double_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 205:8@
@@ -1004,19 +1004,19 @@ instance WriteRaw Ordinary_double_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_double_struct ordinary_double_member_2 -> writeRaw (Proxy @"ordinary_double_member") ptr_0 ordinary_double_member_2
 deriving via (EquivStorable Ordinary_double_struct) instance Storable Ordinary_double_struct
-instance HasCField Ordinary_double_struct "ordinary_double_member"
-    where type CFieldType Ordinary_double_struct
-                          "ordinary_double_member" = CDouble
-          offset# = \_ -> \_ -> 0
+instance (~) ty CDouble =>
+         HasField "ordinary_double_member" Ordinary_double_struct ty
+    where hasField = \x_0 -> (\y_1 -> Ordinary_double_struct{ordinary_double_member = y_1},
+                              getField @"ordinary_double_member" x_0)
 instance (~) ty CDouble =>
          HasField "ordinary_double_member"
                   (Ptr Ordinary_double_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"ordinary_double_member")
-instance (~) ty CDouble =>
-         HasField "ordinary_double_member" Ordinary_double_struct ty
-    where hasField = \x_0 -> (\y_1 -> Ordinary_double_struct{ordinary_double_member = y_1},
-                              getField @"ordinary_double_member" x_0)
+instance HasCField Ordinary_double_struct "ordinary_double_member"
+    where type CFieldType Ordinary_double_struct
+                          "ordinary_double_member" = CDouble
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_char_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 208:8@
@@ -1041,22 +1041,22 @@ instance WriteRaw Ordinary_signed_char_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_char_struct ordinary_signed_char_member_2 -> writeRaw (Proxy @"ordinary_signed_char_member") ptr_0 ordinary_signed_char_member_2
 deriving via (EquivStorable Ordinary_signed_char_struct) instance Storable Ordinary_signed_char_struct
-instance HasCField Ordinary_signed_char_struct
-                   "ordinary_signed_char_member"
-    where type CFieldType Ordinary_signed_char_struct
-                          "ordinary_signed_char_member" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "ordinary_signed_char_member"
-                  (Ptr Ordinary_signed_char_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_char_member")
 instance (~) ty CChar =>
          HasField "ordinary_signed_char_member"
                   Ordinary_signed_char_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_char_struct{ordinary_signed_char_member = y_1},
                               getField @"ordinary_signed_char_member" x_0)
+instance (~) ty CChar =>
+         HasField "ordinary_signed_char_member"
+                  (Ptr Ordinary_signed_char_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_char_member")
+instance HasCField Ordinary_signed_char_struct
+                   "ordinary_signed_char_member"
+    where type CFieldType Ordinary_signed_char_struct
+                          "ordinary_signed_char_member" = CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_char_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 209:8@
@@ -1081,22 +1081,22 @@ instance WriteRaw Explicit_signed_char_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_char_struct explicit_signed_char_member_2 -> writeRaw (Proxy @"explicit_signed_char_member") ptr_0 explicit_signed_char_member_2
 deriving via (EquivStorable Explicit_signed_char_struct) instance Storable Explicit_signed_char_struct
-instance HasCField Explicit_signed_char_struct
-                   "explicit_signed_char_member"
-    where type CFieldType Explicit_signed_char_struct
-                          "explicit_signed_char_member" = CSChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CSChar =>
-         HasField "explicit_signed_char_member"
-                  (Ptr Explicit_signed_char_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_char_member")
 instance (~) ty CSChar =>
          HasField "explicit_signed_char_member"
                   Explicit_signed_char_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_char_struct{explicit_signed_char_member = y_1},
                               getField @"explicit_signed_char_member" x_0)
+instance (~) ty CSChar =>
+         HasField "explicit_signed_char_member"
+                  (Ptr Explicit_signed_char_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_char_member")
+instance HasCField Explicit_signed_char_struct
+                   "explicit_signed_char_member"
+    where type CFieldType Explicit_signed_char_struct
+                          "explicit_signed_char_member" = CSChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_char_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 210:8@
@@ -1121,17 +1121,17 @@ instance WriteRaw Unsigned_char_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_char_struct unsigned_char_member_2 -> writeRaw (Proxy @"unsigned_char_member") ptr_0 unsigned_char_member_2
 deriving via (EquivStorable Unsigned_char_struct) instance Storable Unsigned_char_struct
-instance HasCField Unsigned_char_struct "unsigned_char_member"
-    where type CFieldType Unsigned_char_struct
-                          "unsigned_char_member" = CUChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CUChar =>
-         HasField "unsigned_char_member" (Ptr Unsigned_char_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_char_member")
 instance (~) ty CUChar =>
          HasField "unsigned_char_member" Unsigned_char_struct ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_char_struct{unsigned_char_member = y_1},
                               getField @"unsigned_char_member" x_0)
+instance (~) ty CUChar =>
+         HasField "unsigned_char_member" (Ptr Unsigned_char_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_char_member")
+instance HasCField Unsigned_char_struct "unsigned_char_member"
+    where type CFieldType Unsigned_char_struct
+                          "unsigned_char_member" = CUChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_short_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 212:8@
@@ -1156,22 +1156,22 @@ instance WriteRaw Ordinary_signed_short_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_short_struct ordinary_signed_short_member_2 -> writeRaw (Proxy @"ordinary_signed_short_member") ptr_0 ordinary_signed_short_member_2
 deriving via (EquivStorable Ordinary_signed_short_struct) instance Storable Ordinary_signed_short_struct
-instance HasCField Ordinary_signed_short_struct
-                   "ordinary_signed_short_member"
-    where type CFieldType Ordinary_signed_short_struct
-                          "ordinary_signed_short_member" = CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "ordinary_signed_short_member"
-                  (Ptr Ordinary_signed_short_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_short_member")
 instance (~) ty CShort =>
          HasField "ordinary_signed_short_member"
                   Ordinary_signed_short_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_short_struct{ordinary_signed_short_member = y_1},
                               getField @"ordinary_signed_short_member" x_0)
+instance (~) ty CShort =>
+         HasField "ordinary_signed_short_member"
+                  (Ptr Ordinary_signed_short_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_short_member")
+instance HasCField Ordinary_signed_short_struct
+                   "ordinary_signed_short_member"
+    where type CFieldType Ordinary_signed_short_struct
+                          "ordinary_signed_short_member" = CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_short_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 213:8@
@@ -1196,22 +1196,22 @@ instance WriteRaw Explicit_signed_short_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_short_struct explicit_signed_short_member_2 -> writeRaw (Proxy @"explicit_signed_short_member") ptr_0 explicit_signed_short_member_2
 deriving via (EquivStorable Explicit_signed_short_struct) instance Storable Explicit_signed_short_struct
-instance HasCField Explicit_signed_short_struct
-                   "explicit_signed_short_member"
-    where type CFieldType Explicit_signed_short_struct
-                          "explicit_signed_short_member" = CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "explicit_signed_short_member"
-                  (Ptr Explicit_signed_short_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_short_member")
 instance (~) ty CShort =>
          HasField "explicit_signed_short_member"
                   Explicit_signed_short_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_short_struct{explicit_signed_short_member = y_1},
                               getField @"explicit_signed_short_member" x_0)
+instance (~) ty CShort =>
+         HasField "explicit_signed_short_member"
+                  (Ptr Explicit_signed_short_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_short_member")
+instance HasCField Explicit_signed_short_struct
+                   "explicit_signed_short_member"
+    where type CFieldType Explicit_signed_short_struct
+                          "explicit_signed_short_member" = CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_short_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 214:8@
@@ -1236,19 +1236,19 @@ instance WriteRaw Unsigned_short_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_short_struct unsigned_short_member_2 -> writeRaw (Proxy @"unsigned_short_member") ptr_0 unsigned_short_member_2
 deriving via (EquivStorable Unsigned_short_struct) instance Storable Unsigned_short_struct
-instance HasCField Unsigned_short_struct "unsigned_short_member"
-    where type CFieldType Unsigned_short_struct
-                          "unsigned_short_member" = CUShort
-          offset# = \_ -> \_ -> 0
+instance (~) ty CUShort =>
+         HasField "unsigned_short_member" Unsigned_short_struct ty
+    where hasField = \x_0 -> (\y_1 -> Unsigned_short_struct{unsigned_short_member = y_1},
+                              getField @"unsigned_short_member" x_0)
 instance (~) ty CUShort =>
          HasField "unsigned_short_member"
                   (Ptr Unsigned_short_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unsigned_short_member")
-instance (~) ty CUShort =>
-         HasField "unsigned_short_member" Unsigned_short_struct ty
-    where hasField = \x_0 -> (\y_1 -> Unsigned_short_struct{unsigned_short_member = y_1},
-                              getField @"unsigned_short_member" x_0)
+instance HasCField Unsigned_short_struct "unsigned_short_member"
+    where type CFieldType Unsigned_short_struct
+                          "unsigned_short_member" = CUShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_int_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 216:8@
@@ -1273,20 +1273,20 @@ instance WriteRaw Ordinary_signed_int_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_int_struct ordinary_signed_int_member_2 -> writeRaw (Proxy @"ordinary_signed_int_member") ptr_0 ordinary_signed_int_member_2
 deriving via (EquivStorable Ordinary_signed_int_struct) instance Storable Ordinary_signed_int_struct
-instance HasCField Ordinary_signed_int_struct
-                   "ordinary_signed_int_member"
-    where type CFieldType Ordinary_signed_int_struct
-                          "ordinary_signed_int_member" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "ordinary_signed_int_member" Ordinary_signed_int_struct ty
+    where hasField = \x_0 -> (\y_1 -> Ordinary_signed_int_struct{ordinary_signed_int_member = y_1},
+                              getField @"ordinary_signed_int_member" x_0)
 instance (~) ty CInt =>
          HasField "ordinary_signed_int_member"
                   (Ptr Ordinary_signed_int_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"ordinary_signed_int_member")
-instance (~) ty CInt =>
-         HasField "ordinary_signed_int_member" Ordinary_signed_int_struct ty
-    where hasField = \x_0 -> (\y_1 -> Ordinary_signed_int_struct{ordinary_signed_int_member = y_1},
-                              getField @"ordinary_signed_int_member" x_0)
+instance HasCField Ordinary_signed_int_struct
+                   "ordinary_signed_int_member"
+    where type CFieldType Ordinary_signed_int_struct
+                          "ordinary_signed_int_member" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_int_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 217:8@
@@ -1311,20 +1311,20 @@ instance WriteRaw Explicit_signed_int_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_int_struct explicit_signed_int_member_2 -> writeRaw (Proxy @"explicit_signed_int_member") ptr_0 explicit_signed_int_member_2
 deriving via (EquivStorable Explicit_signed_int_struct) instance Storable Explicit_signed_int_struct
-instance HasCField Explicit_signed_int_struct
-                   "explicit_signed_int_member"
-    where type CFieldType Explicit_signed_int_struct
-                          "explicit_signed_int_member" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "explicit_signed_int_member" Explicit_signed_int_struct ty
+    where hasField = \x_0 -> (\y_1 -> Explicit_signed_int_struct{explicit_signed_int_member = y_1},
+                              getField @"explicit_signed_int_member" x_0)
 instance (~) ty CInt =>
          HasField "explicit_signed_int_member"
                   (Ptr Explicit_signed_int_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"explicit_signed_int_member")
-instance (~) ty CInt =>
-         HasField "explicit_signed_int_member" Explicit_signed_int_struct ty
-    where hasField = \x_0 -> (\y_1 -> Explicit_signed_int_struct{explicit_signed_int_member = y_1},
-                              getField @"explicit_signed_int_member" x_0)
+instance HasCField Explicit_signed_int_struct
+                   "explicit_signed_int_member"
+    where type CFieldType Explicit_signed_int_struct
+                          "explicit_signed_int_member" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_int_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 218:8@
@@ -1349,17 +1349,17 @@ instance WriteRaw Unsigned_int_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_int_struct unsigned_int_member_2 -> writeRaw (Proxy @"unsigned_int_member") ptr_0 unsigned_int_member_2
 deriving via (EquivStorable Unsigned_int_struct) instance Storable Unsigned_int_struct
-instance HasCField Unsigned_int_struct "unsigned_int_member"
-    where type CFieldType Unsigned_int_struct
-                          "unsigned_int_member" = CUInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unsigned_int_member" (Ptr Unsigned_int_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_int_member")
 instance (~) ty CUInt =>
          HasField "unsigned_int_member" Unsigned_int_struct ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_int_struct{unsigned_int_member = y_1},
                               getField @"unsigned_int_member" x_0)
+instance (~) ty CUInt =>
+         HasField "unsigned_int_member" (Ptr Unsigned_int_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_int_member")
+instance HasCField Unsigned_int_struct "unsigned_int_member"
+    where type CFieldType Unsigned_int_struct
+                          "unsigned_int_member" = CUInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 220:8@
@@ -1384,22 +1384,22 @@ instance WriteRaw Ordinary_signed_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_struct ordinary_signed_long_member_2 -> writeRaw (Proxy @"ordinary_signed_long_member") ptr_0 ordinary_signed_long_member_2
 deriving via (EquivStorable Ordinary_signed_long_struct) instance Storable Ordinary_signed_long_struct
-instance HasCField Ordinary_signed_long_struct
-                   "ordinary_signed_long_member"
-    where type CFieldType Ordinary_signed_long_struct
-                          "ordinary_signed_long_member" = CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "ordinary_signed_long_member"
-                  (Ptr Ordinary_signed_long_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_member")
 instance (~) ty CLong =>
          HasField "ordinary_signed_long_member"
                   Ordinary_signed_long_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_struct{ordinary_signed_long_member = y_1},
                               getField @"ordinary_signed_long_member" x_0)
+instance (~) ty CLong =>
+         HasField "ordinary_signed_long_member"
+                  (Ptr Ordinary_signed_long_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_member")
+instance HasCField Ordinary_signed_long_struct
+                   "ordinary_signed_long_member"
+    where type CFieldType Ordinary_signed_long_struct
+                          "ordinary_signed_long_member" = CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 221:8@
@@ -1424,22 +1424,22 @@ instance WriteRaw Explicit_signed_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_struct explicit_signed_long_member_2 -> writeRaw (Proxy @"explicit_signed_long_member") ptr_0 explicit_signed_long_member_2
 deriving via (EquivStorable Explicit_signed_long_struct) instance Storable Explicit_signed_long_struct
-instance HasCField Explicit_signed_long_struct
-                   "explicit_signed_long_member"
-    where type CFieldType Explicit_signed_long_struct
-                          "explicit_signed_long_member" = CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "explicit_signed_long_member"
-                  (Ptr Explicit_signed_long_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_member")
 instance (~) ty CLong =>
          HasField "explicit_signed_long_member"
                   Explicit_signed_long_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_struct{explicit_signed_long_member = y_1},
                               getField @"explicit_signed_long_member" x_0)
+instance (~) ty CLong =>
+         HasField "explicit_signed_long_member"
+                  (Ptr Explicit_signed_long_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_member")
+instance HasCField Explicit_signed_long_struct
+                   "explicit_signed_long_member"
+    where type CFieldType Explicit_signed_long_struct
+                          "explicit_signed_long_member" = CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 222:8@
@@ -1464,17 +1464,17 @@ instance WriteRaw Unsigned_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_struct unsigned_long_member_2 -> writeRaw (Proxy @"unsigned_long_member") ptr_0 unsigned_long_member_2
 deriving via (EquivStorable Unsigned_long_struct) instance Storable Unsigned_long_struct
-instance HasCField Unsigned_long_struct "unsigned_long_member"
-    where type CFieldType Unsigned_long_struct
-                          "unsigned_long_member" = CULong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CULong =>
-         HasField "unsigned_long_member" (Ptr Unsigned_long_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_member")
 instance (~) ty CULong =>
          HasField "unsigned_long_member" Unsigned_long_struct ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_struct{unsigned_long_member = y_1},
                               getField @"unsigned_long_member" x_0)
+instance (~) ty CULong =>
+         HasField "unsigned_long_member" (Ptr Unsigned_long_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_member")
+instance HasCField Unsigned_long_struct "unsigned_long_member"
+    where type CFieldType Unsigned_long_struct
+                          "unsigned_long_member" = CULong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 224:8@
@@ -1499,22 +1499,22 @@ instance WriteRaw Ordinary_signed_long_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_long_struct ordinary_signed_long_long_member_2 -> writeRaw (Proxy @"ordinary_signed_long_long_member") ptr_0 ordinary_signed_long_long_member_2
 deriving via (EquivStorable Ordinary_signed_long_long_struct) instance Storable Ordinary_signed_long_long_struct
-instance HasCField Ordinary_signed_long_long_struct
-                   "ordinary_signed_long_long_member"
-    where type CFieldType Ordinary_signed_long_long_struct
-                          "ordinary_signed_long_long_member" = CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CLLong =>
-         HasField "ordinary_signed_long_long_member"
-                  (Ptr Ordinary_signed_long_long_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_long_member")
 instance (~) ty CLLong =>
          HasField "ordinary_signed_long_long_member"
                   Ordinary_signed_long_long_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_long_struct{ordinary_signed_long_long_member = y_1},
                               getField @"ordinary_signed_long_long_member" x_0)
+instance (~) ty CLLong =>
+         HasField "ordinary_signed_long_long_member"
+                  (Ptr Ordinary_signed_long_long_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_long_member")
+instance HasCField Ordinary_signed_long_long_struct
+                   "ordinary_signed_long_long_member"
+    where type CFieldType Ordinary_signed_long_long_struct
+                          "ordinary_signed_long_long_member" = CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 225:8@
@@ -1539,22 +1539,22 @@ instance WriteRaw Explicit_signed_long_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_long_struct explicit_signed_long_long_member_2 -> writeRaw (Proxy @"explicit_signed_long_long_member") ptr_0 explicit_signed_long_long_member_2
 deriving via (EquivStorable Explicit_signed_long_long_struct) instance Storable Explicit_signed_long_long_struct
-instance HasCField Explicit_signed_long_long_struct
-                   "explicit_signed_long_long_member"
-    where type CFieldType Explicit_signed_long_long_struct
-                          "explicit_signed_long_long_member" = CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CLLong =>
-         HasField "explicit_signed_long_long_member"
-                  (Ptr Explicit_signed_long_long_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_long_member")
 instance (~) ty CLLong =>
          HasField "explicit_signed_long_long_member"
                   Explicit_signed_long_long_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_long_struct{explicit_signed_long_long_member = y_1},
                               getField @"explicit_signed_long_long_member" x_0)
+instance (~) ty CLLong =>
+         HasField "explicit_signed_long_long_member"
+                  (Ptr Explicit_signed_long_long_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_long_member")
+instance HasCField Explicit_signed_long_long_struct
+                   "explicit_signed_long_long_member"
+    where type CFieldType Explicit_signed_long_long_struct
+                          "explicit_signed_long_long_member" = CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_long_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 226:8@
@@ -1579,20 +1579,20 @@ instance WriteRaw Unsigned_long_long_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_long_struct unsigned_long_long_member_2 -> writeRaw (Proxy @"unsigned_long_long_member") ptr_0 unsigned_long_long_member_2
 deriving via (EquivStorable Unsigned_long_long_struct) instance Storable Unsigned_long_long_struct
-instance HasCField Unsigned_long_long_struct
-                   "unsigned_long_long_member"
-    where type CFieldType Unsigned_long_long_struct
-                          "unsigned_long_long_member" = CULLong
-          offset# = \_ -> \_ -> 0
+instance (~) ty CULLong =>
+         HasField "unsigned_long_long_member" Unsigned_long_long_struct ty
+    where hasField = \x_0 -> (\y_1 -> Unsigned_long_long_struct{unsigned_long_long_member = y_1},
+                              getField @"unsigned_long_long_member" x_0)
 instance (~) ty CULLong =>
          HasField "unsigned_long_long_member"
                   (Ptr Unsigned_long_long_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unsigned_long_long_member")
-instance (~) ty CULLong =>
-         HasField "unsigned_long_long_member" Unsigned_long_long_struct ty
-    where hasField = \x_0 -> (\y_1 -> Unsigned_long_long_struct{unsigned_long_long_member = y_1},
-                              getField @"unsigned_long_long_member" x_0)
+instance HasCField Unsigned_long_long_struct
+                   "unsigned_long_long_member"
+    where type CFieldType Unsigned_long_long_struct
+                          "unsigned_long_long_member" = CULLong
+          offset# = \_ -> \_ -> 0
 {-| Structs: pointers
 
     NOTE: @'Ordinary_signed_char_pointer_struct'@ is commented out in the original test suite, unclear why (no reason is given).
@@ -1621,22 +1621,22 @@ instance WriteRaw Ordinary_void_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_void_pointer_struct ordinary_void_pointer_member_2 -> writeRaw (Proxy @"ordinary_void_pointer_member") ptr_0 ordinary_void_pointer_member_2
 deriving via (EquivStorable Ordinary_void_pointer_struct) instance Storable Ordinary_void_pointer_struct
-instance HasCField Ordinary_void_pointer_struct
-                   "ordinary_void_pointer_member"
-    where type CFieldType Ordinary_void_pointer_struct
-                          "ordinary_void_pointer_member" = Ptr Void
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Void) =>
-         HasField "ordinary_void_pointer_member"
-                  (Ptr Ordinary_void_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_void_pointer_member")
 instance (~) ty (Ptr Void) =>
          HasField "ordinary_void_pointer_member"
                   Ordinary_void_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_void_pointer_struct{ordinary_void_pointer_member = y_1},
                               getField @"ordinary_void_pointer_member" x_0)
+instance (~) ty (Ptr Void) =>
+         HasField "ordinary_void_pointer_member"
+                  (Ptr Ordinary_void_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_void_pointer_member")
+instance HasCField Ordinary_void_pointer_struct
+                   "ordinary_void_pointer_member"
+    where type CFieldType Ordinary_void_pointer_struct
+                          "ordinary_void_pointer_member" = Ptr Void
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_float_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 237:8@
@@ -1661,22 +1661,22 @@ instance WriteRaw Ordinary_float_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_float_pointer_struct ordinary_float_pointer_member_2 -> writeRaw (Proxy @"ordinary_float_pointer_member") ptr_0 ordinary_float_pointer_member_2
 deriving via (EquivStorable Ordinary_float_pointer_struct) instance Storable Ordinary_float_pointer_struct
-instance HasCField Ordinary_float_pointer_struct
-                   "ordinary_float_pointer_member"
-    where type CFieldType Ordinary_float_pointer_struct
-                          "ordinary_float_pointer_member" = Ptr CFloat
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CFloat) =>
-         HasField "ordinary_float_pointer_member"
-                  (Ptr Ordinary_float_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_float_pointer_member")
 instance (~) ty (Ptr CFloat) =>
          HasField "ordinary_float_pointer_member"
                   Ordinary_float_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_float_pointer_struct{ordinary_float_pointer_member = y_1},
                               getField @"ordinary_float_pointer_member" x_0)
+instance (~) ty (Ptr CFloat) =>
+         HasField "ordinary_float_pointer_member"
+                  (Ptr Ordinary_float_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_float_pointer_member")
+instance HasCField Ordinary_float_pointer_struct
+                   "ordinary_float_pointer_member"
+    where type CFieldType Ordinary_float_pointer_struct
+                          "ordinary_float_pointer_member" = Ptr CFloat
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_double_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 238:8@
@@ -1701,22 +1701,22 @@ instance WriteRaw Ordinary_double_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_double_pointer_struct ordinary_double_pointer_member_2 -> writeRaw (Proxy @"ordinary_double_pointer_member") ptr_0 ordinary_double_pointer_member_2
 deriving via (EquivStorable Ordinary_double_pointer_struct) instance Storable Ordinary_double_pointer_struct
-instance HasCField Ordinary_double_pointer_struct
-                   "ordinary_double_pointer_member"
-    where type CFieldType Ordinary_double_pointer_struct
-                          "ordinary_double_pointer_member" = Ptr CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CDouble) =>
-         HasField "ordinary_double_pointer_member"
-                  (Ptr Ordinary_double_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_double_pointer_member")
 instance (~) ty (Ptr CDouble) =>
          HasField "ordinary_double_pointer_member"
                   Ordinary_double_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_double_pointer_struct{ordinary_double_pointer_member = y_1},
                               getField @"ordinary_double_pointer_member" x_0)
+instance (~) ty (Ptr CDouble) =>
+         HasField "ordinary_double_pointer_member"
+                  (Ptr Ordinary_double_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_double_pointer_member")
+instance HasCField Ordinary_double_pointer_struct
+                   "ordinary_double_pointer_member"
+    where type CFieldType Ordinary_double_pointer_struct
+                          "ordinary_double_pointer_member" = Ptr CDouble
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 241:8@
@@ -1741,22 +1741,22 @@ instance WriteRaw Ordinary_signed_char_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_char_pointer_struct ordinary_signed_char_pointer_member_2 -> writeRaw (Proxy @"ordinary_signed_char_pointer_member") ptr_0 ordinary_signed_char_pointer_member_2
 deriving via (EquivStorable Ordinary_signed_char_pointer_struct) instance Storable Ordinary_signed_char_pointer_struct
-instance HasCField Ordinary_signed_char_pointer_struct
-                   "ordinary_signed_char_pointer_member"
-    where type CFieldType Ordinary_signed_char_pointer_struct
-                          "ordinary_signed_char_pointer_member" = Ptr CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CChar) =>
-         HasField "ordinary_signed_char_pointer_member"
-                  (Ptr Ordinary_signed_char_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_member")
 instance (~) ty (Ptr CChar) =>
          HasField "ordinary_signed_char_pointer_member"
                   Ordinary_signed_char_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_char_pointer_struct{ordinary_signed_char_pointer_member = y_1},
                               getField @"ordinary_signed_char_pointer_member" x_0)
+instance (~) ty (Ptr CChar) =>
+         HasField "ordinary_signed_char_pointer_member"
+                  (Ptr Ordinary_signed_char_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_member")
+instance HasCField Ordinary_signed_char_pointer_struct
+                   "ordinary_signed_char_pointer_member"
+    where type CFieldType Ordinary_signed_char_pointer_struct
+                          "ordinary_signed_char_pointer_member" = Ptr CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_char_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 242:8@
@@ -1781,22 +1781,22 @@ instance WriteRaw Explicit_signed_char_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_char_pointer_struct explicit_signed_char_pointer_member_2 -> writeRaw (Proxy @"explicit_signed_char_pointer_member") ptr_0 explicit_signed_char_pointer_member_2
 deriving via (EquivStorable Explicit_signed_char_pointer_struct) instance Storable Explicit_signed_char_pointer_struct
-instance HasCField Explicit_signed_char_pointer_struct
-                   "explicit_signed_char_pointer_member"
-    where type CFieldType Explicit_signed_char_pointer_struct
-                          "explicit_signed_char_pointer_member" = Ptr CSChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CSChar) =>
-         HasField "explicit_signed_char_pointer_member"
-                  (Ptr Explicit_signed_char_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_char_pointer_member")
 instance (~) ty (Ptr CSChar) =>
          HasField "explicit_signed_char_pointer_member"
                   Explicit_signed_char_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_char_pointer_struct{explicit_signed_char_pointer_member = y_1},
                               getField @"explicit_signed_char_pointer_member" x_0)
+instance (~) ty (Ptr CSChar) =>
+         HasField "explicit_signed_char_pointer_member"
+                  (Ptr Explicit_signed_char_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_char_pointer_member")
+instance HasCField Explicit_signed_char_pointer_struct
+                   "explicit_signed_char_pointer_member"
+    where type CFieldType Explicit_signed_char_pointer_struct
+                          "explicit_signed_char_pointer_member" = Ptr CSChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_char_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 243:8@
@@ -1821,22 +1821,22 @@ instance WriteRaw Unsigned_char_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_char_pointer_struct unsigned_char_pointer_member_2 -> writeRaw (Proxy @"unsigned_char_pointer_member") ptr_0 unsigned_char_pointer_member_2
 deriving via (EquivStorable Unsigned_char_pointer_struct) instance Storable Unsigned_char_pointer_struct
-instance HasCField Unsigned_char_pointer_struct
-                   "unsigned_char_pointer_member"
-    where type CFieldType Unsigned_char_pointer_struct
-                          "unsigned_char_pointer_member" = Ptr CUChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUChar) =>
-         HasField "unsigned_char_pointer_member"
-                  (Ptr Unsigned_char_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_char_pointer_member")
 instance (~) ty (Ptr CUChar) =>
          HasField "unsigned_char_pointer_member"
                   Unsigned_char_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_char_pointer_struct{unsigned_char_pointer_member = y_1},
                               getField @"unsigned_char_pointer_member" x_0)
+instance (~) ty (Ptr CUChar) =>
+         HasField "unsigned_char_pointer_member"
+                  (Ptr Unsigned_char_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_char_pointer_member")
+instance HasCField Unsigned_char_pointer_struct
+                   "unsigned_char_pointer_member"
+    where type CFieldType Unsigned_char_pointer_struct
+                          "unsigned_char_pointer_member" = Ptr CUChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 245:8@
@@ -1861,22 +1861,22 @@ instance WriteRaw Ordinary_signed_short_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_short_pointer_struct ordinary_signed_short_pointer_member_2 -> writeRaw (Proxy @"ordinary_signed_short_pointer_member") ptr_0 ordinary_signed_short_pointer_member_2
 deriving via (EquivStorable Ordinary_signed_short_pointer_struct) instance Storable Ordinary_signed_short_pointer_struct
-instance HasCField Ordinary_signed_short_pointer_struct
-                   "ordinary_signed_short_pointer_member"
-    where type CFieldType Ordinary_signed_short_pointer_struct
-                          "ordinary_signed_short_pointer_member" = Ptr CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CShort) =>
-         HasField "ordinary_signed_short_pointer_member"
-                  (Ptr Ordinary_signed_short_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_member")
 instance (~) ty (Ptr CShort) =>
          HasField "ordinary_signed_short_pointer_member"
                   Ordinary_signed_short_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_short_pointer_struct{ordinary_signed_short_pointer_member = y_1},
                               getField @"ordinary_signed_short_pointer_member" x_0)
+instance (~) ty (Ptr CShort) =>
+         HasField "ordinary_signed_short_pointer_member"
+                  (Ptr Ordinary_signed_short_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_member")
+instance HasCField Ordinary_signed_short_pointer_struct
+                   "ordinary_signed_short_pointer_member"
+    where type CFieldType Ordinary_signed_short_pointer_struct
+                          "ordinary_signed_short_pointer_member" = Ptr CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_short_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 246:8@
@@ -1901,22 +1901,22 @@ instance WriteRaw Explicit_signed_short_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_short_pointer_struct explicit_signed_short_pointer_member_2 -> writeRaw (Proxy @"explicit_signed_short_pointer_member") ptr_0 explicit_signed_short_pointer_member_2
 deriving via (EquivStorable Explicit_signed_short_pointer_struct) instance Storable Explicit_signed_short_pointer_struct
-instance HasCField Explicit_signed_short_pointer_struct
-                   "explicit_signed_short_pointer_member"
-    where type CFieldType Explicit_signed_short_pointer_struct
-                          "explicit_signed_short_pointer_member" = Ptr CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CShort) =>
-         HasField "explicit_signed_short_pointer_member"
-                  (Ptr Explicit_signed_short_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_short_pointer_member")
 instance (~) ty (Ptr CShort) =>
          HasField "explicit_signed_short_pointer_member"
                   Explicit_signed_short_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_short_pointer_struct{explicit_signed_short_pointer_member = y_1},
                               getField @"explicit_signed_short_pointer_member" x_0)
+instance (~) ty (Ptr CShort) =>
+         HasField "explicit_signed_short_pointer_member"
+                  (Ptr Explicit_signed_short_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_short_pointer_member")
+instance HasCField Explicit_signed_short_pointer_struct
+                   "explicit_signed_short_pointer_member"
+    where type CFieldType Explicit_signed_short_pointer_struct
+                          "explicit_signed_short_pointer_member" = Ptr CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_short_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 247:8@
@@ -1941,22 +1941,22 @@ instance WriteRaw Unsigned_short_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_short_pointer_struct unsigned_short_pointer_member_2 -> writeRaw (Proxy @"unsigned_short_pointer_member") ptr_0 unsigned_short_pointer_member_2
 deriving via (EquivStorable Unsigned_short_pointer_struct) instance Storable Unsigned_short_pointer_struct
-instance HasCField Unsigned_short_pointer_struct
-                   "unsigned_short_pointer_member"
-    where type CFieldType Unsigned_short_pointer_struct
-                          "unsigned_short_pointer_member" = Ptr CUShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUShort) =>
-         HasField "unsigned_short_pointer_member"
-                  (Ptr Unsigned_short_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_short_pointer_member")
 instance (~) ty (Ptr CUShort) =>
          HasField "unsigned_short_pointer_member"
                   Unsigned_short_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_short_pointer_struct{unsigned_short_pointer_member = y_1},
                               getField @"unsigned_short_pointer_member" x_0)
+instance (~) ty (Ptr CUShort) =>
+         HasField "unsigned_short_pointer_member"
+                  (Ptr Unsigned_short_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_short_pointer_member")
+instance HasCField Unsigned_short_pointer_struct
+                   "unsigned_short_pointer_member"
+    where type CFieldType Unsigned_short_pointer_struct
+                          "unsigned_short_pointer_member" = Ptr CUShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 249:8@
@@ -1981,22 +1981,22 @@ instance WriteRaw Ordinary_signed_int_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_int_pointer_struct ordinary_signed_int_pointer_member_2 -> writeRaw (Proxy @"ordinary_signed_int_pointer_member") ptr_0 ordinary_signed_int_pointer_member_2
 deriving via (EquivStorable Ordinary_signed_int_pointer_struct) instance Storable Ordinary_signed_int_pointer_struct
-instance HasCField Ordinary_signed_int_pointer_struct
-                   "ordinary_signed_int_pointer_member"
-    where type CFieldType Ordinary_signed_int_pointer_struct
-                          "ordinary_signed_int_pointer_member" = Ptr CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "ordinary_signed_int_pointer_member"
-                  (Ptr Ordinary_signed_int_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_member")
 instance (~) ty (Ptr CInt) =>
          HasField "ordinary_signed_int_pointer_member"
                   Ordinary_signed_int_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_int_pointer_struct{ordinary_signed_int_pointer_member = y_1},
                               getField @"ordinary_signed_int_pointer_member" x_0)
+instance (~) ty (Ptr CInt) =>
+         HasField "ordinary_signed_int_pointer_member"
+                  (Ptr Ordinary_signed_int_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_member")
+instance HasCField Ordinary_signed_int_pointer_struct
+                   "ordinary_signed_int_pointer_member"
+    where type CFieldType Ordinary_signed_int_pointer_struct
+                          "ordinary_signed_int_pointer_member" = Ptr CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_int_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 250:8@
@@ -2021,22 +2021,22 @@ instance WriteRaw Explicit_signed_int_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_int_pointer_struct explicit_signed_int_pointer_member_2 -> writeRaw (Proxy @"explicit_signed_int_pointer_member") ptr_0 explicit_signed_int_pointer_member_2
 deriving via (EquivStorable Explicit_signed_int_pointer_struct) instance Storable Explicit_signed_int_pointer_struct
-instance HasCField Explicit_signed_int_pointer_struct
-                   "explicit_signed_int_pointer_member"
-    where type CFieldType Explicit_signed_int_pointer_struct
-                          "explicit_signed_int_pointer_member" = Ptr CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "explicit_signed_int_pointer_member"
-                  (Ptr Explicit_signed_int_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_int_pointer_member")
 instance (~) ty (Ptr CInt) =>
          HasField "explicit_signed_int_pointer_member"
                   Explicit_signed_int_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_int_pointer_struct{explicit_signed_int_pointer_member = y_1},
                               getField @"explicit_signed_int_pointer_member" x_0)
+instance (~) ty (Ptr CInt) =>
+         HasField "explicit_signed_int_pointer_member"
+                  (Ptr Explicit_signed_int_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_int_pointer_member")
+instance HasCField Explicit_signed_int_pointer_struct
+                   "explicit_signed_int_pointer_member"
+    where type CFieldType Explicit_signed_int_pointer_struct
+                          "explicit_signed_int_pointer_member" = Ptr CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_int_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 251:8@
@@ -2061,22 +2061,22 @@ instance WriteRaw Unsigned_int_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_int_pointer_struct unsigned_int_pointer_member_2 -> writeRaw (Proxy @"unsigned_int_pointer_member") ptr_0 unsigned_int_pointer_member_2
 deriving via (EquivStorable Unsigned_int_pointer_struct) instance Storable Unsigned_int_pointer_struct
-instance HasCField Unsigned_int_pointer_struct
-                   "unsigned_int_pointer_member"
-    where type CFieldType Unsigned_int_pointer_struct
-                          "unsigned_int_pointer_member" = Ptr CUInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CUInt) =>
-         HasField "unsigned_int_pointer_member"
-                  (Ptr Unsigned_int_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_int_pointer_member")
 instance (~) ty (Ptr CUInt) =>
          HasField "unsigned_int_pointer_member"
                   Unsigned_int_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_int_pointer_struct{unsigned_int_pointer_member = y_1},
                               getField @"unsigned_int_pointer_member" x_0)
+instance (~) ty (Ptr CUInt) =>
+         HasField "unsigned_int_pointer_member"
+                  (Ptr Unsigned_int_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_int_pointer_member")
+instance HasCField Unsigned_int_pointer_struct
+                   "unsigned_int_pointer_member"
+    where type CFieldType Unsigned_int_pointer_struct
+                          "unsigned_int_pointer_member" = Ptr CUInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 253:8@
@@ -2101,22 +2101,22 @@ instance WriteRaw Ordinary_signed_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_pointer_struct ordinary_signed_long_pointer_member_2 -> writeRaw (Proxy @"ordinary_signed_long_pointer_member") ptr_0 ordinary_signed_long_pointer_member_2
 deriving via (EquivStorable Ordinary_signed_long_pointer_struct) instance Storable Ordinary_signed_long_pointer_struct
-instance HasCField Ordinary_signed_long_pointer_struct
-                   "ordinary_signed_long_pointer_member"
-    where type CFieldType Ordinary_signed_long_pointer_struct
-                          "ordinary_signed_long_pointer_member" = Ptr CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLong) =>
-         HasField "ordinary_signed_long_pointer_member"
-                  (Ptr Ordinary_signed_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_member")
 instance (~) ty (Ptr CLong) =>
          HasField "ordinary_signed_long_pointer_member"
                   Ordinary_signed_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_pointer_struct{ordinary_signed_long_pointer_member = y_1},
                               getField @"ordinary_signed_long_pointer_member" x_0)
+instance (~) ty (Ptr CLong) =>
+         HasField "ordinary_signed_long_pointer_member"
+                  (Ptr Ordinary_signed_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_member")
+instance HasCField Ordinary_signed_long_pointer_struct
+                   "ordinary_signed_long_pointer_member"
+    where type CFieldType Ordinary_signed_long_pointer_struct
+                          "ordinary_signed_long_pointer_member" = Ptr CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 254:8@
@@ -2141,22 +2141,22 @@ instance WriteRaw Explicit_signed_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_pointer_struct explicit_signed_long_pointer_member_2 -> writeRaw (Proxy @"explicit_signed_long_pointer_member") ptr_0 explicit_signed_long_pointer_member_2
 deriving via (EquivStorable Explicit_signed_long_pointer_struct) instance Storable Explicit_signed_long_pointer_struct
-instance HasCField Explicit_signed_long_pointer_struct
-                   "explicit_signed_long_pointer_member"
-    where type CFieldType Explicit_signed_long_pointer_struct
-                          "explicit_signed_long_pointer_member" = Ptr CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLong) =>
-         HasField "explicit_signed_long_pointer_member"
-                  (Ptr Explicit_signed_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_pointer_member")
 instance (~) ty (Ptr CLong) =>
          HasField "explicit_signed_long_pointer_member"
                   Explicit_signed_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_pointer_struct{explicit_signed_long_pointer_member = y_1},
                               getField @"explicit_signed_long_pointer_member" x_0)
+instance (~) ty (Ptr CLong) =>
+         HasField "explicit_signed_long_pointer_member"
+                  (Ptr Explicit_signed_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_pointer_member")
+instance HasCField Explicit_signed_long_pointer_struct
+                   "explicit_signed_long_pointer_member"
+    where type CFieldType Explicit_signed_long_pointer_struct
+                          "explicit_signed_long_pointer_member" = Ptr CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 255:8@
@@ -2181,22 +2181,22 @@ instance WriteRaw Unsigned_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_pointer_struct unsigned_long_pointer_member_2 -> writeRaw (Proxy @"unsigned_long_pointer_member") ptr_0 unsigned_long_pointer_member_2
 deriving via (EquivStorable Unsigned_long_pointer_struct) instance Storable Unsigned_long_pointer_struct
-instance HasCField Unsigned_long_pointer_struct
-                   "unsigned_long_pointer_member"
-    where type CFieldType Unsigned_long_pointer_struct
-                          "unsigned_long_pointer_member" = Ptr CULong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CULong) =>
-         HasField "unsigned_long_pointer_member"
-                  (Ptr Unsigned_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_pointer_member")
 instance (~) ty (Ptr CULong) =>
          HasField "unsigned_long_pointer_member"
                   Unsigned_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_pointer_struct{unsigned_long_pointer_member = y_1},
                               getField @"unsigned_long_pointer_member" x_0)
+instance (~) ty (Ptr CULong) =>
+         HasField "unsigned_long_pointer_member"
+                  (Ptr Unsigned_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_pointer_member")
+instance HasCField Unsigned_long_pointer_struct
+                   "unsigned_long_pointer_member"
+    where type CFieldType Unsigned_long_pointer_struct
+                          "unsigned_long_pointer_member" = Ptr CULong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 257:8@
@@ -2221,22 +2221,22 @@ instance WriteRaw Ordinary_signed_long_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_long_pointer_struct ordinary_signed_long_long_pointer_member_2 -> writeRaw (Proxy @"ordinary_signed_long_long_pointer_member") ptr_0 ordinary_signed_long_long_pointer_member_2
 deriving via (EquivStorable Ordinary_signed_long_long_pointer_struct) instance Storable Ordinary_signed_long_long_pointer_struct
-instance HasCField Ordinary_signed_long_long_pointer_struct
-                   "ordinary_signed_long_long_pointer_member"
-    where type CFieldType Ordinary_signed_long_long_pointer_struct
-                          "ordinary_signed_long_long_pointer_member" = Ptr CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLLong) =>
-         HasField "ordinary_signed_long_long_pointer_member"
-                  (Ptr Ordinary_signed_long_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_member")
 instance (~) ty (Ptr CLLong) =>
          HasField "ordinary_signed_long_long_pointer_member"
                   Ordinary_signed_long_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_long_pointer_struct{ordinary_signed_long_long_pointer_member = y_1},
                               getField @"ordinary_signed_long_long_pointer_member" x_0)
+instance (~) ty (Ptr CLLong) =>
+         HasField "ordinary_signed_long_long_pointer_member"
+                  (Ptr Ordinary_signed_long_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_member")
+instance HasCField Ordinary_signed_long_long_pointer_struct
+                   "ordinary_signed_long_long_pointer_member"
+    where type CFieldType Ordinary_signed_long_long_pointer_struct
+                          "ordinary_signed_long_long_pointer_member" = Ptr CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 258:8@
@@ -2261,22 +2261,22 @@ instance WriteRaw Explicit_signed_long_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_long_pointer_struct explicit_signed_long_long_pointer_member_2 -> writeRaw (Proxy @"explicit_signed_long_long_pointer_member") ptr_0 explicit_signed_long_long_pointer_member_2
 deriving via (EquivStorable Explicit_signed_long_long_pointer_struct) instance Storable Explicit_signed_long_long_pointer_struct
-instance HasCField Explicit_signed_long_long_pointer_struct
-                   "explicit_signed_long_long_pointer_member"
-    where type CFieldType Explicit_signed_long_long_pointer_struct
-                          "explicit_signed_long_long_pointer_member" = Ptr CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CLLong) =>
-         HasField "explicit_signed_long_long_pointer_member"
-                  (Ptr Explicit_signed_long_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_member")
 instance (~) ty (Ptr CLLong) =>
          HasField "explicit_signed_long_long_pointer_member"
                   Explicit_signed_long_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_long_pointer_struct{explicit_signed_long_long_pointer_member = y_1},
                               getField @"explicit_signed_long_long_pointer_member" x_0)
+instance (~) ty (Ptr CLLong) =>
+         HasField "explicit_signed_long_long_pointer_member"
+                  (Ptr Explicit_signed_long_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_member")
+instance HasCField Explicit_signed_long_long_pointer_struct
+                   "explicit_signed_long_long_pointer_member"
+    where type CFieldType Explicit_signed_long_long_pointer_struct
+                          "explicit_signed_long_long_pointer_member" = Ptr CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_long_pointer_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 259:8@
@@ -2301,22 +2301,22 @@ instance WriteRaw Unsigned_long_long_pointer_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_long_pointer_struct unsigned_long_long_pointer_member_2 -> writeRaw (Proxy @"unsigned_long_long_pointer_member") ptr_0 unsigned_long_long_pointer_member_2
 deriving via (EquivStorable Unsigned_long_long_pointer_struct) instance Storable Unsigned_long_long_pointer_struct
-instance HasCField Unsigned_long_long_pointer_struct
-                   "unsigned_long_long_pointer_member"
-    where type CFieldType Unsigned_long_long_pointer_struct
-                          "unsigned_long_long_pointer_member" = Ptr CULLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CULLong) =>
-         HasField "unsigned_long_long_pointer_member"
-                  (Ptr Unsigned_long_long_pointer_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_long_pointer_member")
 instance (~) ty (Ptr CULLong) =>
          HasField "unsigned_long_long_pointer_member"
                   Unsigned_long_long_pointer_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_long_pointer_struct{unsigned_long_long_pointer_member = y_1},
                               getField @"unsigned_long_long_pointer_member" x_0)
+instance (~) ty (Ptr CULLong) =>
+         HasField "unsigned_long_long_pointer_member"
+                  (Ptr Unsigned_long_long_pointer_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_long_pointer_member")
+instance HasCField Unsigned_long_long_pointer_struct
+                   "unsigned_long_long_pointer_member"
+    where type CFieldType Unsigned_long_long_pointer_struct
+                          "unsigned_long_long_pointer_member" = Ptr CULLong
+          offset# = \_ -> \_ -> 0
 {-| Structs: arrays
 
     __C declaration:__ @struct ordinary_float_array_struct@
@@ -2344,22 +2344,22 @@ instance WriteRaw Ordinary_float_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_float_array_struct ordinary_float_array_member_2 -> writeRaw (Proxy @"ordinary_float_array_member") ptr_0 ordinary_float_array_member_2
 deriving via (EquivStorable Ordinary_float_array_struct) instance Storable Ordinary_float_array_struct
-instance HasCField Ordinary_float_array_struct
-                   "ordinary_float_array_member"
-    where type CFieldType Ordinary_float_array_struct
-                          "ordinary_float_array_member" = ConstantArray 10 CFloat
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CFloat) =>
-         HasField "ordinary_float_array_member"
-                  (Ptr Ordinary_float_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_float_array_member")
 instance (~) ty (ConstantArray 10 CFloat) =>
          HasField "ordinary_float_array_member"
                   Ordinary_float_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_float_array_struct{ordinary_float_array_member = y_1},
                               getField @"ordinary_float_array_member" x_0)
+instance (~) ty (ConstantArray 10 CFloat) =>
+         HasField "ordinary_float_array_member"
+                  (Ptr Ordinary_float_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_float_array_member")
+instance HasCField Ordinary_float_array_struct
+                   "ordinary_float_array_member"
+    where type CFieldType Ordinary_float_array_struct
+                          "ordinary_float_array_member" = ConstantArray 10 CFloat
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_double_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 266:8@
@@ -2385,22 +2385,22 @@ instance WriteRaw Ordinary_double_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_double_array_struct ordinary_double_array_member_2 -> writeRaw (Proxy @"ordinary_double_array_member") ptr_0 ordinary_double_array_member_2
 deriving via (EquivStorable Ordinary_double_array_struct) instance Storable Ordinary_double_array_struct
-instance HasCField Ordinary_double_array_struct
-                   "ordinary_double_array_member"
-    where type CFieldType Ordinary_double_array_struct
-                          "ordinary_double_array_member" = ConstantArray 10 CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CDouble) =>
-         HasField "ordinary_double_array_member"
-                  (Ptr Ordinary_double_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_double_array_member")
 instance (~) ty (ConstantArray 10 CDouble) =>
          HasField "ordinary_double_array_member"
                   Ordinary_double_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_double_array_struct{ordinary_double_array_member = y_1},
                               getField @"ordinary_double_array_member" x_0)
+instance (~) ty (ConstantArray 10 CDouble) =>
+         HasField "ordinary_double_array_member"
+                  (Ptr Ordinary_double_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_double_array_member")
+instance HasCField Ordinary_double_array_struct
+                   "ordinary_double_array_member"
+    where type CFieldType Ordinary_double_array_struct
+                          "ordinary_double_array_member" = ConstantArray 10 CDouble
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_char_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 269:8@
@@ -2426,22 +2426,22 @@ instance WriteRaw Ordinary_signed_char_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_char_array_struct ordinary_signed_char_array_member_2 -> writeRaw (Proxy @"ordinary_signed_char_array_member") ptr_0 ordinary_signed_char_array_member_2
 deriving via (EquivStorable Ordinary_signed_char_array_struct) instance Storable Ordinary_signed_char_array_struct
-instance HasCField Ordinary_signed_char_array_struct
-                   "ordinary_signed_char_array_member"
-    where type CFieldType Ordinary_signed_char_array_struct
-                          "ordinary_signed_char_array_member" = ConstantArray 10 CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CChar) =>
-         HasField "ordinary_signed_char_array_member"
-                  (Ptr Ordinary_signed_char_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_char_array_member")
 instance (~) ty (ConstantArray 10 CChar) =>
          HasField "ordinary_signed_char_array_member"
                   Ordinary_signed_char_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_char_array_struct{ordinary_signed_char_array_member = y_1},
                               getField @"ordinary_signed_char_array_member" x_0)
+instance (~) ty (ConstantArray 10 CChar) =>
+         HasField "ordinary_signed_char_array_member"
+                  (Ptr Ordinary_signed_char_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_char_array_member")
+instance HasCField Ordinary_signed_char_array_struct
+                   "ordinary_signed_char_array_member"
+    where type CFieldType Ordinary_signed_char_array_struct
+                          "ordinary_signed_char_array_member" = ConstantArray 10 CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_char_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 270:8@
@@ -2467,22 +2467,22 @@ instance WriteRaw Explicit_signed_char_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_char_array_struct explicit_signed_char_array_member_2 -> writeRaw (Proxy @"explicit_signed_char_array_member") ptr_0 explicit_signed_char_array_member_2
 deriving via (EquivStorable Explicit_signed_char_array_struct) instance Storable Explicit_signed_char_array_struct
-instance HasCField Explicit_signed_char_array_struct
-                   "explicit_signed_char_array_member"
-    where type CFieldType Explicit_signed_char_array_struct
-                          "explicit_signed_char_array_member" = ConstantArray 10 CSChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CSChar) =>
-         HasField "explicit_signed_char_array_member"
-                  (Ptr Explicit_signed_char_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_char_array_member")
 instance (~) ty (ConstantArray 10 CSChar) =>
          HasField "explicit_signed_char_array_member"
                   Explicit_signed_char_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_char_array_struct{explicit_signed_char_array_member = y_1},
                               getField @"explicit_signed_char_array_member" x_0)
+instance (~) ty (ConstantArray 10 CSChar) =>
+         HasField "explicit_signed_char_array_member"
+                  (Ptr Explicit_signed_char_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_char_array_member")
+instance HasCField Explicit_signed_char_array_struct
+                   "explicit_signed_char_array_member"
+    where type CFieldType Explicit_signed_char_array_struct
+                          "explicit_signed_char_array_member" = ConstantArray 10 CSChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_char_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 271:8@
@@ -2508,20 +2508,20 @@ instance WriteRaw Unsigned_char_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_char_array_struct unsigned_char_array_member_2 -> writeRaw (Proxy @"unsigned_char_array_member") ptr_0 unsigned_char_array_member_2
 deriving via (EquivStorable Unsigned_char_array_struct) instance Storable Unsigned_char_array_struct
-instance HasCField Unsigned_char_array_struct
-                   "unsigned_char_array_member"
-    where type CFieldType Unsigned_char_array_struct
-                          "unsigned_char_array_member" = ConstantArray 10 CUChar
-          offset# = \_ -> \_ -> 0
+instance (~) ty (ConstantArray 10 CUChar) =>
+         HasField "unsigned_char_array_member" Unsigned_char_array_struct ty
+    where hasField = \x_0 -> (\y_1 -> Unsigned_char_array_struct{unsigned_char_array_member = y_1},
+                              getField @"unsigned_char_array_member" x_0)
 instance (~) ty (ConstantArray 10 CUChar) =>
          HasField "unsigned_char_array_member"
                   (Ptr Unsigned_char_array_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unsigned_char_array_member")
-instance (~) ty (ConstantArray 10 CUChar) =>
-         HasField "unsigned_char_array_member" Unsigned_char_array_struct ty
-    where hasField = \x_0 -> (\y_1 -> Unsigned_char_array_struct{unsigned_char_array_member = y_1},
-                              getField @"unsigned_char_array_member" x_0)
+instance HasCField Unsigned_char_array_struct
+                   "unsigned_char_array_member"
+    where type CFieldType Unsigned_char_array_struct
+                          "unsigned_char_array_member" = ConstantArray 10 CUChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_short_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 273:8@
@@ -2547,22 +2547,22 @@ instance WriteRaw Ordinary_signed_short_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_short_array_struct ordinary_signed_short_array_member_2 -> writeRaw (Proxy @"ordinary_signed_short_array_member") ptr_0 ordinary_signed_short_array_member_2
 deriving via (EquivStorable Ordinary_signed_short_array_struct) instance Storable Ordinary_signed_short_array_struct
-instance HasCField Ordinary_signed_short_array_struct
-                   "ordinary_signed_short_array_member"
-    where type CFieldType Ordinary_signed_short_array_struct
-                          "ordinary_signed_short_array_member" = ConstantArray 10 CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CShort) =>
-         HasField "ordinary_signed_short_array_member"
-                  (Ptr Ordinary_signed_short_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_short_array_member")
 instance (~) ty (ConstantArray 10 CShort) =>
          HasField "ordinary_signed_short_array_member"
                   Ordinary_signed_short_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_short_array_struct{ordinary_signed_short_array_member = y_1},
                               getField @"ordinary_signed_short_array_member" x_0)
+instance (~) ty (ConstantArray 10 CShort) =>
+         HasField "ordinary_signed_short_array_member"
+                  (Ptr Ordinary_signed_short_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_short_array_member")
+instance HasCField Ordinary_signed_short_array_struct
+                   "ordinary_signed_short_array_member"
+    where type CFieldType Ordinary_signed_short_array_struct
+                          "ordinary_signed_short_array_member" = ConstantArray 10 CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_short_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 274:8@
@@ -2588,22 +2588,22 @@ instance WriteRaw Explicit_signed_short_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_short_array_struct explicit_signed_short_array_member_2 -> writeRaw (Proxy @"explicit_signed_short_array_member") ptr_0 explicit_signed_short_array_member_2
 deriving via (EquivStorable Explicit_signed_short_array_struct) instance Storable Explicit_signed_short_array_struct
-instance HasCField Explicit_signed_short_array_struct
-                   "explicit_signed_short_array_member"
-    where type CFieldType Explicit_signed_short_array_struct
-                          "explicit_signed_short_array_member" = ConstantArray 10 CShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CShort) =>
-         HasField "explicit_signed_short_array_member"
-                  (Ptr Explicit_signed_short_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_short_array_member")
 instance (~) ty (ConstantArray 10 CShort) =>
          HasField "explicit_signed_short_array_member"
                   Explicit_signed_short_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_short_array_struct{explicit_signed_short_array_member = y_1},
                               getField @"explicit_signed_short_array_member" x_0)
+instance (~) ty (ConstantArray 10 CShort) =>
+         HasField "explicit_signed_short_array_member"
+                  (Ptr Explicit_signed_short_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_short_array_member")
+instance HasCField Explicit_signed_short_array_struct
+                   "explicit_signed_short_array_member"
+    where type CFieldType Explicit_signed_short_array_struct
+                          "explicit_signed_short_array_member" = ConstantArray 10 CShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_short_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 275:8@
@@ -2629,22 +2629,22 @@ instance WriteRaw Unsigned_short_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_short_array_struct unsigned_short_array_member_2 -> writeRaw (Proxy @"unsigned_short_array_member") ptr_0 unsigned_short_array_member_2
 deriving via (EquivStorable Unsigned_short_array_struct) instance Storable Unsigned_short_array_struct
-instance HasCField Unsigned_short_array_struct
-                   "unsigned_short_array_member"
-    where type CFieldType Unsigned_short_array_struct
-                          "unsigned_short_array_member" = ConstantArray 10 CUShort
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CUShort) =>
-         HasField "unsigned_short_array_member"
-                  (Ptr Unsigned_short_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_short_array_member")
 instance (~) ty (ConstantArray 10 CUShort) =>
          HasField "unsigned_short_array_member"
                   Unsigned_short_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_short_array_struct{unsigned_short_array_member = y_1},
                               getField @"unsigned_short_array_member" x_0)
+instance (~) ty (ConstantArray 10 CUShort) =>
+         HasField "unsigned_short_array_member"
+                  (Ptr Unsigned_short_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_short_array_member")
+instance HasCField Unsigned_short_array_struct
+                   "unsigned_short_array_member"
+    where type CFieldType Unsigned_short_array_struct
+                          "unsigned_short_array_member" = ConstantArray 10 CUShort
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_int_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 277:8@
@@ -2670,22 +2670,22 @@ instance WriteRaw Ordinary_signed_int_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_int_array_struct ordinary_signed_int_array_member_2 -> writeRaw (Proxy @"ordinary_signed_int_array_member") ptr_0 ordinary_signed_int_array_member_2
 deriving via (EquivStorable Ordinary_signed_int_array_struct) instance Storable Ordinary_signed_int_array_struct
-instance HasCField Ordinary_signed_int_array_struct
-                   "ordinary_signed_int_array_member"
-    where type CFieldType Ordinary_signed_int_array_struct
-                          "ordinary_signed_int_array_member" = ConstantArray 10 CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CInt) =>
-         HasField "ordinary_signed_int_array_member"
-                  (Ptr Ordinary_signed_int_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_int_array_member")
 instance (~) ty (ConstantArray 10 CInt) =>
          HasField "ordinary_signed_int_array_member"
                   Ordinary_signed_int_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_int_array_struct{ordinary_signed_int_array_member = y_1},
                               getField @"ordinary_signed_int_array_member" x_0)
+instance (~) ty (ConstantArray 10 CInt) =>
+         HasField "ordinary_signed_int_array_member"
+                  (Ptr Ordinary_signed_int_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_int_array_member")
+instance HasCField Ordinary_signed_int_array_struct
+                   "ordinary_signed_int_array_member"
+    where type CFieldType Ordinary_signed_int_array_struct
+                          "ordinary_signed_int_array_member" = ConstantArray 10 CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_int_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 278:8@
@@ -2711,22 +2711,22 @@ instance WriteRaw Explicit_signed_int_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_int_array_struct explicit_signed_int_array_member_2 -> writeRaw (Proxy @"explicit_signed_int_array_member") ptr_0 explicit_signed_int_array_member_2
 deriving via (EquivStorable Explicit_signed_int_array_struct) instance Storable Explicit_signed_int_array_struct
-instance HasCField Explicit_signed_int_array_struct
-                   "explicit_signed_int_array_member"
-    where type CFieldType Explicit_signed_int_array_struct
-                          "explicit_signed_int_array_member" = ConstantArray 10 CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CInt) =>
-         HasField "explicit_signed_int_array_member"
-                  (Ptr Explicit_signed_int_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_int_array_member")
 instance (~) ty (ConstantArray 10 CInt) =>
          HasField "explicit_signed_int_array_member"
                   Explicit_signed_int_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_int_array_struct{explicit_signed_int_array_member = y_1},
                               getField @"explicit_signed_int_array_member" x_0)
+instance (~) ty (ConstantArray 10 CInt) =>
+         HasField "explicit_signed_int_array_member"
+                  (Ptr Explicit_signed_int_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_int_array_member")
+instance HasCField Explicit_signed_int_array_struct
+                   "explicit_signed_int_array_member"
+    where type CFieldType Explicit_signed_int_array_struct
+                          "explicit_signed_int_array_member" = ConstantArray 10 CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_int_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 279:8@
@@ -2752,20 +2752,20 @@ instance WriteRaw Unsigned_int_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_int_array_struct unsigned_int_array_member_2 -> writeRaw (Proxy @"unsigned_int_array_member") ptr_0 unsigned_int_array_member_2
 deriving via (EquivStorable Unsigned_int_array_struct) instance Storable Unsigned_int_array_struct
-instance HasCField Unsigned_int_array_struct
-                   "unsigned_int_array_member"
-    where type CFieldType Unsigned_int_array_struct
-                          "unsigned_int_array_member" = ConstantArray 10 CUInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty (ConstantArray 10 CUInt) =>
+         HasField "unsigned_int_array_member" Unsigned_int_array_struct ty
+    where hasField = \x_0 -> (\y_1 -> Unsigned_int_array_struct{unsigned_int_array_member = y_1},
+                              getField @"unsigned_int_array_member" x_0)
 instance (~) ty (ConstantArray 10 CUInt) =>
          HasField "unsigned_int_array_member"
                   (Ptr Unsigned_int_array_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unsigned_int_array_member")
-instance (~) ty (ConstantArray 10 CUInt) =>
-         HasField "unsigned_int_array_member" Unsigned_int_array_struct ty
-    where hasField = \x_0 -> (\y_1 -> Unsigned_int_array_struct{unsigned_int_array_member = y_1},
-                              getField @"unsigned_int_array_member" x_0)
+instance HasCField Unsigned_int_array_struct
+                   "unsigned_int_array_member"
+    where type CFieldType Unsigned_int_array_struct
+                          "unsigned_int_array_member" = ConstantArray 10 CUInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 281:8@
@@ -2791,22 +2791,22 @@ instance WriteRaw Ordinary_signed_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_array_struct ordinary_signed_long_array_member_2 -> writeRaw (Proxy @"ordinary_signed_long_array_member") ptr_0 ordinary_signed_long_array_member_2
 deriving via (EquivStorable Ordinary_signed_long_array_struct) instance Storable Ordinary_signed_long_array_struct
-instance HasCField Ordinary_signed_long_array_struct
-                   "ordinary_signed_long_array_member"
-    where type CFieldType Ordinary_signed_long_array_struct
-                          "ordinary_signed_long_array_member" = ConstantArray 10 CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLong) =>
-         HasField "ordinary_signed_long_array_member"
-                  (Ptr Ordinary_signed_long_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_array_member")
 instance (~) ty (ConstantArray 10 CLong) =>
          HasField "ordinary_signed_long_array_member"
                   Ordinary_signed_long_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_array_struct{ordinary_signed_long_array_member = y_1},
                               getField @"ordinary_signed_long_array_member" x_0)
+instance (~) ty (ConstantArray 10 CLong) =>
+         HasField "ordinary_signed_long_array_member"
+                  (Ptr Ordinary_signed_long_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_array_member")
+instance HasCField Ordinary_signed_long_array_struct
+                   "ordinary_signed_long_array_member"
+    where type CFieldType Ordinary_signed_long_array_struct
+                          "ordinary_signed_long_array_member" = ConstantArray 10 CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 282:8@
@@ -2832,22 +2832,22 @@ instance WriteRaw Explicit_signed_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_array_struct explicit_signed_long_array_member_2 -> writeRaw (Proxy @"explicit_signed_long_array_member") ptr_0 explicit_signed_long_array_member_2
 deriving via (EquivStorable Explicit_signed_long_array_struct) instance Storable Explicit_signed_long_array_struct
-instance HasCField Explicit_signed_long_array_struct
-                   "explicit_signed_long_array_member"
-    where type CFieldType Explicit_signed_long_array_struct
-                          "explicit_signed_long_array_member" = ConstantArray 10 CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLong) =>
-         HasField "explicit_signed_long_array_member"
-                  (Ptr Explicit_signed_long_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_array_member")
 instance (~) ty (ConstantArray 10 CLong) =>
          HasField "explicit_signed_long_array_member"
                   Explicit_signed_long_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_array_struct{explicit_signed_long_array_member = y_1},
                               getField @"explicit_signed_long_array_member" x_0)
+instance (~) ty (ConstantArray 10 CLong) =>
+         HasField "explicit_signed_long_array_member"
+                  (Ptr Explicit_signed_long_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_array_member")
+instance HasCField Explicit_signed_long_array_struct
+                   "explicit_signed_long_array_member"
+    where type CFieldType Explicit_signed_long_array_struct
+                          "explicit_signed_long_array_member" = ConstantArray 10 CLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 283:8@
@@ -2873,20 +2873,20 @@ instance WriteRaw Unsigned_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_array_struct unsigned_long_array_member_2 -> writeRaw (Proxy @"unsigned_long_array_member") ptr_0 unsigned_long_array_member_2
 deriving via (EquivStorable Unsigned_long_array_struct) instance Storable Unsigned_long_array_struct
-instance HasCField Unsigned_long_array_struct
-                   "unsigned_long_array_member"
-    where type CFieldType Unsigned_long_array_struct
-                          "unsigned_long_array_member" = ConstantArray 10 CULong
-          offset# = \_ -> \_ -> 0
+instance (~) ty (ConstantArray 10 CULong) =>
+         HasField "unsigned_long_array_member" Unsigned_long_array_struct ty
+    where hasField = \x_0 -> (\y_1 -> Unsigned_long_array_struct{unsigned_long_array_member = y_1},
+                              getField @"unsigned_long_array_member" x_0)
 instance (~) ty (ConstantArray 10 CULong) =>
          HasField "unsigned_long_array_member"
                   (Ptr Unsigned_long_array_struct)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unsigned_long_array_member")
-instance (~) ty (ConstantArray 10 CULong) =>
-         HasField "unsigned_long_array_member" Unsigned_long_array_struct ty
-    where hasField = \x_0 -> (\y_1 -> Unsigned_long_array_struct{unsigned_long_array_member = y_1},
-                              getField @"unsigned_long_array_member" x_0)
+instance HasCField Unsigned_long_array_struct
+                   "unsigned_long_array_member"
+    where type CFieldType Unsigned_long_array_struct
+                          "unsigned_long_array_member" = ConstantArray 10 CULong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 285:8@
@@ -2912,22 +2912,22 @@ instance WriteRaw Ordinary_signed_long_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_long_array_struct ordinary_signed_long_long_array_member_2 -> writeRaw (Proxy @"ordinary_signed_long_long_array_member") ptr_0 ordinary_signed_long_long_array_member_2
 deriving via (EquivStorable Ordinary_signed_long_long_array_struct) instance Storable Ordinary_signed_long_long_array_struct
-instance HasCField Ordinary_signed_long_long_array_struct
-                   "ordinary_signed_long_long_array_member"
-    where type CFieldType Ordinary_signed_long_long_array_struct
-                          "ordinary_signed_long_long_array_member" = ConstantArray 10 CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLLong) =>
-         HasField "ordinary_signed_long_long_array_member"
-                  (Ptr Ordinary_signed_long_long_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_long_array_member")
 instance (~) ty (ConstantArray 10 CLLong) =>
          HasField "ordinary_signed_long_long_array_member"
                   Ordinary_signed_long_long_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_long_array_struct{ordinary_signed_long_long_array_member = y_1},
                               getField @"ordinary_signed_long_long_array_member" x_0)
+instance (~) ty (ConstantArray 10 CLLong) =>
+         HasField "ordinary_signed_long_long_array_member"
+                  (Ptr Ordinary_signed_long_long_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_long_array_member")
+instance HasCField Ordinary_signed_long_long_array_struct
+                   "ordinary_signed_long_long_array_member"
+    where type CFieldType Ordinary_signed_long_long_array_struct
+                          "ordinary_signed_long_long_array_member" = ConstantArray 10 CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 286:8@
@@ -2953,22 +2953,22 @@ instance WriteRaw Explicit_signed_long_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_long_array_struct explicit_signed_long_long_array_member_2 -> writeRaw (Proxy @"explicit_signed_long_long_array_member") ptr_0 explicit_signed_long_long_array_member_2
 deriving via (EquivStorable Explicit_signed_long_long_array_struct) instance Storable Explicit_signed_long_long_array_struct
-instance HasCField Explicit_signed_long_long_array_struct
-                   "explicit_signed_long_long_array_member"
-    where type CFieldType Explicit_signed_long_long_array_struct
-                          "explicit_signed_long_long_array_member" = ConstantArray 10 CLLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CLLong) =>
-         HasField "explicit_signed_long_long_array_member"
-                  (Ptr Explicit_signed_long_long_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_long_array_member")
 instance (~) ty (ConstantArray 10 CLLong) =>
          HasField "explicit_signed_long_long_array_member"
                   Explicit_signed_long_long_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_long_array_struct{explicit_signed_long_long_array_member = y_1},
                               getField @"explicit_signed_long_long_array_member" x_0)
+instance (~) ty (ConstantArray 10 CLLong) =>
+         HasField "explicit_signed_long_long_array_member"
+                  (Ptr Explicit_signed_long_long_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_long_array_member")
+instance HasCField Explicit_signed_long_long_array_struct
+                   "explicit_signed_long_long_array_member"
+    where type CFieldType Explicit_signed_long_long_array_struct
+                          "explicit_signed_long_long_array_member" = ConstantArray 10 CLLong
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_long_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 287:8@
@@ -2994,22 +2994,22 @@ instance WriteRaw Unsigned_long_long_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_long_array_struct unsigned_long_long_array_member_2 -> writeRaw (Proxy @"unsigned_long_long_array_member") ptr_0 unsigned_long_long_array_member_2
 deriving via (EquivStorable Unsigned_long_long_array_struct) instance Storable Unsigned_long_long_array_struct
-instance HasCField Unsigned_long_long_array_struct
-                   "unsigned_long_long_array_member"
-    where type CFieldType Unsigned_long_long_array_struct
-                          "unsigned_long_long_array_member" = ConstantArray 10 CULLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 CULLong) =>
-         HasField "unsigned_long_long_array_member"
-                  (Ptr Unsigned_long_long_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_long_array_member")
 instance (~) ty (ConstantArray 10 CULLong) =>
          HasField "unsigned_long_long_array_member"
                   Unsigned_long_long_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_long_array_struct{unsigned_long_long_array_member = y_1},
                               getField @"unsigned_long_long_array_member" x_0)
+instance (~) ty (ConstantArray 10 CULLong) =>
+         HasField "unsigned_long_long_array_member"
+                  (Ptr Unsigned_long_long_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_long_array_member")
+instance HasCField Unsigned_long_long_array_struct
+                   "unsigned_long_long_array_member"
+    where type CFieldType Unsigned_long_long_array_struct
+                          "unsigned_long_long_array_member" = ConstantArray 10 CULLong
+          offset# = \_ -> \_ -> 0
 {-| Structs: arrays of pointers
 
     NOTE: Here too @'Ordinary_signed_char_pointer_array_struct'@ was commented out in the original test suite, with no reason given.
@@ -3039,22 +3039,22 @@ instance WriteRaw Ordinary_void_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_void_pointer_array_struct ordinary_void_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_void_pointer_array_member") ptr_0 ordinary_void_pointer_array_member_2
 deriving via (EquivStorable Ordinary_void_pointer_array_struct) instance Storable Ordinary_void_pointer_array_struct
-instance HasCField Ordinary_void_pointer_array_struct
-                   "ordinary_void_pointer_array_member"
-    where type CFieldType Ordinary_void_pointer_array_struct
-                          "ordinary_void_pointer_array_member" = ConstantArray 10 (Ptr Void)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr Void)) =>
-         HasField "ordinary_void_pointer_array_member"
-                  (Ptr Ordinary_void_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_void_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr Void)) =>
          HasField "ordinary_void_pointer_array_member"
                   Ordinary_void_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_void_pointer_array_struct{ordinary_void_pointer_array_member = y_1},
                               getField @"ordinary_void_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr Void)) =>
+         HasField "ordinary_void_pointer_array_member"
+                  (Ptr Ordinary_void_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_void_pointer_array_member")
+instance HasCField Ordinary_void_pointer_array_struct
+                   "ordinary_void_pointer_array_member"
+    where type CFieldType Ordinary_void_pointer_array_struct
+                          "ordinary_void_pointer_array_member" = ConstantArray 10 (Ptr Void)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_float_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 298:8@
@@ -3080,23 +3080,23 @@ instance WriteRaw Ordinary_float_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_float_pointer_array_struct ordinary_float_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_float_pointer_array_member") ptr_0 ordinary_float_pointer_array_member_2
 deriving via (EquivStorable Ordinary_float_pointer_array_struct) instance Storable Ordinary_float_pointer_array_struct
-instance HasCField Ordinary_float_pointer_array_struct
-                   "ordinary_float_pointer_array_member"
-    where type CFieldType Ordinary_float_pointer_array_struct
-                          "ordinary_float_pointer_array_member" = ConstantArray 10
-                                                                                (Ptr CFloat)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CFloat)) =>
-         HasField "ordinary_float_pointer_array_member"
-                  (Ptr Ordinary_float_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_float_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CFloat)) =>
          HasField "ordinary_float_pointer_array_member"
                   Ordinary_float_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_float_pointer_array_struct{ordinary_float_pointer_array_member = y_1},
                               getField @"ordinary_float_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CFloat)) =>
+         HasField "ordinary_float_pointer_array_member"
+                  (Ptr Ordinary_float_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_float_pointer_array_member")
+instance HasCField Ordinary_float_pointer_array_struct
+                   "ordinary_float_pointer_array_member"
+    where type CFieldType Ordinary_float_pointer_array_struct
+                          "ordinary_float_pointer_array_member" = ConstantArray 10
+                                                                                (Ptr CFloat)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_double_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 299:8@
@@ -3122,23 +3122,23 @@ instance WriteRaw Ordinary_double_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_double_pointer_array_struct ordinary_double_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_double_pointer_array_member") ptr_0 ordinary_double_pointer_array_member_2
 deriving via (EquivStorable Ordinary_double_pointer_array_struct) instance Storable Ordinary_double_pointer_array_struct
-instance HasCField Ordinary_double_pointer_array_struct
-                   "ordinary_double_pointer_array_member"
-    where type CFieldType Ordinary_double_pointer_array_struct
-                          "ordinary_double_pointer_array_member" = ConstantArray 10
-                                                                                 (Ptr CDouble)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CDouble)) =>
-         HasField "ordinary_double_pointer_array_member"
-                  (Ptr Ordinary_double_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_double_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CDouble)) =>
          HasField "ordinary_double_pointer_array_member"
                   Ordinary_double_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_double_pointer_array_struct{ordinary_double_pointer_array_member = y_1},
                               getField @"ordinary_double_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CDouble)) =>
+         HasField "ordinary_double_pointer_array_member"
+                  (Ptr Ordinary_double_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_double_pointer_array_member")
+instance HasCField Ordinary_double_pointer_array_struct
+                   "ordinary_double_pointer_array_member"
+    where type CFieldType Ordinary_double_pointer_array_struct
+                          "ordinary_double_pointer_array_member" = ConstantArray 10
+                                                                                 (Ptr CDouble)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_char_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 302:8@
@@ -3164,23 +3164,23 @@ instance WriteRaw Ordinary_signed_char_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_char_pointer_array_struct ordinary_signed_char_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_signed_char_pointer_array_member") ptr_0 ordinary_signed_char_pointer_array_member_2
 deriving via (EquivStorable Ordinary_signed_char_pointer_array_struct) instance Storable Ordinary_signed_char_pointer_array_struct
-instance HasCField Ordinary_signed_char_pointer_array_struct
-                   "ordinary_signed_char_pointer_array_member"
-    where type CFieldType Ordinary_signed_char_pointer_array_struct
-                          "ordinary_signed_char_pointer_array_member" = ConstantArray 10
-                                                                                      (Ptr CChar)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CChar)) =>
-         HasField "ordinary_signed_char_pointer_array_member"
-                  (Ptr Ordinary_signed_char_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CChar)) =>
          HasField "ordinary_signed_char_pointer_array_member"
                   Ordinary_signed_char_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_char_pointer_array_struct{ordinary_signed_char_pointer_array_member = y_1},
                               getField @"ordinary_signed_char_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CChar)) =>
+         HasField "ordinary_signed_char_pointer_array_member"
+                  (Ptr Ordinary_signed_char_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_char_pointer_array_member")
+instance HasCField Ordinary_signed_char_pointer_array_struct
+                   "ordinary_signed_char_pointer_array_member"
+    where type CFieldType Ordinary_signed_char_pointer_array_struct
+                          "ordinary_signed_char_pointer_array_member" = ConstantArray 10
+                                                                                      (Ptr CChar)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_char_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 303:8@
@@ -3206,23 +3206,23 @@ instance WriteRaw Explicit_signed_char_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_char_pointer_array_struct explicit_signed_char_pointer_array_member_2 -> writeRaw (Proxy @"explicit_signed_char_pointer_array_member") ptr_0 explicit_signed_char_pointer_array_member_2
 deriving via (EquivStorable Explicit_signed_char_pointer_array_struct) instance Storable Explicit_signed_char_pointer_array_struct
-instance HasCField Explicit_signed_char_pointer_array_struct
-                   "explicit_signed_char_pointer_array_member"
-    where type CFieldType Explicit_signed_char_pointer_array_struct
-                          "explicit_signed_char_pointer_array_member" = ConstantArray 10
-                                                                                      (Ptr CSChar)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CSChar)) =>
-         HasField "explicit_signed_char_pointer_array_member"
-                  (Ptr Explicit_signed_char_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_char_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CSChar)) =>
          HasField "explicit_signed_char_pointer_array_member"
                   Explicit_signed_char_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_char_pointer_array_struct{explicit_signed_char_pointer_array_member = y_1},
                               getField @"explicit_signed_char_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CSChar)) =>
+         HasField "explicit_signed_char_pointer_array_member"
+                  (Ptr Explicit_signed_char_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_char_pointer_array_member")
+instance HasCField Explicit_signed_char_pointer_array_struct
+                   "explicit_signed_char_pointer_array_member"
+    where type CFieldType Explicit_signed_char_pointer_array_struct
+                          "explicit_signed_char_pointer_array_member" = ConstantArray 10
+                                                                                      (Ptr CSChar)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_char_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 304:8@
@@ -3248,23 +3248,23 @@ instance WriteRaw Unsigned_char_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_char_pointer_array_struct unsigned_char_pointer_array_member_2 -> writeRaw (Proxy @"unsigned_char_pointer_array_member") ptr_0 unsigned_char_pointer_array_member_2
 deriving via (EquivStorable Unsigned_char_pointer_array_struct) instance Storable Unsigned_char_pointer_array_struct
-instance HasCField Unsigned_char_pointer_array_struct
-                   "unsigned_char_pointer_array_member"
-    where type CFieldType Unsigned_char_pointer_array_struct
-                          "unsigned_char_pointer_array_member" = ConstantArray 10
-                                                                               (Ptr CUChar)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUChar)) =>
-         HasField "unsigned_char_pointer_array_member"
-                  (Ptr Unsigned_char_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_char_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CUChar)) =>
          HasField "unsigned_char_pointer_array_member"
                   Unsigned_char_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_char_pointer_array_struct{unsigned_char_pointer_array_member = y_1},
                               getField @"unsigned_char_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CUChar)) =>
+         HasField "unsigned_char_pointer_array_member"
+                  (Ptr Unsigned_char_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_char_pointer_array_member")
+instance HasCField Unsigned_char_pointer_array_struct
+                   "unsigned_char_pointer_array_member"
+    where type CFieldType Unsigned_char_pointer_array_struct
+                          "unsigned_char_pointer_array_member" = ConstantArray 10
+                                                                               (Ptr CUChar)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_short_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 306:8@
@@ -3290,23 +3290,23 @@ instance WriteRaw Ordinary_signed_short_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_short_pointer_array_struct ordinary_signed_short_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_signed_short_pointer_array_member") ptr_0 ordinary_signed_short_pointer_array_member_2
 deriving via (EquivStorable Ordinary_signed_short_pointer_array_struct) instance Storable Ordinary_signed_short_pointer_array_struct
-instance HasCField Ordinary_signed_short_pointer_array_struct
-                   "ordinary_signed_short_pointer_array_member"
-    where type CFieldType Ordinary_signed_short_pointer_array_struct
-                          "ordinary_signed_short_pointer_array_member" = ConstantArray 10
-                                                                                       (Ptr CShort)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
-         HasField "ordinary_signed_short_pointer_array_member"
-                  (Ptr Ordinary_signed_short_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
          HasField "ordinary_signed_short_pointer_array_member"
                   Ordinary_signed_short_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_short_pointer_array_struct{ordinary_signed_short_pointer_array_member = y_1},
                               getField @"ordinary_signed_short_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
+         HasField "ordinary_signed_short_pointer_array_member"
+                  (Ptr Ordinary_signed_short_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_short_pointer_array_member")
+instance HasCField Ordinary_signed_short_pointer_array_struct
+                   "ordinary_signed_short_pointer_array_member"
+    where type CFieldType Ordinary_signed_short_pointer_array_struct
+                          "ordinary_signed_short_pointer_array_member" = ConstantArray 10
+                                                                                       (Ptr CShort)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_short_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 307:8@
@@ -3332,23 +3332,23 @@ instance WriteRaw Explicit_signed_short_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_short_pointer_array_struct explicit_signed_short_pointer_array_member_2 -> writeRaw (Proxy @"explicit_signed_short_pointer_array_member") ptr_0 explicit_signed_short_pointer_array_member_2
 deriving via (EquivStorable Explicit_signed_short_pointer_array_struct) instance Storable Explicit_signed_short_pointer_array_struct
-instance HasCField Explicit_signed_short_pointer_array_struct
-                   "explicit_signed_short_pointer_array_member"
-    where type CFieldType Explicit_signed_short_pointer_array_struct
-                          "explicit_signed_short_pointer_array_member" = ConstantArray 10
-                                                                                       (Ptr CShort)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
-         HasField "explicit_signed_short_pointer_array_member"
-                  (Ptr Explicit_signed_short_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_short_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
          HasField "explicit_signed_short_pointer_array_member"
                   Explicit_signed_short_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_short_pointer_array_struct{explicit_signed_short_pointer_array_member = y_1},
                               getField @"explicit_signed_short_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CShort)) =>
+         HasField "explicit_signed_short_pointer_array_member"
+                  (Ptr Explicit_signed_short_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_short_pointer_array_member")
+instance HasCField Explicit_signed_short_pointer_array_struct
+                   "explicit_signed_short_pointer_array_member"
+    where type CFieldType Explicit_signed_short_pointer_array_struct
+                          "explicit_signed_short_pointer_array_member" = ConstantArray 10
+                                                                                       (Ptr CShort)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_short_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 308:8@
@@ -3374,23 +3374,23 @@ instance WriteRaw Unsigned_short_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_short_pointer_array_struct unsigned_short_pointer_array_member_2 -> writeRaw (Proxy @"unsigned_short_pointer_array_member") ptr_0 unsigned_short_pointer_array_member_2
 deriving via (EquivStorable Unsigned_short_pointer_array_struct) instance Storable Unsigned_short_pointer_array_struct
-instance HasCField Unsigned_short_pointer_array_struct
-                   "unsigned_short_pointer_array_member"
-    where type CFieldType Unsigned_short_pointer_array_struct
-                          "unsigned_short_pointer_array_member" = ConstantArray 10
-                                                                                (Ptr CUShort)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUShort)) =>
-         HasField "unsigned_short_pointer_array_member"
-                  (Ptr Unsigned_short_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_short_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CUShort)) =>
          HasField "unsigned_short_pointer_array_member"
                   Unsigned_short_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_short_pointer_array_struct{unsigned_short_pointer_array_member = y_1},
                               getField @"unsigned_short_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CUShort)) =>
+         HasField "unsigned_short_pointer_array_member"
+                  (Ptr Unsigned_short_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_short_pointer_array_member")
+instance HasCField Unsigned_short_pointer_array_struct
+                   "unsigned_short_pointer_array_member"
+    where type CFieldType Unsigned_short_pointer_array_struct
+                          "unsigned_short_pointer_array_member" = ConstantArray 10
+                                                                                (Ptr CUShort)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_int_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 310:8@
@@ -3416,23 +3416,23 @@ instance WriteRaw Ordinary_signed_int_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_int_pointer_array_struct ordinary_signed_int_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_signed_int_pointer_array_member") ptr_0 ordinary_signed_int_pointer_array_member_2
 deriving via (EquivStorable Ordinary_signed_int_pointer_array_struct) instance Storable Ordinary_signed_int_pointer_array_struct
-instance HasCField Ordinary_signed_int_pointer_array_struct
-                   "ordinary_signed_int_pointer_array_member"
-    where type CFieldType Ordinary_signed_int_pointer_array_struct
-                          "ordinary_signed_int_pointer_array_member" = ConstantArray 10
-                                                                                     (Ptr CInt)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
-         HasField "ordinary_signed_int_pointer_array_member"
-                  (Ptr Ordinary_signed_int_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
          HasField "ordinary_signed_int_pointer_array_member"
                   Ordinary_signed_int_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_int_pointer_array_struct{ordinary_signed_int_pointer_array_member = y_1},
                               getField @"ordinary_signed_int_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
+         HasField "ordinary_signed_int_pointer_array_member"
+                  (Ptr Ordinary_signed_int_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_int_pointer_array_member")
+instance HasCField Ordinary_signed_int_pointer_array_struct
+                   "ordinary_signed_int_pointer_array_member"
+    where type CFieldType Ordinary_signed_int_pointer_array_struct
+                          "ordinary_signed_int_pointer_array_member" = ConstantArray 10
+                                                                                     (Ptr CInt)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_int_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 311:8@
@@ -3458,23 +3458,23 @@ instance WriteRaw Explicit_signed_int_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_int_pointer_array_struct explicit_signed_int_pointer_array_member_2 -> writeRaw (Proxy @"explicit_signed_int_pointer_array_member") ptr_0 explicit_signed_int_pointer_array_member_2
 deriving via (EquivStorable Explicit_signed_int_pointer_array_struct) instance Storable Explicit_signed_int_pointer_array_struct
-instance HasCField Explicit_signed_int_pointer_array_struct
-                   "explicit_signed_int_pointer_array_member"
-    where type CFieldType Explicit_signed_int_pointer_array_struct
-                          "explicit_signed_int_pointer_array_member" = ConstantArray 10
-                                                                                     (Ptr CInt)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
-         HasField "explicit_signed_int_pointer_array_member"
-                  (Ptr Explicit_signed_int_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_int_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
          HasField "explicit_signed_int_pointer_array_member"
                   Explicit_signed_int_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_int_pointer_array_struct{explicit_signed_int_pointer_array_member = y_1},
                               getField @"explicit_signed_int_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CInt)) =>
+         HasField "explicit_signed_int_pointer_array_member"
+                  (Ptr Explicit_signed_int_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_int_pointer_array_member")
+instance HasCField Explicit_signed_int_pointer_array_struct
+                   "explicit_signed_int_pointer_array_member"
+    where type CFieldType Explicit_signed_int_pointer_array_struct
+                          "explicit_signed_int_pointer_array_member" = ConstantArray 10
+                                                                                     (Ptr CInt)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_int_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 312:8@
@@ -3500,22 +3500,22 @@ instance WriteRaw Unsigned_int_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_int_pointer_array_struct unsigned_int_pointer_array_member_2 -> writeRaw (Proxy @"unsigned_int_pointer_array_member") ptr_0 unsigned_int_pointer_array_member_2
 deriving via (EquivStorable Unsigned_int_pointer_array_struct) instance Storable Unsigned_int_pointer_array_struct
-instance HasCField Unsigned_int_pointer_array_struct
-                   "unsigned_int_pointer_array_member"
-    where type CFieldType Unsigned_int_pointer_array_struct
-                          "unsigned_int_pointer_array_member" = ConstantArray 10 (Ptr CUInt)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CUInt)) =>
-         HasField "unsigned_int_pointer_array_member"
-                  (Ptr Unsigned_int_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_int_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CUInt)) =>
          HasField "unsigned_int_pointer_array_member"
                   Unsigned_int_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_int_pointer_array_struct{unsigned_int_pointer_array_member = y_1},
                               getField @"unsigned_int_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CUInt)) =>
+         HasField "unsigned_int_pointer_array_member"
+                  (Ptr Unsigned_int_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_int_pointer_array_member")
+instance HasCField Unsigned_int_pointer_array_struct
+                   "unsigned_int_pointer_array_member"
+    where type CFieldType Unsigned_int_pointer_array_struct
+                          "unsigned_int_pointer_array_member" = ConstantArray 10 (Ptr CUInt)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 314:8@
@@ -3541,23 +3541,23 @@ instance WriteRaw Ordinary_signed_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_pointer_array_struct ordinary_signed_long_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_signed_long_pointer_array_member") ptr_0 ordinary_signed_long_pointer_array_member_2
 deriving via (EquivStorable Ordinary_signed_long_pointer_array_struct) instance Storable Ordinary_signed_long_pointer_array_struct
-instance HasCField Ordinary_signed_long_pointer_array_struct
-                   "ordinary_signed_long_pointer_array_member"
-    where type CFieldType Ordinary_signed_long_pointer_array_struct
-                          "ordinary_signed_long_pointer_array_member" = ConstantArray 10
-                                                                                      (Ptr CLong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
-         HasField "ordinary_signed_long_pointer_array_member"
-                  (Ptr Ordinary_signed_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
          HasField "ordinary_signed_long_pointer_array_member"
                   Ordinary_signed_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_pointer_array_struct{ordinary_signed_long_pointer_array_member = y_1},
                               getField @"ordinary_signed_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
+         HasField "ordinary_signed_long_pointer_array_member"
+                  (Ptr Ordinary_signed_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_pointer_array_member")
+instance HasCField Ordinary_signed_long_pointer_array_struct
+                   "ordinary_signed_long_pointer_array_member"
+    where type CFieldType Ordinary_signed_long_pointer_array_struct
+                          "ordinary_signed_long_pointer_array_member" = ConstantArray 10
+                                                                                      (Ptr CLong)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 315:8@
@@ -3583,23 +3583,23 @@ instance WriteRaw Explicit_signed_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_pointer_array_struct explicit_signed_long_pointer_array_member_2 -> writeRaw (Proxy @"explicit_signed_long_pointer_array_member") ptr_0 explicit_signed_long_pointer_array_member_2
 deriving via (EquivStorable Explicit_signed_long_pointer_array_struct) instance Storable Explicit_signed_long_pointer_array_struct
-instance HasCField Explicit_signed_long_pointer_array_struct
-                   "explicit_signed_long_pointer_array_member"
-    where type CFieldType Explicit_signed_long_pointer_array_struct
-                          "explicit_signed_long_pointer_array_member" = ConstantArray 10
-                                                                                      (Ptr CLong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
-         HasField "explicit_signed_long_pointer_array_member"
-                  (Ptr Explicit_signed_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
          HasField "explicit_signed_long_pointer_array_member"
                   Explicit_signed_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_pointer_array_struct{explicit_signed_long_pointer_array_member = y_1},
                               getField @"explicit_signed_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CLong)) =>
+         HasField "explicit_signed_long_pointer_array_member"
+                  (Ptr Explicit_signed_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_pointer_array_member")
+instance HasCField Explicit_signed_long_pointer_array_struct
+                   "explicit_signed_long_pointer_array_member"
+    where type CFieldType Explicit_signed_long_pointer_array_struct
+                          "explicit_signed_long_pointer_array_member" = ConstantArray 10
+                                                                                      (Ptr CLong)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 316:8@
@@ -3625,23 +3625,23 @@ instance WriteRaw Unsigned_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_pointer_array_struct unsigned_long_pointer_array_member_2 -> writeRaw (Proxy @"unsigned_long_pointer_array_member") ptr_0 unsigned_long_pointer_array_member_2
 deriving via (EquivStorable Unsigned_long_pointer_array_struct) instance Storable Unsigned_long_pointer_array_struct
-instance HasCField Unsigned_long_pointer_array_struct
-                   "unsigned_long_pointer_array_member"
-    where type CFieldType Unsigned_long_pointer_array_struct
-                          "unsigned_long_pointer_array_member" = ConstantArray 10
-                                                                               (Ptr CULong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CULong)) =>
-         HasField "unsigned_long_pointer_array_member"
-                  (Ptr Unsigned_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CULong)) =>
          HasField "unsigned_long_pointer_array_member"
                   Unsigned_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_pointer_array_struct{unsigned_long_pointer_array_member = y_1},
                               getField @"unsigned_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CULong)) =>
+         HasField "unsigned_long_pointer_array_member"
+                  (Ptr Unsigned_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_pointer_array_member")
+instance HasCField Unsigned_long_pointer_array_struct
+                   "unsigned_long_pointer_array_member"
+    where type CFieldType Unsigned_long_pointer_array_struct
+                          "unsigned_long_pointer_array_member" = ConstantArray 10
+                                                                               (Ptr CULong)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct ordinary_signed_long_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 318:8@
@@ -3667,23 +3667,23 @@ instance WriteRaw Ordinary_signed_long_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Ordinary_signed_long_long_pointer_array_struct ordinary_signed_long_long_pointer_array_member_2 -> writeRaw (Proxy @"ordinary_signed_long_long_pointer_array_member") ptr_0 ordinary_signed_long_long_pointer_array_member_2
 deriving via (EquivStorable Ordinary_signed_long_long_pointer_array_struct) instance Storable Ordinary_signed_long_long_pointer_array_struct
-instance HasCField Ordinary_signed_long_long_pointer_array_struct
-                   "ordinary_signed_long_long_pointer_array_member"
-    where type CFieldType Ordinary_signed_long_long_pointer_array_struct
-                          "ordinary_signed_long_long_pointer_array_member" = ConstantArray 10
-                                                                                           (Ptr CLLong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
-         HasField "ordinary_signed_long_long_pointer_array_member"
-                  (Ptr Ordinary_signed_long_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
          HasField "ordinary_signed_long_long_pointer_array_member"
                   Ordinary_signed_long_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Ordinary_signed_long_long_pointer_array_struct{ordinary_signed_long_long_pointer_array_member = y_1},
                               getField @"ordinary_signed_long_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
+         HasField "ordinary_signed_long_long_pointer_array_member"
+                  (Ptr Ordinary_signed_long_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"ordinary_signed_long_long_pointer_array_member")
+instance HasCField Ordinary_signed_long_long_pointer_array_struct
+                   "ordinary_signed_long_long_pointer_array_member"
+    where type CFieldType Ordinary_signed_long_long_pointer_array_struct
+                          "ordinary_signed_long_long_pointer_array_member" = ConstantArray 10
+                                                                                           (Ptr CLLong)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct explicit_signed_long_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 319:8@
@@ -3709,23 +3709,23 @@ instance WriteRaw Explicit_signed_long_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Explicit_signed_long_long_pointer_array_struct explicit_signed_long_long_pointer_array_member_2 -> writeRaw (Proxy @"explicit_signed_long_long_pointer_array_member") ptr_0 explicit_signed_long_long_pointer_array_member_2
 deriving via (EquivStorable Explicit_signed_long_long_pointer_array_struct) instance Storable Explicit_signed_long_long_pointer_array_struct
-instance HasCField Explicit_signed_long_long_pointer_array_struct
-                   "explicit_signed_long_long_pointer_array_member"
-    where type CFieldType Explicit_signed_long_long_pointer_array_struct
-                          "explicit_signed_long_long_pointer_array_member" = ConstantArray 10
-                                                                                           (Ptr CLLong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
-         HasField "explicit_signed_long_long_pointer_array_member"
-                  (Ptr Explicit_signed_long_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
          HasField "explicit_signed_long_long_pointer_array_member"
                   Explicit_signed_long_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Explicit_signed_long_long_pointer_array_struct{explicit_signed_long_long_pointer_array_member = y_1},
                               getField @"explicit_signed_long_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CLLong)) =>
+         HasField "explicit_signed_long_long_pointer_array_member"
+                  (Ptr Explicit_signed_long_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"explicit_signed_long_long_pointer_array_member")
+instance HasCField Explicit_signed_long_long_pointer_array_struct
+                   "explicit_signed_long_long_pointer_array_member"
+    where type CFieldType Explicit_signed_long_long_pointer_array_struct
+                          "explicit_signed_long_long_pointer_array_member" = ConstantArray 10
+                                                                                           (Ptr CLLong)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct unsigned_long_long_pointer_array_struct@
 
     __defined at:__ @comprehensive\/c2hsc.h 320:8@
@@ -3751,23 +3751,23 @@ instance WriteRaw Unsigned_long_long_pointer_array_struct
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Unsigned_long_long_pointer_array_struct unsigned_long_long_pointer_array_member_2 -> writeRaw (Proxy @"unsigned_long_long_pointer_array_member") ptr_0 unsigned_long_long_pointer_array_member_2
 deriving via (EquivStorable Unsigned_long_long_pointer_array_struct) instance Storable Unsigned_long_long_pointer_array_struct
-instance HasCField Unsigned_long_long_pointer_array_struct
-                   "unsigned_long_long_pointer_array_member"
-    where type CFieldType Unsigned_long_long_pointer_array_struct
-                          "unsigned_long_long_pointer_array_member" = ConstantArray 10
-                                                                                    (Ptr CULLong)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 10 (Ptr CULLong)) =>
-         HasField "unsigned_long_long_pointer_array_member"
-                  (Ptr Unsigned_long_long_pointer_array_struct)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unsigned_long_long_pointer_array_member")
 instance (~) ty (ConstantArray 10 (Ptr CULLong)) =>
          HasField "unsigned_long_long_pointer_array_member"
                   Unsigned_long_long_pointer_array_struct
                   ty
     where hasField = \x_0 -> (\y_1 -> Unsigned_long_long_pointer_array_struct{unsigned_long_long_pointer_array_member = y_1},
                               getField @"unsigned_long_long_pointer_array_member" x_0)
+instance (~) ty (ConstantArray 10 (Ptr CULLong)) =>
+         HasField "unsigned_long_long_pointer_array_member"
+                  (Ptr Unsigned_long_long_pointer_array_struct)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unsigned_long_long_pointer_array_member")
+instance HasCField Unsigned_long_long_pointer_array_struct
+                   "unsigned_long_long_pointer_array_member"
+    where type CFieldType Unsigned_long_long_pointer_array_struct
+                          "unsigned_long_long_pointer_array_member" = ConstantArray 10
+                                                                                    (Ptr CULLong)
+          offset# = \_ -> \_ -> 0
 {-| Sanity checks
 
     NOTE: The @smoke.h@ test is moved to a separate header.
@@ -3796,14 +3796,14 @@ newtype An_int
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrap" An_int ty
+    where hasField = \x_0 -> (\y_1 -> An_int{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CInt => HasField "unwrap" (Ptr An_int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField An_int "unwrap"
     where type CFieldType An_int "unwrap" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrap" An_int ty
-    where hasField = \x_0 -> (\y_1 -> An_int{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct \@cal_table_table@
 
     __defined at:__ @comprehensive\/c2hsc.h 341:5@
@@ -3836,26 +3836,26 @@ instance WriteRaw Cal_table_table
                                        Cal_table_table raw_2
                                                        val_3 -> writeRaw (Proxy @"raw") ptr_0 raw_2 >> writeRaw (Proxy @"val") ptr_0 val_3
 deriving via (EquivStorable Cal_table_table) instance Storable Cal_table_table
-instance HasCField Cal_table_table "raw"
-    where type CFieldType Cal_table_table "raw" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "raw" (Ptr Cal_table_table) (Ptr ty)
-    where getField = fromPtr (Proxy @"raw")
 instance (~) ty CInt => HasField "raw" Cal_table_table ty
     where hasField = \x_0 -> (\y_1 -> Cal_table_table{raw = y_1,
                                                       val = getField @"val" x_0},
                               getField @"raw" x_0)
-instance HasCField Cal_table_table "val"
-    where type CFieldType Cal_table_table "val" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "val" (Ptr Cal_table_table) (Ptr ty)
-    where getField = fromPtr (Proxy @"val")
+         HasField "raw" (Ptr Cal_table_table) (Ptr ty)
+    where getField = fromPtr (Proxy @"raw")
+instance HasCField Cal_table_table "raw"
+    where type CFieldType Cal_table_table "raw" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "val" Cal_table_table ty
     where hasField = \x_0 -> (\y_1 -> Cal_table_table{val = y_1,
                                                       raw = getField @"raw" x_0},
                               getField @"val" x_0)
+instance (~) ty CInt =>
+         HasField "val" (Ptr Cal_table_table) (Ptr ty)
+    where getField = fromPtr (Proxy @"val")
+instance HasCField Cal_table_table "val"
+    where type CFieldType Cal_table_table "val" = CInt
+          offset# = \_ -> \_ -> 4
 {-| Issues without test cases in the original test suite
 
     These are examples from open issues on the c2hsc repository, that don't (yet) have corresponding test cases in the c2hsc test suite.
@@ -3892,27 +3892,27 @@ instance WriteRaw Cal_table
                                        Cal_table size_2
                                                  table_3 -> writeRaw (Proxy @"size") ptr_0 size_2 >> writeRaw (Proxy @"table") ptr_0 table_3
 deriving via (EquivStorable Cal_table) instance Storable Cal_table
-instance HasCField Cal_table "size"
-    where type CFieldType Cal_table "size" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "size" (Ptr Cal_table) (Ptr ty)
-    where getField = fromPtr (Proxy @"size")
 instance (~) ty CInt => HasField "size" Cal_table ty
     where hasField = \x_0 -> (\y_1 -> Cal_table{size = y_1,
                                                 table = getField @"table" x_0},
                               getField @"size" x_0)
-instance HasCField Cal_table "table"
-    where type CFieldType Cal_table "table" = ConstantArray 32
-                                                            Cal_table_table
-          offset# = \_ -> \_ -> 4
-instance (~) ty (ConstantArray 32 Cal_table_table) =>
-         HasField "table" (Ptr Cal_table) (Ptr ty)
-    where getField = fromPtr (Proxy @"table")
+instance (~) ty CInt => HasField "size" (Ptr Cal_table) (Ptr ty)
+    where getField = fromPtr (Proxy @"size")
+instance HasCField Cal_table "size"
+    where type CFieldType Cal_table "size" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (ConstantArray 32 Cal_table_table) =>
          HasField "table" Cal_table ty
     where hasField = \x_0 -> (\y_1 -> Cal_table{table = y_1,
                                                 size = getField @"size" x_0},
                               getField @"table" x_0)
+instance (~) ty (ConstantArray 32 Cal_table_table) =>
+         HasField "table" (Ptr Cal_table) (Ptr ty)
+    where getField = fromPtr (Proxy @"table")
+instance HasCField Cal_table "table"
+    where type CFieldType Cal_table "table" = ConstantArray 32
+                                                            Cal_table_table
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union \@Elf32_External_Dyn_d_un@
 
     __defined at:__ @comprehensive\/c2hsc.h 349:3@
@@ -4001,20 +4001,20 @@ set_elf32_External_Dyn_d_un_d_ptr :: ConstantArray 4 CUChar ->
 
 -}
 set_elf32_External_Dyn_d_un_d_ptr = setUnionPayload
+instance (~) ty (ConstantArray 4 CUChar) =>
+         HasField "d_val" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
+    where getField = fromPtr (Proxy @"d_val")
 instance HasCField Elf32_External_Dyn_d_un "d_val"
     where type CFieldType Elf32_External_Dyn_d_un
                           "d_val" = ConstantArray 4 CUChar
           offset# = \_ -> \_ -> 0
 instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_val" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
-    where getField = fromPtr (Proxy @"d_val")
+         HasField "d_ptr" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
+    where getField = fromPtr (Proxy @"d_ptr")
 instance HasCField Elf32_External_Dyn_d_un "d_ptr"
     where type CFieldType Elf32_External_Dyn_d_un
                           "d_ptr" = ConstantArray 4 CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_ptr" (Ptr Elf32_External_Dyn_d_un) (Ptr ty)
-    where getField = fromPtr (Proxy @"d_ptr")
 {-| __C declaration:__ @struct Elf32_External_Dyn@
 
     __defined at:__ @comprehensive\/c2hsc.h 347:9@
@@ -4047,30 +4047,30 @@ instance WriteRaw Elf32_External_Dyn
                                        Elf32_External_Dyn d_tag_2
                                                           d_un_3 -> writeRaw (Proxy @"d_tag") ptr_0 d_tag_2 >> writeRaw (Proxy @"d_un") ptr_0 d_un_3
 deriving via (EquivStorable Elf32_External_Dyn) instance Storable Elf32_External_Dyn
-instance HasCField Elf32_External_Dyn "d_tag"
-    where type CFieldType Elf32_External_Dyn "d_tag" = ConstantArray 4
-                                                                     CUChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 CUChar) =>
-         HasField "d_tag" (Ptr Elf32_External_Dyn) (Ptr ty)
-    where getField = fromPtr (Proxy @"d_tag")
 instance (~) ty (ConstantArray 4 CUChar) =>
          HasField "d_tag" Elf32_External_Dyn ty
     where hasField = \x_0 -> (\y_1 -> Elf32_External_Dyn{d_tag = y_1,
                                                          d_un = getField @"d_un" x_0},
                               getField @"d_tag" x_0)
-instance HasCField Elf32_External_Dyn "d_un"
-    where type CFieldType Elf32_External_Dyn
-                          "d_un" = Elf32_External_Dyn_d_un
-          offset# = \_ -> \_ -> 4
-instance (~) ty Elf32_External_Dyn_d_un =>
-         HasField "d_un" (Ptr Elf32_External_Dyn) (Ptr ty)
-    where getField = fromPtr (Proxy @"d_un")
+instance (~) ty (ConstantArray 4 CUChar) =>
+         HasField "d_tag" (Ptr Elf32_External_Dyn) (Ptr ty)
+    where getField = fromPtr (Proxy @"d_tag")
+instance HasCField Elf32_External_Dyn "d_tag"
+    where type CFieldType Elf32_External_Dyn "d_tag" = ConstantArray 4
+                                                                     CUChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Elf32_External_Dyn_d_un =>
          HasField "d_un" Elf32_External_Dyn ty
     where hasField = \x_0 -> (\y_1 -> Elf32_External_Dyn{d_un = y_1,
                                                          d_tag = getField @"d_tag" x_0},
                               getField @"d_un" x_0)
+instance (~) ty Elf32_External_Dyn_d_un =>
+         HasField "d_un" (Ptr Elf32_External_Dyn) (Ptr ty)
+    where getField = fromPtr (Proxy @"d_un")
+instance HasCField Elf32_External_Dyn "d_un"
+    where type CFieldType Elf32_External_Dyn
+                          "d_un" = Elf32_External_Dyn_d_un
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @bug_24@
 
     __defined at:__ @comprehensive\/c2hsc.h 358:15@
@@ -4085,15 +4085,15 @@ newtype Bug_24
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr CInt) => HasField "unwrap" Bug_24 ty
+    where hasField = \x_0 -> (\y_1 -> Bug_24{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (Ptr CInt) =>
          HasField "unwrap" (Ptr Bug_24) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bug_24 "unwrap"
     where type CFieldType Bug_24 "unwrap" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) => HasField "unwrap" Bug_24 ty
-    where hasField = \x_0 -> (\y_1 -> Bug_24{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @bug_24_2@
 
     __defined at:__ @comprehensive\/c2hsc.h 359:21@
@@ -4108,15 +4108,15 @@ newtype Bug_24_2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (PtrConst CInt) => HasField "unwrap" Bug_24_2 ty
+    where hasField = \x_0 -> (\y_1 -> Bug_24_2{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (PtrConst CInt) =>
          HasField "unwrap" (Ptr Bug_24_2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Bug_24_2 "unwrap"
     where type CFieldType Bug_24_2 "unwrap" = PtrConst CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst CInt) => HasField "unwrap" Bug_24_2 ty
-    where hasField = \x_0 -> (\y_1 -> Bug_24_2{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @MyArray_27@
 
     __defined at:__ @comprehensive\/c2hsc.h 364:13@
@@ -4128,15 +4128,15 @@ newtype MyArray_27
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 20 CInt) =>
+         HasField "unwrap" MyArray_27 ty
+    where hasField = \x_0 -> (\y_1 -> MyArray_27{unwrap = y_1},
+                              getField @"unwrap" x_0)
+instance (~) ty (ConstantArray 20 CInt) =>
          HasField "unwrap" (Ptr MyArray_27) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField MyArray_27 "unwrap"
     where type CFieldType MyArray_27 "unwrap" = ConstantArray 20 CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 20 CInt) =>
-         HasField "unwrap" MyArray_27 ty
-    where hasField = \x_0 -> (\y_1 -> MyArray_27{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct MyStruct_27@
 
     __defined at:__ @comprehensive\/c2hsc.h 365:9@
@@ -4161,15 +4161,15 @@ instance WriteRaw MyStruct_27
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        MyStruct_27 x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
 deriving via (EquivStorable MyStruct_27) instance Storable MyStruct_27
-instance HasCField MyStruct_27 "x"
-    where type CFieldType MyStruct_27 "x" = MyArray_27
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyArray_27 =>
-         HasField "x" (Ptr MyStruct_27) (Ptr ty)
-    where getField = fromPtr (Proxy @"x")
 instance (~) ty MyArray_27 => HasField "x" MyStruct_27 ty
     where hasField = \x_0 -> (\y_1 -> MyStruct_27{x = y_1},
                               getField @"x" x_0)
+instance (~) ty MyArray_27 =>
+         HasField "x" (Ptr MyStruct_27) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField MyStruct_27 "x"
+    where type CFieldType MyStruct_27 "x" = MyArray_27
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_comprehensivec2hsc_Example_Safe_foo_function@
 foreign import ccall safe "hs_bindgen_3fd2a5c6e681c44b" hs_bindgen_3fd2a5c6e681c44b_base ::
     FunPtr Void

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/Example.hs
@@ -67,6 +67,13 @@ newtype Uint = Uint
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrap" Uint ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Uint {unwrap = y1}, RIP.getField @"unwrap" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Uint) (RIP.Ptr ty) where
 
@@ -77,13 +84,6 @@ instance HasCField.HasCField Uint "unwrap" where
   type CFieldType Uint "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrap" Uint ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Uint {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @size_t@
 
@@ -114,6 +114,14 @@ newtype Size_t = Size_t
     )
 
 instance ( ty ~ RIP.CULong
+         ) => RIP.CompatHasField.HasField "unwrap" Size_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Size_t {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.CULong
          ) => RIP.HasField "unwrap" (RIP.Ptr Size_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -123,14 +131,6 @@ instance HasCField.HasCField Size_t "unwrap" where
   type CFieldType Size_t "unwrap" = RIP.CULong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CULong
-         ) => RIP.CompatHasField.HasField "unwrap" Size_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Size_t {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct bar1_t@
 
@@ -263,17 +263,6 @@ instance Marshal.WriteRaw Bar1_t where
 
 deriving via Marshal.EquivStorable Bar1_t instance RIP.Storable Bar1_t
 
-instance HasCField.HasCField Bar1_t "a" where
-
-  type CFieldType Bar1_t "a" = RIP.Ptr RIP.Void
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "a" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance ( ty ~ RIP.Ptr RIP.Void
          ) => RIP.CompatHasField.HasField "a" Bar1_t ty where
 
@@ -295,15 +284,16 @@ instance ( ty ~ RIP.Ptr RIP.Void
       , RIP.getField @"a" x0
       )
 
-instance HasCField.HasCField Bar1_t "b" where
+instance ( ty ~ RIP.Ptr RIP.Void
+         ) => RIP.HasField "a" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField Bar1_t "a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "a" = RIP.Ptr RIP.Void
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" Bar1_t ty where
 
@@ -325,16 +315,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" Bar1_t ty where
       , RIP.getField @"b" x0
       )
 
-instance HasCField.HasCField Bar1_t "c" where
+instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "c" = RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
 
-  offset# = \_ -> \_ -> 12
+instance HasCField.HasCField Bar1_t "b" where
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "c" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "b" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"c")
+  offset# = \_ -> \_ -> 8
 
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "c" Bar1_t ty where
 
@@ -356,16 +345,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "c" Bar1_t ty where
       , RIP.getField @"c" x0
       )
 
-instance HasCField.HasCField Bar1_t "d" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "c" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "d" = RIP.Ptr RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"c")
 
-  offset# = \_ -> \_ -> 16
+instance HasCField.HasCField Bar1_t "c" where
 
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "d" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "c" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"d")
+  offset# = \_ -> \_ -> 12
 
 instance ( ty ~ RIP.Ptr RIP.CChar
          ) => RIP.CompatHasField.HasField "d" Bar1_t ty where
@@ -388,17 +377,16 @@ instance ( ty ~ RIP.Ptr RIP.CChar
       , RIP.getField @"d" x0
       )
 
-instance HasCField.HasCField Bar1_t "e" where
+instance ( ty ~ RIP.Ptr RIP.CChar
+         ) => RIP.HasField "d" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "e" =
-    RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
+  getField = HasCField.fromPtr (RIP.Proxy @"d")
 
-  offset# = \_ -> \_ -> 24
+instance HasCField.HasCField Bar1_t "d" where
 
-instance ( ty ~ RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
-         ) => RIP.HasField "e" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "d" = RIP.Ptr RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"e")
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
          ) => RIP.CompatHasField.HasField "e" Bar1_t ty where
@@ -421,17 +409,17 @@ instance ( ty ~ RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
       , RIP.getField @"e" x0
       )
 
-instance HasCField.HasCField Bar1_t "f" where
+instance ( ty ~ RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
+         ) => RIP.HasField "e" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "f" =
-    RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
+  getField = HasCField.fromPtr (RIP.Proxy @"e")
 
-  offset# = \_ -> \_ -> 32
+instance HasCField.HasCField Bar1_t "e" where
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
-         ) => RIP.HasField "f" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "e" =
+    RIP.FunPtr (IO (RIP.Ptr RIP.CChar))
 
-  getField = HasCField.fromPtr (RIP.Proxy @"f")
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
          ) => RIP.CompatHasField.HasField "f" Bar1_t ty where
@@ -454,17 +442,17 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
       , RIP.getField @"f" x0
       )
 
-instance HasCField.HasCField Bar1_t "g" where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
+         ) => RIP.HasField "f" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "g" =
-    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
+  getField = HasCField.fromPtr (RIP.Proxy @"f")
 
-  offset# = \_ -> \_ -> 40
+instance HasCField.HasCField Bar1_t "f" where
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
-         ) => RIP.HasField "g" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "f" =
+    RIP.FunPtr (RIP.Ptr RIP.Void -> IO ())
 
-  getField = HasCField.fromPtr (RIP.Proxy @"g")
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
          ) => RIP.CompatHasField.HasField "g" Bar1_t ty where
@@ -487,17 +475,17 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
       , RIP.getField @"g" x0
       )
 
-instance HasCField.HasCField Bar1_t "h" where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
+         ) => RIP.HasField "g" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "h" =
-    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
+  getField = HasCField.fromPtr (RIP.Proxy @"g")
 
-  offset# = \_ -> \_ -> 48
+instance HasCField.HasCField Bar1_t "g" where
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
-         ) => RIP.HasField "h" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "g" =
+    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr RIP.CInt))
 
-  getField = HasCField.fromPtr (RIP.Proxy @"h")
+  offset# = \_ -> \_ -> 40
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
          ) => RIP.CompatHasField.HasField "h" Bar1_t ty where
@@ -520,17 +508,17 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
       , RIP.getField @"h" x0
       )
 
-instance HasCField.HasCField Bar1_t "i" where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
+         ) => RIP.HasField "h" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "i" =
-    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
+  getField = HasCField.fromPtr (RIP.Proxy @"h")
 
-  offset# = \_ -> \_ -> 56
+instance HasCField.HasCField Bar1_t "h" where
 
-instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
-         ) => RIP.HasField "i" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "h" =
+    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr RIP.CInt)))
 
-  getField = HasCField.fromPtr (RIP.Proxy @"i")
+  offset# = \_ -> \_ -> 48
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
          ) => RIP.CompatHasField.HasField "i" Bar1_t ty where
@@ -553,17 +541,17 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RI
       , RIP.getField @"i" x0
       )
 
-instance HasCField.HasCField Bar1_t "j" where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
+         ) => RIP.HasField "i" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "j" =
-    CA.ConstantArray 2 RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"i")
 
-  offset# = \_ -> \_ -> 64
+instance HasCField.HasCField Bar1_t "i" where
 
-instance ( ty ~ CA.ConstantArray 2 RIP.CChar
-         ) => RIP.HasField "j" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "i" =
+    RIP.FunPtr (RIP.Ptr RIP.Void -> IO (RIP.Ptr (RIP.Ptr (RIP.Ptr RIP.CInt))))
 
-  getField = HasCField.fromPtr (RIP.Proxy @"j")
+  offset# = \_ -> \_ -> 56
 
 instance ( ty ~ CA.ConstantArray 2 RIP.CChar
          ) => RIP.CompatHasField.HasField "j" Bar1_t ty where
@@ -586,16 +574,17 @@ instance ( ty ~ CA.ConstantArray 2 RIP.CChar
       , RIP.getField @"j" x0
       )
 
-instance HasCField.HasCField Bar1_t "k" where
+instance ( ty ~ CA.ConstantArray 2 RIP.CChar
+         ) => RIP.HasField "j" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
 
-  type CFieldType Bar1_t "k" = RIP.Ptr Bar1_t
+  getField = HasCField.fromPtr (RIP.Proxy @"j")
 
-  offset# = \_ -> \_ -> 72
+instance HasCField.HasCField Bar1_t "j" where
 
-instance ( ty ~ RIP.Ptr Bar1_t
-         ) => RIP.HasField "k" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+  type CFieldType Bar1_t "j" =
+    CA.ConstantArray 2 RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"k")
+  offset# = \_ -> \_ -> 64
 
 instance ( ty ~ RIP.Ptr Bar1_t
          ) => RIP.CompatHasField.HasField "k" Bar1_t ty where
@@ -617,6 +606,17 @@ instance ( ty ~ RIP.Ptr Bar1_t
                  }
       , RIP.getField @"k" x0
       )
+
+instance ( ty ~ RIP.Ptr Bar1_t
+         ) => RIP.HasField "k" (RIP.Ptr Bar1_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"k")
+
+instance HasCField.HasCField Bar1_t "k" where
+
+  type CFieldType Bar1_t "k" = RIP.Ptr Bar1_t
+
+  offset# = \_ -> \_ -> 72
 
 {-| __C declaration:__ @struct bar2_t@
 
@@ -659,20 +659,20 @@ instance Marshal.WriteRaw Bar2_t where
 
 deriving via Marshal.EquivStorable Bar2_t instance RIP.Storable Bar2_t
 
-instance HasCField.HasCField Bar2_t "a" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" Bar2_t ty where
 
-  type CFieldType Bar2_t "a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> Bar2_t {a = y1}, RIP.getField @"a" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr Bar2_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" Bar2_t ty where
+instance HasCField.HasCField Bar2_t "a" where
 
-  hasField =
-    \x0 -> (\y1 -> Bar2_t {a = y1}, RIP.getField @"a" x0)
+  type CFieldType Bar2_t "a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct bar3_t@
 
@@ -715,20 +715,20 @@ instance Marshal.WriteRaw Bar3_t where
 
 deriving via Marshal.EquivStorable Bar3_t instance RIP.Storable Bar3_t
 
-instance HasCField.HasCField Bar3_t "a" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" Bar3_t ty where
 
-  type CFieldType Bar3_t "a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> Bar3_t {a = y1}, RIP.getField @"a" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr Bar3_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" Bar3_t ty where
+instance HasCField.HasCField Bar3_t "a" where
 
-  hasField =
-    \x0 -> (\y1 -> Bar3_t {a = y1}, RIP.getField @"a" x0)
+  type CFieldType Bar3_t "a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @BAZ1@
 
@@ -818,6 +818,14 @@ instance Read Baz2_t where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrap" Baz2_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Baz2_t {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Baz2_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -827,14 +835,6 @@ instance HasCField.HasCField Baz2_t "unwrap" where
   type CFieldType Baz2_t "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrap" Baz2_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Baz2_t {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @BAZ2@
 
@@ -924,6 +924,14 @@ instance Read Baz3_t where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrap" Baz3_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Baz3_t {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Baz3_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -933,14 +941,6 @@ instance HasCField.HasCField Baz3_t "unwrap" where
   type CFieldType Baz3_t "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrap" Baz3_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Baz3_t {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @BAZ3@
 
@@ -1030,6 +1030,14 @@ instance Read Baz4_t where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrap" Baz4_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Baz4_t {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrap" (RIP.Ptr Baz4_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -1039,14 +1047,6 @@ instance HasCField.HasCField Baz4_t "unwrap" where
   type CFieldType Baz4_t "unwrap" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrap" Baz4_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Baz4_t {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @BAZ4@
 

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/bindingspec.yaml
@@ -57,11 +57,12 @@ hstypes:
       - j
       - k
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -74,11 +75,12 @@ hstypes:
       fields:
       - a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -91,11 +93,12 @@ hstypes:
       fields:
       - a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,12 +112,13 @@ hstypes:
       - unwrap
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -132,12 +136,13 @@ hstypes:
       - unwrap
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -155,12 +160,13 @@ hstypes:
       - unwrap
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -180,7 +186,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -188,6 +193,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -210,7 +217,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -218,6 +224,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/th.txt
@@ -658,14 +658,14 @@ newtype Uint
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CUInt => HasField "unwrap" Uint ty
+    where hasField = \x_0 -> (\y_1 -> Uint{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr Uint) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Uint "unwrap"
     where type CFieldType Uint "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" Uint ty
-    where hasField = \x_0 -> (\y_1 -> Uint{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @size_t@
 
     __defined at:__ @comprehensive\/smoke.h 8:23@
@@ -690,14 +690,14 @@ newtype Size_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CULong => HasField "unwrap" Size_t ty
+    where hasField = \x_0 -> (\y_1 -> Size_t{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CULong => HasField "unwrap" (Ptr Size_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Size_t "unwrap"
     where type CFieldType Size_t "unwrap" = CULong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULong => HasField "unwrap" Size_t ty
-    where hasField = \x_0 -> (\y_1 -> Size_t{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct bar1_t@
 
     __defined at:__ @comprehensive\/smoke.h 39:8@
@@ -802,11 +802,6 @@ instance WriteRaw Bar1_t
                                               j_11
                                               k_12 -> writeRaw (Proxy @"a") ptr_0 a_2 >> (writeRaw (Proxy @"b") ptr_0 b_3 >> (writeRaw (Proxy @"c") ptr_0 c_4 >> (writeRaw (Proxy @"d") ptr_0 d_5 >> (writeRaw (Proxy @"e") ptr_0 e_6 >> (writeRaw (Proxy @"f") ptr_0 f_7 >> (writeRaw (Proxy @"g") ptr_0 g_8 >> (writeRaw (Proxy @"h") ptr_0 h_9 >> (writeRaw (Proxy @"i") ptr_0 i_10 >> (writeRaw (Proxy @"j") ptr_0 j_11 >> writeRaw (Proxy @"k") ptr_0 k_12)))))))))
 deriving via (EquivStorable Bar1_t) instance Storable Bar1_t
-instance HasCField Bar1_t "a"
-    where type CFieldType Bar1_t "a" = Ptr Void
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Void) => HasField "a" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty (Ptr Void) => HasField "a" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{a = y_1,
                                              b = getField @"b" x_0,
@@ -820,11 +815,11 @@ instance (~) ty (Ptr Void) => HasField "a" Bar1_t ty
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"a" x_0)
-instance HasCField Bar1_t "b"
-    where type CFieldType Bar1_t "b" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "b" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty (Ptr Void) => HasField "a" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField Bar1_t "a"
+    where type CFieldType Bar1_t "a" = Ptr Void
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{b = y_1,
                                              a = getField @"a" x_0,
@@ -838,11 +833,11 @@ instance (~) ty CInt => HasField "b" Bar1_t ty
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"b" x_0)
-instance HasCField Bar1_t "c"
-    where type CFieldType Bar1_t "c" = CChar
-          offset# = \_ -> \_ -> 12
-instance (~) ty CChar => HasField "c" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"c")
+instance (~) ty CInt => HasField "b" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField Bar1_t "b"
+    where type CFieldType Bar1_t "b" = CInt
+          offset# = \_ -> \_ -> 8
 instance (~) ty CChar => HasField "c" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{c = y_1,
                                              a = getField @"a" x_0,
@@ -856,11 +851,11 @@ instance (~) ty CChar => HasField "c" Bar1_t ty
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"c" x_0)
-instance HasCField Bar1_t "d"
-    where type CFieldType Bar1_t "d" = Ptr CChar
-          offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr CChar) => HasField "d" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"d")
+instance (~) ty CChar => HasField "c" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"c")
+instance HasCField Bar1_t "c"
+    where type CFieldType Bar1_t "c" = CChar
+          offset# = \_ -> \_ -> 12
 instance (~) ty (Ptr CChar) => HasField "d" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{d = y_1,
                                              a = getField @"a" x_0,
@@ -874,12 +869,11 @@ instance (~) ty (Ptr CChar) => HasField "d" Bar1_t ty
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"d" x_0)
-instance HasCField Bar1_t "e"
-    where type CFieldType Bar1_t "e" = FunPtr (IO (Ptr CChar))
-          offset# = \_ -> \_ -> 24
-instance (~) ty (FunPtr (IO (Ptr CChar))) =>
-         HasField "e" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"e")
+instance (~) ty (Ptr CChar) => HasField "d" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"d")
+instance HasCField Bar1_t "d"
+    where type CFieldType Bar1_t "d" = Ptr CChar
+          offset# = \_ -> \_ -> 16
 instance (~) ty (FunPtr (IO (Ptr CChar))) => HasField "e" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{e = y_1,
                                              a = getField @"a" x_0,
@@ -893,12 +887,12 @@ instance (~) ty (FunPtr (IO (Ptr CChar))) => HasField "e" Bar1_t ty
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"e" x_0)
-instance HasCField Bar1_t "f"
-    where type CFieldType Bar1_t "f" = FunPtr (Ptr Void -> IO ())
-          offset# = \_ -> \_ -> 32
-instance (~) ty (FunPtr (Ptr Void -> IO ())) =>
-         HasField "f" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"f")
+instance (~) ty (FunPtr (IO (Ptr CChar))) =>
+         HasField "e" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"e")
+instance HasCField Bar1_t "e"
+    where type CFieldType Bar1_t "e" = FunPtr (IO (Ptr CChar))
+          offset# = \_ -> \_ -> 24
 instance (~) ty (FunPtr (Ptr Void -> IO ())) =>
          HasField "f" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{f = y_1,
@@ -913,13 +907,12 @@ instance (~) ty (FunPtr (Ptr Void -> IO ())) =>
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"f" x_0)
-instance HasCField Bar1_t "g"
-    where type CFieldType Bar1_t "g" = FunPtr (Ptr Void ->
-                                               IO (Ptr CInt))
-          offset# = \_ -> \_ -> 40
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr CInt))) =>
-         HasField "g" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"g")
+instance (~) ty (FunPtr (Ptr Void -> IO ())) =>
+         HasField "f" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"f")
+instance HasCField Bar1_t "f"
+    where type CFieldType Bar1_t "f" = FunPtr (Ptr Void -> IO ())
+          offset# = \_ -> \_ -> 32
 instance (~) ty (FunPtr (Ptr Void -> IO (Ptr CInt))) =>
          HasField "g" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{g = y_1,
@@ -934,13 +927,13 @@ instance (~) ty (FunPtr (Ptr Void -> IO (Ptr CInt))) =>
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"g" x_0)
-instance HasCField Bar1_t "h"
-    where type CFieldType Bar1_t "h" = FunPtr (Ptr Void ->
-                                               IO (Ptr (Ptr CInt)))
-          offset# = \_ -> \_ -> 48
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))) =>
-         HasField "h" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"h")
+instance (~) ty (FunPtr (Ptr Void -> IO (Ptr CInt))) =>
+         HasField "g" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"g")
+instance HasCField Bar1_t "g"
+    where type CFieldType Bar1_t "g" = FunPtr (Ptr Void ->
+                                               IO (Ptr CInt))
+          offset# = \_ -> \_ -> 40
 instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))) =>
          HasField "h" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{h = y_1,
@@ -955,13 +948,13 @@ instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))) =>
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"h" x_0)
-instance HasCField Bar1_t "i"
-    where type CFieldType Bar1_t "i" = FunPtr (Ptr Void ->
-                                               IO (Ptr (Ptr (Ptr CInt))))
-          offset# = \_ -> \_ -> 56
-instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))) =>
-         HasField "i" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"i")
+instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr CInt)))) =>
+         HasField "h" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"h")
+instance HasCField Bar1_t "h"
+    where type CFieldType Bar1_t "h" = FunPtr (Ptr Void ->
+                                               IO (Ptr (Ptr CInt)))
+          offset# = \_ -> \_ -> 48
 instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))) =>
          HasField "i" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{i = y_1,
@@ -976,12 +969,13 @@ instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))) =>
                                              j = getField @"j" x_0,
                                              k = getField @"k" x_0},
                               getField @"i" x_0)
-instance HasCField Bar1_t "j"
-    where type CFieldType Bar1_t "j" = ConstantArray 2 CChar
-          offset# = \_ -> \_ -> 64
-instance (~) ty (ConstantArray 2 CChar) =>
-         HasField "j" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"j")
+instance (~) ty (FunPtr (Ptr Void -> IO (Ptr (Ptr (Ptr CInt))))) =>
+         HasField "i" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"i")
+instance HasCField Bar1_t "i"
+    where type CFieldType Bar1_t "i" = FunPtr (Ptr Void ->
+                                               IO (Ptr (Ptr (Ptr CInt))))
+          offset# = \_ -> \_ -> 56
 instance (~) ty (ConstantArray 2 CChar) => HasField "j" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{j = y_1,
                                              a = getField @"a" x_0,
@@ -995,11 +989,12 @@ instance (~) ty (ConstantArray 2 CChar) => HasField "j" Bar1_t ty
                                              i = getField @"i" x_0,
                                              k = getField @"k" x_0},
                               getField @"j" x_0)
-instance HasCField Bar1_t "k"
-    where type CFieldType Bar1_t "k" = Ptr Bar1_t
-          offset# = \_ -> \_ -> 72
-instance (~) ty (Ptr Bar1_t) => HasField "k" (Ptr Bar1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"k")
+instance (~) ty (ConstantArray 2 CChar) =>
+         HasField "j" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"j")
+instance HasCField Bar1_t "j"
+    where type CFieldType Bar1_t "j" = ConstantArray 2 CChar
+          offset# = \_ -> \_ -> 64
 instance (~) ty (Ptr Bar1_t) => HasField "k" Bar1_t ty
     where hasField = \x_0 -> (\y_1 -> Bar1_t{k = y_1,
                                              a = getField @"a" x_0,
@@ -1013,6 +1008,11 @@ instance (~) ty (Ptr Bar1_t) => HasField "k" Bar1_t ty
                                              i = getField @"i" x_0,
                                              j = getField @"j" x_0},
                               getField @"k" x_0)
+instance (~) ty (Ptr Bar1_t) => HasField "k" (Ptr Bar1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"k")
+instance HasCField Bar1_t "k"
+    where type CFieldType Bar1_t "k" = Ptr Bar1_t
+          offset# = \_ -> \_ -> 72
 {-| __C declaration:__ @struct bar2_t@
 
     __defined at:__ @comprehensive\/smoke.h 54:16@
@@ -1037,14 +1037,14 @@ instance WriteRaw Bar2_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Bar2_t a_2 -> writeRaw (Proxy @"a") ptr_0 a_2
 deriving via (EquivStorable Bar2_t) instance Storable Bar2_t
-instance HasCField Bar2_t "a"
-    where type CFieldType Bar2_t "a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr Bar2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CInt => HasField "a" Bar2_t ty
     where hasField = \x_0 -> (\y_1 -> Bar2_t{a = y_1},
                               getField @"a" x_0)
+instance (~) ty CInt => HasField "a" (Ptr Bar2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField Bar2_t "a"
+    where type CFieldType Bar2_t "a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct bar3_t@
 
     __defined at:__ @comprehensive\/smoke.h 58:9@
@@ -1069,14 +1069,14 @@ instance WriteRaw Bar3_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Bar3_t a_2 -> writeRaw (Proxy @"a") ptr_0 a_2
 deriving via (EquivStorable Bar3_t) instance Storable Bar3_t
-instance HasCField Bar3_t "a"
-    where type CFieldType Bar3_t "a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr Bar3_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CInt => HasField "a" Bar3_t ty
     where hasField = \x_0 -> (\y_1 -> Bar3_t{a = y_1},
                               getField @"a" x_0)
+instance (~) ty CInt => HasField "a" (Ptr Bar3_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField Bar3_t "a"
+    where type CFieldType Bar3_t "a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @BAZ1@
 
     __defined at:__ @comprehensive\/smoke.h 62:1@
@@ -1124,14 +1124,14 @@ instance Read Baz2_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrap" Baz2_t ty
+    where hasField = \x_0 -> (\y_1 -> Baz2_t{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr Baz2_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz2_t "unwrap"
     where type CFieldType Baz2_t "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" Baz2_t ty
-    where hasField = \x_0 -> (\y_1 -> Baz2_t{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @BAZ2@
 
     __defined at:__ @comprehensive\/smoke.h 67:3@
@@ -1179,14 +1179,14 @@ instance Read Baz3_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrap" Baz3_t ty
+    where hasField = \x_0 -> (\y_1 -> Baz3_t{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr Baz3_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz3_t "unwrap"
     where type CFieldType Baz3_t "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" Baz3_t ty
-    where hasField = \x_0 -> (\y_1 -> Baz3_t{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @BAZ3@
 
     __defined at:__ @comprehensive\/smoke.h 71:3@
@@ -1234,14 +1234,14 @@ instance Read Baz4_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrap" Baz4_t ty
+    where hasField = \x_0 -> (\y_1 -> Baz4_t{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty CUInt => HasField "unwrap" (Ptr Baz4_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField Baz4_t "unwrap"
     where type CFieldType Baz4_t "unwrap" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrap" Baz4_t ty
-    where hasField = \x_0 -> (\y_1 -> Baz4_t{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @BAZ4@
 
     __defined at:__ @comprehensive\/smoke.h 75:3@

--- a/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/Example.hs
@@ -52,6 +52,13 @@ newtype A = A
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapA")
@@ -62,10 +69,3 @@ instance HasCField.HasCField A "unwrapA" where
     HsBindgen.Runtime.LibC.CSize
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)

--- a/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/declarations_required_for_scoping/th.txt
@@ -47,15 +47,15 @@ newtype A
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 -- __unique:__ @test_declarationsdeclarations_requ_Example_Safe_f@
 foreign import ccall safe "hs_bindgen_0d1c75136a36e326" hs_bindgen_0d1c75136a36e326_base ::
     Word64

--- a/hs-bindgen/test-artefacts/fixtures/declarations/definitions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/definitions/Example.hs
@@ -68,20 +68,20 @@ instance Marshal.WriteRaw X where
 
 deriving via Marshal.EquivStorable X instance RIP.Storable X
 
-instance HasCField.HasCField X "x_n" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "x_n" X ty where
 
-  type CFieldType X "x_n" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> X {x_n = y1}, RIP.getField @"x_n" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x_n")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "x_n" X ty where
+instance HasCField.HasCField X "x_n" where
 
-  hasField =
-    \x0 -> (\y1 -> X {x_n = y1}, RIP.getField @"x_n" x0)
+  type CFieldType X "x_n" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union Y@
 
@@ -152,22 +152,22 @@ set_y_o ::
   -> Y
 set_y_o = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"y_m")
+
 instance HasCField.HasCField Y "y_m" where
 
   type CFieldType Y "y_m" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"y_m")
+  getField = HasCField.fromPtr (RIP.Proxy @"y_o")
 
 instance HasCField.HasCField Y "y_o" where
 
   type CFieldType Y "y_o" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"y_o")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/definitions/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/definitions/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - x_n
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -36,7 +37,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/declarations/definitions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/definitions/th.txt
@@ -50,14 +50,14 @@ instance WriteRaw X
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        X x_n_2 -> writeRaw (Proxy @"x_n") ptr_0 x_n_2
 deriving via (EquivStorable X) instance Storable X
-instance HasCField X "x_n"
-    where type CFieldType X "x_n" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
-    where getField = fromPtr (Proxy @"x_n")
 instance (~) ty CInt => HasField "x_n" X ty
     where hasField = \x_0 -> (\y_1 -> X{x_n = y_1},
                               getField @"x_n" x_0)
+instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
+    where getField = fromPtr (Proxy @"x_n")
+instance HasCField X "x_n"
+    where type CFieldType X "x_n" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union Y@
 
     __defined at:__ @declarations\/definitions.h 26:7@
@@ -137,16 +137,16 @@ set_y_o :: CInt -> Y
 
 -}
 set_y_o = setUnionPayload
+instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
+    where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
-    where getField = fromPtr (Proxy @"y_m")
+instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
+    where getField = fromPtr (Proxy @"y_o")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
-    where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsdefinitions_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_9cdc88a6d09442d6" hs_bindgen_9cdc88a6d09442d6_base ::
     Double

--- a/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/Example.hs
@@ -64,23 +64,23 @@ instance Marshal.WriteRaw S1_t where
 
 deriving via Marshal.EquivStorable S1_t instance RIP.Storable S1_t
 
-instance HasCField.HasCField S1_t "s1_t_a" where
-
-  type CFieldType S1_t "s1_t_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_t_a" (RIP.Ptr S1_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_t_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_t_a" S1_t ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          S1_t {s1_t_a = y1}, RIP.getField @"s1_t_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s1_t_a" (RIP.Ptr S1_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_t_a")
+
+instance HasCField.HasCField S1_t "s1_t_a" where
+
+  type CFieldType S1_t "s1_t_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S2@
 
@@ -123,18 +123,18 @@ instance Marshal.WriteRaw S2 where
 
 deriving via Marshal.EquivStorable S2 instance RIP.Storable S2
 
-instance HasCField.HasCField S2 "s2_a" where
-
-  type CFieldType S2 "s2_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s2_a" (RIP.Ptr S2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_a" S2 ty where
 
   hasField =
     \x0 ->
       (\y1 -> S2 {s2_a = y1}, RIP.getField @"s2_a" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s2_a" (RIP.Ptr S2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_a")
+
+instance HasCField.HasCField S2 "s2_a" where
+
+  type CFieldType S2 "s2_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - s1_t_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       fields:
       - s2_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/forward_declaration/th.txt
@@ -23,14 +23,14 @@ instance WriteRaw S1_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S1_t s1_t_a_2 -> writeRaw (Proxy @"s1_t_a") ptr_0 s1_t_a_2
 deriving via (EquivStorable S1_t) instance Storable S1_t
-instance HasCField S1_t "s1_t_a"
-    where type CFieldType S1_t "s1_t_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_t_a" (Ptr S1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_t_a")
 instance (~) ty CInt => HasField "s1_t_a" S1_t ty
     where hasField = \x_0 -> (\y_1 -> S1_t{s1_t_a = y_1},
                               getField @"s1_t_a" x_0)
+instance (~) ty CInt => HasField "s1_t_a" (Ptr S1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_t_a")
+instance HasCField S1_t "s1_t_a"
+    where type CFieldType S1_t "s1_t_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @declarations\/forward_declaration.h 9:8@
@@ -55,11 +55,11 @@ instance WriteRaw S2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S2 s2_a_2 -> writeRaw (Proxy @"s2_a") ptr_0 s2_a_2
 deriving via (EquivStorable S2) instance Storable S2
-instance HasCField S2 "s2_a"
-    where type CFieldType S2 "s2_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s2_a" (Ptr S2) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_a")
 instance (~) ty CInt => HasField "s2_a" S2 ty
     where hasField = \x_0 -> (\y_1 -> S2{s2_a = y_1},
                               getField @"s2_a" x_0)
+instance (~) ty CInt => HasField "s2_a" (Ptr S2) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_a")
+instance HasCField S2 "s2_a"
+    where type CFieldType S2 "s2_a" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/Example.hs
@@ -85,17 +85,6 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCField.HasCField Bar "bar_ptrA" where
-
-  type CFieldType Bar "bar_ptrA" = RIP.Ptr Foo
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Foo
-         ) => RIP.HasField "bar_ptrA" (RIP.Ptr Bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrA")
-
 instance ( ty ~ RIP.Ptr Foo
          ) => RIP.CompatHasField.HasField "bar_ptrA" Bar ty where
 
@@ -106,16 +95,16 @@ instance ( ty ~ RIP.Ptr Foo
       , RIP.getField @"bar_ptrA" x0
       )
 
-instance HasCField.HasCField Bar "bar_ptrB" where
+instance ( ty ~ RIP.Ptr Foo
+         ) => RIP.HasField "bar_ptrA" (RIP.Ptr Bar) (RIP.Ptr ty) where
 
-  type CFieldType Bar "bar_ptrB" = RIP.Ptr Bar
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrA")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField Bar "bar_ptrA" where
 
-instance ( ty ~ RIP.Ptr Bar
-         ) => RIP.HasField "bar_ptrB" (RIP.Ptr Bar) (RIP.Ptr ty) where
+  type CFieldType Bar "bar_ptrA" = RIP.Ptr Foo
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrB")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Bar
          ) => RIP.CompatHasField.HasField "bar_ptrB" Bar ty where
@@ -126,6 +115,17 @@ instance ( ty ~ RIP.Ptr Bar
           Bar {bar_ptrB = y1, bar_ptrA = RIP.getField @"bar_ptrA" x0}
       , RIP.getField @"bar_ptrB" x0
       )
+
+instance ( ty ~ RIP.Ptr Bar
+         ) => RIP.HasField "bar_ptrB" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_ptrB")
+
+instance HasCField.HasCField Bar "bar_ptrB" where
+
+  type CFieldType Bar "bar_ptrB" = RIP.Ptr Bar
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct baz@
 

--- a/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/bindingspec.yaml
@@ -27,11 +27,12 @@ hstypes:
       - bar_ptrA
       - bar_ptrB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/opaque_declaration/th.txt
@@ -38,24 +38,24 @@ instance WriteRaw Bar
                                        Bar bar_ptrA_2
                                            bar_ptrB_3 -> writeRaw (Proxy @"bar_ptrA") ptr_0 bar_ptrA_2 >> writeRaw (Proxy @"bar_ptrB") ptr_0 bar_ptrB_3
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCField Bar "bar_ptrA"
-    where type CFieldType Bar "bar_ptrA" = Ptr Foo
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Foo) => HasField "bar_ptrA" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_ptrA")
 instance (~) ty (Ptr Foo) => HasField "bar_ptrA" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_ptrA = y_1,
                                           bar_ptrB = getField @"bar_ptrB" x_0},
                               getField @"bar_ptrA" x_0)
-instance HasCField Bar "bar_ptrB"
-    where type CFieldType Bar "bar_ptrB" = Ptr Bar
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Bar) => HasField "bar_ptrB" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_ptrB")
+instance (~) ty (Ptr Foo) => HasField "bar_ptrA" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_ptrA")
+instance HasCField Bar "bar_ptrA"
+    where type CFieldType Bar "bar_ptrA" = Ptr Foo
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Bar) => HasField "bar_ptrB" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_ptrB = y_1,
                                           bar_ptrA = getField @"bar_ptrA" x_0},
                               getField @"bar_ptrB" x_0)
+instance (~) ty (Ptr Bar) => HasField "bar_ptrB" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_ptrB")
+instance HasCField Bar "bar_ptrB"
+    where type CFieldType Bar "bar_ptrB" = Ptr Bar
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct baz@
 
     __defined at:__ @declarations\/opaque_declaration.h 9:8@

--- a/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/Example.hs
@@ -59,6 +59,14 @@ newtype Int_t = Int_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapInt_t" Int_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Int_t {unwrapInt_t = y1}, RIP.getField @"unwrapInt_t" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapInt_t" (RIP.Ptr Int_t) (RIP.Ptr ty) where
 
   getField =
@@ -69,14 +77,6 @@ instance HasCField.HasCField Int_t "unwrapInt_t" where
   type CFieldType Int_t "unwrapInt_t" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapInt_t" Int_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Int_t {unwrapInt_t = y1}, RIP.getField @"unwrapInt_t" x0)
 
 {-| __C declaration:__ @struct X@
 
@@ -119,20 +119,20 @@ instance Marshal.WriteRaw X where
 
 deriving via Marshal.EquivStorable X instance RIP.Storable X
 
-instance HasCField.HasCField X "x_n" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "x_n" X ty where
 
-  type CFieldType X "x_n" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> X {x_n = y1}, RIP.getField @"x_n" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "x_n" (RIP.Ptr X) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"x_n")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "x_n" X ty where
+instance HasCField.HasCField X "x_n" where
 
-  hasField =
-    \x0 -> (\y1 -> X {x_n = y1}, RIP.getField @"x_n" x0)
+  type CFieldType X "x_n" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union Y@
 
@@ -203,22 +203,22 @@ set_y_o ::
   -> Y
 set_y_o = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"y_m")
+
 instance HasCField.HasCField Y "y_m" where
 
   type CFieldType Y "y_m" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
-instance (ty ~ RIP.CInt) => RIP.HasField "y_m" (RIP.Ptr Y) (RIP.Ptr ty) where
+instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"y_m")
+  getField = HasCField.fromPtr (RIP.Proxy @"y_o")
 
 instance HasCField.HasCField Y "y_o" where
 
   type CFieldType Y "y_o" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "y_o" (RIP.Ptr Y) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"y_o")

--- a/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/bindingspec.yaml
@@ -23,7 +23,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -31,6 +30,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,11 +51,12 @@ hstypes:
       fields:
       - x_n
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -69,7 +71,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/redeclaration/th.txt
@@ -36,14 +36,14 @@ newtype Int_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapInt_t" Int_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_t{unwrapInt_t = y_1},
+                              getField @"unwrapInt_t" x_0)
 instance (~) ty CInt => HasField "unwrapInt_t" (Ptr Int_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_t")
 instance HasCField Int_t "unwrapInt_t"
     where type CFieldType Int_t "unwrapInt_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapInt_t" Int_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_t{unwrapInt_t = y_1},
-                              getField @"unwrapInt_t" x_0)
 {-| __C declaration:__ @struct X@
 
     __defined at:__ @declarations\/redeclaration.h 26:8@
@@ -68,14 +68,14 @@ instance WriteRaw X
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        X x_n_2 -> writeRaw (Proxy @"x_n") ptr_0 x_n_2
 deriving via (EquivStorable X) instance Storable X
-instance HasCField X "x_n"
-    where type CFieldType X "x_n" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
-    where getField = fromPtr (Proxy @"x_n")
 instance (~) ty CInt => HasField "x_n" X ty
     where hasField = \x_0 -> (\y_1 -> X{x_n = y_1},
                               getField @"x_n" x_0)
+instance (~) ty CInt => HasField "x_n" (Ptr X) (Ptr ty)
+    where getField = fromPtr (Proxy @"x_n")
+instance HasCField X "x_n"
+    where type CFieldType X "x_n" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union Y@
 
     __defined at:__ @declarations\/redeclaration.h 30:7@
@@ -155,16 +155,16 @@ set_y_o :: CInt -> Y
 
 -}
 set_y_o = setUnionPayload
+instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
+    where getField = fromPtr (Proxy @"y_m")
 instance HasCField Y "y_m"
     where type CFieldType Y "y_m" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_m" (Ptr Y) (Ptr ty)
-    where getField = fromPtr (Proxy @"y_m")
+instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
+    where getField = fromPtr (Proxy @"y_o")
 instance HasCField Y "y_o"
     where type CFieldType Y "y_o" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "y_o" (Ptr Y) (Ptr ty)
-    where getField = fromPtr (Proxy @"y_o")
 -- __unique:__ @test_declarationsredeclaration_Example_get_x@
 foreign import ccall unsafe "hs_bindgen_6f47e5cbb92690b9" hs_bindgen_6f47e5cbb92690b9_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/Example.hs
@@ -51,6 +51,16 @@ newtype ParsedAndSelected1 = ParsedAndSelected1
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapParsedAndSelected1" ParsedAndSelected1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          ParsedAndSelected1 {unwrapParsedAndSelected1 = y1}
+      , RIP.getField @"unwrapParsedAndSelected1" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapParsedAndSelected1" (RIP.Ptr ParsedAndSelected1) (RIP.Ptr ty) where
 
   getField =
@@ -62,13 +72,3 @@ instance HasCField.HasCField ParsedAndSelected1 "unwrapParsedAndSelected1" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapParsedAndSelected1" ParsedAndSelected1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          ParsedAndSelected1 {unwrapParsedAndSelected1 = y1}
-      , RIP.getField @"unwrapParsedAndSelected1" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/declarations/select_scoping/th.txt
@@ -25,6 +25,10 @@ newtype ParsedAndSelected1
                       Storable,
                       WriteRaw)
 instance (~) ty CInt =>
+         HasField "unwrapParsedAndSelected1" ParsedAndSelected1 ty
+    where hasField = \x_0 -> (\y_1 -> ParsedAndSelected1{unwrapParsedAndSelected1 = y_1},
+                              getField @"unwrapParsedAndSelected1" x_0)
+instance (~) ty CInt =>
          HasField "unwrapParsedAndSelected1"
                   (Ptr ParsedAndSelected1)
                   (Ptr ty)
@@ -33,7 +37,3 @@ instance HasCField ParsedAndSelected1 "unwrapParsedAndSelected1"
     where type CFieldType ParsedAndSelected1
                           "unwrapParsedAndSelected1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapParsedAndSelected1" ParsedAndSelected1 ty
-    where hasField = \x_0 -> (\y_1 -> ParsedAndSelected1{unwrapParsedAndSelected1 = y_1},
-                              getField @"unwrapParsedAndSelected1" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/Example.hs
@@ -42,6 +42,14 @@ newtype Triplet = Triplet
     )
 
 instance ( ty ~ CA.ConstantArray 3 RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapTriplet" Triplet ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Triplet {unwrapTriplet = y1}, RIP.getField @"unwrapTriplet" x0)
+
+instance ( ty ~ CA.ConstantArray 3 RIP.CInt
          ) => RIP.HasField "unwrapTriplet" (RIP.Ptr Triplet) (RIP.Ptr ty) where
 
   getField =
@@ -53,11 +61,3 @@ instance HasCField.HasCField Triplet "unwrapTriplet" where
     CA.ConstantArray 3 RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapTriplet" Triplet ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Triplet {unwrapTriplet = y1}, RIP.getField @"unwrapTriplet" x0)

--- a/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - unwrapTriplet
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/data_kind_pragma/th.txt
@@ -10,13 +10,13 @@ newtype Triplet
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 3 CInt) =>
+         HasField "unwrapTriplet" Triplet ty
+    where hasField = \x_0 -> (\y_1 -> Triplet{unwrapTriplet = y_1},
+                              getField @"unwrapTriplet" x_0)
+instance (~) ty (ConstantArray 3 CInt) =>
          HasField "unwrapTriplet" (Ptr Triplet) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTriplet")
 instance HasCField Triplet "unwrapTriplet"
     where type CFieldType Triplet "unwrapTriplet" = ConstantArray 3
                                                                   CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 CInt) =>
-         HasField "unwrapTriplet" Triplet ty
-    where hasField = \x_0 -> (\y_1 -> Triplet{unwrapTriplet = y_1},
-                              getField @"unwrapTriplet" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/Example.hs
@@ -125,6 +125,14 @@ newtype Size_type = Size_type
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.CompatHasField.HasField "unwrapSize_type" Size_type ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Size_type {unwrapSize_type = y1}, RIP.getField @"unwrapSize_type" x0)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.HasField "unwrapSize_type" (RIP.Ptr Size_type) (RIP.Ptr ty) where
 
   getField =
@@ -136,14 +144,6 @@ instance HasCField.HasCField Size_type "unwrapSize_type" where
     HsBindgen.Runtime.LibC.CSize
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.CompatHasField.HasField "unwrapSize_type" Size_type ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Size_type {unwrapSize_type = y1}, RIP.getField @"unwrapSize_type" x0)
 
 {-| __C declaration:__ @struct opaque_struct@
 
@@ -245,6 +245,15 @@ instance Read Color_enum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapColor_enum" Color_enum ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Color_enum {unwrapColor_enum = y1}
+      , RIP.getField @"unwrapColor_enum" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapColor_enum" (RIP.Ptr Color_enum) (RIP.Ptr ty) where
 
   getField =
@@ -256,15 +265,6 @@ instance HasCField.HasCField Color_enum "unwrapColor_enum" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapColor_enum" Color_enum ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Color_enum {unwrapColor_enum = y1}
-      , RIP.getField @"unwrapColor_enum" x0
-      )
 
 {-| Red color
 
@@ -348,6 +348,16 @@ instance RIP.FromFunPtr Event_callback_t_Aux where
   fromFunPtr = hs_bindgen_9e9d478c2d75628c
 
 instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapEvent_callback_t_Aux" Event_callback_t_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Event_callback_t_Aux {unwrapEvent_callback_t_Aux = y1}
+      , RIP.getField @"unwrapEvent_callback_t_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
          ) => RIP.HasField "unwrapEvent_callback_t_Aux" (RIP.Ptr Event_callback_t_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -359,16 +369,6 @@ instance HasCField.HasCField Event_callback_t_Aux "unwrapEvent_callback_t_Aux" w
     RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapEvent_callback_t_Aux" Event_callback_t_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Event_callback_t_Aux {unwrapEvent_callback_t_Aux = y1}
-      , RIP.getField @"unwrapEvent_callback_t_Aux" x0
-      )
 
 {-| Callback function type.
 
@@ -397,6 +397,16 @@ newtype Event_callback_t = Event_callback_t
     )
 
 instance ( ty ~ RIP.FunPtr Event_callback_t_Aux
+         ) => RIP.CompatHasField.HasField "unwrapEvent_callback_t" Event_callback_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Event_callback_t {unwrapEvent_callback_t = y1}
+      , RIP.getField @"unwrapEvent_callback_t" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Event_callback_t_Aux
          ) => RIP.HasField "unwrapEvent_callback_t" (RIP.Ptr Event_callback_t) (RIP.Ptr ty) where
 
   getField =
@@ -408,16 +418,6 @@ instance HasCField.HasCField Event_callback_t "unwrapEvent_callback_t" where
     RIP.FunPtr Event_callback_t_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Event_callback_t_Aux
-         ) => RIP.CompatHasField.HasField "unwrapEvent_callback_t" Event_callback_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Event_callback_t {unwrapEvent_callback_t = y1}
-      , RIP.getField @"unwrapEvent_callback_t" x0
-      )
 
 {-| Structure with documented fields.
 
@@ -517,19 +517,6 @@ instance Marshal.WriteRaw Config_t where
 
 deriving via Marshal.EquivStorable Config_t instance RIP.Storable Config_t
 
-instance HasCField.HasCField Config_t "config_t_id" where
-
-  type CFieldType Config_t "config_t_id" =
-    HsBindgen.Runtime.LibC.Word32
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "config_t_id" (RIP.Ptr Config_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"config_t_id")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.CompatHasField.HasField "config_t_id" Config_t ty where
 
@@ -545,18 +532,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word32
       , RIP.getField @"config_t_id" x0
       )
 
-instance HasCField.HasCField Config_t "config_t_name" where
-
-  type CFieldType Config_t "config_t_name" =
-    CA.ConstantArray 64 RIP.CChar
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ CA.ConstantArray 64 RIP.CChar
-         ) => RIP.HasField "config_t_name" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.HasField "config_t_id" (RIP.Ptr Config_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"config_t_name")
+    HasCField.fromPtr (RIP.Proxy @"config_t_id")
+
+instance HasCField.HasCField Config_t "config_t_id" where
+
+  type CFieldType Config_t "config_t_id" =
+    HsBindgen.Runtime.LibC.Word32
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ CA.ConstantArray 64 RIP.CChar
          ) => RIP.CompatHasField.HasField "config_t_name" Config_t ty where
@@ -573,18 +560,18 @@ instance ( ty ~ CA.ConstantArray 64 RIP.CChar
       , RIP.getField @"config_t_name" x0
       )
 
-instance HasCField.HasCField Config_t "config_t_flags" where
-
-  type CFieldType Config_t "config_t_flags" =
-    HsBindgen.Runtime.LibC.Word32
-
-  offset# = \_ -> \_ -> 68
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "config_t_flags" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance ( ty ~ CA.ConstantArray 64 RIP.CChar
+         ) => RIP.HasField "config_t_name" (RIP.Ptr Config_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"config_t_flags")
+    HasCField.fromPtr (RIP.Proxy @"config_t_name")
+
+instance HasCField.HasCField Config_t "config_t_name" where
+
+  type CFieldType Config_t "config_t_name" =
+    CA.ConstantArray 64 RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.CompatHasField.HasField "config_t_flags" Config_t ty where
@@ -601,18 +588,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word32
       , RIP.getField @"config_t_flags" x0
       )
 
-instance HasCField.HasCField Config_t "config_t_callback" where
-
-  type CFieldType Config_t "config_t_callback" =
-    Event_callback_t
-
-  offset# = \_ -> \_ -> 72
-
-instance ( ty ~ Event_callback_t
-         ) => RIP.HasField "config_t_callback" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.HasField "config_t_flags" (RIP.Ptr Config_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"config_t_callback")
+    HasCField.fromPtr (RIP.Proxy @"config_t_flags")
+
+instance HasCField.HasCField Config_t "config_t_flags" where
+
+  type CFieldType Config_t "config_t_flags" =
+    HsBindgen.Runtime.LibC.Word32
+
+  offset# = \_ -> \_ -> 68
 
 instance ( ty ~ Event_callback_t
          ) => RIP.CompatHasField.HasField "config_t_callback" Config_t ty where
@@ -629,18 +616,18 @@ instance ( ty ~ Event_callback_t
       , RIP.getField @"config_t_callback" x0
       )
 
-instance HasCField.HasCField Config_t "config_t_user_data" where
-
-  type CFieldType Config_t "config_t_user_data" =
-    RIP.Ptr RIP.Void
-
-  offset# = \_ -> \_ -> 80
-
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "config_t_user_data" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+instance ( ty ~ Event_callback_t
+         ) => RIP.HasField "config_t_callback" (RIP.Ptr Config_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"config_t_user_data")
+    HasCField.fromPtr (RIP.Proxy @"config_t_callback")
+
+instance HasCField.HasCField Config_t "config_t_callback" where
+
+  type CFieldType Config_t "config_t_callback" =
+    Event_callback_t
+
+  offset# = \_ -> \_ -> 72
 
 instance ( ty ~ RIP.Ptr RIP.Void
          ) => RIP.CompatHasField.HasField "config_t_user_data" Config_t ty where
@@ -656,6 +643,19 @@ instance ( ty ~ RIP.Ptr RIP.Void
                    }
       , RIP.getField @"config_t_user_data" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.Void
+         ) => RIP.HasField "config_t_user_data" (RIP.Ptr Config_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"config_t_user_data")
+
+instance HasCField.HasCField Config_t "config_t_user_data" where
+
+  type CFieldType Config_t "config_t_user_data" =
+    RIP.Ptr RIP.Void
+
+  offset# = \_ -> \_ -> 80
 
 {-| Enumeration with documented values.
 
@@ -735,6 +735,15 @@ instance Read Status_code_t where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapStatus_code_t" Status_code_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Status_code_t {unwrapStatus_code_t = y1}
+      , RIP.getField @"unwrapStatus_code_t" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapStatus_code_t" (RIP.Ptr Status_code_t) (RIP.Ptr ty) where
 
   getField =
@@ -746,15 +755,6 @@ instance HasCField.HasCField Status_code_t "unwrapStatus_code_t" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapStatus_code_t" Status_code_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Status_code_t {unwrapStatus_code_t = y1}
-      , RIP.getField @"unwrapStatus_code_t" x0
-      )
 
 {-| Operation successful.
 
@@ -865,19 +865,6 @@ instance Marshal.WriteRaw Data_union_t_as_parts where
 
 deriving via Marshal.EquivStorable Data_union_t_as_parts instance RIP.Storable Data_union_t_as_parts
 
-instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_low" where
-
-  type CFieldType Data_union_t_as_parts "data_union_t_as_parts_low" =
-    HsBindgen.Runtime.LibC.Word16
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "data_union_t_as_parts_low" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_low")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.CompatHasField.HasField "data_union_t_as_parts_low" Data_union_t_as_parts ty where
 
@@ -890,18 +877,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word16
       , RIP.getField @"data_union_t_as_parts_low" x0
       )
 
-instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_high" where
-
-  type CFieldType Data_union_t_as_parts "data_union_t_as_parts_high" =
-    HsBindgen.Runtime.LibC.Word16
-
-  offset# = \_ -> \_ -> 2
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "data_union_t_as_parts_high" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
+         ) => RIP.HasField "data_union_t_as_parts_low" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_high")
+    HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_low")
+
+instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_low" where
+
+  type CFieldType Data_union_t_as_parts "data_union_t_as_parts_low" =
+    HsBindgen.Runtime.LibC.Word16
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.CompatHasField.HasField "data_union_t_as_parts_high" Data_union_t_as_parts ty where
@@ -914,6 +901,19 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word16
                                 }
       , RIP.getField @"data_union_t_as_parts_high" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.HasField "data_union_t_as_parts_high" (RIP.Ptr Data_union_t_as_parts) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts_high")
+
+instance HasCField.HasCField Data_union_t_as_parts "data_union_t_as_parts_high" where
+
+  type CFieldType Data_union_t_as_parts "data_union_t_as_parts_high" =
+    HsBindgen.Runtime.LibC.Word16
+
+  offset# = \_ -> \_ -> 2
 
 {-| Union with documented fields.
 
@@ -1040,23 +1040,16 @@ set_data_union_t_as_parts ::
   -> Data_union_t
 set_data_union_t_as_parts = RIP.setUnionPayload
 
-instance HasCField.HasCField Data_union_t "data_union_t_as_int" where
-
-  type CFieldType Data_union_t "data_union_t_as_int" =
-    HsBindgen.Runtime.LibC.Int32
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "data_union_t_as_int" (RIP.Ptr Data_union_t) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_int")
 
-instance HasCField.HasCField Data_union_t "data_union_t_as_float" where
+instance HasCField.HasCField Data_union_t "data_union_t_as_int" where
 
-  type CFieldType Data_union_t "data_union_t_as_float" =
-    RIP.CFloat
+  type CFieldType Data_union_t "data_union_t_as_int" =
+    HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
 
@@ -1066,10 +1059,10 @@ instance ( ty ~ RIP.CFloat
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_float")
 
-instance HasCField.HasCField Data_union_t "data_union_t_as_bytes" where
+instance HasCField.HasCField Data_union_t "data_union_t_as_float" where
 
-  type CFieldType Data_union_t "data_union_t_as_bytes" =
-    CA.ConstantArray 4 HsBindgen.Runtime.LibC.Word8
+  type CFieldType Data_union_t "data_union_t_as_float" =
+    RIP.CFloat
 
   offset# = \_ -> \_ -> 0
 
@@ -1079,10 +1072,10 @@ instance ( ty ~ CA.ConstantArray 4 HsBindgen.Runtime.LibC.Word8
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_bytes")
 
-instance HasCField.HasCField Data_union_t "data_union_t_as_parts" where
+instance HasCField.HasCField Data_union_t "data_union_t_as_bytes" where
 
-  type CFieldType Data_union_t "data_union_t_as_parts" =
-    Data_union_t_as_parts
+  type CFieldType Data_union_t "data_union_t_as_bytes" =
+    CA.ConstantArray 4 HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
 
@@ -1091,6 +1084,13 @@ instance ( ty ~ Data_union_t_as_parts
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"data_union_t_as_parts")
+
+instance HasCField.HasCField Data_union_t "data_union_t_as_parts" where
+
+  type CFieldType Data_union_t "data_union_t_as_parts" =
+    Data_union_t_as_parts
+
+  offset# = \_ -> \_ -> 0
 
 {-| Bit field structure.
 
@@ -1176,21 +1176,6 @@ instance Marshal.WriteRaw Bitfield_t where
 
 deriving via Marshal.EquivStorable Bitfield_t instance RIP.Storable Bitfield_t
 
-instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag1" where
-
-  type CBitfieldType Bitfield_t "bitfield_t_flag1" =
-    RIP.CUInt
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 1
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_flag1" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag1")
-
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "bitfield_t_flag1" Bitfield_t ty where
 
@@ -1205,20 +1190,20 @@ instance ( ty ~ RIP.CUInt
       , RIP.getField @"bitfield_t_flag1" x0
       )
 
-instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag2" where
-
-  type CBitfieldType Bitfield_t "bitfield_t_flag2" =
-    RIP.CUInt
-
-  bitfieldOffset# = \_ -> \_ -> 1
-
-  bitfieldWidth# = \_ -> \_ -> 1
-
 instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_flag2" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bitfield_t_flag1" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag2")
+    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag1")
+
+instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag1" where
+
+  type CBitfieldType Bitfield_t "bitfield_t_flag1" =
+    RIP.CUInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 1
 
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "bitfield_t_flag2" Bitfield_t ty where
@@ -1234,20 +1219,20 @@ instance ( ty ~ RIP.CUInt
       , RIP.getField @"bitfield_t_flag2" x0
       )
 
-instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_counter" where
-
-  type CBitfieldType Bitfield_t "bitfield_t_counter" =
-    RIP.CUInt
-
-  bitfieldOffset# = \_ -> \_ -> 2
-
-  bitfieldWidth# = \_ -> \_ -> 6
-
 instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_counter" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bitfield_t_flag2" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_counter")
+    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_flag2")
+
+instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_flag2" where
+
+  type CBitfieldType Bitfield_t "bitfield_t_flag2" =
+    RIP.CUInt
+
+  bitfieldOffset# = \_ -> \_ -> 1
+
+  bitfieldWidth# = \_ -> \_ -> 1
 
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "bitfield_t_counter" Bitfield_t ty where
@@ -1263,20 +1248,20 @@ instance ( ty ~ RIP.CUInt
       , RIP.getField @"bitfield_t_counter" x0
       )
 
-instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_reserved" where
-
-  type CBitfieldType Bitfield_t "bitfield_t_reserved" =
-    RIP.CUInt
-
-  bitfieldOffset# = \_ -> \_ -> 8
-
-  bitfieldWidth# = \_ -> \_ -> 24
-
 instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "bitfield_t_reserved" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bitfield_t_counter" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_reserved")
+    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_counter")
+
+instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_counter" where
+
+  type CBitfieldType Bitfield_t "bitfield_t_counter" =
+    RIP.CUInt
+
+  bitfieldOffset# = \_ -> \_ -> 2
+
+  bitfieldWidth# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "bitfield_t_reserved" Bitfield_t ty where
@@ -1291,6 +1276,21 @@ instance ( ty ~ RIP.CUInt
                      }
       , RIP.getField @"bitfield_t_reserved" x0
       )
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.HasField "bitfield_t_reserved" (RIP.Ptr Bitfield_t) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bitfield_t_reserved")
+
+instance HasCBitfield.HasCBitfield Bitfield_t "bitfield_t_reserved" where
+
+  type CBitfieldType Bitfield_t "bitfield_t_reserved" =
+    RIP.CUInt
+
+  bitfieldOffset# = \_ -> \_ -> 8
+
+  bitfieldWidth# = \_ -> \_ -> 24
 
 {-| Auxiliary type used by 'Processor_fn_t'
 
@@ -1341,6 +1341,16 @@ instance RIP.FromFunPtr Processor_fn_t_Aux where
   fromFunPtr = hs_bindgen_0d4b3d0461629423
 
 instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapProcessor_fn_t_Aux" Processor_fn_t_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Processor_fn_t_Aux {unwrapProcessor_fn_t_Aux = y1}
+      , RIP.getField @"unwrapProcessor_fn_t_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
          ) => RIP.HasField "unwrapProcessor_fn_t_Aux" (RIP.Ptr Processor_fn_t_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -1352,16 +1362,6 @@ instance HasCField.HasCField Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux" where
     RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.Ptr RIP.Void -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapProcessor_fn_t_Aux" Processor_fn_t_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Processor_fn_t_Aux {unwrapProcessor_fn_t_Aux = y1}
-      , RIP.getField @"unwrapProcessor_fn_t_Aux" x0
-      )
 
 {-| Function pointer typedef.
 
@@ -1390,6 +1390,15 @@ newtype Processor_fn_t = Processor_fn_t
     )
 
 instance ( ty ~ RIP.FunPtr Processor_fn_t_Aux
+         ) => RIP.CompatHasField.HasField "unwrapProcessor_fn_t" Processor_fn_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Processor_fn_t {unwrapProcessor_fn_t = y1}
+      , RIP.getField @"unwrapProcessor_fn_t" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Processor_fn_t_Aux
          ) => RIP.HasField "unwrapProcessor_fn_t" (RIP.Ptr Processor_fn_t) (RIP.Ptr ty) where
 
   getField =
@@ -1401,15 +1410,6 @@ instance HasCField.HasCField Processor_fn_t "unwrapProcessor_fn_t" where
     RIP.FunPtr Processor_fn_t_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Processor_fn_t_Aux
-         ) => RIP.CompatHasField.HasField "unwrapProcessor_fn_t" Processor_fn_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Processor_fn_t {unwrapProcessor_fn_t = y1}
-      , RIP.getField @"unwrapProcessor_fn_t" x0
-      )
 
 {-| Array typedef with size.
 
@@ -1432,6 +1432,15 @@ newtype Filename_t = Filename_t
     )
 
 instance ( ty ~ CA.ConstantArray 256 RIP.CChar
+         ) => RIP.CompatHasField.HasField "unwrapFilename_t" Filename_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Filename_t {unwrapFilename_t = y1}
+      , RIP.getField @"unwrapFilename_t" x0
+      )
+
+instance ( ty ~ CA.ConstantArray 256 RIP.CChar
          ) => RIP.HasField "unwrapFilename_t" (RIP.Ptr Filename_t) (RIP.Ptr ty) where
 
   getField =
@@ -1443,15 +1452,6 @@ instance HasCField.HasCField Filename_t "unwrapFilename_t" where
     CA.ConstantArray 256 RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 256 RIP.CChar
-         ) => RIP.CompatHasField.HasField "unwrapFilename_t" Filename_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Filename_t {unwrapFilename_t = y1}
-      , RIP.getField @"unwrapFilename_t" x0
-      )
 
 {-| Structure with flexible array member.
 
@@ -1500,19 +1500,6 @@ instance Marshal.WriteRaw Flexible_array_Aux where
 
 deriving via Marshal.EquivStorable Flexible_array_Aux instance RIP.Storable Flexible_array_Aux
 
-instance HasCField.HasCField Flexible_array_Aux "flexible_array_count" where
-
-  type CFieldType Flexible_array_Aux "flexible_array_count" =
-    HsBindgen.Runtime.LibC.CSize
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "flexible_array_count" (RIP.Ptr Flexible_array_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"flexible_array_count")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.CompatHasField.HasField "flexible_array_count" Flexible_array_Aux ty where
 
@@ -1521,6 +1508,19 @@ instance ( ty ~ HsBindgen.Runtime.LibC.CSize
       ( \y1 -> Flexible_array {flexible_array_count = y1}
       , RIP.getField @"flexible_array_count" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.HasField "flexible_array_count" (RIP.Ptr Flexible_array_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"flexible_array_count")
+
+instance HasCField.HasCField Flexible_array_Aux "flexible_array_count" where
+
+  type CFieldType Flexible_array_Aux "flexible_array_count" =
+    HsBindgen.Runtime.LibC.CSize
+
+  offset# = \_ -> \_ -> 0
 
 instance FLAM.Offset RIP.CInt Flexible_array_Aux where
 
@@ -1608,19 +1608,6 @@ instance Marshal.WriteRaw Dyn_array_t where
 
 deriving via Marshal.EquivStorable Dyn_array_t instance RIP.Storable Dyn_array_t
 
-instance HasCField.HasCField Dyn_array_t "dyn_array_t_data" where
-
-  type CFieldType Dyn_array_t "dyn_array_t_data" =
-    RIP.Ptr RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "dyn_array_t_data" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_data")
-
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.CompatHasField.HasField "dyn_array_t_data" Dyn_array_t ty where
 
@@ -1634,18 +1621,18 @@ instance ( ty ~ RIP.Ptr RIP.CInt
       , RIP.getField @"dyn_array_t_data" x0
       )
 
-instance HasCField.HasCField Dyn_array_t "dyn_array_t_size" where
-
-  type CFieldType Dyn_array_t "dyn_array_t_size" =
-    HsBindgen.Runtime.LibC.CSize
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "dyn_array_t_size" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "dyn_array_t_data" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_size")
+    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_data")
+
+instance HasCField.HasCField Dyn_array_t "dyn_array_t_data" where
+
+  type CFieldType Dyn_array_t "dyn_array_t_data" =
+    RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.CompatHasField.HasField "dyn_array_t_size" Dyn_array_t ty where
@@ -1660,18 +1647,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.CSize
       , RIP.getField @"dyn_array_t_size" x0
       )
 
-instance HasCField.HasCField Dyn_array_t "dyn_array_t_capacity" where
-
-  type CFieldType Dyn_array_t "dyn_array_t_capacity" =
-    HsBindgen.Runtime.LibC.CSize
-
-  offset# = \_ -> \_ -> 16
-
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "dyn_array_t_capacity" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+         ) => RIP.HasField "dyn_array_t_size" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_capacity")
+    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_size")
+
+instance HasCField.HasCField Dyn_array_t "dyn_array_t_size" where
+
+  type CFieldType Dyn_array_t "dyn_array_t_size" =
+    HsBindgen.Runtime.LibC.CSize
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.CompatHasField.HasField "dyn_array_t_capacity" Dyn_array_t ty where
@@ -1685,6 +1672,19 @@ instance ( ty ~ HsBindgen.Runtime.LibC.CSize
                       }
       , RIP.getField @"dyn_array_t_capacity" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.HasField "dyn_array_t_capacity" (RIP.Ptr Dyn_array_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"dyn_array_t_capacity")
+
+instance HasCField.HasCField Dyn_array_t "dyn_array_t_capacity" where
+
+  type CFieldType Dyn_array_t "dyn_array_t_capacity" =
+    HsBindgen.Runtime.LibC.CSize
+
+  offset# = \_ -> \_ -> 16
 
 {-| __C declaration:__ @struct \@multi_anon_t_pos@
 
@@ -1740,19 +1740,6 @@ instance Marshal.WriteRaw Multi_anon_t_pos where
 
 deriving via Marshal.EquivStorable Multi_anon_t_pos instance RIP.Storable Multi_anon_t_pos
 
-instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_x" where
-
-  type CFieldType Multi_anon_t_pos "multi_anon_t_pos_x" =
-    RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_pos_x" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_x")
-
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "multi_anon_t_pos_x" Multi_anon_t_pos ty where
 
@@ -1765,18 +1752,18 @@ instance ( ty ~ RIP.CFloat
       , RIP.getField @"multi_anon_t_pos_x" x0
       )
 
-instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_y" where
-
-  type CFieldType Multi_anon_t_pos "multi_anon_t_pos_y" =
-    RIP.CFloat
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_pos_y" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
+         ) => RIP.HasField "multi_anon_t_pos_x" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_y")
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_x")
+
+instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_x" where
+
+  type CFieldType Multi_anon_t_pos "multi_anon_t_pos_x" =
+    RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "multi_anon_t_pos_y" Multi_anon_t_pos ty where
@@ -1789,6 +1776,19 @@ instance ( ty ~ RIP.CFloat
                            }
       , RIP.getField @"multi_anon_t_pos_y" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "multi_anon_t_pos_y" (RIP.Ptr Multi_anon_t_pos) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos_y")
+
+instance HasCField.HasCField Multi_anon_t_pos "multi_anon_t_pos_y" where
+
+  type CFieldType Multi_anon_t_pos "multi_anon_t_pos_y" =
+    RIP.CFloat
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@multi_anon_t_dim@
 
@@ -1844,19 +1844,6 @@ instance Marshal.WriteRaw Multi_anon_t_dim where
 
 deriving via Marshal.EquivStorable Multi_anon_t_dim instance RIP.Storable Multi_anon_t_dim
 
-instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_w" where
-
-  type CFieldType Multi_anon_t_dim "multi_anon_t_dim_w" =
-    RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_dim_w" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_w")
-
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "multi_anon_t_dim_w" Multi_anon_t_dim ty where
 
@@ -1869,18 +1856,18 @@ instance ( ty ~ RIP.CFloat
       , RIP.getField @"multi_anon_t_dim_w" x0
       )
 
-instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_h" where
-
-  type CFieldType Multi_anon_t_dim "multi_anon_t_dim_h" =
-    RIP.CFloat
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "multi_anon_t_dim_h" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
+         ) => RIP.HasField "multi_anon_t_dim_w" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_h")
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_w")
+
+instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_w" where
+
+  type CFieldType Multi_anon_t_dim "multi_anon_t_dim_w" =
+    RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "multi_anon_t_dim_h" Multi_anon_t_dim ty where
@@ -1893,6 +1880,19 @@ instance ( ty ~ RIP.CFloat
                            }
       , RIP.getField @"multi_anon_t_dim_h" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "multi_anon_t_dim_h" (RIP.Ptr Multi_anon_t_dim) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim_h")
+
+instance HasCField.HasCField Multi_anon_t_dim "multi_anon_t_dim_h" where
+
+  type CFieldType Multi_anon_t_dim "multi_anon_t_dim_h" =
+    RIP.CFloat
+
+  offset# = \_ -> \_ -> 4
 
 {-| Struct with multiple anonymous inner structs.
 
@@ -1956,19 +1956,6 @@ instance Marshal.WriteRaw Multi_anon_t where
 
 deriving via Marshal.EquivStorable Multi_anon_t instance RIP.Storable Multi_anon_t
 
-instance HasCField.HasCField Multi_anon_t "multi_anon_t_pos" where
-
-  type CFieldType Multi_anon_t "multi_anon_t_pos" =
-    Multi_anon_t_pos
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Multi_anon_t_pos
-         ) => RIP.HasField "multi_anon_t_pos" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos")
-
 instance ( ty ~ Multi_anon_t_pos
          ) => RIP.CompatHasField.HasField "multi_anon_t_pos" Multi_anon_t ty where
 
@@ -1979,18 +1966,18 @@ instance ( ty ~ Multi_anon_t_pos
       , RIP.getField @"multi_anon_t_pos" x0
       )
 
-instance HasCField.HasCField Multi_anon_t "multi_anon_t_dim" where
-
-  type CFieldType Multi_anon_t "multi_anon_t_dim" =
-    Multi_anon_t_dim
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ Multi_anon_t_dim
-         ) => RIP.HasField "multi_anon_t_dim" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
+instance ( ty ~ Multi_anon_t_pos
+         ) => RIP.HasField "multi_anon_t_pos" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim")
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_pos")
+
+instance HasCField.HasCField Multi_anon_t "multi_anon_t_pos" where
+
+  type CFieldType Multi_anon_t "multi_anon_t_pos" =
+    Multi_anon_t_pos
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Multi_anon_t_dim
          ) => RIP.CompatHasField.HasField "multi_anon_t_dim" Multi_anon_t ty where
@@ -2001,6 +1988,19 @@ instance ( ty ~ Multi_anon_t_dim
           Multi_anon_t {multi_anon_t_dim = y1, multi_anon_t_pos = RIP.getField @"multi_anon_t_pos" x0}
       , RIP.getField @"multi_anon_t_dim" x0
       )
+
+instance ( ty ~ Multi_anon_t_dim
+         ) => RIP.HasField "multi_anon_t_dim" (RIP.Ptr Multi_anon_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"multi_anon_t_dim")
+
+instance HasCField.HasCField Multi_anon_t "multi_anon_t_dim" where
+
+  type CFieldType Multi_anon_t "multi_anon_t_dim" =
+    Multi_anon_t_dim
+
+  offset# = \_ -> \_ -> 8
 
 {-| Named inner struct
 
@@ -2058,19 +2058,6 @@ instance Marshal.WriteRaw Named_inner where
 
 deriving via Marshal.EquivStorable Named_inner instance RIP.Storable Named_inner
 
-instance HasCField.HasCField Named_inner "named_inner_nx" where
-
-  type CFieldType Named_inner "named_inner_nx" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_inner_nx" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"named_inner_nx")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "named_inner_nx" Named_inner ty where
 
@@ -2081,18 +2068,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"named_inner_nx" x0
       )
 
-instance HasCField.HasCField Named_inner "named_inner_ny" where
-
-  type CFieldType Named_inner "named_inner_ny" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_inner_ny" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
+         ) => RIP.HasField "named_inner_nx" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"named_inner_ny")
+    HasCField.fromPtr (RIP.Proxy @"named_inner_nx")
+
+instance HasCField.HasCField Named_inner "named_inner_nx" where
+
+  type CFieldType Named_inner "named_inner_nx" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "named_inner_ny" Named_inner ty where
@@ -2103,6 +2090,19 @@ instance ( ty ~ RIP.CInt
           Named_inner {named_inner_ny = y1, named_inner_nx = RIP.getField @"named_inner_nx" x0}
       , RIP.getField @"named_inner_ny" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "named_inner_ny" (RIP.Ptr Named_inner) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"named_inner_ny")
+
+instance HasCField.HasCField Named_inner "named_inner_ny" where
+
+  type CFieldType Named_inner "named_inner_ny" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| Struct with a named inner struct.
 
@@ -2160,19 +2160,6 @@ instance Marshal.WriteRaw Named_outer where
 
 deriving via Marshal.EquivStorable Named_outer instance RIP.Storable Named_outer
 
-instance HasCField.HasCField Named_outer "named_outer_inner_field" where
-
-  type CFieldType Named_outer "named_outer_inner_field" =
-    Named_inner
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Named_inner
-         ) => RIP.HasField "named_outer_inner_field" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"named_outer_inner_field")
-
 instance ( ty ~ Named_inner
          ) => RIP.CompatHasField.HasField "named_outer_inner_field" Named_outer ty where
 
@@ -2185,18 +2172,18 @@ instance ( ty ~ Named_inner
       , RIP.getField @"named_outer_inner_field" x0
       )
 
-instance HasCField.HasCField Named_outer "named_outer_nz" where
-
-  type CFieldType Named_outer "named_outer_nz" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "named_outer_nz" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
+instance ( ty ~ Named_inner
+         ) => RIP.HasField "named_outer_inner_field" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"named_outer_nz")
+    HasCField.fromPtr (RIP.Proxy @"named_outer_inner_field")
+
+instance HasCField.HasCField Named_outer "named_outer_inner_field" where
+
+  type CFieldType Named_outer "named_outer_inner_field" =
+    Named_inner
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "named_outer_nz" Named_outer ty where
@@ -2209,6 +2196,19 @@ instance ( ty ~ RIP.CInt
                       }
       , RIP.getField @"named_outer_nz" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "named_outer_nz" (RIP.Ptr Named_outer) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"named_outer_nz")
+
+instance HasCField.HasCField Named_outer "named_outer_nz" where
+
+  type CFieldType Named_outer "named_outer_nz" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@deep_mid_anon_field@
 
@@ -2253,19 +2253,6 @@ instance Marshal.WriteRaw Deep_mid_anon_field where
 
 deriving via Marshal.EquivStorable Deep_mid_anon_field instance RIP.Storable Deep_mid_anon_field
 
-instance HasCField.HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a" where
-
-  type CFieldType Deep_mid_anon_field "deep_mid_anon_field_deep_a" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_mid_anon_field_deep_a" (RIP.Ptr Deep_mid_anon_field) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field_deep_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "deep_mid_anon_field_deep_a" Deep_mid_anon_field ty where
 
@@ -2275,6 +2262,19 @@ instance ( ty ~ RIP.CInt
           Deep_mid_anon_field {deep_mid_anon_field_deep_a = y1}
       , RIP.getField @"deep_mid_anon_field_deep_a" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "deep_mid_anon_field_deep_a" (RIP.Ptr Deep_mid_anon_field) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field_deep_a")
+
+instance HasCField.HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a" where
+
+  type CFieldType Deep_mid_anon_field "deep_mid_anon_field_deep_a" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| The named mid-level struct
 
@@ -2332,18 +2332,6 @@ instance Marshal.WriteRaw Deep_mid where
 
 deriving via Marshal.EquivStorable Deep_mid instance RIP.Storable Deep_mid
 
-instance HasCField.HasCField Deep_mid "deep_mid_m" where
-
-  type CFieldType Deep_mid "deep_mid_m" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_mid_m" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"deep_mid_m")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "deep_mid_m" Deep_mid ty where
 
@@ -2354,18 +2342,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"deep_mid_m" x0
       )
 
-instance HasCField.HasCField Deep_mid "deep_mid_anon_field" where
-
-  type CFieldType Deep_mid "deep_mid_anon_field" =
-    Deep_mid_anon_field
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Deep_mid_anon_field
-         ) => RIP.HasField "deep_mid_anon_field" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "deep_mid_m" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field")
+    HasCField.fromPtr (RIP.Proxy @"deep_mid_m")
+
+instance HasCField.HasCField Deep_mid "deep_mid_m" where
+
+  type CFieldType Deep_mid "deep_mid_m" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Deep_mid_anon_field
          ) => RIP.CompatHasField.HasField "deep_mid_anon_field" Deep_mid ty where
@@ -2376,6 +2363,19 @@ instance ( ty ~ Deep_mid_anon_field
           Deep_mid {deep_mid_anon_field = y1, deep_mid_m = RIP.getField @"deep_mid_m" x0}
       , RIP.getField @"deep_mid_anon_field" x0
       )
+
+instance ( ty ~ Deep_mid_anon_field
+         ) => RIP.HasField "deep_mid_anon_field" (RIP.Ptr Deep_mid) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"deep_mid_anon_field")
+
+instance HasCField.HasCField Deep_mid "deep_mid_anon_field" where
+
+  type CFieldType Deep_mid "deep_mid_anon_field" =
+    Deep_mid_anon_field
+
+  offset# = \_ -> \_ -> 4
 
 {-| Deeply nested mix of named and anonymous structs.
 
@@ -2433,19 +2433,6 @@ instance Marshal.WriteRaw Deep_outer where
 
 deriving via Marshal.EquivStorable Deep_outer instance RIP.Storable Deep_outer
 
-instance HasCField.HasCField Deep_outer "deep_outer_mid_field" where
-
-  type CFieldType Deep_outer "deep_outer_mid_field" =
-    Deep_mid
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Deep_mid
-         ) => RIP.HasField "deep_outer_mid_field" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"deep_outer_mid_field")
-
 instance ( ty ~ Deep_mid
          ) => RIP.CompatHasField.HasField "deep_outer_mid_field" Deep_outer ty where
 
@@ -2456,17 +2443,18 @@ instance ( ty ~ Deep_mid
       , RIP.getField @"deep_outer_mid_field" x0
       )
 
-instance HasCField.HasCField Deep_outer "deep_outer_o" where
-
-  type CFieldType Deep_outer "deep_outer_o" = RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "deep_outer_o" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
+instance ( ty ~ Deep_mid
+         ) => RIP.HasField "deep_outer_mid_field" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"deep_outer_o")
+    HasCField.fromPtr (RIP.Proxy @"deep_outer_mid_field")
+
+instance HasCField.HasCField Deep_outer "deep_outer_mid_field" where
+
+  type CFieldType Deep_outer "deep_outer_mid_field" =
+    Deep_mid
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "deep_outer_o" Deep_outer ty where
@@ -2479,6 +2467,18 @@ instance ( ty ~ RIP.CInt
                      }
       , RIP.getField @"deep_outer_o" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "deep_outer_o" (RIP.Ptr Deep_outer) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"deep_outer_o")
+
+instance HasCField.HasCField Deep_outer "deep_outer_o" where
+
+  type CFieldType Deep_outer "deep_outer_o" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@unnamed_field_t_anon\'ua@
 
@@ -2536,19 +2536,6 @@ instance Marshal.WriteRaw Unnamed_field_t_anon'ua where
 
 deriving via Marshal.EquivStorable Unnamed_field_t_anon'ua instance RIP.Storable Unnamed_field_t_anon'ua
 
-instance HasCField.HasCField Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ua" where
-
-  type CFieldType Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ua" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_anon'ua_ua" (RIP.Ptr Unnamed_field_t_anon'ua) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua_ua")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "unnamed_field_t_anon'ua_ua" Unnamed_field_t_anon'ua ty where
 
@@ -2561,18 +2548,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"unnamed_field_t_anon'ua_ua" x0
       )
 
-instance HasCField.HasCField Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ub" where
-
-  type CFieldType Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ub" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_anon'ua_ub" (RIP.Ptr Unnamed_field_t_anon'ua) (RIP.Ptr ty) where
+         ) => RIP.HasField "unnamed_field_t_anon'ua_ua" (RIP.Ptr Unnamed_field_t_anon'ua) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua_ub")
+    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua_ua")
+
+instance HasCField.HasCField Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ua" where
+
+  type CFieldType Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ua" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "unnamed_field_t_anon'ua_ub" Unnamed_field_t_anon'ua ty where
@@ -2585,6 +2572,19 @@ instance ( ty ~ RIP.CInt
                                   }
       , RIP.getField @"unnamed_field_t_anon'ua_ub" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unnamed_field_t_anon'ua_ub" (RIP.Ptr Unnamed_field_t_anon'ua) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua_ub")
+
+instance HasCField.HasCField Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ub" where
+
+  type CFieldType Unnamed_field_t_anon'ua "unnamed_field_t_anon'ua_ub" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| Struct with unnamed anonymous field.
 
@@ -2656,19 +2656,6 @@ instance Marshal.WriteRaw Unnamed_field_t where
 
 deriving via Marshal.EquivStorable Unnamed_field_t instance RIP.Storable Unnamed_field_t
 
-instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_before" where
-
-  type CFieldType Unnamed_field_t "unnamed_field_t_before" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_before" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_before")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "unnamed_field_t_before" Unnamed_field_t ty where
 
@@ -2682,18 +2669,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"unnamed_field_t_before" x0
       )
 
-instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_anon'ua" where
-
-  type CFieldType Unnamed_field_t "unnamed_field_t_anon'ua" =
-    Unnamed_field_t_anon'ua
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Unnamed_field_t_anon'ua
-         ) => RIP.HasField "unnamed_field_t_anon'ua" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unnamed_field_t_before" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua")
+    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_before")
+
+instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_before" where
+
+  type CFieldType Unnamed_field_t "unnamed_field_t_before" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Unnamed_field_t_anon'ua
          ) => RIP.CompatHasField.HasField "unnamed_field_t_anon'ua" Unnamed_field_t ty where
@@ -2708,18 +2695,18 @@ instance ( ty ~ Unnamed_field_t_anon'ua
       , RIP.getField @"unnamed_field_t_anon'ua" x0
       )
 
-instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_after" where
-
-  type CFieldType Unnamed_field_t "unnamed_field_t_after" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unnamed_field_t_after" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+instance ( ty ~ Unnamed_field_t_anon'ua
+         ) => RIP.HasField "unnamed_field_t_anon'ua" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_after")
+    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_anon'ua")
+
+instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_anon'ua" where
+
+  type CFieldType Unnamed_field_t "unnamed_field_t_anon'ua" =
+    Unnamed_field_t_anon'ua
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "unnamed_field_t_after" Unnamed_field_t ty where
@@ -2733,6 +2720,19 @@ instance ( ty ~ RIP.CInt
                           }
       , RIP.getField @"unnamed_field_t_after" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unnamed_field_t_after" (RIP.Ptr Unnamed_field_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unnamed_field_t_after")
+
+instance HasCField.HasCField Unnamed_field_t "unnamed_field_t_after" where
+
+  type CFieldType Unnamed_field_t "unnamed_field_t_after" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 12
 
 {-| API version number (not in any group).
 
@@ -2765,6 +2765,15 @@ newtype Api_version_t = Api_version_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapApi_version_t" Api_version_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Api_version_t {unwrapApi_version_t = y1}
+      , RIP.getField @"unwrapApi_version_t" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapApi_version_t" (RIP.Ptr Api_version_t) (RIP.Ptr ty) where
 
   getField =
@@ -2776,12 +2785,3 @@ instance HasCField.HasCField Api_version_t "unwrapApi_version_t" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapApi_version_t" Api_version_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Api_version_t {unwrapApi_version_t = y1}
-      , RIP.getField @"unwrapApi_version_t" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/bindingspec.yaml
@@ -113,7 +113,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -121,6 +120,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -143,11 +144,12 @@ hstypes:
       - bitfield_t_counter
       - bitfield_t_reserved
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -161,12 +163,13 @@ hstypes:
       - unwrapColor_enum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -187,11 +190,12 @@ hstypes:
       - config_t_callback
       - config_t_user_data
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -206,7 +210,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -219,11 +223,12 @@ hstypes:
       - data_union_t_as_parts_low
       - data_union_t_as_parts_high
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -237,11 +242,12 @@ hstypes:
       - deep_mid_m
       - deep_mid_anon_field
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -254,11 +260,12 @@ hstypes:
       fields:
       - deep_mid_anon_field_deep_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -272,11 +279,12 @@ hstypes:
       - deep_outer_mid_field
       - deep_outer_o
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -291,11 +299,12 @@ hstypes:
       - dyn_array_t_size
       - dyn_array_t_capacity
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -308,12 +317,13 @@ hstypes:
       fields:
       - unwrapEvent_callback_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -327,11 +337,12 @@ hstypes:
       fields:
       - unwrapFilename_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -347,12 +358,13 @@ hstypes:
       fields:
       - flexible_array_count
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -366,11 +378,12 @@ hstypes:
       - multi_anon_t_pos
       - multi_anon_t_dim
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -384,11 +397,12 @@ hstypes:
       - multi_anon_t_dim_w
       - multi_anon_t_dim_h
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -402,11 +416,12 @@ hstypes:
       - multi_anon_t_pos_x
       - multi_anon_t_pos_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -420,11 +435,12 @@ hstypes:
       - named_inner_nx
       - named_inner_ny
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -438,11 +454,12 @@ hstypes:
       - named_outer_inner_field
       - named_outer_nz
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -459,12 +476,13 @@ hstypes:
       fields:
       - unwrapProcessor_fn_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -481,7 +499,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -489,6 +506,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -509,12 +528,13 @@ hstypes:
       - unwrapStatus_code_t
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -532,11 +552,12 @@ hstypes:
       - unnamed_field_t_anon'ua
       - unnamed_field_t_after
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -550,11 +571,12 @@ hstypes:
       - unnamed_field_t_anon'ua_ua
       - unnamed_field_t_anon'ua_ub
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/th.txt
@@ -589,16 +589,16 @@ newtype Size_type
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "unwrapSize_type" Size_type ty
+    where hasField = \x_0 -> (\y_1 -> Size_type{unwrapSize_type = y_1},
+                              getField @"unwrapSize_type" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "unwrapSize_type" (Ptr Size_type) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSize_type")
 instance HasCField Size_type "unwrapSize_type"
     where type CFieldType Size_type
                           "unwrapSize_type" = HsBindgen.Runtime.LibC.CSize
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "unwrapSize_type" Size_type ty
-    where hasField = \x_0 -> (\y_1 -> Size_type{unwrapSize_type = y_1},
-                              getField @"unwrapSize_type" x_0)
 {-| __C declaration:__ @struct opaque_struct@
 
     __defined at:__ @documentation\/doxygen_docs.h 76:8@
@@ -656,15 +656,15 @@ instance Read Color_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapColor_enum" Color_enum ty
+    where hasField = \x_0 -> (\y_1 -> Color_enum{unwrapColor_enum = y_1},
+                              getField @"unwrapColor_enum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapColor_enum" (Ptr Color_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapColor_enum")
 instance HasCField Color_enum "unwrapColor_enum"
     where type CFieldType Color_enum "unwrapColor_enum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapColor_enum" Color_enum ty
-    where hasField = \x_0 -> (\y_1 -> Color_enum{unwrapColor_enum = y_1},
-                              getField @"unwrapColor_enum" x_0)
 {-| Red color
 
     __C declaration:__ @COLOR_RED@
@@ -733,6 +733,10 @@ instance ToFunPtr Event_callback_t_Aux
 instance FromFunPtr Event_callback_t_Aux
     where fromFunPtr = hs_bindgen_9e9d478c2d75628c
 instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
+         HasField "unwrapEvent_callback_t_Aux" Event_callback_t_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Event_callback_t_Aux{unwrapEvent_callback_t_Aux = y_1},
+                              getField @"unwrapEvent_callback_t_Aux" x_0)
+instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
          HasField "unwrapEvent_callback_t_Aux"
                   (Ptr Event_callback_t_Aux)
                   (Ptr ty)
@@ -742,10 +746,6 @@ instance HasCField Event_callback_t_Aux
     where type CFieldType Event_callback_t_Aux
                           "unwrapEvent_callback_t_Aux" = CInt -> Ptr Void -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
-         HasField "unwrapEvent_callback_t_Aux" Event_callback_t_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Event_callback_t_Aux{unwrapEvent_callback_t_Aux = y_1},
-                              getField @"unwrapEvent_callback_t_Aux" x_0)
 {-| Callback function type.
 
     [__@event_type@__]: Type of event
@@ -769,16 +769,16 @@ newtype Event_callback_t
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Event_callback_t_Aux) =>
+         HasField "unwrapEvent_callback_t" Event_callback_t ty
+    where hasField = \x_0 -> (\y_1 -> Event_callback_t{unwrapEvent_callback_t = y_1},
+                              getField @"unwrapEvent_callback_t" x_0)
+instance (~) ty (FunPtr Event_callback_t_Aux) =>
          HasField "unwrapEvent_callback_t" (Ptr Event_callback_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEvent_callback_t")
 instance HasCField Event_callback_t "unwrapEvent_callback_t"
     where type CFieldType Event_callback_t
                           "unwrapEvent_callback_t" = FunPtr Event_callback_t_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Event_callback_t_Aux) =>
-         HasField "unwrapEvent_callback_t" Event_callback_t ty
-    where hasField = \x_0 -> (\y_1 -> Event_callback_t{unwrapEvent_callback_t = y_1},
-                              getField @"unwrapEvent_callback_t" x_0)
 {-| Structure with documented fields.
 
     This structure demonstrates field documentation.
@@ -851,13 +851,6 @@ instance WriteRaw Config_t
                                                 config_t_callback_5
                                                 config_t_user_data_6 -> writeRaw (Proxy @"config_t_id") ptr_0 config_t_id_2 >> (writeRaw (Proxy @"config_t_name") ptr_0 config_t_name_3 >> (writeRaw (Proxy @"config_t_flags") ptr_0 config_t_flags_4 >> (writeRaw (Proxy @"config_t_callback") ptr_0 config_t_callback_5 >> writeRaw (Proxy @"config_t_user_data") ptr_0 config_t_user_data_6)))
 deriving via (EquivStorable Config_t) instance Storable Config_t
-instance HasCField Config_t "config_t_id"
-    where type CFieldType Config_t
-                          "config_t_id" = HsBindgen.Runtime.LibC.Word32
-          offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "config_t_id" (Ptr Config_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_t_id")
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "config_t_id" Config_t ty
     where hasField = \x_0 -> (\y_1 -> Config_t{config_t_id = y_1,
@@ -866,13 +859,13 @@ instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
                                                config_t_callback = getField @"config_t_callback" x_0,
                                                config_t_user_data = getField @"config_t_user_data" x_0},
                               getField @"config_t_id" x_0)
-instance HasCField Config_t "config_t_name"
-    where type CFieldType Config_t "config_t_name" = ConstantArray 64
-                                                                   CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty (ConstantArray 64 CChar) =>
-         HasField "config_t_name" (Ptr Config_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_t_name")
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "config_t_id" (Ptr Config_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_t_id")
+instance HasCField Config_t "config_t_id"
+    where type CFieldType Config_t
+                          "config_t_id" = HsBindgen.Runtime.LibC.Word32
+          offset# = \_ -> \_ -> 0
 instance (~) ty (ConstantArray 64 CChar) =>
          HasField "config_t_name" Config_t ty
     where hasField = \x_0 -> (\y_1 -> Config_t{config_t_name = y_1,
@@ -881,13 +874,13 @@ instance (~) ty (ConstantArray 64 CChar) =>
                                                config_t_callback = getField @"config_t_callback" x_0,
                                                config_t_user_data = getField @"config_t_user_data" x_0},
                               getField @"config_t_name" x_0)
-instance HasCField Config_t "config_t_flags"
-    where type CFieldType Config_t
-                          "config_t_flags" = HsBindgen.Runtime.LibC.Word32
-          offset# = \_ -> \_ -> 68
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "config_t_flags" (Ptr Config_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_t_flags")
+instance (~) ty (ConstantArray 64 CChar) =>
+         HasField "config_t_name" (Ptr Config_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_t_name")
+instance HasCField Config_t "config_t_name"
+    where type CFieldType Config_t "config_t_name" = ConstantArray 64
+                                                                   CChar
+          offset# = \_ -> \_ -> 4
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "config_t_flags" Config_t ty
     where hasField = \x_0 -> (\y_1 -> Config_t{config_t_flags = y_1,
@@ -896,13 +889,13 @@ instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
                                                config_t_callback = getField @"config_t_callback" x_0,
                                                config_t_user_data = getField @"config_t_user_data" x_0},
                               getField @"config_t_flags" x_0)
-instance HasCField Config_t "config_t_callback"
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "config_t_flags" (Ptr Config_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_t_flags")
+instance HasCField Config_t "config_t_flags"
     where type CFieldType Config_t
-                          "config_t_callback" = Event_callback_t
-          offset# = \_ -> \_ -> 72
-instance (~) ty Event_callback_t =>
-         HasField "config_t_callback" (Ptr Config_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_t_callback")
+                          "config_t_flags" = HsBindgen.Runtime.LibC.Word32
+          offset# = \_ -> \_ -> 68
 instance (~) ty Event_callback_t =>
          HasField "config_t_callback" Config_t ty
     where hasField = \x_0 -> (\y_1 -> Config_t{config_t_callback = y_1,
@@ -911,12 +904,13 @@ instance (~) ty Event_callback_t =>
                                                config_t_flags = getField @"config_t_flags" x_0,
                                                config_t_user_data = getField @"config_t_user_data" x_0},
                               getField @"config_t_callback" x_0)
-instance HasCField Config_t "config_t_user_data"
-    where type CFieldType Config_t "config_t_user_data" = Ptr Void
-          offset# = \_ -> \_ -> 80
-instance (~) ty (Ptr Void) =>
-         HasField "config_t_user_data" (Ptr Config_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_t_user_data")
+instance (~) ty Event_callback_t =>
+         HasField "config_t_callback" (Ptr Config_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_t_callback")
+instance HasCField Config_t "config_t_callback"
+    where type CFieldType Config_t
+                          "config_t_callback" = Event_callback_t
+          offset# = \_ -> \_ -> 72
 instance (~) ty (Ptr Void) =>
          HasField "config_t_user_data" Config_t ty
     where hasField = \x_0 -> (\y_1 -> Config_t{config_t_user_data = y_1,
@@ -925,6 +919,12 @@ instance (~) ty (Ptr Void) =>
                                                config_t_flags = getField @"config_t_flags" x_0,
                                                config_t_callback = getField @"config_t_callback" x_0},
                               getField @"config_t_user_data" x_0)
+instance (~) ty (Ptr Void) =>
+         HasField "config_t_user_data" (Ptr Config_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_t_user_data")
+instance HasCField Config_t "config_t_user_data"
+    where type CFieldType Config_t "config_t_user_data" = Ptr Void
+          offset# = \_ -> \_ -> 80
 {-| Enumeration with documented values.
 
     This enum shows different status codes.
@@ -968,15 +968,15 @@ instance Read Status_code_t
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CInt =>
+         HasField "unwrapStatus_code_t" Status_code_t ty
+    where hasField = \x_0 -> (\y_1 -> Status_code_t{unwrapStatus_code_t = y_1},
+                              getField @"unwrapStatus_code_t" x_0)
+instance (~) ty CInt =>
          HasField "unwrapStatus_code_t" (Ptr Status_code_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStatus_code_t")
 instance HasCField Status_code_t "unwrapStatus_code_t"
     where type CFieldType Status_code_t "unwrapStatus_code_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapStatus_code_t" Status_code_t ty
-    where hasField = \x_0 -> (\y_1 -> Status_code_t{unwrapStatus_code_t = y_1},
-                              getField @"unwrapStatus_code_t" x_0)
 {-| Operation successful.
 
     __C declaration:__ @STATUS_OK@
@@ -1063,36 +1063,36 @@ instance WriteRaw Data_union_t_as_parts
                                        Data_union_t_as_parts data_union_t_as_parts_low_2
                                                              data_union_t_as_parts_high_3 -> writeRaw (Proxy @"data_union_t_as_parts_low") ptr_0 data_union_t_as_parts_low_2 >> writeRaw (Proxy @"data_union_t_as_parts_high") ptr_0 data_union_t_as_parts_high_3
 deriving via (EquivStorable Data_union_t_as_parts) instance Storable Data_union_t_as_parts
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "data_union_t_as_parts_low" Data_union_t_as_parts ty
+    where hasField = \x_0 -> (\y_1 -> Data_union_t_as_parts{data_union_t_as_parts_low = y_1,
+                                                            data_union_t_as_parts_high = getField @"data_union_t_as_parts_high" x_0},
+                              getField @"data_union_t_as_parts_low" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "data_union_t_as_parts_low"
+                  (Ptr Data_union_t_as_parts)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"data_union_t_as_parts_low")
 instance HasCField Data_union_t_as_parts
                    "data_union_t_as_parts_low"
     where type CFieldType Data_union_t_as_parts
                           "data_union_t_as_parts_low" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "data_union_t_as_parts_low"
-                  (Ptr Data_union_t_as_parts)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"data_union_t_as_parts_low")
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "data_union_t_as_parts_low" Data_union_t_as_parts ty
-    where hasField = \x_0 -> (\y_1 -> Data_union_t_as_parts{data_union_t_as_parts_low = y_1,
-                                                            data_union_t_as_parts_high = getField @"data_union_t_as_parts_high" x_0},
-                              getField @"data_union_t_as_parts_low" x_0)
-instance HasCField Data_union_t_as_parts
-                   "data_union_t_as_parts_high"
-    where type CFieldType Data_union_t_as_parts
-                          "data_union_t_as_parts_high" = HsBindgen.Runtime.LibC.Word16
-          offset# = \_ -> \_ -> 2
+         HasField "data_union_t_as_parts_high" Data_union_t_as_parts ty
+    where hasField = \x_0 -> (\y_1 -> Data_union_t_as_parts{data_union_t_as_parts_high = y_1,
+                                                            data_union_t_as_parts_low = getField @"data_union_t_as_parts_low" x_0},
+                              getField @"data_union_t_as_parts_high" x_0)
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "data_union_t_as_parts_high"
                   (Ptr Data_union_t_as_parts)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_parts_high")
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "data_union_t_as_parts_high" Data_union_t_as_parts ty
-    where hasField = \x_0 -> (\y_1 -> Data_union_t_as_parts{data_union_t_as_parts_high = y_1,
-                                                            data_union_t_as_parts_low = getField @"data_union_t_as_parts_low" x_0},
-                              getField @"data_union_t_as_parts_high" x_0)
+instance HasCField Data_union_t_as_parts
+                   "data_union_t_as_parts_high"
+    where type CFieldType Data_union_t_as_parts
+                          "data_union_t_as_parts_high" = HsBindgen.Runtime.LibC.Word16
+          offset# = \_ -> \_ -> 2
 {-| Union with documented fields.
 
     This union demonstrates different data representations.
@@ -1255,34 +1255,34 @@ set_data_union_t_as_parts :: Data_union_t_as_parts -> Data_union_t
 
 -}
 set_data_union_t_as_parts = setUnionPayload
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "data_union_t_as_int" (Ptr Data_union_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"data_union_t_as_int")
 instance HasCField Data_union_t "data_union_t_as_int"
     where type CFieldType Data_union_t
                           "data_union_t_as_int" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "data_union_t_as_int" (Ptr Data_union_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"data_union_t_as_int")
-instance HasCField Data_union_t "data_union_t_as_float"
-    where type CFieldType Data_union_t "data_union_t_as_float" = CFloat
-          offset# = \_ -> \_ -> 0
 instance (~) ty CFloat =>
          HasField "data_union_t_as_float" (Ptr Data_union_t) (Ptr ty)
     where getField = fromPtr (Proxy @"data_union_t_as_float")
+instance HasCField Data_union_t "data_union_t_as_float"
+    where type CFieldType Data_union_t "data_union_t_as_float" = CFloat
+          offset# = \_ -> \_ -> 0
+instance (~) ty (ConstantArray 4 HsBindgen.Runtime.LibC.Word8) =>
+         HasField "data_union_t_as_bytes" (Ptr Data_union_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"data_union_t_as_bytes")
 instance HasCField Data_union_t "data_union_t_as_bytes"
     where type CFieldType Data_union_t
                           "data_union_t_as_bytes" = ConstantArray 4
                                                                   HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 4 HsBindgen.Runtime.LibC.Word8) =>
-         HasField "data_union_t_as_bytes" (Ptr Data_union_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"data_union_t_as_bytes")
+instance (~) ty Data_union_t_as_parts =>
+         HasField "data_union_t_as_parts" (Ptr Data_union_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"data_union_t_as_parts")
 instance HasCField Data_union_t "data_union_t_as_parts"
     where type CFieldType Data_union_t
                           "data_union_t_as_parts" = Data_union_t_as_parts
           offset# = \_ -> \_ -> 0
-instance (~) ty Data_union_t_as_parts =>
-         HasField "data_union_t_as_parts" (Ptr Data_union_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"data_union_t_as_parts")
 {-| Bit field structure.
 
     Demonstrates bit field documentation.
@@ -1343,39 +1343,32 @@ instance WriteRaw Bitfield_t
                                                   bitfield_t_counter_4
                                                   bitfield_t_reserved_5 -> poke (Proxy @"bitfield_t_flag1") ptr_0 bitfield_t_flag1_2 >> (poke (Proxy @"bitfield_t_flag2") ptr_0 bitfield_t_flag2_3 >> (poke (Proxy @"bitfield_t_counter") ptr_0 bitfield_t_counter_4 >> poke (Proxy @"bitfield_t_reserved") ptr_0 bitfield_t_reserved_5))
 deriving via (EquivStorable Bitfield_t) instance Storable Bitfield_t
-instance HasCBitfield Bitfield_t "bitfield_t_flag1"
-    where type CBitfieldType Bitfield_t "bitfield_t_flag1" = CUInt
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 1
-instance (~) ty CUInt =>
-         HasField "bitfield_t_flag1" (Ptr Bitfield_t) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bitfield_t_flag1")
 instance (~) ty CUInt => HasField "bitfield_t_flag1" Bitfield_t ty
     where hasField = \x_0 -> (\y_1 -> Bitfield_t{bitfield_t_flag1 = y_1,
                                                  bitfield_t_flag2 = getField @"bitfield_t_flag2" x_0,
                                                  bitfield_t_counter = getField @"bitfield_t_counter" x_0,
                                                  bitfield_t_reserved = getField @"bitfield_t_reserved" x_0},
                               getField @"bitfield_t_flag1" x_0)
-instance HasCBitfield Bitfield_t "bitfield_t_flag2"
-    where type CBitfieldType Bitfield_t "bitfield_t_flag2" = CUInt
-          bitfieldOffset# = \_ -> \_ -> 1
-          bitfieldWidth# = \_ -> \_ -> 1
 instance (~) ty CUInt =>
-         HasField "bitfield_t_flag2" (Ptr Bitfield_t) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bitfield_t_flag2")
+         HasField "bitfield_t_flag1" (Ptr Bitfield_t) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bitfield_t_flag1")
+instance HasCBitfield Bitfield_t "bitfield_t_flag1"
+    where type CBitfieldType Bitfield_t "bitfield_t_flag1" = CUInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 1
 instance (~) ty CUInt => HasField "bitfield_t_flag2" Bitfield_t ty
     where hasField = \x_0 -> (\y_1 -> Bitfield_t{bitfield_t_flag2 = y_1,
                                                  bitfield_t_flag1 = getField @"bitfield_t_flag1" x_0,
                                                  bitfield_t_counter = getField @"bitfield_t_counter" x_0,
                                                  bitfield_t_reserved = getField @"bitfield_t_reserved" x_0},
                               getField @"bitfield_t_flag2" x_0)
-instance HasCBitfield Bitfield_t "bitfield_t_counter"
-    where type CBitfieldType Bitfield_t "bitfield_t_counter" = CUInt
-          bitfieldOffset# = \_ -> \_ -> 2
-          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CUInt =>
-         HasField "bitfield_t_counter" (Ptr Bitfield_t) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bitfield_t_counter")
+         HasField "bitfield_t_flag2" (Ptr Bitfield_t) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bitfield_t_flag2")
+instance HasCBitfield Bitfield_t "bitfield_t_flag2"
+    where type CBitfieldType Bitfield_t "bitfield_t_flag2" = CUInt
+          bitfieldOffset# = \_ -> \_ -> 1
+          bitfieldWidth# = \_ -> \_ -> 1
 instance (~) ty CUInt =>
          HasField "bitfield_t_counter" Bitfield_t ty
     where hasField = \x_0 -> (\y_1 -> Bitfield_t{bitfield_t_counter = y_1,
@@ -1383,13 +1376,13 @@ instance (~) ty CUInt =>
                                                  bitfield_t_flag2 = getField @"bitfield_t_flag2" x_0,
                                                  bitfield_t_reserved = getField @"bitfield_t_reserved" x_0},
                               getField @"bitfield_t_counter" x_0)
-instance HasCBitfield Bitfield_t "bitfield_t_reserved"
-    where type CBitfieldType Bitfield_t "bitfield_t_reserved" = CUInt
-          bitfieldOffset# = \_ -> \_ -> 8
-          bitfieldWidth# = \_ -> \_ -> 24
 instance (~) ty CUInt =>
-         HasField "bitfield_t_reserved" (Ptr Bitfield_t) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bitfield_t_reserved")
+         HasField "bitfield_t_counter" (Ptr Bitfield_t) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bitfield_t_counter")
+instance HasCBitfield Bitfield_t "bitfield_t_counter"
+    where type CBitfieldType Bitfield_t "bitfield_t_counter" = CUInt
+          bitfieldOffset# = \_ -> \_ -> 2
+          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CUInt =>
          HasField "bitfield_t_reserved" Bitfield_t ty
     where hasField = \x_0 -> (\y_1 -> Bitfield_t{bitfield_t_reserved = y_1,
@@ -1397,6 +1390,13 @@ instance (~) ty CUInt =>
                                                  bitfield_t_flag2 = getField @"bitfield_t_flag2" x_0,
                                                  bitfield_t_counter = getField @"bitfield_t_counter" x_0},
                               getField @"bitfield_t_reserved" x_0)
+instance (~) ty CUInt =>
+         HasField "bitfield_t_reserved" (Ptr Bitfield_t) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bitfield_t_reserved")
+instance HasCBitfield Bitfield_t "bitfield_t_reserved"
+    where type CBitfieldType Bitfield_t "bitfield_t_reserved" = CUInt
+          bitfieldOffset# = \_ -> \_ -> 8
+          bitfieldWidth# = \_ -> \_ -> 24
 {-| Auxiliary type used by 'Processor_fn_t'
 
     __C declaration:__ @processor_fn_t@
@@ -1435,6 +1435,10 @@ instance ToFunPtr Processor_fn_t_Aux
 instance FromFunPtr Processor_fn_t_Aux
     where fromFunPtr = hs_bindgen_0d4b3d0461629423
 instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
+         HasField "unwrapProcessor_fn_t_Aux" Processor_fn_t_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Processor_fn_t_Aux{unwrapProcessor_fn_t_Aux = y_1},
+                              getField @"unwrapProcessor_fn_t_Aux" x_0)
+instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
          HasField "unwrapProcessor_fn_t_Aux"
                   (Ptr Processor_fn_t_Aux)
                   (Ptr ty)
@@ -1443,10 +1447,6 @@ instance HasCField Processor_fn_t_Aux "unwrapProcessor_fn_t_Aux"
     where type CFieldType Processor_fn_t_Aux
                           "unwrapProcessor_fn_t_Aux" = CInt -> Ptr Void -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> Ptr Void -> IO CInt) =>
-         HasField "unwrapProcessor_fn_t_Aux" Processor_fn_t_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Processor_fn_t_Aux{unwrapProcessor_fn_t_Aux = y_1},
-                              getField @"unwrapProcessor_fn_t_Aux" x_0)
 {-| Function pointer typedef.
 
     [__@input@__]: Input value
@@ -1470,16 +1470,16 @@ newtype Processor_fn_t
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Processor_fn_t_Aux) =>
+         HasField "unwrapProcessor_fn_t" Processor_fn_t ty
+    where hasField = \x_0 -> (\y_1 -> Processor_fn_t{unwrapProcessor_fn_t = y_1},
+                              getField @"unwrapProcessor_fn_t" x_0)
+instance (~) ty (FunPtr Processor_fn_t_Aux) =>
          HasField "unwrapProcessor_fn_t" (Ptr Processor_fn_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProcessor_fn_t")
 instance HasCField Processor_fn_t "unwrapProcessor_fn_t"
     where type CFieldType Processor_fn_t
                           "unwrapProcessor_fn_t" = FunPtr Processor_fn_t_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Processor_fn_t_Aux) =>
-         HasField "unwrapProcessor_fn_t" Processor_fn_t ty
-    where hasField = \x_0 -> (\y_1 -> Processor_fn_t{unwrapProcessor_fn_t = y_1},
-                              getField @"unwrapProcessor_fn_t" x_0)
 {-| Array typedef with size.
 
     __C declaration:__ @filename_t@
@@ -1493,16 +1493,16 @@ newtype Filename_t
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 256 CChar) =>
+         HasField "unwrapFilename_t" Filename_t ty
+    where hasField = \x_0 -> (\y_1 -> Filename_t{unwrapFilename_t = y_1},
+                              getField @"unwrapFilename_t" x_0)
+instance (~) ty (ConstantArray 256 CChar) =>
          HasField "unwrapFilename_t" (Ptr Filename_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFilename_t")
 instance HasCField Filename_t "unwrapFilename_t"
     where type CFieldType Filename_t
                           "unwrapFilename_t" = ConstantArray 256 CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 256 CChar) =>
-         HasField "unwrapFilename_t" Filename_t ty
-    where hasField = \x_0 -> (\y_1 -> Filename_t{unwrapFilename_t = y_1},
-                              getField @"unwrapFilename_t" x_0)
 {-| Structure with flexible array member.
 
     Used for variable-length data buffers.
@@ -1533,17 +1533,17 @@ instance WriteRaw Flexible_array_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Flexible_array flexible_array_count_2 -> writeRaw (Proxy @"flexible_array_count") ptr_0 flexible_array_count_2
 deriving via (EquivStorable Flexible_array_Aux) instance Storable Flexible_array_Aux
-instance HasCField Flexible_array_Aux "flexible_array_count"
-    where type CFieldType Flexible_array_Aux
-                          "flexible_array_count" = HsBindgen.Runtime.LibC.CSize
-          offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"flexible_array_count")
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "flexible_array_count" Flexible_array_Aux ty
     where hasField = \x_0 -> (\y_1 -> Flexible_array{flexible_array_count = y_1},
                               getField @"flexible_array_count" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "flexible_array_count" (Ptr Flexible_array_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"flexible_array_count")
+instance HasCField Flexible_array_Aux "flexible_array_count"
+    where type CFieldType Flexible_array_Aux
+                          "flexible_array_count" = HsBindgen.Runtime.LibC.CSize
+          offset# = \_ -> \_ -> 0
 instance Offset CInt Flexible_array_Aux
     where offset = \_proxy_0 -> 8
 type Flexible_array = WithFlam CInt Flexible_array_Aux
@@ -1597,44 +1597,44 @@ instance WriteRaw Dyn_array_t
                                                    dyn_array_t_size_3
                                                    dyn_array_t_capacity_4 -> writeRaw (Proxy @"dyn_array_t_data") ptr_0 dyn_array_t_data_2 >> (writeRaw (Proxy @"dyn_array_t_size") ptr_0 dyn_array_t_size_3 >> writeRaw (Proxy @"dyn_array_t_capacity") ptr_0 dyn_array_t_capacity_4)
 deriving via (EquivStorable Dyn_array_t) instance Storable Dyn_array_t
-instance HasCField Dyn_array_t "dyn_array_t_data"
-    where type CFieldType Dyn_array_t "dyn_array_t_data" = Ptr CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "dyn_array_t_data" (Ptr Dyn_array_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"dyn_array_t_data")
 instance (~) ty (Ptr CInt) =>
          HasField "dyn_array_t_data" Dyn_array_t ty
     where hasField = \x_0 -> (\y_1 -> Dyn_array_t{dyn_array_t_data = y_1,
                                                   dyn_array_t_size = getField @"dyn_array_t_size" x_0,
                                                   dyn_array_t_capacity = getField @"dyn_array_t_capacity" x_0},
                               getField @"dyn_array_t_data" x_0)
-instance HasCField Dyn_array_t "dyn_array_t_size"
-    where type CFieldType Dyn_array_t
-                          "dyn_array_t_size" = HsBindgen.Runtime.LibC.CSize
-          offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "dyn_array_t_size" (Ptr Dyn_array_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"dyn_array_t_size")
+instance (~) ty (Ptr CInt) =>
+         HasField "dyn_array_t_data" (Ptr Dyn_array_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"dyn_array_t_data")
+instance HasCField Dyn_array_t "dyn_array_t_data"
+    where type CFieldType Dyn_array_t "dyn_array_t_data" = Ptr CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "dyn_array_t_size" Dyn_array_t ty
     where hasField = \x_0 -> (\y_1 -> Dyn_array_t{dyn_array_t_size = y_1,
                                                   dyn_array_t_data = getField @"dyn_array_t_data" x_0,
                                                   dyn_array_t_capacity = getField @"dyn_array_t_capacity" x_0},
                               getField @"dyn_array_t_size" x_0)
-instance HasCField Dyn_array_t "dyn_array_t_capacity"
-    where type CFieldType Dyn_array_t
-                          "dyn_array_t_capacity" = HsBindgen.Runtime.LibC.CSize
-          offset# = \_ -> \_ -> 16
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "dyn_array_t_capacity" (Ptr Dyn_array_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"dyn_array_t_capacity")
+         HasField "dyn_array_t_size" (Ptr Dyn_array_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"dyn_array_t_size")
+instance HasCField Dyn_array_t "dyn_array_t_size"
+    where type CFieldType Dyn_array_t
+                          "dyn_array_t_size" = HsBindgen.Runtime.LibC.CSize
+          offset# = \_ -> \_ -> 8
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "dyn_array_t_capacity" Dyn_array_t ty
     where hasField = \x_0 -> (\y_1 -> Dyn_array_t{dyn_array_t_capacity = y_1,
                                                   dyn_array_t_data = getField @"dyn_array_t_data" x_0,
                                                   dyn_array_t_size = getField @"dyn_array_t_size" x_0},
                               getField @"dyn_array_t_capacity" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "dyn_array_t_capacity" (Ptr Dyn_array_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"dyn_array_t_capacity")
+instance HasCField Dyn_array_t "dyn_array_t_capacity"
+    where type CFieldType Dyn_array_t
+                          "dyn_array_t_capacity" = HsBindgen.Runtime.LibC.CSize
+          offset# = \_ -> \_ -> 16
 {-| __C declaration:__ @struct \@multi_anon_t_pos@
 
     __defined at:__ @documentation\/doxygen_docs.h 586:5@
@@ -1671,30 +1671,30 @@ instance WriteRaw Multi_anon_t_pos
                                        Multi_anon_t_pos multi_anon_t_pos_x_2
                                                         multi_anon_t_pos_y_3 -> writeRaw (Proxy @"multi_anon_t_pos_x") ptr_0 multi_anon_t_pos_x_2 >> writeRaw (Proxy @"multi_anon_t_pos_y") ptr_0 multi_anon_t_pos_y_3
 deriving via (EquivStorable Multi_anon_t_pos) instance Storable Multi_anon_t_pos
-instance HasCField Multi_anon_t_pos "multi_anon_t_pos_x"
-    where type CFieldType Multi_anon_t_pos
-                          "multi_anon_t_pos_x" = CFloat
-          offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_pos_x" (Ptr Multi_anon_t_pos) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_pos_x")
 instance (~) ty CFloat =>
          HasField "multi_anon_t_pos_x" Multi_anon_t_pos ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t_pos{multi_anon_t_pos_x = y_1,
                                                        multi_anon_t_pos_y = getField @"multi_anon_t_pos_y" x_0},
                               getField @"multi_anon_t_pos_x" x_0)
-instance HasCField Multi_anon_t_pos "multi_anon_t_pos_y"
-    where type CFieldType Multi_anon_t_pos
-                          "multi_anon_t_pos_y" = CFloat
-          offset# = \_ -> \_ -> 4
 instance (~) ty CFloat =>
-         HasField "multi_anon_t_pos_y" (Ptr Multi_anon_t_pos) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_pos_y")
+         HasField "multi_anon_t_pos_x" (Ptr Multi_anon_t_pos) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_pos_x")
+instance HasCField Multi_anon_t_pos "multi_anon_t_pos_x"
+    where type CFieldType Multi_anon_t_pos
+                          "multi_anon_t_pos_x" = CFloat
+          offset# = \_ -> \_ -> 0
 instance (~) ty CFloat =>
          HasField "multi_anon_t_pos_y" Multi_anon_t_pos ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t_pos{multi_anon_t_pos_y = y_1,
                                                        multi_anon_t_pos_x = getField @"multi_anon_t_pos_x" x_0},
                               getField @"multi_anon_t_pos_y" x_0)
+instance (~) ty CFloat =>
+         HasField "multi_anon_t_pos_y" (Ptr Multi_anon_t_pos) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_pos_y")
+instance HasCField Multi_anon_t_pos "multi_anon_t_pos_y"
+    where type CFieldType Multi_anon_t_pos
+                          "multi_anon_t_pos_y" = CFloat
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@multi_anon_t_dim@
 
     __defined at:__ @documentation\/doxygen_docs.h 594:5@
@@ -1731,30 +1731,30 @@ instance WriteRaw Multi_anon_t_dim
                                        Multi_anon_t_dim multi_anon_t_dim_w_2
                                                         multi_anon_t_dim_h_3 -> writeRaw (Proxy @"multi_anon_t_dim_w") ptr_0 multi_anon_t_dim_w_2 >> writeRaw (Proxy @"multi_anon_t_dim_h") ptr_0 multi_anon_t_dim_h_3
 deriving via (EquivStorable Multi_anon_t_dim) instance Storable Multi_anon_t_dim
-instance HasCField Multi_anon_t_dim "multi_anon_t_dim_w"
-    where type CFieldType Multi_anon_t_dim
-                          "multi_anon_t_dim_w" = CFloat
-          offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "multi_anon_t_dim_w" (Ptr Multi_anon_t_dim) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_dim_w")
 instance (~) ty CFloat =>
          HasField "multi_anon_t_dim_w" Multi_anon_t_dim ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t_dim{multi_anon_t_dim_w = y_1,
                                                        multi_anon_t_dim_h = getField @"multi_anon_t_dim_h" x_0},
                               getField @"multi_anon_t_dim_w" x_0)
-instance HasCField Multi_anon_t_dim "multi_anon_t_dim_h"
-    where type CFieldType Multi_anon_t_dim
-                          "multi_anon_t_dim_h" = CFloat
-          offset# = \_ -> \_ -> 4
 instance (~) ty CFloat =>
-         HasField "multi_anon_t_dim_h" (Ptr Multi_anon_t_dim) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_dim_h")
+         HasField "multi_anon_t_dim_w" (Ptr Multi_anon_t_dim) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_dim_w")
+instance HasCField Multi_anon_t_dim "multi_anon_t_dim_w"
+    where type CFieldType Multi_anon_t_dim
+                          "multi_anon_t_dim_w" = CFloat
+          offset# = \_ -> \_ -> 0
 instance (~) ty CFloat =>
          HasField "multi_anon_t_dim_h" Multi_anon_t_dim ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t_dim{multi_anon_t_dim_h = y_1,
                                                        multi_anon_t_dim_w = getField @"multi_anon_t_dim_w" x_0},
                               getField @"multi_anon_t_dim_h" x_0)
+instance (~) ty CFloat =>
+         HasField "multi_anon_t_dim_h" (Ptr Multi_anon_t_dim) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_dim_h")
+instance HasCField Multi_anon_t_dim "multi_anon_t_dim_h"
+    where type CFieldType Multi_anon_t_dim
+                          "multi_anon_t_dim_h" = CFloat
+          offset# = \_ -> \_ -> 4
 {-| Struct with multiple anonymous inner structs.
 
     Tests that doxygen comment enrichment correctly associates field comments with anonymous inner structs at multiple nesting levels.
@@ -1799,30 +1799,30 @@ instance WriteRaw Multi_anon_t
                                        Multi_anon_t multi_anon_t_pos_2
                                                     multi_anon_t_dim_3 -> writeRaw (Proxy @"multi_anon_t_pos") ptr_0 multi_anon_t_pos_2 >> writeRaw (Proxy @"multi_anon_t_dim") ptr_0 multi_anon_t_dim_3
 deriving via (EquivStorable Multi_anon_t) instance Storable Multi_anon_t
-instance HasCField Multi_anon_t "multi_anon_t_pos"
-    where type CFieldType Multi_anon_t
-                          "multi_anon_t_pos" = Multi_anon_t_pos
-          offset# = \_ -> \_ -> 0
-instance (~) ty Multi_anon_t_pos =>
-         HasField "multi_anon_t_pos" (Ptr Multi_anon_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_pos")
 instance (~) ty Multi_anon_t_pos =>
          HasField "multi_anon_t_pos" Multi_anon_t ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t{multi_anon_t_pos = y_1,
                                                    multi_anon_t_dim = getField @"multi_anon_t_dim" x_0},
                               getField @"multi_anon_t_pos" x_0)
-instance HasCField Multi_anon_t "multi_anon_t_dim"
+instance (~) ty Multi_anon_t_pos =>
+         HasField "multi_anon_t_pos" (Ptr Multi_anon_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_pos")
+instance HasCField Multi_anon_t "multi_anon_t_pos"
     where type CFieldType Multi_anon_t
-                          "multi_anon_t_dim" = Multi_anon_t_dim
-          offset# = \_ -> \_ -> 8
-instance (~) ty Multi_anon_t_dim =>
-         HasField "multi_anon_t_dim" (Ptr Multi_anon_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"multi_anon_t_dim")
+                          "multi_anon_t_pos" = Multi_anon_t_pos
+          offset# = \_ -> \_ -> 0
 instance (~) ty Multi_anon_t_dim =>
          HasField "multi_anon_t_dim" Multi_anon_t ty
     where hasField = \x_0 -> (\y_1 -> Multi_anon_t{multi_anon_t_dim = y_1,
                                                    multi_anon_t_pos = getField @"multi_anon_t_pos" x_0},
                               getField @"multi_anon_t_dim" x_0)
+instance (~) ty Multi_anon_t_dim =>
+         HasField "multi_anon_t_dim" (Ptr Multi_anon_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"multi_anon_t_dim")
+instance HasCField Multi_anon_t "multi_anon_t_dim"
+    where type CFieldType Multi_anon_t
+                          "multi_anon_t_dim" = Multi_anon_t_dim
+          offset# = \_ -> \_ -> 8
 {-| Named inner struct
 
     __C declaration:__ @struct named_inner@
@@ -1861,26 +1861,26 @@ instance WriteRaw Named_inner
                                        Named_inner named_inner_nx_2
                                                    named_inner_ny_3 -> writeRaw (Proxy @"named_inner_nx") ptr_0 named_inner_nx_2 >> writeRaw (Proxy @"named_inner_ny") ptr_0 named_inner_ny_3
 deriving via (EquivStorable Named_inner) instance Storable Named_inner
-instance HasCField Named_inner "named_inner_nx"
-    where type CFieldType Named_inner "named_inner_nx" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "named_inner_nx" (Ptr Named_inner) (Ptr ty)
-    where getField = fromPtr (Proxy @"named_inner_nx")
 instance (~) ty CInt => HasField "named_inner_nx" Named_inner ty
     where hasField = \x_0 -> (\y_1 -> Named_inner{named_inner_nx = y_1,
                                                   named_inner_ny = getField @"named_inner_ny" x_0},
                               getField @"named_inner_nx" x_0)
-instance HasCField Named_inner "named_inner_ny"
-    where type CFieldType Named_inner "named_inner_ny" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "named_inner_ny" (Ptr Named_inner) (Ptr ty)
-    where getField = fromPtr (Proxy @"named_inner_ny")
+         HasField "named_inner_nx" (Ptr Named_inner) (Ptr ty)
+    where getField = fromPtr (Proxy @"named_inner_nx")
+instance HasCField Named_inner "named_inner_nx"
+    where type CFieldType Named_inner "named_inner_nx" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "named_inner_ny" Named_inner ty
     where hasField = \x_0 -> (\y_1 -> Named_inner{named_inner_ny = y_1,
                                                   named_inner_nx = getField @"named_inner_nx" x_0},
                               getField @"named_inner_ny" x_0)
+instance (~) ty CInt =>
+         HasField "named_inner_ny" (Ptr Named_inner) (Ptr ty)
+    where getField = fromPtr (Proxy @"named_inner_ny")
+instance HasCField Named_inner "named_inner_ny"
+    where type CFieldType Named_inner "named_inner_ny" = CInt
+          offset# = \_ -> \_ -> 4
 {-| Struct with a named inner struct.
 
     Tests that doxygen comment enrichment uses the qualified name "named_outer::named_inner" for lookups.
@@ -1919,28 +1919,28 @@ instance WriteRaw Named_outer
                                        Named_outer named_outer_inner_field_2
                                                    named_outer_nz_3 -> writeRaw (Proxy @"named_outer_inner_field") ptr_0 named_outer_inner_field_2 >> writeRaw (Proxy @"named_outer_nz") ptr_0 named_outer_nz_3
 deriving via (EquivStorable Named_outer) instance Storable Named_outer
-instance HasCField Named_outer "named_outer_inner_field"
-    where type CFieldType Named_outer
-                          "named_outer_inner_field" = Named_inner
-          offset# = \_ -> \_ -> 0
-instance (~) ty Named_inner =>
-         HasField "named_outer_inner_field" (Ptr Named_outer) (Ptr ty)
-    where getField = fromPtr (Proxy @"named_outer_inner_field")
 instance (~) ty Named_inner =>
          HasField "named_outer_inner_field" Named_outer ty
     where hasField = \x_0 -> (\y_1 -> Named_outer{named_outer_inner_field = y_1,
                                                   named_outer_nz = getField @"named_outer_nz" x_0},
                               getField @"named_outer_inner_field" x_0)
-instance HasCField Named_outer "named_outer_nz"
-    where type CFieldType Named_outer "named_outer_nz" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "named_outer_nz" (Ptr Named_outer) (Ptr ty)
-    where getField = fromPtr (Proxy @"named_outer_nz")
+instance (~) ty Named_inner =>
+         HasField "named_outer_inner_field" (Ptr Named_outer) (Ptr ty)
+    where getField = fromPtr (Proxy @"named_outer_inner_field")
+instance HasCField Named_outer "named_outer_inner_field"
+    where type CFieldType Named_outer
+                          "named_outer_inner_field" = Named_inner
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "named_outer_nz" Named_outer ty
     where hasField = \x_0 -> (\y_1 -> Named_outer{named_outer_nz = y_1,
                                                   named_outer_inner_field = getField @"named_outer_inner_field" x_0},
                               getField @"named_outer_nz" x_0)
+instance (~) ty CInt =>
+         HasField "named_outer_nz" (Ptr Named_outer) (Ptr ty)
+    where getField = fromPtr (Proxy @"named_outer_nz")
+instance HasCField Named_outer "named_outer_nz"
+    where type CFieldType Named_outer "named_outer_nz" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@deep_mid_anon_field@
 
     __defined at:__ @documentation\/doxygen_docs.h 629:9@
@@ -1967,19 +1967,19 @@ instance WriteRaw Deep_mid_anon_field
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Deep_mid_anon_field deep_mid_anon_field_deep_a_2 -> writeRaw (Proxy @"deep_mid_anon_field_deep_a") ptr_0 deep_mid_anon_field_deep_a_2
 deriving via (EquivStorable Deep_mid_anon_field) instance Storable Deep_mid_anon_field
-instance HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a"
-    where type CFieldType Deep_mid_anon_field
-                          "deep_mid_anon_field_deep_a" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "deep_mid_anon_field_deep_a" Deep_mid_anon_field ty
+    where hasField = \x_0 -> (\y_1 -> Deep_mid_anon_field{deep_mid_anon_field_deep_a = y_1},
+                              getField @"deep_mid_anon_field_deep_a" x_0)
 instance (~) ty CInt =>
          HasField "deep_mid_anon_field_deep_a"
                   (Ptr Deep_mid_anon_field)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"deep_mid_anon_field_deep_a")
-instance (~) ty CInt =>
-         HasField "deep_mid_anon_field_deep_a" Deep_mid_anon_field ty
-    where hasField = \x_0 -> (\y_1 -> Deep_mid_anon_field{deep_mid_anon_field_deep_a = y_1},
-                              getField @"deep_mid_anon_field_deep_a" x_0)
+instance HasCField Deep_mid_anon_field "deep_mid_anon_field_deep_a"
+    where type CFieldType Deep_mid_anon_field
+                          "deep_mid_anon_field_deep_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| The named mid-level struct
 
     __C declaration:__ @struct deep_mid@
@@ -2018,28 +2018,28 @@ instance WriteRaw Deep_mid
                                        Deep_mid deep_mid_m_2
                                                 deep_mid_anon_field_3 -> writeRaw (Proxy @"deep_mid_m") ptr_0 deep_mid_m_2 >> writeRaw (Proxy @"deep_mid_anon_field") ptr_0 deep_mid_anon_field_3
 deriving via (EquivStorable Deep_mid) instance Storable Deep_mid
-instance HasCField Deep_mid "deep_mid_m"
-    where type CFieldType Deep_mid "deep_mid_m" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "deep_mid_m" (Ptr Deep_mid) (Ptr ty)
-    where getField = fromPtr (Proxy @"deep_mid_m")
 instance (~) ty CInt => HasField "deep_mid_m" Deep_mid ty
     where hasField = \x_0 -> (\y_1 -> Deep_mid{deep_mid_m = y_1,
                                                deep_mid_anon_field = getField @"deep_mid_anon_field" x_0},
                               getField @"deep_mid_m" x_0)
-instance HasCField Deep_mid "deep_mid_anon_field"
-    where type CFieldType Deep_mid
-                          "deep_mid_anon_field" = Deep_mid_anon_field
-          offset# = \_ -> \_ -> 4
-instance (~) ty Deep_mid_anon_field =>
-         HasField "deep_mid_anon_field" (Ptr Deep_mid) (Ptr ty)
-    where getField = fromPtr (Proxy @"deep_mid_anon_field")
+instance (~) ty CInt =>
+         HasField "deep_mid_m" (Ptr Deep_mid) (Ptr ty)
+    where getField = fromPtr (Proxy @"deep_mid_m")
+instance HasCField Deep_mid "deep_mid_m"
+    where type CFieldType Deep_mid "deep_mid_m" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty Deep_mid_anon_field =>
          HasField "deep_mid_anon_field" Deep_mid ty
     where hasField = \x_0 -> (\y_1 -> Deep_mid{deep_mid_anon_field = y_1,
                                                deep_mid_m = getField @"deep_mid_m" x_0},
                               getField @"deep_mid_anon_field" x_0)
+instance (~) ty Deep_mid_anon_field =>
+         HasField "deep_mid_anon_field" (Ptr Deep_mid) (Ptr ty)
+    where getField = fromPtr (Proxy @"deep_mid_anon_field")
+instance HasCField Deep_mid "deep_mid_anon_field"
+    where type CFieldType Deep_mid
+                          "deep_mid_anon_field" = Deep_mid_anon_field
+          offset# = \_ -> \_ -> 4
 {-| Deeply nested mix of named and anonymous structs.
 
     Tests the full genealogy walk through mixed named/anonymous nesting.
@@ -2078,27 +2078,27 @@ instance WriteRaw Deep_outer
                                        Deep_outer deep_outer_mid_field_2
                                                   deep_outer_o_3 -> writeRaw (Proxy @"deep_outer_mid_field") ptr_0 deep_outer_mid_field_2 >> writeRaw (Proxy @"deep_outer_o") ptr_0 deep_outer_o_3
 deriving via (EquivStorable Deep_outer) instance Storable Deep_outer
-instance HasCField Deep_outer "deep_outer_mid_field"
-    where type CFieldType Deep_outer "deep_outer_mid_field" = Deep_mid
-          offset# = \_ -> \_ -> 0
-instance (~) ty Deep_mid =>
-         HasField "deep_outer_mid_field" (Ptr Deep_outer) (Ptr ty)
-    where getField = fromPtr (Proxy @"deep_outer_mid_field")
 instance (~) ty Deep_mid =>
          HasField "deep_outer_mid_field" Deep_outer ty
     where hasField = \x_0 -> (\y_1 -> Deep_outer{deep_outer_mid_field = y_1,
                                                  deep_outer_o = getField @"deep_outer_o" x_0},
                               getField @"deep_outer_mid_field" x_0)
-instance HasCField Deep_outer "deep_outer_o"
-    where type CFieldType Deep_outer "deep_outer_o" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "deep_outer_o" (Ptr Deep_outer) (Ptr ty)
-    where getField = fromPtr (Proxy @"deep_outer_o")
+instance (~) ty Deep_mid =>
+         HasField "deep_outer_mid_field" (Ptr Deep_outer) (Ptr ty)
+    where getField = fromPtr (Proxy @"deep_outer_mid_field")
+instance HasCField Deep_outer "deep_outer_mid_field"
+    where type CFieldType Deep_outer "deep_outer_mid_field" = Deep_mid
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "deep_outer_o" Deep_outer ty
     where hasField = \x_0 -> (\y_1 -> Deep_outer{deep_outer_o = y_1,
                                                  deep_outer_mid_field = getField @"deep_outer_mid_field" x_0},
                               getField @"deep_outer_o" x_0)
+instance (~) ty CInt =>
+         HasField "deep_outer_o" (Ptr Deep_outer) (Ptr ty)
+    where getField = fromPtr (Proxy @"deep_outer_o")
+instance HasCField Deep_outer "deep_outer_o"
+    where type CFieldType Deep_outer "deep_outer_o" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@unnamed_field_t_anon\'ua@
 
     __defined at:__ @documentation\/doxygen_docs.h 647:5@
@@ -2135,36 +2135,36 @@ instance WriteRaw Unnamed_field_t_anon'ua
                                        Unnamed_field_t_anon'ua unnamed_field_t_anon'ua_ua_2
                                                                unnamed_field_t_anon'ua_ub_3 -> writeRaw (Proxy @"unnamed_field_t_anon'ua_ua") ptr_0 unnamed_field_t_anon'ua_ua_2 >> writeRaw (Proxy @"unnamed_field_t_anon'ua_ub") ptr_0 unnamed_field_t_anon'ua_ub_3
 deriving via (EquivStorable Unnamed_field_t_anon'ua) instance Storable Unnamed_field_t_anon'ua
+instance (~) ty CInt =>
+         HasField "unnamed_field_t_anon'ua_ua" Unnamed_field_t_anon'ua ty
+    where hasField = \x_0 -> (\y_1 -> Unnamed_field_t_anon'ua{unnamed_field_t_anon'ua_ua = y_1,
+                                                              unnamed_field_t_anon'ua_ub = getField @"unnamed_field_t_anon'ua_ub" x_0},
+                              getField @"unnamed_field_t_anon'ua_ua" x_0)
+instance (~) ty CInt =>
+         HasField "unnamed_field_t_anon'ua_ua"
+                  (Ptr Unnamed_field_t_anon'ua)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"unnamed_field_t_anon'ua_ua")
 instance HasCField Unnamed_field_t_anon'ua
                    "unnamed_field_t_anon'ua_ua"
     where type CFieldType Unnamed_field_t_anon'ua
                           "unnamed_field_t_anon'ua_ua" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
-         HasField "unnamed_field_t_anon'ua_ua"
-                  (Ptr Unnamed_field_t_anon'ua)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"unnamed_field_t_anon'ua_ua")
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_anon'ua_ua" Unnamed_field_t_anon'ua ty
-    where hasField = \x_0 -> (\y_1 -> Unnamed_field_t_anon'ua{unnamed_field_t_anon'ua_ua = y_1,
-                                                              unnamed_field_t_anon'ua_ub = getField @"unnamed_field_t_anon'ua_ub" x_0},
-                              getField @"unnamed_field_t_anon'ua_ua" x_0)
-instance HasCField Unnamed_field_t_anon'ua
-                   "unnamed_field_t_anon'ua_ub"
-    where type CFieldType Unnamed_field_t_anon'ua
-                          "unnamed_field_t_anon'ua_ub" = CInt
-          offset# = \_ -> \_ -> 4
+         HasField "unnamed_field_t_anon'ua_ub" Unnamed_field_t_anon'ua ty
+    where hasField = \x_0 -> (\y_1 -> Unnamed_field_t_anon'ua{unnamed_field_t_anon'ua_ub = y_1,
+                                                              unnamed_field_t_anon'ua_ua = getField @"unnamed_field_t_anon'ua_ua" x_0},
+                              getField @"unnamed_field_t_anon'ua_ub" x_0)
 instance (~) ty CInt =>
          HasField "unnamed_field_t_anon'ua_ub"
                   (Ptr Unnamed_field_t_anon'ua)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unnamed_field_t_anon'ua_ub")
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_anon'ua_ub" Unnamed_field_t_anon'ua ty
-    where hasField = \x_0 -> (\y_1 -> Unnamed_field_t_anon'ua{unnamed_field_t_anon'ua_ub = y_1,
-                                                              unnamed_field_t_anon'ua_ua = getField @"unnamed_field_t_anon'ua_ua" x_0},
-                              getField @"unnamed_field_t_anon'ua_ub" x_0)
+instance HasCField Unnamed_field_t_anon'ua
+                   "unnamed_field_t_anon'ua_ub"
+    where type CFieldType Unnamed_field_t_anon'ua
+                          "unnamed_field_t_anon'ua_ub" = CInt
+          offset# = \_ -> \_ -> 4
 {-| Struct with unnamed anonymous field.
 
     Tests the case where the anonymous inner struct has no field name. The inner fields are flattened directly into the parent.
@@ -2213,45 +2213,45 @@ instance WriteRaw Unnamed_field_t
                                                        unnamed_field_t_anon'ua_3
                                                        unnamed_field_t_after_4 -> writeRaw (Proxy @"unnamed_field_t_before") ptr_0 unnamed_field_t_before_2 >> (writeRaw (Proxy @"unnamed_field_t_anon'ua") ptr_0 unnamed_field_t_anon'ua_3 >> writeRaw (Proxy @"unnamed_field_t_after") ptr_0 unnamed_field_t_after_4)
 deriving via (EquivStorable Unnamed_field_t) instance Storable Unnamed_field_t
-instance HasCField Unnamed_field_t "unnamed_field_t_before"
-    where type CFieldType Unnamed_field_t
-                          "unnamed_field_t_before" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_before" (Ptr Unnamed_field_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"unnamed_field_t_before")
 instance (~) ty CInt =>
          HasField "unnamed_field_t_before" Unnamed_field_t ty
     where hasField = \x_0 -> (\y_1 -> Unnamed_field_t{unnamed_field_t_before = y_1,
                                                       unnamed_field_t_anon'ua = getField @"unnamed_field_t_anon'ua" x_0,
                                                       unnamed_field_t_after = getField @"unnamed_field_t_after" x_0},
                               getField @"unnamed_field_t_before" x_0)
-instance HasCField Unnamed_field_t "unnamed_field_t_anon'ua"
+instance (~) ty CInt =>
+         HasField "unnamed_field_t_before" (Ptr Unnamed_field_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"unnamed_field_t_before")
+instance HasCField Unnamed_field_t "unnamed_field_t_before"
     where type CFieldType Unnamed_field_t
-                          "unnamed_field_t_anon'ua" = Unnamed_field_t_anon'ua
-          offset# = \_ -> \_ -> 4
-instance (~) ty Unnamed_field_t_anon'ua =>
-         HasField "unnamed_field_t_anon'ua" (Ptr Unnamed_field_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"unnamed_field_t_anon'ua")
+                          "unnamed_field_t_before" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty Unnamed_field_t_anon'ua =>
          HasField "unnamed_field_t_anon'ua" Unnamed_field_t ty
     where hasField = \x_0 -> (\y_1 -> Unnamed_field_t{unnamed_field_t_anon'ua = y_1,
                                                       unnamed_field_t_before = getField @"unnamed_field_t_before" x_0,
                                                       unnamed_field_t_after = getField @"unnamed_field_t_after" x_0},
                               getField @"unnamed_field_t_anon'ua" x_0)
-instance HasCField Unnamed_field_t "unnamed_field_t_after"
+instance (~) ty Unnamed_field_t_anon'ua =>
+         HasField "unnamed_field_t_anon'ua" (Ptr Unnamed_field_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"unnamed_field_t_anon'ua")
+instance HasCField Unnamed_field_t "unnamed_field_t_anon'ua"
     where type CFieldType Unnamed_field_t
-                          "unnamed_field_t_after" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "unnamed_field_t_after" (Ptr Unnamed_field_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"unnamed_field_t_after")
+                          "unnamed_field_t_anon'ua" = Unnamed_field_t_anon'ua
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
          HasField "unnamed_field_t_after" Unnamed_field_t ty
     where hasField = \x_0 -> (\y_1 -> Unnamed_field_t{unnamed_field_t_after = y_1,
                                                       unnamed_field_t_before = getField @"unnamed_field_t_before" x_0,
                                                       unnamed_field_t_anon'ua = getField @"unnamed_field_t_anon'ua" x_0},
                               getField @"unnamed_field_t_after" x_0)
+instance (~) ty CInt =>
+         HasField "unnamed_field_t_after" (Ptr Unnamed_field_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"unnamed_field_t_after")
+instance HasCField Unnamed_field_t "unnamed_field_t_after"
+    where type CFieldType Unnamed_field_t
+                          "unnamed_field_t_after" = CInt
+          offset# = \_ -> \_ -> 12
 {-| API version number (not in any group).
 
     __C declaration:__ @api_version_t@
@@ -2279,15 +2279,15 @@ newtype Api_version_t
                       Storable,
                       WriteRaw)
 instance (~) ty CInt =>
+         HasField "unwrapApi_version_t" Api_version_t ty
+    where hasField = \x_0 -> (\y_1 -> Api_version_t{unwrapApi_version_t = y_1},
+                              getField @"unwrapApi_version_t" x_0)
+instance (~) ty CInt =>
          HasField "unwrapApi_version_t" (Ptr Api_version_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapApi_version_t")
 instance HasCField Api_version_t "unwrapApi_version_t"
     where type CFieldType Api_version_t "unwrapApi_version_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapApi_version_t" Api_version_t ty
-    where hasField = \x_0 -> (\y_1 -> Api_version_t{unwrapApi_version_t = y_1},
-                              getField @"unwrapApi_version_t" x_0)
 -- __unique:__ @test_documentationdoxygen_docs_Example_Safe_process_data@
 foreign import ccall safe "hs_bindgen_7eada9f65d982412" hs_bindgen_7eada9f65d982412_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/Example.hs
@@ -78,19 +78,6 @@ instance Marshal.WriteRaw Banner_point where
 
 deriving via Marshal.EquivStorable Banner_point instance RIP.Storable Banner_point
 
-instance HasCField.HasCField Banner_point "banner_point_x" where
-
-  type CFieldType Banner_point "banner_point_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "banner_point_x" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"banner_point_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "banner_point_x" Banner_point ty where
 
@@ -101,18 +88,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"banner_point_x" x0
       )
 
-instance HasCField.HasCField Banner_point "banner_point_y" where
-
-  type CFieldType Banner_point "banner_point_y" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "banner_point_y" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
+         ) => RIP.HasField "banner_point_x" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"banner_point_y")
+    HasCField.fromPtr (RIP.Proxy @"banner_point_x")
+
+instance HasCField.HasCField Banner_point "banner_point_x" where
+
+  type CFieldType Banner_point "banner_point_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "banner_point_y" Banner_point ty where
@@ -123,3 +110,16 @@ instance ( ty ~ RIP.CInt
           Banner_point {banner_point_y = y1, banner_point_x = RIP.getField @"banner_point_x" x0}
       , RIP.getField @"banner_point_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "banner_point_y" (RIP.Ptr Banner_point) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"banner_point_y")
+
+instance HasCField.HasCField Banner_point "banner_point_y" where
+
+  type CFieldType Banner_point "banner_point_y" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/bindingspec.yaml
@@ -15,11 +15,12 @@ hstypes:
       - banner_point_x
       - banner_point_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/javadoc_banner/th.txt
@@ -58,26 +58,26 @@ instance WriteRaw Banner_point
                                        Banner_point banner_point_x_2
                                                     banner_point_y_3 -> writeRaw (Proxy @"banner_point_x") ptr_0 banner_point_x_2 >> writeRaw (Proxy @"banner_point_y") ptr_0 banner_point_y_3
 deriving via (EquivStorable Banner_point) instance Storable Banner_point
-instance HasCField Banner_point "banner_point_x"
-    where type CFieldType Banner_point "banner_point_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "banner_point_x" (Ptr Banner_point) (Ptr ty)
-    where getField = fromPtr (Proxy @"banner_point_x")
 instance (~) ty CInt => HasField "banner_point_x" Banner_point ty
     where hasField = \x_0 -> (\y_1 -> Banner_point{banner_point_x = y_1,
                                                    banner_point_y = getField @"banner_point_y" x_0},
                               getField @"banner_point_x" x_0)
-instance HasCField Banner_point "banner_point_y"
-    where type CFieldType Banner_point "banner_point_y" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "banner_point_y" (Ptr Banner_point) (Ptr ty)
-    where getField = fromPtr (Proxy @"banner_point_y")
+         HasField "banner_point_x" (Ptr Banner_point) (Ptr ty)
+    where getField = fromPtr (Proxy @"banner_point_x")
+instance HasCField Banner_point "banner_point_x"
+    where type CFieldType Banner_point "banner_point_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "banner_point_y" Banner_point ty
     where hasField = \x_0 -> (\y_1 -> Banner_point{banner_point_y = y_1,
                                                    banner_point_x = getField @"banner_point_x" x_0},
                               getField @"banner_point_y" x_0)
+instance (~) ty CInt =>
+         HasField "banner_point_y" (Ptr Banner_point) (Ptr ty)
+    where getField = fromPtr (Proxy @"banner_point_y")
+instance HasCField Banner_point "banner_point_y"
+    where type CFieldType Banner_point "banner_point_y" = CInt
+          offset# = \_ -> \_ -> 4
 -- __unique:__ @test_documentationjavadoc_banner_Example_Safe_banner_double@
 foreign import ccall safe "hs_bindgen_7d3fd818d0780e11" hs_bindgen_7d3fd818d0780e11_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/Example.hs
@@ -52,6 +52,15 @@ newtype Adio'0301s = Adio'0301s
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapAdio'0301s" Adio'0301s ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Adio'0301s {unwrapAdio'0301s = y1}
+      , RIP.getField @"unwrapAdio'0301s" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapAdio'0301s" (RIP.Ptr Adio'0301s) (RIP.Ptr ty) where
 
   getField =
@@ -63,15 +72,6 @@ instance HasCField.HasCField Adio'0301s "unwrapAdio'0301s" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapAdio'0301s" Adio'0301s ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Adio'0301s {unwrapAdio'0301s = y1}
-      , RIP.getField @"unwrapAdio'0301s" x0
-      )
 
 {-| __C declaration:__ @数字@
 
@@ -102,6 +102,14 @@ newtype C数字 = C数字
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapC\25968\23383" C数字 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         C数字 {unwrapC数字 = y1}, RIP.getField @"unwrapC\25968\23383" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapC\25968\23383" (RIP.Ptr C数字) (RIP.Ptr ty) where
 
   getField =
@@ -112,11 +120,3 @@ instance HasCField.HasCField C数字 "unwrapC\25968\23383" where
   type CFieldType C数字 "unwrapC\25968\23383" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapC\25968\23383" C数字 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         C数字 {unwrapC数字 = y1}, RIP.getField @"unwrapC\25968\23383" x0)

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/adios/th.txt
@@ -92,15 +92,15 @@ newtype Adio'0301s
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapAdio'0301s" Adio'0301s ty
+    where hasField = \x_0 -> (\y_1 -> Adio'0301s{unwrapAdio'0301s = y_1},
+                              getField @"unwrapAdio'0301s" x_0)
 instance (~) ty CInt =>
          HasField "unwrapAdio'0301s" (Ptr Adio'0301s) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapAdio'0301s")
 instance HasCField Adio'0301s "unwrapAdio'0301s"
     where type CFieldType Adio'0301s "unwrapAdio'0301s" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapAdio'0301s" Adio'0301s ty
-    where hasField = \x_0 -> (\y_1 -> Adio'0301s{unwrapAdio'0301s = y_1},
-                              getField @"unwrapAdio'0301s" x_0)
 {-| __C declaration:__ @数字@
 
     __defined at:__ @edge-cases\/adios.h 17:13@
@@ -125,15 +125,15 @@ newtype C数字
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapC\25968\23383" C数字 ty
+    where hasField = \x_0 -> (\y_1 -> C数字{unwrapC数字 = y_1},
+                              getField @"unwrapC\25968\23383" x_0)
 instance (~) ty CInt =>
          HasField "unwrapC\25968\23383" (Ptr C数字) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapC\25968\23383")
 instance HasCField C数字 "unwrapC\25968\23383"
     where type CFieldType C数字 "unwrapC\25968\23383" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapC\25968\23383" C数字 ty
-    where hasField = \x_0 -> (\y_1 -> C数字{unwrapC数字 = y_1},
-                              getField @"unwrapC\25968\23383" x_0)
 -- __unique:__ @test_edgecasesadios_Example_Safe_adiós_fun@
 foreign import ccall safe "hs_bindgen_2f6d4be143076044" hs_bindgen_2f6d4be143076044_base ::
     IO Int32

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/Example.hs
@@ -73,19 +73,6 @@ instance Marshal.WriteRaw Some_struct_field1 where
 
 deriving via Marshal.EquivStorable Some_struct_field1 instance RIP.Storable Some_struct_field1
 
-instance HasCField.HasCField Some_struct_field1 "some_struct_field1_x" where
-
-  type CFieldType Some_struct_field1 "some_struct_field1_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "some_struct_field1_x" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"some_struct_field1_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "some_struct_field1_x" Some_struct_field1 ty where
 
@@ -98,18 +85,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"some_struct_field1_x" x0
       )
 
-instance HasCField.HasCField Some_struct_field1 "some_struct_field1_y" where
-
-  type CFieldType Some_struct_field1 "some_struct_field1_y" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "some_struct_field1_y" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
+         ) => RIP.HasField "some_struct_field1_x" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"some_struct_field1_y")
+    HasCField.fromPtr (RIP.Proxy @"some_struct_field1_x")
+
+instance HasCField.HasCField Some_struct_field1 "some_struct_field1_x" where
+
+  type CFieldType Some_struct_field1 "some_struct_field1_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "some_struct_field1_y" Some_struct_field1 ty where
@@ -122,6 +109,19 @@ instance ( ty ~ RIP.CInt
                              }
       , RIP.getField @"some_struct_field1_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "some_struct_field1_y" (RIP.Ptr Some_struct_field1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"some_struct_field1_y")
+
+instance HasCField.HasCField Some_struct_field1 "some_struct_field1_y" where
+
+  type CFieldType Some_struct_field1 "some_struct_field1_y" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct some_struct@
 
@@ -182,19 +182,6 @@ instance Marshal.WriteRaw Some_struct where
 
 deriving via Marshal.EquivStorable Some_struct instance RIP.Storable Some_struct
 
-instance HasCField.HasCField Some_struct "some_struct_field1" where
-
-  type CFieldType Some_struct "some_struct_field1" =
-    Some_struct_field1
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field1" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"some_struct_field1")
-
 instance ( ty ~ Some_struct_field1
          ) => RIP.CompatHasField.HasField "some_struct_field1" Some_struct ty where
 
@@ -208,18 +195,18 @@ instance ( ty ~ Some_struct_field1
       , RIP.getField @"some_struct_field1" x0
       )
 
-instance HasCField.HasCField Some_struct "some_struct_field2" where
-
-  type CFieldType Some_struct "some_struct_field2" =
-    Some_struct_field1
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field2" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+         ) => RIP.HasField "some_struct_field1" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"some_struct_field2")
+    HasCField.fromPtr (RIP.Proxy @"some_struct_field1")
+
+instance HasCField.HasCField Some_struct "some_struct_field1" where
+
+  type CFieldType Some_struct "some_struct_field1" =
+    Some_struct_field1
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Some_struct_field1
          ) => RIP.CompatHasField.HasField "some_struct_field2" Some_struct ty where
@@ -234,18 +221,18 @@ instance ( ty ~ Some_struct_field1
       , RIP.getField @"some_struct_field2" x0
       )
 
-instance HasCField.HasCField Some_struct "some_struct_field3" where
-
-  type CFieldType Some_struct "some_struct_field3" =
-    Some_struct_field1
-
-  offset# = \_ -> \_ -> 16
-
 instance ( ty ~ Some_struct_field1
-         ) => RIP.HasField "some_struct_field3" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+         ) => RIP.HasField "some_struct_field2" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"some_struct_field3")
+    HasCField.fromPtr (RIP.Proxy @"some_struct_field2")
+
+instance HasCField.HasCField Some_struct "some_struct_field2" where
+
+  type CFieldType Some_struct "some_struct_field2" =
+    Some_struct_field1
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ Some_struct_field1
          ) => RIP.CompatHasField.HasField "some_struct_field3" Some_struct ty where
@@ -259,3 +246,16 @@ instance ( ty ~ Some_struct_field1
                       }
       , RIP.getField @"some_struct_field3" x0
       )
+
+instance ( ty ~ Some_struct_field1
+         ) => RIP.HasField "some_struct_field3" (RIP.Ptr Some_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"some_struct_field3")
+
+instance HasCField.HasCField Some_struct "some_struct_field3" where
+
+  type CFieldType Some_struct "some_struct_field3" =
+    Some_struct_field1
+
+  offset# = \_ -> \_ -> 16

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/bindingspec.yaml
@@ -19,11 +19,12 @@ hstypes:
       - some_struct_field2
       - some_struct_field3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       - some_struct_field1_x
       - some_struct_field1_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_fields/th.txt
@@ -31,30 +31,30 @@ instance WriteRaw Some_struct_field1
                                        Some_struct_field1 some_struct_field1_x_2
                                                           some_struct_field1_y_3 -> writeRaw (Proxy @"some_struct_field1_x") ptr_0 some_struct_field1_x_2 >> writeRaw (Proxy @"some_struct_field1_y") ptr_0 some_struct_field1_y_3
 deriving via (EquivStorable Some_struct_field1) instance Storable Some_struct_field1
-instance HasCField Some_struct_field1 "some_struct_field1_x"
-    where type CFieldType Some_struct_field1
-                          "some_struct_field1_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "some_struct_field1_x" (Ptr Some_struct_field1) (Ptr ty)
-    where getField = fromPtr (Proxy @"some_struct_field1_x")
 instance (~) ty CInt =>
          HasField "some_struct_field1_x" Some_struct_field1 ty
     where hasField = \x_0 -> (\y_1 -> Some_struct_field1{some_struct_field1_x = y_1,
                                                          some_struct_field1_y = getField @"some_struct_field1_y" x_0},
                               getField @"some_struct_field1_x" x_0)
-instance HasCField Some_struct_field1 "some_struct_field1_y"
-    where type CFieldType Some_struct_field1
-                          "some_struct_field1_y" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "some_struct_field1_y" (Ptr Some_struct_field1) (Ptr ty)
-    where getField = fromPtr (Proxy @"some_struct_field1_y")
+         HasField "some_struct_field1_x" (Ptr Some_struct_field1) (Ptr ty)
+    where getField = fromPtr (Proxy @"some_struct_field1_x")
+instance HasCField Some_struct_field1 "some_struct_field1_x"
+    where type CFieldType Some_struct_field1
+                          "some_struct_field1_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "some_struct_field1_y" Some_struct_field1 ty
     where hasField = \x_0 -> (\y_1 -> Some_struct_field1{some_struct_field1_y = y_1,
                                                          some_struct_field1_x = getField @"some_struct_field1_x" x_0},
                               getField @"some_struct_field1_y" x_0)
+instance (~) ty CInt =>
+         HasField "some_struct_field1_y" (Ptr Some_struct_field1) (Ptr ty)
+    where getField = fromPtr (Proxy @"some_struct_field1_y")
+instance HasCField Some_struct_field1 "some_struct_field1_y"
+    where type CFieldType Some_struct_field1
+                          "some_struct_field1_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct some_struct@
 
     __defined at:__ @edge-cases\/anon_multiple_fields.h 4:8@
@@ -95,42 +95,42 @@ instance WriteRaw Some_struct
                                                    some_struct_field2_3
                                                    some_struct_field3_4 -> writeRaw (Proxy @"some_struct_field1") ptr_0 some_struct_field1_2 >> (writeRaw (Proxy @"some_struct_field2") ptr_0 some_struct_field2_3 >> writeRaw (Proxy @"some_struct_field3") ptr_0 some_struct_field3_4)
 deriving via (EquivStorable Some_struct) instance Storable Some_struct
-instance HasCField Some_struct "some_struct_field1"
-    where type CFieldType Some_struct
-                          "some_struct_field1" = Some_struct_field1
-          offset# = \_ -> \_ -> 0
-instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field1" (Ptr Some_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"some_struct_field1")
 instance (~) ty Some_struct_field1 =>
          HasField "some_struct_field1" Some_struct ty
     where hasField = \x_0 -> (\y_1 -> Some_struct{some_struct_field1 = y_1,
                                                   some_struct_field2 = getField @"some_struct_field2" x_0,
                                                   some_struct_field3 = getField @"some_struct_field3" x_0},
                               getField @"some_struct_field1" x_0)
-instance HasCField Some_struct "some_struct_field2"
-    where type CFieldType Some_struct
-                          "some_struct_field2" = Some_struct_field1
-          offset# = \_ -> \_ -> 8
 instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field2" (Ptr Some_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"some_struct_field2")
+         HasField "some_struct_field1" (Ptr Some_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"some_struct_field1")
+instance HasCField Some_struct "some_struct_field1"
+    where type CFieldType Some_struct
+                          "some_struct_field1" = Some_struct_field1
+          offset# = \_ -> \_ -> 0
 instance (~) ty Some_struct_field1 =>
          HasField "some_struct_field2" Some_struct ty
     where hasField = \x_0 -> (\y_1 -> Some_struct{some_struct_field2 = y_1,
                                                   some_struct_field1 = getField @"some_struct_field1" x_0,
                                                   some_struct_field3 = getField @"some_struct_field3" x_0},
                               getField @"some_struct_field2" x_0)
-instance HasCField Some_struct "some_struct_field3"
-    where type CFieldType Some_struct
-                          "some_struct_field3" = Some_struct_field1
-          offset# = \_ -> \_ -> 16
 instance (~) ty Some_struct_field1 =>
-         HasField "some_struct_field3" (Ptr Some_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"some_struct_field3")
+         HasField "some_struct_field2" (Ptr Some_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"some_struct_field2")
+instance HasCField Some_struct "some_struct_field2"
+    where type CFieldType Some_struct
+                          "some_struct_field2" = Some_struct_field1
+          offset# = \_ -> \_ -> 8
 instance (~) ty Some_struct_field1 =>
          HasField "some_struct_field3" Some_struct ty
     where hasField = \x_0 -> (\y_1 -> Some_struct{some_struct_field3 = y_1,
                                                   some_struct_field1 = getField @"some_struct_field1" x_0,
                                                   some_struct_field2 = getField @"some_struct_field2" x_0},
                               getField @"some_struct_field3" x_0)
+instance (~) ty Some_struct_field1 =>
+         HasField "some_struct_field3" (Ptr Some_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"some_struct_field3")
+instance HasCField Some_struct "some_struct_field3"
+    where type CFieldType Some_struct
+                          "some_struct_field3" = Some_struct_field1
+          offset# = \_ -> \_ -> 16

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/Example.hs
@@ -79,17 +79,6 @@ instance Marshal.WriteRaw Point1a where
 
 deriving via Marshal.EquivStorable Point1a instance RIP.Storable Point1a
 
-instance HasCField.HasCField Point1a "point1a_x" where
-
-  type CFieldType Point1a "point1a_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point1a_x" (RIP.Ptr Point1a) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"point1a_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point1a_x" Point1a ty where
 
@@ -100,16 +89,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"point1a_x" x0
       )
 
-instance HasCField.HasCField Point1a "point1a_y" where
-
-  type CFieldType Point1a "point1a_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point1a_y" (RIP.Ptr Point1a) (RIP.Ptr ty) where
+         ) => RIP.HasField "point1a_x" (RIP.Ptr Point1a) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"point1a_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"point1a_x")
+
+instance HasCField.HasCField Point1a "point1a_x" where
+
+  type CFieldType Point1a "point1a_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point1a_y" Point1a ty where
@@ -120,6 +109,17 @@ instance ( ty ~ RIP.CInt
           Point1a {point1a_y = y1, point1a_x = RIP.getField @"point1a_x" x0}
       , RIP.getField @"point1a_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "point1a_y" (RIP.Ptr Point1a) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"point1a_y")
+
+instance HasCField.HasCField Point1a "point1a_y" where
+
+  type CFieldType Point1a "point1a_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @point1b@
 
@@ -139,6 +139,14 @@ newtype Point1b = Point1b
     )
 
 instance ( ty ~ Point1a
+         ) => RIP.CompatHasField.HasField "unwrapPoint1b" Point1b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Point1b {unwrapPoint1b = y1}, RIP.getField @"unwrapPoint1b" x0)
+
+instance ( ty ~ Point1a
          ) => RIP.HasField "unwrapPoint1b" (RIP.Ptr Point1b) (RIP.Ptr ty) where
 
   getField =
@@ -149,14 +157,6 @@ instance HasCField.HasCField Point1b "unwrapPoint1b" where
   type CFieldType Point1b "unwrapPoint1b" = Point1a
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Point1a
-         ) => RIP.CompatHasField.HasField "unwrapPoint1b" Point1b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Point1b {unwrapPoint1b = y1}, RIP.getField @"unwrapPoint1b" x0)
 
 {-| __C declaration:__ @struct point2a@
 
@@ -208,17 +208,6 @@ instance Marshal.WriteRaw Point2a where
 
 deriving via Marshal.EquivStorable Point2a instance RIP.Storable Point2a
 
-instance HasCField.HasCField Point2a "point2a_x" where
-
-  type CFieldType Point2a "point2a_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point2a_x" (RIP.Ptr Point2a) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"point2a_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point2a_x" Point2a ty where
 
@@ -229,16 +218,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"point2a_x" x0
       )
 
-instance HasCField.HasCField Point2a "point2a_y" where
-
-  type CFieldType Point2a "point2a_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point2a_y" (RIP.Ptr Point2a) (RIP.Ptr ty) where
+         ) => RIP.HasField "point2a_x" (RIP.Ptr Point2a) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"point2a_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"point2a_x")
+
+instance HasCField.HasCField Point2a "point2a_x" where
+
+  type CFieldType Point2a "point2a_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point2a_y" Point2a ty where
@@ -249,6 +238,17 @@ instance ( ty ~ RIP.CInt
           Point2a {point2a_y = y1, point2a_x = RIP.getField @"point2a_x" x0}
       , RIP.getField @"point2a_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "point2a_y" (RIP.Ptr Point2a) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"point2a_y")
+
+instance HasCField.HasCField Point2a "point2a_y" where
+
+  type CFieldType Point2a "point2a_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @point2b@
 
@@ -269,6 +269,14 @@ newtype Point2b = Point2b
     )
 
 instance ( ty ~ RIP.Ptr Point2a
+         ) => RIP.CompatHasField.HasField "unwrapPoint2b" Point2b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Point2b {unwrapPoint2b = y1}, RIP.getField @"unwrapPoint2b" x0)
+
+instance ( ty ~ RIP.Ptr Point2a
          ) => RIP.HasField "unwrapPoint2b" (RIP.Ptr Point2b) (RIP.Ptr ty) where
 
   getField =
@@ -280,14 +288,6 @@ instance HasCField.HasCField Point2b "unwrapPoint2b" where
     RIP.Ptr Point2a
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Point2a
-         ) => RIP.CompatHasField.HasField "unwrapPoint2b" Point2b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Point2b {unwrapPoint2b = y1}, RIP.getField @"unwrapPoint2b" x0)
 
 {-| __C declaration:__ @struct \@point3a_Aux@
 
@@ -339,19 +339,6 @@ instance Marshal.WriteRaw Point3a_Aux where
 
 deriving via Marshal.EquivStorable Point3a_Aux instance RIP.Storable Point3a_Aux
 
-instance HasCField.HasCField Point3a_Aux "point3a_Aux_x" where
-
-  type CFieldType Point3a_Aux "point3a_Aux_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point3a_Aux_x" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"point3a_Aux_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point3a_Aux_x" Point3a_Aux ty where
 
@@ -362,18 +349,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"point3a_Aux_x" x0
       )
 
-instance HasCField.HasCField Point3a_Aux "point3a_Aux_y" where
-
-  type CFieldType Point3a_Aux "point3a_Aux_y" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "point3a_Aux_y" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
+         ) => RIP.HasField "point3a_Aux_x" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"point3a_Aux_y")
+    HasCField.fromPtr (RIP.Proxy @"point3a_Aux_x")
+
+instance HasCField.HasCField Point3a_Aux "point3a_Aux_x" where
+
+  type CFieldType Point3a_Aux "point3a_Aux_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "point3a_Aux_y" Point3a_Aux ty where
@@ -384,6 +371,19 @@ instance ( ty ~ RIP.CInt
           Point3a_Aux {point3a_Aux_y = y1, point3a_Aux_x = RIP.getField @"point3a_Aux_x" x0}
       , RIP.getField @"point3a_Aux_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "point3a_Aux_y" (RIP.Ptr Point3a_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"point3a_Aux_y")
+
+instance HasCField.HasCField Point3a_Aux "point3a_Aux_y" where
+
+  type CFieldType Point3a_Aux "point3a_Aux_y" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @point3a@
 
@@ -404,6 +404,14 @@ newtype Point3a = Point3a
     )
 
 instance ( ty ~ RIP.Ptr Point3a_Aux
+         ) => RIP.CompatHasField.HasField "unwrapPoint3a" Point3a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Point3a {unwrapPoint3a = y1}, RIP.getField @"unwrapPoint3a" x0)
+
+instance ( ty ~ RIP.Ptr Point3a_Aux
          ) => RIP.HasField "unwrapPoint3a" (RIP.Ptr Point3a) (RIP.Ptr ty) where
 
   getField =
@@ -415,14 +423,6 @@ instance HasCField.HasCField Point3a "unwrapPoint3a" where
     RIP.Ptr Point3a_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Point3a_Aux
-         ) => RIP.CompatHasField.HasField "unwrapPoint3a" Point3a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Point3a {unwrapPoint3a = y1}, RIP.getField @"unwrapPoint3a" x0)
 
 {-| __C declaration:__ @point3b@
 
@@ -443,6 +443,14 @@ newtype Point3b = Point3b
     )
 
 instance ( ty ~ RIP.Ptr Point3a_Aux
+         ) => RIP.CompatHasField.HasField "unwrapPoint3b" Point3b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Point3b {unwrapPoint3b = y1}, RIP.getField @"unwrapPoint3b" x0)
+
+instance ( ty ~ RIP.Ptr Point3a_Aux
          ) => RIP.HasField "unwrapPoint3b" (RIP.Ptr Point3b) (RIP.Ptr ty) where
 
   getField =
@@ -454,11 +462,3 @@ instance HasCField.HasCField Point3b "unwrapPoint3b" where
     RIP.Ptr Point3a_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Point3a_Aux
-         ) => RIP.CompatHasField.HasField "unwrapPoint3b" Point3b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Point3b {unwrapPoint3b = y1}, RIP.getField @"unwrapPoint3b" x0)

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/bindingspec.yaml
@@ -39,11 +39,12 @@ hstypes:
       - point1a_x
       - point1a_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -56,11 +57,12 @@ hstypes:
       fields:
       - unwrapPoint1b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -74,11 +76,12 @@ hstypes:
       - point2a_x
       - point2a_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -91,12 +94,13 @@ hstypes:
       fields:
       - unwrapPoint2b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -110,12 +114,13 @@ hstypes:
       fields:
       - unwrapPoint3a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -130,11 +135,12 @@ hstypes:
       - point3a_Aux_x
       - point3a_Aux_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -147,12 +153,13 @@ hstypes:
       fields:
       - unwrapPoint3b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/anon_multiple_typedefs/th.txt
@@ -55,24 +55,24 @@ instance WriteRaw Point1a
                                        Point1a point1a_x_2
                                                point1a_y_3 -> writeRaw (Proxy @"point1a_x") ptr_0 point1a_x_2 >> writeRaw (Proxy @"point1a_y") ptr_0 point1a_y_3
 deriving via (EquivStorable Point1a) instance Storable Point1a
-instance HasCField Point1a "point1a_x"
-    where type CFieldType Point1a "point1a_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "point1a_x" (Ptr Point1a) (Ptr ty)
-    where getField = fromPtr (Proxy @"point1a_x")
 instance (~) ty CInt => HasField "point1a_x" Point1a ty
     where hasField = \x_0 -> (\y_1 -> Point1a{point1a_x = y_1,
                                               point1a_y = getField @"point1a_y" x_0},
                               getField @"point1a_x" x_0)
-instance HasCField Point1a "point1a_y"
-    where type CFieldType Point1a "point1a_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "point1a_y" (Ptr Point1a) (Ptr ty)
-    where getField = fromPtr (Proxy @"point1a_y")
+instance (~) ty CInt => HasField "point1a_x" (Ptr Point1a) (Ptr ty)
+    where getField = fromPtr (Proxy @"point1a_x")
+instance HasCField Point1a "point1a_x"
+    where type CFieldType Point1a "point1a_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "point1a_y" Point1a ty
     where hasField = \x_0 -> (\y_1 -> Point1a{point1a_y = y_1,
                                               point1a_x = getField @"point1a_x" x_0},
                               getField @"point1a_y" x_0)
+instance (~) ty CInt => HasField "point1a_y" (Ptr Point1a) (Ptr ty)
+    where getField = fromPtr (Proxy @"point1a_y")
+instance HasCField Point1a "point1a_y"
+    where type CFieldType Point1a "point1a_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @point1b@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 5:43@
@@ -83,15 +83,15 @@ newtype Point1b
     = Point1b {unwrapPoint1b :: Point1a}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Point1a => HasField "unwrapPoint1b" Point1b ty
+    where hasField = \x_0 -> (\y_1 -> Point1b{unwrapPoint1b = y_1},
+                              getField @"unwrapPoint1b" x_0)
 instance (~) ty Point1a =>
          HasField "unwrapPoint1b" (Ptr Point1b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint1b")
 instance HasCField Point1b "unwrapPoint1b"
     where type CFieldType Point1b "unwrapPoint1b" = Point1a
           offset# = \_ -> \_ -> 0
-instance (~) ty Point1a => HasField "unwrapPoint1b" Point1b ty
-    where hasField = \x_0 -> (\y_1 -> Point1b{unwrapPoint1b = y_1},
-                              getField @"unwrapPoint1b" x_0)
 {-| __C declaration:__ @struct point2a@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 8:9@
@@ -124,24 +124,24 @@ instance WriteRaw Point2a
                                        Point2a point2a_x_2
                                                point2a_y_3 -> writeRaw (Proxy @"point2a_x") ptr_0 point2a_x_2 >> writeRaw (Proxy @"point2a_y") ptr_0 point2a_y_3
 deriving via (EquivStorable Point2a) instance Storable Point2a
-instance HasCField Point2a "point2a_x"
-    where type CFieldType Point2a "point2a_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "point2a_x" (Ptr Point2a) (Ptr ty)
-    where getField = fromPtr (Proxy @"point2a_x")
 instance (~) ty CInt => HasField "point2a_x" Point2a ty
     where hasField = \x_0 -> (\y_1 -> Point2a{point2a_x = y_1,
                                               point2a_y = getField @"point2a_y" x_0},
                               getField @"point2a_x" x_0)
-instance HasCField Point2a "point2a_y"
-    where type CFieldType Point2a "point2a_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "point2a_y" (Ptr Point2a) (Ptr ty)
-    where getField = fromPtr (Proxy @"point2a_y")
+instance (~) ty CInt => HasField "point2a_x" (Ptr Point2a) (Ptr ty)
+    where getField = fromPtr (Proxy @"point2a_x")
+instance HasCField Point2a "point2a_x"
+    where type CFieldType Point2a "point2a_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "point2a_y" Point2a ty
     where hasField = \x_0 -> (\y_1 -> Point2a{point2a_y = y_1,
                                               point2a_x = getField @"point2a_x" x_0},
                               getField @"point2a_y" x_0)
+instance (~) ty CInt => HasField "point2a_y" (Ptr Point2a) (Ptr ty)
+    where getField = fromPtr (Proxy @"point2a_y")
+instance HasCField Point2a "point2a_y"
+    where type CFieldType Point2a "point2a_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @point2b@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 8:44@
@@ -157,15 +157,15 @@ newtype Point2b
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Point2a) =>
+         HasField "unwrapPoint2b" Point2b ty
+    where hasField = \x_0 -> (\y_1 -> Point2b{unwrapPoint2b = y_1},
+                              getField @"unwrapPoint2b" x_0)
+instance (~) ty (Ptr Point2a) =>
          HasField "unwrapPoint2b" (Ptr Point2b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint2b")
 instance HasCField Point2b "unwrapPoint2b"
     where type CFieldType Point2b "unwrapPoint2b" = Ptr Point2a
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Point2a) =>
-         HasField "unwrapPoint2b" Point2b ty
-    where hasField = \x_0 -> (\y_1 -> Point2b{unwrapPoint2b = y_1},
-                              getField @"unwrapPoint2b" x_0)
 {-| __C declaration:__ @struct \@point3a_Aux@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 11:9@
@@ -198,26 +198,26 @@ instance WriteRaw Point3a_Aux
                                        Point3a_Aux point3a_Aux_x_2
                                                    point3a_Aux_y_3 -> writeRaw (Proxy @"point3a_Aux_x") ptr_0 point3a_Aux_x_2 >> writeRaw (Proxy @"point3a_Aux_y") ptr_0 point3a_Aux_y_3
 deriving via (EquivStorable Point3a_Aux) instance Storable Point3a_Aux
-instance HasCField Point3a_Aux "point3a_Aux_x"
-    where type CFieldType Point3a_Aux "point3a_Aux_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"point3a_Aux_x")
 instance (~) ty CInt => HasField "point3a_Aux_x" Point3a_Aux ty
     where hasField = \x_0 -> (\y_1 -> Point3a_Aux{point3a_Aux_x = y_1,
                                                   point3a_Aux_y = getField @"point3a_Aux_y" x_0},
                               getField @"point3a_Aux_x" x_0)
-instance HasCField Point3a_Aux "point3a_Aux_y"
-    where type CFieldType Point3a_Aux "point3a_Aux_y" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"point3a_Aux_y")
+         HasField "point3a_Aux_x" (Ptr Point3a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"point3a_Aux_x")
+instance HasCField Point3a_Aux "point3a_Aux_x"
+    where type CFieldType Point3a_Aux "point3a_Aux_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "point3a_Aux_y" Point3a_Aux ty
     where hasField = \x_0 -> (\y_1 -> Point3a_Aux{point3a_Aux_y = y_1,
                                                   point3a_Aux_x = getField @"point3a_Aux_x" x_0},
                               getField @"point3a_Aux_y" x_0)
+instance (~) ty CInt =>
+         HasField "point3a_Aux_y" (Ptr Point3a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"point3a_Aux_y")
+instance HasCField Point3a_Aux "point3a_Aux_y"
+    where type CFieldType Point3a_Aux "point3a_Aux_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @point3a@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 11:35@
@@ -233,15 +233,15 @@ newtype Point3a
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Point3a_Aux) =>
+         HasField "unwrapPoint3a" Point3a ty
+    where hasField = \x_0 -> (\y_1 -> Point3a{unwrapPoint3a = y_1},
+                              getField @"unwrapPoint3a" x_0)
+instance (~) ty (Ptr Point3a_Aux) =>
          HasField "unwrapPoint3a" (Ptr Point3a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint3a")
 instance HasCField Point3a "unwrapPoint3a"
     where type CFieldType Point3a "unwrapPoint3a" = Ptr Point3a_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Point3a_Aux) =>
-         HasField "unwrapPoint3a" Point3a ty
-    where hasField = \x_0 -> (\y_1 -> Point3a{unwrapPoint3a = y_1},
-                              getField @"unwrapPoint3a" x_0)
 {-| __C declaration:__ @point3b@
 
     __defined at:__ @edge-cases\/anon_multiple_typedefs.h 11:45@
@@ -257,15 +257,15 @@ newtype Point3b
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Point3a_Aux) =>
+         HasField "unwrapPoint3b" Point3b ty
+    where hasField = \x_0 -> (\y_1 -> Point3b{unwrapPoint3b = y_1},
+                              getField @"unwrapPoint3b" x_0)
+instance (~) ty (Ptr Point3a_Aux) =>
          HasField "unwrapPoint3b" (Ptr Point3b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPoint3b")
 instance HasCField Point3b "unwrapPoint3b"
     where type CFieldType Point3b "unwrapPoint3b" = Ptr Point3a_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Point3a_Aux) =>
-         HasField "unwrapPoint3b" Point3b ty
-    where hasField = \x_0 -> (\y_1 -> Point3b{unwrapPoint3b = y_1},
-                              getField @"unwrapPoint3b" x_0)
 -- __unique:__ @test_edgecasesanon_multiple_typed_Example_Safe_test@
 foreign import ccall safe "hs_bindgen_c97a0d4458699ad7" hs_bindgen_c97a0d4458699ad7_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/Example.hs
@@ -39,6 +39,15 @@ newtype FunPtr_Aux = FunPtr_Aux
   deriving stock (RIP.Generic)
 
 instance ( ty ~ (Foo -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapFunPtr_Aux" FunPtr_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> FunPtr_Aux {unwrapFunPtr_Aux = y1}
+      , RIP.getField @"unwrapFunPtr_Aux" x0
+      )
+
+instance ( ty ~ (Foo -> IO ())
          ) => RIP.HasField "unwrapFunPtr_Aux" (RIP.Ptr FunPtr_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -50,15 +59,6 @@ instance HasCField.HasCField FunPtr_Aux "unwrapFunPtr_Aux" where
     Foo -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (Foo -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapFunPtr_Aux" FunPtr_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> FunPtr_Aux {unwrapFunPtr_Aux = y1}
-      , RIP.getField @"unwrapFunPtr_Aux" x0
-      )
 
 {-| __C declaration:__ @FunPtr@
 
@@ -79,6 +79,14 @@ newtype FunPtr = FunPtr
     )
 
 instance ( ty ~ RIP.FunPtr FunPtr_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunPtr" FunPtr ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         FunPtr {unwrapFunPtr = y1}, RIP.getField @"unwrapFunPtr" x0)
+
+instance ( ty ~ RIP.FunPtr FunPtr_Aux
          ) => RIP.HasField "unwrapFunPtr" (RIP.Ptr FunPtr) (RIP.Ptr ty) where
 
   getField =
@@ -90,14 +98,6 @@ instance HasCField.HasCField FunPtr "unwrapFunPtr" where
     RIP.FunPtr FunPtr_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr FunPtr_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunPtr" FunPtr ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         FunPtr {unwrapFunPtr = y1}, RIP.getField @"unwrapFunPtr" x0)
 
 {-| __C declaration:__ @struct foo@
 
@@ -149,17 +149,6 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCField.HasCField Foo "foo_x" where
-
-  type CFieldType Foo "foo_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_x" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_x" Foo ty where
 
   hasField =
@@ -169,16 +158,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_x" Foo ty where
       , RIP.getField @"foo_x" x0
       )
 
-instance HasCField.HasCField Foo "foo_y" where
-
-  type CFieldType Foo "foo_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_y" (RIP.Ptr Foo) (RIP.Ptr ty) where
+         ) => RIP.HasField "foo_x" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_x")
+
+instance HasCField.HasCField Foo "foo_x" where
+
+  type CFieldType Foo "foo_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_y" Foo ty where
 
@@ -188,3 +177,14 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_y" Foo ty where
           Foo {foo_y = y1, foo_x = RIP.getField @"foo_x" x0}
       , RIP.getField @"foo_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_y" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_y")
+
+instance HasCField.HasCField Foo "foo_y" where
+
+  type CFieldType Foo "foo_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - foo_x
       - foo_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -35,12 +36,13 @@ hstypes:
       fields:
       - unwrapFunPtr
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/aux_funptr_newtypes/th.txt
@@ -11,15 +11,15 @@ newtype FunPtr_Aux
     = FunPtr_Aux {unwrapFunPtr_Aux :: (Foo -> IO ())}
     deriving stock Generic
 instance (~) ty (Foo -> IO ()) =>
+         HasField "unwrapFunPtr_Aux" FunPtr_Aux ty
+    where hasField = \x_0 -> (\y_1 -> FunPtr_Aux{unwrapFunPtr_Aux = y_1},
+                              getField @"unwrapFunPtr_Aux" x_0)
+instance (~) ty (Foo -> IO ()) =>
          HasField "unwrapFunPtr_Aux" (Ptr FunPtr_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunPtr_Aux")
 instance HasCField FunPtr_Aux "unwrapFunPtr_Aux"
     where type CFieldType FunPtr_Aux "unwrapFunPtr_Aux" = Foo -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (Foo -> IO ()) =>
-         HasField "unwrapFunPtr_Aux" FunPtr_Aux ty
-    where hasField = \x_0 -> (\y_1 -> FunPtr_Aux{unwrapFunPtr_Aux = y_1},
-                              getField @"unwrapFunPtr_Aux" x_0)
 {-| __C declaration:__ @FunPtr@
 
     __defined at:__ @edge-cases\/aux_funptr_newtypes.h 6:16@
@@ -35,15 +35,15 @@ newtype FunPtr
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr FunPtr_Aux) =>
+         HasField "unwrapFunPtr" FunPtr ty
+    where hasField = \x_0 -> (\y_1 -> FunPtr{unwrapFunPtr = y_1},
+                              getField @"unwrapFunPtr" x_0)
+instance (~) ty (FunPtr FunPtr_Aux) =>
          HasField "unwrapFunPtr" (Ptr FunPtr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunPtr")
 instance HasCField FunPtr "unwrapFunPtr"
     where type CFieldType FunPtr "unwrapFunPtr" = FunPtr FunPtr_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr FunPtr_Aux) =>
-         HasField "unwrapFunPtr" FunPtr ty
-    where hasField = \x_0 -> (\y_1 -> FunPtr{unwrapFunPtr = y_1},
-                              getField @"unwrapFunPtr" x_0)
 {-| __C declaration:__ @struct foo@
 
     __defined at:__ @edge-cases\/aux_funptr_newtypes.h 8:8@
@@ -76,21 +76,21 @@ instance WriteRaw Foo
                                        Foo foo_x_2
                                            foo_y_3 -> writeRaw (Proxy @"foo_x") ptr_0 foo_x_2 >> writeRaw (Proxy @"foo_y") ptr_0 foo_y_3
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCField Foo "foo_x"
-    where type CFieldType Foo "foo_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_x" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_x")
 instance (~) ty CInt => HasField "foo_x" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_x = y_1,
                                           foo_y = getField @"foo_y" x_0},
                               getField @"foo_x" x_0)
-instance HasCField Foo "foo_y"
-    where type CFieldType Foo "foo_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "foo_y" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_y")
+instance (~) ty CInt => HasField "foo_x" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_x")
+instance HasCField Foo "foo_x"
+    where type CFieldType Foo "foo_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "foo_y" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_y = y_1,
                                           foo_x = getField @"foo_x" x_0},
                               getField @"foo_y" x_0)
+instance (~) ty CInt => HasField "foo_y" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_y")
+instance HasCField Foo "foo_y"
+    where type CFieldType Foo "foo_y" = CInt
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/Example.hs
@@ -101,19 +101,6 @@ instance Marshal.WriteRaw Another_typedef_struct_t where
 
 deriving via Marshal.EquivStorable Another_typedef_struct_t instance RIP.Storable Another_typedef_struct_t
 
-instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_foo" where
-
-  type CFieldType Another_typedef_struct_t "another_typedef_struct_t_foo" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "another_typedef_struct_t_foo" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_foo")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "another_typedef_struct_t_foo" Another_typedef_struct_t ty where
 
@@ -126,18 +113,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"another_typedef_struct_t_foo" x0
       )
 
-instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_bar" where
-
-  type CFieldType Another_typedef_struct_t "another_typedef_struct_t_bar" =
-    RIP.CChar
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "another_typedef_struct_t_bar" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "another_typedef_struct_t_foo" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_bar")
+    HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_foo")
+
+instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_foo" where
+
+  type CFieldType Another_typedef_struct_t "another_typedef_struct_t_foo" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "another_typedef_struct_t_bar" Another_typedef_struct_t ty where
@@ -150,6 +137,19 @@ instance ( ty ~ RIP.CChar
                                    }
       , RIP.getField @"another_typedef_struct_t_bar" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "another_typedef_struct_t_bar" (RIP.Ptr Another_typedef_struct_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"another_typedef_struct_t_bar")
+
+instance HasCField.HasCField Another_typedef_struct_t "another_typedef_struct_t_bar" where
+
+  type CFieldType Another_typedef_struct_t "another_typedef_struct_t_bar" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @enum another_typedef_enum_e@
 
@@ -231,6 +231,16 @@ instance Read Another_typedef_enum_e where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapAnother_typedef_enum_e" Another_typedef_enum_e ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Another_typedef_enum_e {unwrapAnother_typedef_enum_e = y1}
+      , RIP.getField @"unwrapAnother_typedef_enum_e" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapAnother_typedef_enum_e" (RIP.Ptr Another_typedef_enum_e) (RIP.Ptr ty) where
 
   getField =
@@ -242,16 +252,6 @@ instance HasCField.HasCField Another_typedef_enum_e "unwrapAnother_typedef_enum_
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapAnother_typedef_enum_e" Another_typedef_enum_e ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Another_typedef_enum_e {unwrapAnother_typedef_enum_e = y1}
-      , RIP.getField @"unwrapAnother_typedef_enum_e" x0
-      )
 
 {-| __C declaration:__ @FOO@
 
@@ -327,6 +327,14 @@ newtype A_type_t = A_type_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapA_type_t" A_type_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         A_type_t {unwrapA_type_t = y1}, RIP.getField @"unwrapA_type_t" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA_type_t" (RIP.Ptr A_type_t) (RIP.Ptr ty) where
 
   getField =
@@ -337,14 +345,6 @@ instance HasCField.HasCField A_type_t "unwrapA_type_t" where
   type CFieldType A_type_t "unwrapA_type_t" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapA_type_t" A_type_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         A_type_t {unwrapA_type_t = y1}, RIP.getField @"unwrapA_type_t" x0)
 
 {-| __C declaration:__ @var_t@
 
@@ -375,6 +375,14 @@ newtype Var_t = Var_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapVar_t" Var_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Var_t {unwrapVar_t = y1}, RIP.getField @"unwrapVar_t" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapVar_t" (RIP.Ptr Var_t) (RIP.Ptr ty) where
 
   getField =
@@ -385,14 +393,6 @@ instance HasCField.HasCField Var_t "unwrapVar_t" where
   type CFieldType Var_t "unwrapVar_t" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapVar_t" Var_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Var_t {unwrapVar_t = y1}, RIP.getField @"unwrapVar_t" x0)
 
 {-| __C declaration:__ @struct a_typedef_struct@
 
@@ -536,19 +536,6 @@ instance Marshal.WriteRaw A_typedef_struct_t where
 
 deriving via Marshal.EquivStorable A_typedef_struct_t instance RIP.Storable A_typedef_struct_t
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_0" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_0" =
-    RIP.CBool
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "a_typedef_struct_t_field_0" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_0")
-
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_0" A_typedef_struct_t ty where
 
@@ -570,18 +557,18 @@ instance ( ty ~ RIP.CBool
       , RIP.getField @"a_typedef_struct_t_field_0" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_1" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_1" =
-    HsBindgen.Runtime.LibC.Word8
-
-  offset# = \_ -> \_ -> 1
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "a_typedef_struct_t_field_1" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CBool
+         ) => RIP.HasField "a_typedef_struct_t_field_0" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_1")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_0")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_0" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_0" =
+    RIP.CBool
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_1" A_typedef_struct_t ty where
@@ -604,18 +591,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word8
       , RIP.getField @"a_typedef_struct_t_field_1" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_2" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_2" =
-    HsBindgen.Runtime.LibC.Word16
-
-  offset# = \_ -> \_ -> 2
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "a_typedef_struct_t_field_2" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.HasField "a_typedef_struct_t_field_1" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_2")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_1")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_1" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_1" =
+    HsBindgen.Runtime.LibC.Word8
+
+  offset# = \_ -> \_ -> 1
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_2" A_typedef_struct_t ty where
@@ -638,18 +625,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word16
       , RIP.getField @"a_typedef_struct_t_field_2" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_3" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_3" =
-    HsBindgen.Runtime.LibC.Word32
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "a_typedef_struct_t_field_3" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.HasField "a_typedef_struct_t_field_2" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_3")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_2")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_2" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_2" =
+    HsBindgen.Runtime.LibC.Word16
+
+  offset# = \_ -> \_ -> 2
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_3" A_typedef_struct_t ty where
@@ -672,18 +659,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word32
       , RIP.getField @"a_typedef_struct_t_field_3" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_4" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_4" =
-    Another_typedef_struct_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ Another_typedef_struct_t
-         ) => RIP.HasField "a_typedef_struct_t_field_4" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.HasField "a_typedef_struct_t_field_3" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_4")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_3")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_3" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_3" =
+    HsBindgen.Runtime.LibC.Word32
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ Another_typedef_struct_t
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_4" A_typedef_struct_t ty where
@@ -706,18 +693,18 @@ instance ( ty ~ Another_typedef_struct_t
       , RIP.getField @"a_typedef_struct_t_field_4" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_5" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_5" =
-    RIP.Ptr Another_typedef_struct_t
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.Ptr Another_typedef_struct_t
-         ) => RIP.HasField "a_typedef_struct_t_field_5" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ Another_typedef_struct_t
+         ) => RIP.HasField "a_typedef_struct_t_field_4" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_5")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_4")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_4" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_4" =
+    Another_typedef_struct_t
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.Ptr Another_typedef_struct_t
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_5" A_typedef_struct_t ty where
@@ -740,18 +727,18 @@ instance ( ty ~ RIP.Ptr Another_typedef_struct_t
       , RIP.getField @"a_typedef_struct_t_field_5" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_6" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_6" =
-    RIP.Ptr RIP.Void
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.HasField "a_typedef_struct_t_field_6" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr Another_typedef_struct_t
+         ) => RIP.HasField "a_typedef_struct_t_field_5" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_6")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_5")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_5" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_5" =
+    RIP.Ptr Another_typedef_struct_t
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ RIP.Ptr RIP.Void
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_6" A_typedef_struct_t ty where
@@ -774,18 +761,18 @@ instance ( ty ~ RIP.Ptr RIP.Void
       , RIP.getField @"a_typedef_struct_t_field_6" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_7" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_7" =
-    CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "a_typedef_struct_t_field_7" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr RIP.Void
+         ) => RIP.HasField "a_typedef_struct_t_field_6" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_7")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_6")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_6" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_6" =
+    RIP.Ptr RIP.Void
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_7" A_typedef_struct_t ty where
@@ -808,18 +795,18 @@ instance ( ty ~ CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
       , RIP.getField @"a_typedef_struct_t_field_7" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_8" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_8" =
-    Another_typedef_enum_e
-
-  offset# = \_ -> \_ -> 60
-
-instance ( ty ~ Another_typedef_enum_e
-         ) => RIP.HasField "a_typedef_struct_t_field_8" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
+         ) => RIP.HasField "a_typedef_struct_t_field_7" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_8")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_7")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_7" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_7" =
+    CA.ConstantArray 7 HsBindgen.Runtime.LibC.Word32
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Another_typedef_enum_e
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_8" A_typedef_struct_t ty where
@@ -842,18 +829,18 @@ instance ( ty ~ Another_typedef_enum_e
       , RIP.getField @"a_typedef_struct_t_field_8" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_9" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_9" =
-    CA.ConstantArray 4 Another_typedef_enum_e
-
-  offset# = \_ -> \_ -> 64
-
-instance ( ty ~ CA.ConstantArray 4 Another_typedef_enum_e
-         ) => RIP.HasField "a_typedef_struct_t_field_9" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ Another_typedef_enum_e
+         ) => RIP.HasField "a_typedef_struct_t_field_8" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_9")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_8")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_8" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_8" =
+    Another_typedef_enum_e
+
+  offset# = \_ -> \_ -> 60
 
 instance ( ty ~ CA.ConstantArray 4 Another_typedef_enum_e
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_9" A_typedef_struct_t ty where
@@ -876,18 +863,18 @@ instance ( ty ~ CA.ConstantArray 4 Another_typedef_enum_e
       , RIP.getField @"a_typedef_struct_t_field_9" x0
       )
 
-instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_10" where
-
-  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_10" =
-    CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
-
-  offset# = \_ -> \_ -> 80
-
-instance ( ty ~ CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
-         ) => RIP.HasField "a_typedef_struct_t_field_10" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+instance ( ty ~ CA.ConstantArray 4 Another_typedef_enum_e
+         ) => RIP.HasField "a_typedef_struct_t_field_9" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_10")
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_9")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_9" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_9" =
+    CA.ConstantArray 4 Another_typedef_enum_e
+
+  offset# = \_ -> \_ -> 64
 
 instance ( ty ~ CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
          ) => RIP.CompatHasField.HasField "a_typedef_struct_t_field_10" A_typedef_struct_t ty where
@@ -909,6 +896,19 @@ instance ( ty ~ CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
                              }
       , RIP.getField @"a_typedef_struct_t_field_10" x0
       )
+
+instance ( ty ~ CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
+         ) => RIP.HasField "a_typedef_struct_t_field_10" (RIP.Ptr A_typedef_struct_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"a_typedef_struct_t_field_10")
+
+instance HasCField.HasCField A_typedef_struct_t "a_typedef_struct_t_field_10" where
+
+  type CFieldType A_typedef_struct_t "a_typedef_struct_t_field_10" =
+    CA.ConstantArray 5 (CA.ConstantArray 3 Another_typedef_enum_e)
+
+  offset# = \_ -> \_ -> 80
 
 {-| __C declaration:__ @macro A_DEFINE_0@
 
@@ -1029,6 +1029,16 @@ instance Read A_typedef_enum_e where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUChar
+         ) => RIP.CompatHasField.HasField "unwrapA_typedef_enum_e" A_typedef_enum_e ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          A_typedef_enum_e {unwrapA_typedef_enum_e = y1}
+      , RIP.getField @"unwrapA_typedef_enum_e" x0
+      )
+
+instance ( ty ~ RIP.CUChar
          ) => RIP.HasField "unwrapA_typedef_enum_e" (RIP.Ptr A_typedef_enum_e) (RIP.Ptr ty) where
 
   getField =
@@ -1040,16 +1050,6 @@ instance HasCField.HasCField A_typedef_enum_e "unwrapA_typedef_enum_e" where
     RIP.CUChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.CompatHasField.HasField "unwrapA_typedef_enum_e" A_typedef_enum_e ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          A_typedef_enum_e {unwrapA_typedef_enum_e = y1}
-      , RIP.getField @"unwrapA_typedef_enum_e" x0
-      )
 
 {-| __C declaration:__ @ENUM_CASE_0@
 
@@ -1136,6 +1136,15 @@ instance RIP.FromFunPtr Callback_t_Aux where
   fromFunPtr = hs_bindgen_d6debb4b8d5bb869
 
 instance ( ty ~ (RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)
+         ) => RIP.CompatHasField.HasField "unwrapCallback_t_Aux" Callback_t_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Callback_t_Aux {unwrapCallback_t_Aux = y1}
+      , RIP.getField @"unwrapCallback_t_Aux" x0
+      )
+
+instance ( ty ~ (RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)
          ) => RIP.HasField "unwrapCallback_t_Aux" (RIP.Ptr Callback_t_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -1147,15 +1156,6 @@ instance HasCField.HasCField Callback_t_Aux "unwrapCallback_t_Aux" where
     RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.Ptr RIP.Void -> HsBindgen.Runtime.LibC.Word32 -> IO HsBindgen.Runtime.LibC.Word32)
-         ) => RIP.CompatHasField.HasField "unwrapCallback_t_Aux" Callback_t_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Callback_t_Aux {unwrapCallback_t_Aux = y1}
-      , RIP.getField @"unwrapCallback_t_Aux" x0
-      )
 
 {-| __C declaration:__ @callback_t@
 
@@ -1176,6 +1176,15 @@ newtype Callback_t = Callback_t
     )
 
 instance ( ty ~ RIP.FunPtr Callback_t_Aux
+         ) => RIP.CompatHasField.HasField "unwrapCallback_t" Callback_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Callback_t {unwrapCallback_t = y1}
+      , RIP.getField @"unwrapCallback_t" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Callback_t_Aux
          ) => RIP.HasField "unwrapCallback_t" (RIP.Ptr Callback_t) (RIP.Ptr ty) where
 
   getField =
@@ -1187,12 +1196,3 @@ instance HasCField.HasCField Callback_t "unwrapCallback_t" where
     RIP.FunPtr Callback_t_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Callback_t_Aux
-         ) => RIP.CompatHasField.HasField "unwrapCallback_t" Callback_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Callback_t {unwrapCallback_t = y1}
-      , RIP.getField @"unwrapCallback_t" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
@@ -47,7 +47,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -55,6 +54,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -75,12 +76,13 @@ hstypes:
       - unwrapA_typedef_enum_e
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -107,11 +109,12 @@ hstypes:
       - a_typedef_struct_t_field_9
       - a_typedef_struct_t_field_10
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -125,12 +128,13 @@ hstypes:
       - unwrapAnother_typedef_enum_e
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -148,11 +152,12 @@ hstypes:
       - another_typedef_struct_t_foo
       - another_typedef_struct_t_bar
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -165,12 +170,13 @@ hstypes:
       fields:
       - unwrapCallback_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -187,7 +193,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -195,6 +200,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/th.txt
@@ -68,36 +68,36 @@ instance WriteRaw Another_typedef_struct_t
                                        Another_typedef_struct_t another_typedef_struct_t_foo_2
                                                                 another_typedef_struct_t_bar_3 -> writeRaw (Proxy @"another_typedef_struct_t_foo") ptr_0 another_typedef_struct_t_foo_2 >> writeRaw (Proxy @"another_typedef_struct_t_bar") ptr_0 another_typedef_struct_t_bar_3
 deriving via (EquivStorable Another_typedef_struct_t) instance Storable Another_typedef_struct_t
-instance HasCField Another_typedef_struct_t
-                   "another_typedef_struct_t_foo"
-    where type CFieldType Another_typedef_struct_t
-                          "another_typedef_struct_t_foo" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "another_typedef_struct_t_foo"
-                  (Ptr Another_typedef_struct_t)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"another_typedef_struct_t_foo")
 instance (~) ty CInt =>
          HasField "another_typedef_struct_t_foo" Another_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> Another_typedef_struct_t{another_typedef_struct_t_foo = y_1,
                                                                another_typedef_struct_t_bar = getField @"another_typedef_struct_t_bar" x_0},
                               getField @"another_typedef_struct_t_foo" x_0)
-instance HasCField Another_typedef_struct_t
-                   "another_typedef_struct_t_bar"
-    where type CFieldType Another_typedef_struct_t
-                          "another_typedef_struct_t_bar" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar =>
-         HasField "another_typedef_struct_t_bar"
+instance (~) ty CInt =>
+         HasField "another_typedef_struct_t_foo"
                   (Ptr Another_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"another_typedef_struct_t_bar")
+    where getField = fromPtr (Proxy @"another_typedef_struct_t_foo")
+instance HasCField Another_typedef_struct_t
+                   "another_typedef_struct_t_foo"
+    where type CFieldType Another_typedef_struct_t
+                          "another_typedef_struct_t_foo" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "another_typedef_struct_t_bar" Another_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> Another_typedef_struct_t{another_typedef_struct_t_bar = y_1,
                                                                another_typedef_struct_t_foo = getField @"another_typedef_struct_t_foo" x_0},
                               getField @"another_typedef_struct_t_bar" x_0)
+instance (~) ty CChar =>
+         HasField "another_typedef_struct_t_bar"
+                  (Ptr Another_typedef_struct_t)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"another_typedef_struct_t_bar")
+instance HasCField Another_typedef_struct_t
+                   "another_typedef_struct_t_bar"
+    where type CFieldType Another_typedef_struct_t
+                          "another_typedef_struct_t_bar" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @enum another_typedef_enum_e@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 10:9@
@@ -139,6 +139,10 @@ instance Read Another_typedef_enum_e
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CUInt =>
+         HasField "unwrapAnother_typedef_enum_e" Another_typedef_enum_e ty
+    where hasField = \x_0 -> (\y_1 -> Another_typedef_enum_e{unwrapAnother_typedef_enum_e = y_1},
+                              getField @"unwrapAnother_typedef_enum_e" x_0)
+instance (~) ty CUInt =>
          HasField "unwrapAnother_typedef_enum_e"
                   (Ptr Another_typedef_enum_e)
                   (Ptr ty)
@@ -148,10 +152,6 @@ instance HasCField Another_typedef_enum_e
     where type CFieldType Another_typedef_enum_e
                           "unwrapAnother_typedef_enum_e" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unwrapAnother_typedef_enum_e" Another_typedef_enum_e ty
-    where hasField = \x_0 -> (\y_1 -> Another_typedef_enum_e{unwrapAnother_typedef_enum_e = y_1},
-                              getField @"unwrapAnother_typedef_enum_e" x_0)
 {-| __C declaration:__ @FOO@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 10:16@
@@ -234,15 +234,15 @@ newtype A_type_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA_type_t" A_type_t ty
+    where hasField = \x_0 -> (\y_1 -> A_type_t{unwrapA_type_t = y_1},
+                              getField @"unwrapA_type_t" x_0)
 instance (~) ty CInt =>
          HasField "unwrapA_type_t" (Ptr A_type_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_type_t")
 instance HasCField A_type_t "unwrapA_type_t"
     where type CFieldType A_type_t "unwrapA_type_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA_type_t" A_type_t ty
-    where hasField = \x_0 -> (\y_1 -> A_type_t{unwrapA_type_t = y_1},
-                              getField @"unwrapA_type_t" x_0)
 {-| __C declaration:__ @var_t@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 15:13@
@@ -267,14 +267,14 @@ newtype Var_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapVar_t" Var_t ty
+    where hasField = \x_0 -> (\y_1 -> Var_t{unwrapVar_t = y_1},
+                              getField @"unwrapVar_t" x_0)
 instance (~) ty CInt => HasField "unwrapVar_t" (Ptr Var_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapVar_t")
 instance HasCField Var_t "unwrapVar_t"
     where type CFieldType Var_t "unwrapVar_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapVar_t" Var_t ty
-    where hasField = \x_0 -> (\y_1 -> Var_t{unwrapVar_t = y_1},
-                              getField @"unwrapVar_t" x_0)
 {-| __C declaration:__ @struct a_typedef_struct@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 35:16@
@@ -383,15 +383,6 @@ instance WriteRaw A_typedef_struct_t
                                                           a_typedef_struct_t_field_9_11
                                                           a_typedef_struct_t_field_10_12 -> writeRaw (Proxy @"a_typedef_struct_t_field_0") ptr_0 a_typedef_struct_t_field_0_2 >> (writeRaw (Proxy @"a_typedef_struct_t_field_1") ptr_0 a_typedef_struct_t_field_1_3 >> (writeRaw (Proxy @"a_typedef_struct_t_field_2") ptr_0 a_typedef_struct_t_field_2_4 >> (writeRaw (Proxy @"a_typedef_struct_t_field_3") ptr_0 a_typedef_struct_t_field_3_5 >> (writeRaw (Proxy @"a_typedef_struct_t_field_4") ptr_0 a_typedef_struct_t_field_4_6 >> (writeRaw (Proxy @"a_typedef_struct_t_field_5") ptr_0 a_typedef_struct_t_field_5_7 >> (writeRaw (Proxy @"a_typedef_struct_t_field_6") ptr_0 a_typedef_struct_t_field_6_8 >> (writeRaw (Proxy @"a_typedef_struct_t_field_7") ptr_0 a_typedef_struct_t_field_7_9 >> (writeRaw (Proxy @"a_typedef_struct_t_field_8") ptr_0 a_typedef_struct_t_field_8_10 >> (writeRaw (Proxy @"a_typedef_struct_t_field_9") ptr_0 a_typedef_struct_t_field_9_11 >> writeRaw (Proxy @"a_typedef_struct_t_field_10") ptr_0 a_typedef_struct_t_field_10_12)))))))))
 deriving via (EquivStorable A_typedef_struct_t) instance Storable A_typedef_struct_t
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_0"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_0" = CBool
-          offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "a_typedef_struct_t_field_0"
-                  (Ptr A_typedef_struct_t)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_0")
 instance (~) ty CBool =>
          HasField "a_typedef_struct_t_field_0" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_0 = y_1,
@@ -406,15 +397,15 @@ instance (~) ty CBool =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_0" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_1"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_1" = HsBindgen.Runtime.LibC.Word8
-          offset# = \_ -> \_ -> 1
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "a_typedef_struct_t_field_1"
+instance (~) ty CBool =>
+         HasField "a_typedef_struct_t_field_0"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_1")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_0")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_0"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_0" = CBool
+          offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "a_typedef_struct_t_field_1" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_1 = y_1,
@@ -429,15 +420,15 @@ instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_1" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_2"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_2" = HsBindgen.Runtime.LibC.Word16
-          offset# = \_ -> \_ -> 2
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "a_typedef_struct_t_field_2"
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "a_typedef_struct_t_field_1"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_2")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_1")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_1"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_1" = HsBindgen.Runtime.LibC.Word8
+          offset# = \_ -> \_ -> 1
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "a_typedef_struct_t_field_2" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_2 = y_1,
@@ -452,15 +443,15 @@ instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_2" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_3"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_3" = HsBindgen.Runtime.LibC.Word32
-          offset# = \_ -> \_ -> 4
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "a_typedef_struct_t_field_3"
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "a_typedef_struct_t_field_2"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_3")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_2")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_2"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_2" = HsBindgen.Runtime.LibC.Word16
+          offset# = \_ -> \_ -> 2
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "a_typedef_struct_t_field_3" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_3 = y_1,
@@ -475,15 +466,15 @@ instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_3" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_4"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_4" = Another_typedef_struct_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty Another_typedef_struct_t =>
-         HasField "a_typedef_struct_t_field_4"
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "a_typedef_struct_t_field_3"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_4")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_3")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_3"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_3" = HsBindgen.Runtime.LibC.Word32
+          offset# = \_ -> \_ -> 4
 instance (~) ty Another_typedef_struct_t =>
          HasField "a_typedef_struct_t_field_4" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_4 = y_1,
@@ -498,15 +489,15 @@ instance (~) ty Another_typedef_struct_t =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_4" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_5"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_5" = Ptr Another_typedef_struct_t
-          offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr Another_typedef_struct_t) =>
-         HasField "a_typedef_struct_t_field_5"
+instance (~) ty Another_typedef_struct_t =>
+         HasField "a_typedef_struct_t_field_4"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_5")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_4")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_4"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_4" = Another_typedef_struct_t
+          offset# = \_ -> \_ -> 8
 instance (~) ty (Ptr Another_typedef_struct_t) =>
          HasField "a_typedef_struct_t_field_5" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_5 = y_1,
@@ -521,15 +512,15 @@ instance (~) ty (Ptr Another_typedef_struct_t) =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_5" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_6"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_6" = Ptr Void
-          offset# = \_ -> \_ -> 24
-instance (~) ty (Ptr Void) =>
-         HasField "a_typedef_struct_t_field_6"
+instance (~) ty (Ptr Another_typedef_struct_t) =>
+         HasField "a_typedef_struct_t_field_5"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_6")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_5")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_5"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_5" = Ptr Another_typedef_struct_t
+          offset# = \_ -> \_ -> 16
 instance (~) ty (Ptr Void) =>
          HasField "a_typedef_struct_t_field_6" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_6 = y_1,
@@ -544,16 +535,15 @@ instance (~) ty (Ptr Void) =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_6" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_7"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_7" = ConstantArray 7
-                                                                       HsBindgen.Runtime.LibC.Word32
-          offset# = \_ -> \_ -> 32
-instance (~) ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
-         HasField "a_typedef_struct_t_field_7"
+instance (~) ty (Ptr Void) =>
+         HasField "a_typedef_struct_t_field_6"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_7")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_6")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_6"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_6" = Ptr Void
+          offset# = \_ -> \_ -> 24
 instance (~) ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
          HasField "a_typedef_struct_t_field_7" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_7 = y_1,
@@ -568,15 +558,16 @@ instance (~) ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_7" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_8"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_8" = Another_typedef_enum_e
-          offset# = \_ -> \_ -> 60
-instance (~) ty Another_typedef_enum_e =>
-         HasField "a_typedef_struct_t_field_8"
+instance (~) ty (ConstantArray 7 HsBindgen.Runtime.LibC.Word32) =>
+         HasField "a_typedef_struct_t_field_7"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_8")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_7")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_7"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_7" = ConstantArray 7
+                                                                       HsBindgen.Runtime.LibC.Word32
+          offset# = \_ -> \_ -> 32
 instance (~) ty Another_typedef_enum_e =>
          HasField "a_typedef_struct_t_field_8" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_8 = y_1,
@@ -591,16 +582,15 @@ instance (~) ty Another_typedef_enum_e =>
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_8" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_9"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_9" = ConstantArray 4
-                                                                       Another_typedef_enum_e
-          offset# = \_ -> \_ -> 64
-instance (~) ty (ConstantArray 4 Another_typedef_enum_e) =>
-         HasField "a_typedef_struct_t_field_9"
+instance (~) ty Another_typedef_enum_e =>
+         HasField "a_typedef_struct_t_field_8"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_9")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_8")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_8"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_8" = Another_typedef_enum_e
+          offset# = \_ -> \_ -> 60
 instance (~) ty (ConstantArray 4 Another_typedef_enum_e) =>
          HasField "a_typedef_struct_t_field_9" A_typedef_struct_t ty
     where hasField = \x_0 -> (\y_1 -> A_typedef_struct_t{a_typedef_struct_t_field_9 = y_1,
@@ -615,18 +605,16 @@ instance (~) ty (ConstantArray 4 Another_typedef_enum_e) =>
                                                          a_typedef_struct_t_field_8 = getField @"a_typedef_struct_t_field_8" x_0,
                                                          a_typedef_struct_t_field_10 = getField @"a_typedef_struct_t_field_10" x_0},
                               getField @"a_typedef_struct_t_field_9" x_0)
-instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
-    where type CFieldType A_typedef_struct_t
-                          "a_typedef_struct_t_field_10" = ConstantArray 5
-                                                                        (ConstantArray 3
-                                                                                       Another_typedef_enum_e)
-          offset# = \_ -> \_ -> 80
-instance (~) ty
-             (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)) =>
-         HasField "a_typedef_struct_t_field_10"
+instance (~) ty (ConstantArray 4 Another_typedef_enum_e) =>
+         HasField "a_typedef_struct_t_field_9"
                   (Ptr A_typedef_struct_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_10")
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_9")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_9"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_9" = ConstantArray 4
+                                                                       Another_typedef_enum_e
+          offset# = \_ -> \_ -> 64
 instance (~) ty
              (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)) =>
          HasField "a_typedef_struct_t_field_10" A_typedef_struct_t ty
@@ -642,6 +630,18 @@ instance (~) ty
                                                          a_typedef_struct_t_field_8 = getField @"a_typedef_struct_t_field_8" x_0,
                                                          a_typedef_struct_t_field_9 = getField @"a_typedef_struct_t_field_9" x_0},
                               getField @"a_typedef_struct_t_field_10" x_0)
+instance (~) ty
+             (ConstantArray 5 (ConstantArray 3 Another_typedef_enum_e)) =>
+         HasField "a_typedef_struct_t_field_10"
+                  (Ptr A_typedef_struct_t)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"a_typedef_struct_t_field_10")
+instance HasCField A_typedef_struct_t "a_typedef_struct_t_field_10"
+    where type CFieldType A_typedef_struct_t
+                          "a_typedef_struct_t_field_10" = ConstantArray 5
+                                                                        (ConstantArray 3
+                                                                                       Another_typedef_enum_e)
+          offset# = \_ -> \_ -> 80
 {-| __C declaration:__ @macro A_DEFINE_0@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 53:9@
@@ -741,16 +741,16 @@ instance Read A_typedef_enum_e
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CUChar =>
+         HasField "unwrapA_typedef_enum_e" A_typedef_enum_e ty
+    where hasField = \x_0 -> (\y_1 -> A_typedef_enum_e{unwrapA_typedef_enum_e = y_1},
+                              getField @"unwrapA_typedef_enum_e" x_0)
+instance (~) ty CUChar =>
          HasField "unwrapA_typedef_enum_e" (Ptr A_typedef_enum_e) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA_typedef_enum_e")
 instance HasCField A_typedef_enum_e "unwrapA_typedef_enum_e"
     where type CFieldType A_typedef_enum_e
                           "unwrapA_typedef_enum_e" = CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CUChar =>
-         HasField "unwrapA_typedef_enum_e" A_typedef_enum_e ty
-    where hasField = \x_0 -> (\y_1 -> A_typedef_enum_e{unwrapA_typedef_enum_e = y_1},
-                              getField @"unwrapA_typedef_enum_e" x_0)
 {-| __C declaration:__ @ENUM_CASE_0@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 63:3@
@@ -825,6 +825,13 @@ instance (~) ty
              (Ptr Void ->
               HsBindgen.Runtime.LibC.Word32 ->
               IO HsBindgen.Runtime.LibC.Word32) =>
+         HasField "unwrapCallback_t_Aux" Callback_t_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Callback_t_Aux{unwrapCallback_t_Aux = y_1},
+                              getField @"unwrapCallback_t_Aux" x_0)
+instance (~) ty
+             (Ptr Void ->
+              HsBindgen.Runtime.LibC.Word32 ->
+              IO HsBindgen.Runtime.LibC.Word32) =>
          HasField "unwrapCallback_t_Aux" (Ptr Callback_t_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCallback_t_Aux")
 instance HasCField Callback_t_Aux "unwrapCallback_t_Aux"
@@ -833,13 +840,6 @@ instance HasCField Callback_t_Aux "unwrapCallback_t_Aux"
                                                    HsBindgen.Runtime.LibC.Word32 ->
                                                    IO HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty
-             (Ptr Void ->
-              HsBindgen.Runtime.LibC.Word32 ->
-              IO HsBindgen.Runtime.LibC.Word32) =>
-         HasField "unwrapCallback_t_Aux" Callback_t_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Callback_t_Aux{unwrapCallback_t_Aux = y_1},
-                              getField @"unwrapCallback_t_Aux" x_0)
 {-| __C declaration:__ @callback_t@
 
     __defined at:__ @edge-cases\/distilled_lib_1.h 77:19@
@@ -855,16 +855,16 @@ newtype Callback_t
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Callback_t_Aux) =>
+         HasField "unwrapCallback_t" Callback_t ty
+    where hasField = \x_0 -> (\y_1 -> Callback_t{unwrapCallback_t = y_1},
+                              getField @"unwrapCallback_t" x_0)
+instance (~) ty (FunPtr Callback_t_Aux) =>
          HasField "unwrapCallback_t" (Ptr Callback_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCallback_t")
 instance HasCField Callback_t "unwrapCallback_t"
     where type CFieldType Callback_t
                           "unwrapCallback_t" = FunPtr Callback_t_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Callback_t_Aux) =>
-         HasField "unwrapCallback_t" Callback_t ty
-    where hasField = \x_0 -> (\y_1 -> Callback_t{unwrapCallback_t = y_1},
-                              getField @"unwrapCallback_t" x_0)
 -- __unique:__ @test_edgecasesdistilled_lib_1_Example_Safe_some_fun@
 foreign import ccall safe "hs_bindgen_57cb99ed92c001ad" hs_bindgen_57cb99ed92c001ad_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/Example.hs
@@ -65,20 +65,20 @@ instance Marshal.WriteRaw A where
 
 deriving via Marshal.EquivStorable A instance RIP.Storable A
 
-instance HasCField.HasCField A "dup" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dup" A ty where
 
-  type CFieldType A "dup" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> A {dup = y1}, RIP.getField @"dup" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "dup" (RIP.Ptr A) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dup")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dup" A ty where
+instance HasCField.HasCField A "dup" where
 
-  hasField =
-    \x0 -> (\y1 -> A {dup = y1}, RIP.getField @"dup" x0)
+  type CFieldType A "dup" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct B@
 
@@ -121,17 +121,17 @@ instance Marshal.WriteRaw B where
 
 deriving via Marshal.EquivStorable B instance RIP.Storable B
 
-instance HasCField.HasCField B "dup" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dup" B ty where
 
-  type CFieldType B "dup" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> B {dup = y1}, RIP.getField @"dup" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "dup" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"dup")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dup" B ty where
+instance HasCField.HasCField B "dup" where
 
-  hasField =
-    \x0 -> (\y1 -> B {dup = y1}, RIP.getField @"dup" x0)
+  type CFieldType B "dup" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - dup
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - dup
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/duplicate_record_field/th.txt
@@ -23,14 +23,14 @@ instance WriteRaw A
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        A dup_2 -> writeRaw (Proxy @"dup") ptr_0 dup_2
 deriving via (EquivStorable A) instance Storable A
-instance HasCField A "dup"
-    where type CFieldType A "dup" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dup" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"dup")
 instance (~) ty CInt => HasField "dup" A ty
     where hasField = \x_0 -> (\y_1 -> A{dup = y_1},
                               getField @"dup" x_0)
+instance (~) ty CInt => HasField "dup" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"dup")
+instance HasCField A "dup"
+    where type CFieldType A "dup" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct B@
 
     __defined at:__ @edge-cases\/duplicate_record_field.h 5:8@
@@ -55,11 +55,11 @@ instance WriteRaw B
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        B dup_2 -> writeRaw (Proxy @"dup") ptr_0 dup_2
 deriving via (EquivStorable B) instance Storable B
-instance HasCField B "dup"
-    where type CFieldType B "dup" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dup" (Ptr B) (Ptr ty)
-    where getField = fromPtr (Proxy @"dup")
 instance (~) ty CInt => HasField "dup" B ty
     where hasField = \x_0 -> (\y_1 -> B{dup = y_1},
                               getField @"dup" x_0)
+instance (~) ty CInt => HasField "dup" (Ptr B) (Ptr ty)
+    where getField = fromPtr (Proxy @"dup")
+instance HasCField B "dup"
+    where type CFieldType B "dup" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/Example.hs
@@ -106,6 +106,14 @@ instance Read Test where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapTest" Test ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Test {unwrapTest = y1}, RIP.getField @"unwrapTest" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapTest" (RIP.Ptr Test) (RIP.Ptr ty) where
 
   getField =
@@ -116,14 +124,6 @@ instance HasCField.HasCField Test "unwrapTest" where
   type CFieldType Test "unwrapTest" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapTest" Test ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Test {unwrapTest = y1}, RIP.getField @"unwrapTest" x0)
 
 {-| __C declaration:__ @test_a@
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
@@ -15,12 +15,13 @@ hstypes:
       - unwrapTest
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/th.txt
@@ -46,14 +46,14 @@ instance Read Test
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapTest" Test ty
+    where hasField = \x_0 -> (\y_1 -> Test{unwrapTest = y_1},
+                              getField @"unwrapTest" x_0)
 instance (~) ty CUInt => HasField "unwrapTest" (Ptr Test) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTest")
 instance HasCField Test "unwrapTest"
     where type CFieldType Test "unwrapTest" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapTest" Test ty
-    where hasField = \x_0 -> (\y_1 -> Test{unwrapTest = y_1},
-                              getField @"unwrapTest" x_0)
 {-| __C declaration:__ @test_a@
 
     __defined at:__ @edge-cases\/enum_as_array_size.h 4:3@

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/Example.hs
@@ -73,18 +73,6 @@ instance Marshal.WriteRaw Pascal_Aux where
 
 deriving via Marshal.EquivStorable Pascal_Aux instance RIP.Storable Pascal_Aux
 
-instance HasCField.HasCField Pascal_Aux "pascal_len" where
-
-  type CFieldType Pascal_Aux "pascal_len" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "pascal_len" (RIP.Ptr Pascal_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"pascal_len")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "pascal_len" Pascal_Aux ty where
 
@@ -92,6 +80,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Pascal {pascal_len = y1}, RIP.getField @"pascal_len" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "pascal_len" (RIP.Ptr Pascal_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"pascal_len")
+
+instance HasCField.HasCField Pascal_Aux "pascal_len" where
+
+  type CFieldType Pascal_Aux "pascal_len" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance FLAM.Offset RIP.CChar Pascal_Aux where
 
@@ -155,17 +155,6 @@ instance Marshal.WriteRaw Foo_bar where
 
 deriving via Marshal.EquivStorable Foo_bar instance RIP.Storable Foo_bar
 
-instance HasCField.HasCField Foo_bar "foo_bar_x" where
-
-  type CFieldType Foo_bar "foo_bar_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_bar_x" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_bar_x" Foo_bar ty where
 
@@ -176,16 +165,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_bar_x" x0
       )
 
-instance HasCField.HasCField Foo_bar "foo_bar_y" where
-
-  type CFieldType Foo_bar "foo_bar_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_bar_y" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
+         ) => RIP.HasField "foo_bar_x" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_x")
+
+instance HasCField.HasCField Foo_bar "foo_bar_x" where
+
+  type CFieldType Foo_bar "foo_bar_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_bar_y" Foo_bar ty where
@@ -196,6 +185,17 @@ instance ( ty ~ RIP.CInt
           Foo_bar {foo_bar_y = y1, foo_bar_x = RIP.getField @"foo_bar_x" x0}
       , RIP.getField @"foo_bar_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_bar_y" (RIP.Ptr Foo_bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_bar_y")
+
+instance HasCField.HasCField Foo_bar "foo_bar_y" where
+
+  type CFieldType Foo_bar "foo_bar_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct foo@
 
@@ -238,17 +238,6 @@ instance Marshal.WriteRaw Foo_Aux where
 
 deriving via Marshal.EquivStorable Foo_Aux instance RIP.Storable Foo_Aux
 
-instance HasCField.HasCField Foo_Aux "foo_len" where
-
-  type CFieldType Foo_Aux "foo_len" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_len" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_len")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_len" Foo_Aux ty where
 
@@ -256,6 +245,17 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Foo {foo_len = y1}, RIP.getField @"foo_len" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_len" (RIP.Ptr Foo_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_len")
+
+instance HasCField.HasCField Foo_Aux "foo_len" where
+
+  type CFieldType Foo_Aux "foo_len" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance FLAM.Offset Foo_bar Foo_Aux where
 
@@ -319,18 +319,6 @@ instance Marshal.WriteRaw Diff_Aux where
 
 deriving via Marshal.EquivStorable Diff_Aux instance RIP.Storable Diff_Aux
 
-instance HasCField.HasCField Diff_Aux "diff_first" where
-
-  type CFieldType Diff_Aux "diff_first" = RIP.CLong
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "diff_first" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"diff_first")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "diff_first" Diff_Aux ty where
 
@@ -341,17 +329,17 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"diff_first" x0
       )
 
-instance HasCField.HasCField Diff_Aux "diff_second" where
-
-  type CFieldType Diff_Aux "diff_second" = RIP.CChar
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "diff_second" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "diff_first" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"diff_second")
+    HasCField.fromPtr (RIP.Proxy @"diff_first")
+
+instance HasCField.HasCField Diff_Aux "diff_first" where
+
+  type CFieldType Diff_Aux "diff_first" = RIP.CLong
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "diff_second" Diff_Aux ty where
@@ -362,6 +350,18 @@ instance ( ty ~ RIP.CChar
           Diff {diff_second = y1, diff_first = RIP.getField @"diff_first" x0}
       , RIP.getField @"diff_second" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "diff_second" (RIP.Ptr Diff_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"diff_second")
+
+instance HasCField.HasCField Diff_Aux "diff_second" where
+
+  type CFieldType Diff_Aux "diff_second" = RIP.CChar
+
+  offset# = \_ -> \_ -> 8
 
 instance FLAM.Offset RIP.CChar Diff_Aux where
 
@@ -418,19 +418,6 @@ instance Marshal.WriteRaw Triplets_Aux where
 
 deriving via Marshal.EquivStorable Triplets_Aux instance RIP.Storable Triplets_Aux
 
-instance HasCField.HasCField Triplets_Aux "triplets_len" where
-
-  type CFieldType Triplets_Aux "triplets_len" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "triplets_len" (RIP.Ptr Triplets_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"triplets_len")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "triplets_len" Triplets_Aux ty where
 
@@ -438,6 +425,19 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Triplets {triplets_len = y1}, RIP.getField @"triplets_len" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "triplets_len" (RIP.Ptr Triplets_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"triplets_len")
+
+instance HasCField.HasCField Triplets_Aux "triplets_len" where
+
+  type CFieldType Triplets_Aux "triplets_len" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance FLAM.Offset (CA.ConstantArray 3 RIP.CInt) Triplets_Aux where
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/bindingspec.yaml
@@ -41,12 +41,13 @@ hstypes:
       - diff_first
       - diff_second
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -61,12 +62,13 @@ hstypes:
       fields:
       - foo_len
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -80,11 +82,12 @@ hstypes:
       - foo_bar_x
       - foo_bar_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -99,12 +102,13 @@ hstypes:
       fields:
       - pascal_len
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -119,12 +123,13 @@ hstypes:
       fields:
       - triplets_len
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw Pascal_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Pascal pascal_len_2 -> writeRaw (Proxy @"pascal_len") ptr_0 pascal_len_2
 deriving via (EquivStorable Pascal_Aux) instance Storable Pascal_Aux
-instance HasCField Pascal_Aux "pascal_len"
-    where type CFieldType Pascal_Aux "pascal_len" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"pascal_len")
 instance (~) ty CInt => HasField "pascal_len" Pascal_Aux ty
     where hasField = \x_0 -> (\y_1 -> Pascal{pascal_len = y_1},
                               getField @"pascal_len" x_0)
+instance (~) ty CInt =>
+         HasField "pascal_len" (Ptr Pascal_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"pascal_len")
+instance HasCField Pascal_Aux "pascal_len"
+    where type CFieldType Pascal_Aux "pascal_len" = CInt
+          offset# = \_ -> \_ -> 0
 instance Offset CChar Pascal_Aux
     where offset = \_proxy_0 -> 4
 type Pascal = WithFlam CChar Pascal_Aux
@@ -67,24 +67,24 @@ instance WriteRaw Foo_bar
                                        Foo_bar foo_bar_x_2
                                                foo_bar_y_3 -> writeRaw (Proxy @"foo_bar_x") ptr_0 foo_bar_x_2 >> writeRaw (Proxy @"foo_bar_y") ptr_0 foo_bar_y_3
 deriving via (EquivStorable Foo_bar) instance Storable Foo_bar
-instance HasCField Foo_bar "foo_bar_x"
-    where type CFieldType Foo_bar "foo_bar_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_bar_x" (Ptr Foo_bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_bar_x")
 instance (~) ty CInt => HasField "foo_bar_x" Foo_bar ty
     where hasField = \x_0 -> (\y_1 -> Foo_bar{foo_bar_x = y_1,
                                               foo_bar_y = getField @"foo_bar_y" x_0},
                               getField @"foo_bar_x" x_0)
-instance HasCField Foo_bar "foo_bar_y"
-    where type CFieldType Foo_bar "foo_bar_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "foo_bar_y" (Ptr Foo_bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_bar_y")
+instance (~) ty CInt => HasField "foo_bar_x" (Ptr Foo_bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_bar_x")
+instance HasCField Foo_bar "foo_bar_x"
+    where type CFieldType Foo_bar "foo_bar_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "foo_bar_y" Foo_bar ty
     where hasField = \x_0 -> (\y_1 -> Foo_bar{foo_bar_y = y_1,
                                               foo_bar_x = getField @"foo_bar_x" x_0},
                               getField @"foo_bar_y" x_0)
+instance (~) ty CInt => HasField "foo_bar_y" (Ptr Foo_bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_bar_y")
+instance HasCField Foo_bar "foo_bar_y"
+    where type CFieldType Foo_bar "foo_bar_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct foo@
 
     __defined at:__ @edge-cases\/flam.h 8:8@
@@ -109,14 +109,14 @@ instance WriteRaw Foo_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Foo foo_len_2 -> writeRaw (Proxy @"foo_len") ptr_0 foo_len_2
 deriving via (EquivStorable Foo_Aux) instance Storable Foo_Aux
-instance HasCField Foo_Aux "foo_len"
-    where type CFieldType Foo_Aux "foo_len" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_len")
 instance (~) ty CInt => HasField "foo_len" Foo_Aux ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_len = y_1},
                               getField @"foo_len" x_0)
+instance (~) ty CInt => HasField "foo_len" (Ptr Foo_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_len")
+instance HasCField Foo_Aux "foo_len"
+    where type CFieldType Foo_Aux "foo_len" = CInt
+          offset# = \_ -> \_ -> 0
 instance Offset Foo_bar Foo_Aux
     where offset = \_proxy_0 -> 4
 type Foo = WithFlam Foo_bar Foo_Aux
@@ -152,26 +152,26 @@ instance WriteRaw Diff_Aux
                                        Diff diff_first_2
                                             diff_second_3 -> writeRaw (Proxy @"diff_first") ptr_0 diff_first_2 >> writeRaw (Proxy @"diff_second") ptr_0 diff_second_3
 deriving via (EquivStorable Diff_Aux) instance Storable Diff_Aux
-instance HasCField Diff_Aux "diff_first"
-    where type CFieldType Diff_Aux "diff_first" = CLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "diff_first" (Ptr Diff_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"diff_first")
 instance (~) ty CLong => HasField "diff_first" Diff_Aux ty
     where hasField = \x_0 -> (\y_1 -> Diff{diff_first = y_1,
                                            diff_second = getField @"diff_second" x_0},
                               getField @"diff_first" x_0)
-instance HasCField Diff_Aux "diff_second"
-    where type CFieldType Diff_Aux "diff_second" = CChar
-          offset# = \_ -> \_ -> 8
-instance (~) ty CChar =>
-         HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"diff_second")
+instance (~) ty CLong =>
+         HasField "diff_first" (Ptr Diff_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"diff_first")
+instance HasCField Diff_Aux "diff_first"
+    where type CFieldType Diff_Aux "diff_first" = CLong
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar => HasField "diff_second" Diff_Aux ty
     where hasField = \x_0 -> (\y_1 -> Diff{diff_second = y_1,
                                            diff_first = getField @"diff_first" x_0},
                               getField @"diff_second" x_0)
+instance (~) ty CChar =>
+         HasField "diff_second" (Ptr Diff_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"diff_second")
+instance HasCField Diff_Aux "diff_second"
+    where type CFieldType Diff_Aux "diff_second" = CChar
+          offset# = \_ -> \_ -> 8
 instance Offset CChar Diff_Aux
     where offset = \_proxy_0 -> 9
 type Diff = WithFlam CChar Diff_Aux
@@ -201,15 +201,15 @@ instance WriteRaw Triplets_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Triplets triplets_len_2 -> writeRaw (Proxy @"triplets_len") ptr_0 triplets_len_2
 deriving via (EquivStorable Triplets_Aux) instance Storable Triplets_Aux
-instance HasCField Triplets_Aux "triplets_len"
-    where type CFieldType Triplets_Aux "triplets_len" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"triplets_len")
 instance (~) ty CInt => HasField "triplets_len" Triplets_Aux ty
     where hasField = \x_0 -> (\y_1 -> Triplets{triplets_len = y_1},
                               getField @"triplets_len" x_0)
+instance (~) ty CInt =>
+         HasField "triplets_len" (Ptr Triplets_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"triplets_len")
+instance HasCField Triplets_Aux "triplets_len"
+    where type CFieldType Triplets_Aux "triplets_len" = CInt
+          offset# = \_ -> \_ -> 0
 instance Offset (ConstantArray 3 CInt) Triplets_Aux
     where offset = \_proxy_0 -> 4
 type Triplets = WithFlam (ConstantArray 3 CInt) Triplets_Aux

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/Example.hs
@@ -65,18 +65,6 @@ instance Marshal.WriteRaw Vector_Aux where
 
 deriving via Marshal.EquivStorable Vector_Aux instance RIP.Storable Vector_Aux
 
-instance HasCField.HasCField Vector_Aux "vector_length" where
-
-  type CFieldType Vector_Aux "vector_length" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vector_length" (RIP.Ptr Vector_Aux) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vector_length")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "vector_length" Vector_Aux ty where
 
@@ -84,6 +72,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Vector {vector_length = y1}, RIP.getField @"vector_length" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "vector_length" (RIP.Ptr Vector_Aux) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vector_length")
+
+instance HasCField.HasCField Vector_Aux "vector_length" where
+
+  type CFieldType Vector_Aux "vector_length" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance FLAM.Offset RIP.CLong Vector_Aux where
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/bindingspec.yaml
@@ -19,12 +19,13 @@ hstypes:
       fields:
       - vector_length
   instances:
-  - CompatHasField
   - Eq
   - Flam_Offset
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/flam_functions/th.txt
@@ -84,15 +84,15 @@ instance WriteRaw Vector_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Vector vector_length_2 -> writeRaw (Proxy @"vector_length") ptr_0 vector_length_2
 deriving via (EquivStorable Vector_Aux) instance Storable Vector_Aux
-instance HasCField Vector_Aux "vector_length"
-    where type CFieldType Vector_Aux "vector_length" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"vector_length")
 instance (~) ty CInt => HasField "vector_length" Vector_Aux ty
     where hasField = \x_0 -> (\y_1 -> Vector{vector_length = y_1},
                               getField @"vector_length" x_0)
+instance (~) ty CInt =>
+         HasField "vector_length" (Ptr Vector_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"vector_length")
+instance HasCField Vector_Aux "vector_length"
+    where type CFieldType Vector_Aux "vector_length" = CInt
+          offset# = \_ -> \_ -> 0
 instance Offset CLong Vector_Aux
     where offset = \_proxy_0 -> 8
 type Vector = WithFlam CLong Vector_Aux

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/Example.hs
@@ -75,17 +75,6 @@ instance Marshal.WriteRaw Pt where
 
 deriving via Marshal.EquivStorable Pt instance RIP.Storable Pt
 
-instance HasCField.HasCField Pt "pt_x" where
-
-  type CFieldType Pt "pt_x" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "pt_x" (RIP.Ptr Pt) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"pt_x")
-
 instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_x" Pt ty where
 
   hasField =
@@ -95,16 +84,16 @@ instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_x" Pt ty where
       , RIP.getField @"pt_x" x0
       )
 
-instance HasCField.HasCField Pt "pt_y" where
-
-  type CFieldType Pt "pt_y" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "pt_y" (RIP.Ptr Pt) (RIP.Ptr ty) where
+         ) => RIP.HasField "pt_x" (RIP.Ptr Pt) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"pt_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"pt_x")
+
+instance HasCField.HasCField Pt "pt_x" where
+
+  type CFieldType Pt "pt_x" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_y" Pt ty where
 
@@ -114,6 +103,17 @@ instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_y" Pt ty where
           Pt {pt_y = y1, pt_x = RIP.getField @"pt_x" x0}
       , RIP.getField @"pt_y" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "pt_y" (RIP.Ptr Pt) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"pt_y")
+
+instance HasCField.HasCField Pt "pt_y" where
+
+  type CFieldType Pt "pt_y" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @macro CHILD_HEADER@
 
@@ -177,16 +177,6 @@ instance Marshal.WriteRaw Rect where
 
 deriving via Marshal.EquivStorable Rect instance RIP.Storable Rect
 
-instance HasCField.HasCField Rect "rect_tl" where
-
-  type CFieldType Rect "rect_tl" = Pt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ Pt) => RIP.HasField "rect_tl" (RIP.Ptr Rect) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"rect_tl")
-
 instance (ty ~ Pt) => RIP.CompatHasField.HasField "rect_tl" Rect ty where
 
   hasField =
@@ -196,15 +186,15 @@ instance (ty ~ Pt) => RIP.CompatHasField.HasField "rect_tl" Rect ty where
       , RIP.getField @"rect_tl" x0
       )
 
-instance HasCField.HasCField Rect "rect_br" where
+instance (ty ~ Pt) => RIP.HasField "rect_tl" (RIP.Ptr Rect) (RIP.Ptr ty) where
 
-  type CFieldType Rect "rect_br" = Pt
+  getField = HasCField.fromPtr (RIP.Proxy @"rect_tl")
 
-  offset# = \_ -> \_ -> 16
+instance HasCField.HasCField Rect "rect_tl" where
 
-instance (ty ~ Pt) => RIP.HasField "rect_br" (RIP.Ptr Rect) (RIP.Ptr ty) where
+  type CFieldType Rect "rect_tl" = Pt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"rect_br")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ Pt) => RIP.CompatHasField.HasField "rect_br" Rect ty where
 
@@ -214,3 +204,13 @@ instance (ty ~ Pt) => RIP.CompatHasField.HasField "rect_br" Rect ty where
           Rect {rect_br = y1, rect_tl = RIP.getField @"rect_tl" x0}
       , RIP.getField @"rect_br" x0
       )
+
+instance (ty ~ Pt) => RIP.HasField "rect_br" (RIP.Ptr Rect) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"rect_br")
+
+instance HasCField.HasCField Rect "rect_br" where
+
+  type CFieldType Rect "rect_br" = Pt
+
+  offset# = \_ -> \_ -> 16

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/bindingspec.yaml
@@ -21,11 +21,12 @@ hstypes:
       - pt_x
       - pt_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -39,11 +40,12 @@ hstypes:
       - rect_tl
       - rect_br
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/include_macro_parent/th.txt
@@ -32,24 +32,24 @@ instance WriteRaw Pt
                                        Pt pt_x_2
                                           pt_y_3 -> writeRaw (Proxy @"pt_x") ptr_0 pt_x_2 >> writeRaw (Proxy @"pt_y") ptr_0 pt_y_3
 deriving via (EquivStorable Pt) instance Storable Pt
-instance HasCField Pt "pt_x"
-    where type CFieldType Pt "pt_x" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble => HasField "pt_x" (Ptr Pt) (Ptr ty)
-    where getField = fromPtr (Proxy @"pt_x")
 instance (~) ty CDouble => HasField "pt_x" Pt ty
     where hasField = \x_0 -> (\y_1 -> Pt{pt_x = y_1,
                                          pt_y = getField @"pt_y" x_0},
                               getField @"pt_x" x_0)
-instance HasCField Pt "pt_y"
-    where type CFieldType Pt "pt_y" = CDouble
-          offset# = \_ -> \_ -> 8
-instance (~) ty CDouble => HasField "pt_y" (Ptr Pt) (Ptr ty)
-    where getField = fromPtr (Proxy @"pt_y")
+instance (~) ty CDouble => HasField "pt_x" (Ptr Pt) (Ptr ty)
+    where getField = fromPtr (Proxy @"pt_x")
+instance HasCField Pt "pt_x"
+    where type CFieldType Pt "pt_x" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty CDouble => HasField "pt_y" Pt ty
     where hasField = \x_0 -> (\y_1 -> Pt{pt_y = y_1,
                                          pt_x = getField @"pt_x" x_0},
                               getField @"pt_y" x_0)
+instance (~) ty CDouble => HasField "pt_y" (Ptr Pt) (Ptr ty)
+    where getField = fromPtr (Proxy @"pt_y")
+instance HasCField Pt "pt_y"
+    where type CFieldType Pt "pt_y" = CDouble
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @macro CHILD_HEADER@
 
     __C literal:__ @\"include_macro_child.h\"@
@@ -120,21 +120,21 @@ instance WriteRaw Rect
                                        Rect rect_tl_2
                                             rect_br_3 -> writeRaw (Proxy @"rect_tl") ptr_0 rect_tl_2 >> writeRaw (Proxy @"rect_br") ptr_0 rect_br_3
 deriving via (EquivStorable Rect) instance Storable Rect
-instance HasCField Rect "rect_tl"
-    where type CFieldType Rect "rect_tl" = Pt
-          offset# = \_ -> \_ -> 0
-instance (~) ty Pt => HasField "rect_tl" (Ptr Rect) (Ptr ty)
-    where getField = fromPtr (Proxy @"rect_tl")
 instance (~) ty Pt => HasField "rect_tl" Rect ty
     where hasField = \x_0 -> (\y_1 -> Rect{rect_tl = y_1,
                                            rect_br = getField @"rect_br" x_0},
                               getField @"rect_tl" x_0)
-instance HasCField Rect "rect_br"
-    where type CFieldType Rect "rect_br" = Pt
-          offset# = \_ -> \_ -> 16
-instance (~) ty Pt => HasField "rect_br" (Ptr Rect) (Ptr ty)
-    where getField = fromPtr (Proxy @"rect_br")
+instance (~) ty Pt => HasField "rect_tl" (Ptr Rect) (Ptr ty)
+    where getField = fromPtr (Proxy @"rect_tl")
+instance HasCField Rect "rect_tl"
+    where type CFieldType Rect "rect_tl" = Pt
+          offset# = \_ -> \_ -> 0
 instance (~) ty Pt => HasField "rect_br" Rect ty
     where hasField = \x_0 -> (\y_1 -> Rect{rect_br = y_1,
                                            rect_tl = getField @"rect_tl" x_0},
                               getField @"rect_br" x_0)
+instance (~) ty Pt => HasField "rect_br" (Ptr Rect) (Ptr ty)
+    where getField = fromPtr (Proxy @"rect_br")
+instance HasCField Rect "rect_br"
+    where type CFieldType Rect "rect_br" = Pt
+          offset# = \_ -> \_ -> 16

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/Example.hs
@@ -75,6 +75,15 @@ instance RIP.FromFunPtr Toggle_Aux where
   fromFunPtr = hs_bindgen_703fc4bdc168721d
 
 instance ( ty ~ IO RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapToggle_Aux" Toggle_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Toggle_Aux {unwrapToggle_Aux = y1}
+      , RIP.getField @"unwrapToggle_Aux" x0
+      )
+
+instance ( ty ~ IO RIP.CBool
          ) => RIP.HasField "unwrapToggle_Aux" (RIP.Ptr Toggle_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -86,15 +95,6 @@ instance HasCField.HasCField Toggle_Aux "unwrapToggle_Aux" where
     IO RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapToggle_Aux" Toggle_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Toggle_Aux {unwrapToggle_Aux = y1}
-      , RIP.getField @"unwrapToggle_Aux" x0
-      )
 
 {-| __C declaration:__ @Toggle@
 
@@ -109,6 +109,14 @@ newtype Toggle = Toggle
   deriving newtype (RIP.HasFFIType)
 
 instance ( ty ~ Block.Block Toggle_Aux
+         ) => RIP.CompatHasField.HasField "unwrapToggle" Toggle ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Toggle {unwrapToggle = y1}, RIP.getField @"unwrapToggle" x0)
+
+instance ( ty ~ Block.Block Toggle_Aux
          ) => RIP.HasField "unwrapToggle" (RIP.Ptr Toggle) (RIP.Ptr ty) where
 
   getField =
@@ -120,14 +128,6 @@ instance HasCField.HasCField Toggle "unwrapToggle" where
     Block.Block Toggle_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Block.Block Toggle_Aux
-         ) => RIP.CompatHasField.HasField "unwrapToggle" Toggle ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Toggle {unwrapToggle = y1}, RIP.getField @"unwrapToggle" x0)
 
 {-| Auxiliary type used by 'Counter'
 
@@ -178,6 +178,15 @@ instance RIP.FromFunPtr Counter_Aux where
   fromFunPtr = hs_bindgen_73304cb84e9a2f8f
 
 instance ( ty ~ IO RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapCounter_Aux" Counter_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Counter_Aux {unwrapCounter_Aux = y1}
+      , RIP.getField @"unwrapCounter_Aux" x0
+      )
+
+instance ( ty ~ IO RIP.CInt
          ) => RIP.HasField "unwrapCounter_Aux" (RIP.Ptr Counter_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -189,15 +198,6 @@ instance HasCField.HasCField Counter_Aux "unwrapCounter_Aux" where
     IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapCounter_Aux" Counter_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Counter_Aux {unwrapCounter_Aux = y1}
-      , RIP.getField @"unwrapCounter_Aux" x0
-      )
 
 {-| __C declaration:__ @Counter@
 
@@ -212,6 +212,14 @@ newtype Counter = Counter
   deriving newtype (RIP.HasFFIType)
 
 instance ( ty ~ Block.Block Counter_Aux
+         ) => RIP.CompatHasField.HasField "unwrapCounter" Counter ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Counter {unwrapCounter = y1}, RIP.getField @"unwrapCounter" x0)
+
+instance ( ty ~ Block.Block Counter_Aux
          ) => RIP.HasField "unwrapCounter" (RIP.Ptr Counter) (RIP.Ptr ty) where
 
   getField =
@@ -223,14 +231,6 @@ instance HasCField.HasCField Counter "unwrapCounter" where
     Block.Block Counter_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Block.Block Counter_Aux
-         ) => RIP.CompatHasField.HasField "unwrapCounter" Counter ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Counter {unwrapCounter = y1}, RIP.getField @"unwrapCounter" x0)
 
 {-| Auxiliary type used by 'VarCounter'
 
@@ -281,6 +281,15 @@ instance RIP.FromFunPtr VarCounter_Aux where
   fromFunPtr = hs_bindgen_43d902480175fccf
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapVarCounter_Aux" VarCounter_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> VarCounter_Aux {unwrapVarCounter_Aux = y1}
+      , RIP.getField @"unwrapVarCounter_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapVarCounter_Aux" (RIP.Ptr VarCounter_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -292,15 +301,6 @@ instance HasCField.HasCField VarCounter_Aux "unwrapVarCounter_Aux" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapVarCounter_Aux" VarCounter_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> VarCounter_Aux {unwrapVarCounter_Aux = y1}
-      , RIP.getField @"unwrapVarCounter_Aux" x0
-      )
 
 {-| __C declaration:__ @VarCounter@
 
@@ -315,6 +315,15 @@ newtype VarCounter = VarCounter
   deriving newtype (RIP.HasFFIType)
 
 instance ( ty ~ Block.Block VarCounter_Aux
+         ) => RIP.CompatHasField.HasField "unwrapVarCounter" VarCounter ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> VarCounter {unwrapVarCounter = y1}
+      , RIP.getField @"unwrapVarCounter" x0
+      )
+
+instance ( ty ~ Block.Block VarCounter_Aux
          ) => RIP.HasField "unwrapVarCounter" (RIP.Ptr VarCounter) (RIP.Ptr ty) where
 
   getField =
@@ -326,12 +335,3 @@ instance HasCField.HasCField VarCounter "unwrapVarCounter" where
     Block.Block VarCounter_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Block.Block VarCounter_Aux
-         ) => RIP.CompatHasField.HasField "unwrapVarCounter" VarCounter ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> VarCounter {unwrapVarCounter = y1}
-      , RIP.getField @"unwrapVarCounter" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - unwrapCounter
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: Toggle
   representation:
     newtype:
@@ -32,11 +33,12 @@ hstypes:
       fields:
       - unwrapToggle
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: VarCounter
   representation:
     newtype:
@@ -44,8 +46,9 @@ hstypes:
       fields:
       - unwrapVarCounter
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/iterator/th.txt
@@ -219,15 +219,15 @@ instance ToFunPtr Toggle_Aux
 instance FromFunPtr Toggle_Aux
     where fromFunPtr = hs_bindgen_703fc4bdc168721d
 instance (~) ty (IO CBool) =>
+         HasField "unwrapToggle_Aux" Toggle_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Toggle_Aux{unwrapToggle_Aux = y_1},
+                              getField @"unwrapToggle_Aux" x_0)
+instance (~) ty (IO CBool) =>
          HasField "unwrapToggle_Aux" (Ptr Toggle_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapToggle_Aux")
 instance HasCField Toggle_Aux "unwrapToggle_Aux"
     where type CFieldType Toggle_Aux "unwrapToggle_Aux" = IO CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO CBool) =>
-         HasField "unwrapToggle_Aux" Toggle_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Toggle_Aux{unwrapToggle_Aux = y_1},
-                              getField @"unwrapToggle_Aux" x_0)
 {-| __C declaration:__ @Toggle@
 
     __defined at:__ @edge-cases\/iterator.h 3:16@
@@ -239,15 +239,15 @@ newtype Toggle
     deriving stock Generic
     deriving newtype HasFFIType
 instance (~) ty (Block Toggle_Aux) =>
+         HasField "unwrapToggle" Toggle ty
+    where hasField = \x_0 -> (\y_1 -> Toggle{unwrapToggle = y_1},
+                              getField @"unwrapToggle" x_0)
+instance (~) ty (Block Toggle_Aux) =>
          HasField "unwrapToggle" (Ptr Toggle) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapToggle")
 instance HasCField Toggle "unwrapToggle"
     where type CFieldType Toggle "unwrapToggle" = Block Toggle_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Block Toggle_Aux) =>
-         HasField "unwrapToggle" Toggle ty
-    where hasField = \x_0 -> (\y_1 -> Toggle{unwrapToggle = y_1},
-                              getField @"unwrapToggle" x_0)
 {-| Auxiliary type used by 'Counter'
 
     __C declaration:__ @Counter@
@@ -282,15 +282,15 @@ instance ToFunPtr Counter_Aux
 instance FromFunPtr Counter_Aux
     where fromFunPtr = hs_bindgen_73304cb84e9a2f8f
 instance (~) ty (IO CInt) =>
+         HasField "unwrapCounter_Aux" Counter_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Counter_Aux{unwrapCounter_Aux = y_1},
+                              getField @"unwrapCounter_Aux" x_0)
+instance (~) ty (IO CInt) =>
          HasField "unwrapCounter_Aux" (Ptr Counter_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCounter_Aux")
 instance HasCField Counter_Aux "unwrapCounter_Aux"
     where type CFieldType Counter_Aux "unwrapCounter_Aux" = IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO CInt) =>
-         HasField "unwrapCounter_Aux" Counter_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Counter_Aux{unwrapCounter_Aux = y_1},
-                              getField @"unwrapCounter_Aux" x_0)
 {-| __C declaration:__ @Counter@
 
     __defined at:__ @edge-cases\/iterator.h 10:14@
@@ -302,15 +302,15 @@ newtype Counter
     deriving stock Generic
     deriving newtype HasFFIType
 instance (~) ty (Block Counter_Aux) =>
+         HasField "unwrapCounter" Counter ty
+    where hasField = \x_0 -> (\y_1 -> Counter{unwrapCounter = y_1},
+                              getField @"unwrapCounter" x_0)
+instance (~) ty (Block Counter_Aux) =>
          HasField "unwrapCounter" (Ptr Counter) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapCounter")
 instance HasCField Counter "unwrapCounter"
     where type CFieldType Counter "unwrapCounter" = Block Counter_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Block Counter_Aux) =>
-         HasField "unwrapCounter" Counter ty
-    where hasField = \x_0 -> (\y_1 -> Counter{unwrapCounter = y_1},
-                              getField @"unwrapCounter" x_0)
 {-| Auxiliary type used by 'VarCounter'
 
     __C declaration:__ @VarCounter@
@@ -347,16 +347,16 @@ instance ToFunPtr VarCounter_Aux
 instance FromFunPtr VarCounter_Aux
     where fromFunPtr = hs_bindgen_43d902480175fccf
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapVarCounter_Aux" VarCounter_Aux ty
+    where hasField = \x_0 -> (\y_1 -> VarCounter_Aux{unwrapVarCounter_Aux = y_1},
+                              getField @"unwrapVarCounter_Aux" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapVarCounter_Aux" (Ptr VarCounter_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapVarCounter_Aux")
 instance HasCField VarCounter_Aux "unwrapVarCounter_Aux"
     where type CFieldType VarCounter_Aux
                           "unwrapVarCounter_Aux" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapVarCounter_Aux" VarCounter_Aux ty
-    where hasField = \x_0 -> (\y_1 -> VarCounter_Aux{unwrapVarCounter_Aux = y_1},
-                              getField @"unwrapVarCounter_Aux" x_0)
 {-| __C declaration:__ @VarCounter@
 
     __defined at:__ @edge-cases\/iterator.h 17:14@
@@ -368,16 +368,16 @@ newtype VarCounter
     deriving stock Generic
     deriving newtype HasFFIType
 instance (~) ty (Block VarCounter_Aux) =>
+         HasField "unwrapVarCounter" VarCounter ty
+    where hasField = \x_0 -> (\y_1 -> VarCounter{unwrapVarCounter = y_1},
+                              getField @"unwrapVarCounter" x_0)
+instance (~) ty (Block VarCounter_Aux) =>
          HasField "unwrapVarCounter" (Ptr VarCounter) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapVarCounter")
 instance HasCField VarCounter "unwrapVarCounter"
     where type CFieldType VarCounter
                           "unwrapVarCounter" = Block VarCounter_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Block VarCounter_Aux) =>
-         HasField "unwrapVarCounter" VarCounter ty
-    where hasField = \x_0 -> (\y_1 -> VarCounter{unwrapVarCounter = y_1},
-                              getField @"unwrapVarCounter" x_0)
 -- __unique:__ @test_edgecasesiterator_Example_Safe_makeToggle@
 foreign import ccall safe "hs_bindgen_9d01035006b66206" hs_bindgen_9d01035006b66206_base ::
     Word8

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/Example.hs
@@ -63,17 +63,17 @@ instance Marshal.WriteRaw T where
 
 deriving via Marshal.EquivStorable T instance RIP.Storable T
 
-instance HasCField.HasCField T "t_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
 
-  type CFieldType T "t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
+instance HasCField.HasCField T "t_x" where
 
-  hasField =
-    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
+  type CFieldType T "t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - t_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/mangle_fun_param_names/th.txt
@@ -104,14 +104,14 @@ instance WriteRaw T
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
 deriving via (EquivStorable T) instance Storable T
-instance HasCField T "t_x"
-    where type CFieldType T "t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 instance (~) ty CInt => HasField "t_x" T ty
     where hasField = \x_0 -> (\y_1 -> T{t_x = y_1},
                               getField @"t_x" x_0)
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_edgecasesmangle_fun_param_na_Example_Safe_param_underscore@
 foreign import ccall safe "hs_bindgen_32fb10fccaa5c64b" hs_bindgen_32fb10fccaa5c64b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/Example.hs
@@ -61,6 +61,14 @@ newtype Int16_T = Int16_T
     )
 
 instance ( ty ~ RIP.CShort
+         ) => RIP.CompatHasField.HasField "unwrapInt16_T" Int16_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Int16_T {unwrapInt16_T = y1}, RIP.getField @"unwrapInt16_T" x0)
+
+instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapInt16_T" (RIP.Ptr Int16_T) (RIP.Ptr ty) where
 
   getField =
@@ -71,14 +79,6 @@ instance HasCField.HasCField Int16_T "unwrapInt16_T" where
   type CFieldType Int16_T "unwrapInt16_T" = RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.CompatHasField.HasField "unwrapInt16_T" Int16_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Int16_T {unwrapInt16_T = y1}, RIP.getField @"unwrapInt16_T" x0)
 
 {-| __C declaration:__ @int32_T@
 
@@ -109,6 +109,14 @@ newtype Int32_T = Int32_T
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapInt32_T" Int32_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Int32_T {unwrapInt32_T = y1}, RIP.getField @"unwrapInt32_T" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapInt32_T" (RIP.Ptr Int32_T) (RIP.Ptr ty) where
 
   getField =
@@ -119,14 +127,6 @@ instance HasCField.HasCField Int32_T "unwrapInt32_T" where
   type CFieldType Int32_T "unwrapInt32_T" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapInt32_T" Int32_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Int32_T {unwrapInt32_T = y1}, RIP.getField @"unwrapInt32_T" x0)
 
 {-| __C declaration:__ @int64_T@
 
@@ -157,6 +157,14 @@ newtype Int64_T = Int64_T
     )
 
 instance ( ty ~ RIP.CLLong
+         ) => RIP.CompatHasField.HasField "unwrapInt64_T" Int64_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Int64_T {unwrapInt64_T = y1}, RIP.getField @"unwrapInt64_T" x0)
+
+instance ( ty ~ RIP.CLLong
          ) => RIP.HasField "unwrapInt64_T" (RIP.Ptr Int64_T) (RIP.Ptr ty) where
 
   getField =
@@ -167,14 +175,6 @@ instance HasCField.HasCField Int64_T "unwrapInt64_T" where
   type CFieldType Int64_T "unwrapInt64_T" = RIP.CLLong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.CompatHasField.HasField "unwrapInt64_T" Int64_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Int64_T {unwrapInt64_T = y1}, RIP.getField @"unwrapInt64_T" x0)
 
 {-| __C declaration:__ @struct cint16_T@
 
@@ -226,18 +226,6 @@ instance Marshal.WriteRaw Cint16_T where
 
 deriving via Marshal.EquivStorable Cint16_T instance RIP.Storable Cint16_T
 
-instance HasCField.HasCField Cint16_T "cint16_T_re" where
-
-  type CFieldType Cint16_T "cint16_T_re" = Int16_T
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Int16_T
-         ) => RIP.HasField "cint16_T_re" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"cint16_T_re")
-
 instance ( ty ~ Int16_T
          ) => RIP.CompatHasField.HasField "cint16_T_re" Cint16_T ty where
 
@@ -248,17 +236,17 @@ instance ( ty ~ Int16_T
       , RIP.getField @"cint16_T_re" x0
       )
 
-instance HasCField.HasCField Cint16_T "cint16_T_im" where
-
-  type CFieldType Cint16_T "cint16_T_im" = Int16_T
-
-  offset# = \_ -> \_ -> 2
-
 instance ( ty ~ Int16_T
-         ) => RIP.HasField "cint16_T_im" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
+         ) => RIP.HasField "cint16_T_re" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"cint16_T_im")
+    HasCField.fromPtr (RIP.Proxy @"cint16_T_re")
+
+instance HasCField.HasCField Cint16_T "cint16_T_re" where
+
+  type CFieldType Cint16_T "cint16_T_re" = Int16_T
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Int16_T
          ) => RIP.CompatHasField.HasField "cint16_T_im" Cint16_T ty where
@@ -269,6 +257,18 @@ instance ( ty ~ Int16_T
           Cint16_T {cint16_T_im = y1, cint16_T_re = RIP.getField @"cint16_T_re" x0}
       , RIP.getField @"cint16_T_im" x0
       )
+
+instance ( ty ~ Int16_T
+         ) => RIP.HasField "cint16_T_im" (RIP.Ptr Cint16_T) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"cint16_T_im")
+
+instance HasCField.HasCField Cint16_T "cint16_T_im" where
+
+  type CFieldType Cint16_T "cint16_T_im" = Int16_T
+
+  offset# = \_ -> \_ -> 2
 
 {-| __C declaration:__ @struct B@
 
@@ -377,16 +377,6 @@ instance Marshal.WriteRaw A where
 
 deriving via Marshal.EquivStorable A instance RIP.Storable A
 
-instance HasCField.HasCField A "a_x" where
-
-  type CFieldType A "a_x" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CDouble) => RIP.HasField "a_x" (RIP.Ptr A) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a_x")
-
 instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "a_x" A ty where
 
   hasField =
@@ -401,16 +391,15 @@ instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "a_x" A ty where
       , RIP.getField @"a_x" x0
       )
 
-instance HasCField.HasCField A "a_label" where
+instance (ty ~ RIP.CDouble) => RIP.HasField "a_x" (RIP.Ptr A) (RIP.Ptr ty) where
 
-  type CFieldType A "a_label" = RIP.Ptr RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"a_x")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField A "a_x" where
 
-instance ( ty ~ RIP.Ptr RIP.CChar
-         ) => RIP.HasField "a_label" (RIP.Ptr A) (RIP.Ptr ty) where
+  type CFieldType A "a_x" = RIP.CDouble
 
-  getField = HasCField.fromPtr (RIP.Proxy @"a_label")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr RIP.CChar
          ) => RIP.CompatHasField.HasField "a_label" A ty where
@@ -427,17 +416,16 @@ instance ( ty ~ RIP.Ptr RIP.CChar
       , RIP.getField @"a_label" x0
       )
 
-instance HasCField.HasCField A "a_samples" where
+instance ( ty ~ RIP.Ptr RIP.CChar
+         ) => RIP.HasField "a_label" (RIP.Ptr A) (RIP.Ptr ty) where
 
-  type CFieldType A "a_samples" =
-    CA.ConstantArray 128 RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"a_label")
 
-  offset# = \_ -> \_ -> 16
+instance HasCField.HasCField A "a_label" where
 
-instance ( ty ~ CA.ConstantArray 128 RIP.CChar
-         ) => RIP.HasField "a_samples" (RIP.Ptr A) (RIP.Ptr ty) where
+  type CFieldType A "a_label" = RIP.Ptr RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"a_samples")
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ CA.ConstantArray 128 RIP.CChar
          ) => RIP.CompatHasField.HasField "a_samples" A ty where
@@ -454,15 +442,17 @@ instance ( ty ~ CA.ConstantArray 128 RIP.CChar
       , RIP.getField @"a_samples" x0
       )
 
-instance HasCField.HasCField A "a_b" where
+instance ( ty ~ CA.ConstantArray 128 RIP.CChar
+         ) => RIP.HasField "a_samples" (RIP.Ptr A) (RIP.Ptr ty) where
 
-  type CFieldType A "a_b" = B
+  getField = HasCField.fromPtr (RIP.Proxy @"a_samples")
 
-  offset# = \_ -> \_ -> 144
+instance HasCField.HasCField A "a_samples" where
 
-instance (ty ~ B) => RIP.HasField "a_b" (RIP.Ptr A) (RIP.Ptr ty) where
+  type CFieldType A "a_samples" =
+    CA.ConstantArray 128 RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"a_b")
+  offset# = \_ -> \_ -> 16
 
 instance (ty ~ B) => RIP.CompatHasField.HasField "a_b" A ty where
 
@@ -478,15 +468,15 @@ instance (ty ~ B) => RIP.CompatHasField.HasField "a_b" A ty where
       , RIP.getField @"a_b" x0
       )
 
-instance HasCField.HasCField A "a_c" where
+instance (ty ~ B) => RIP.HasField "a_b" (RIP.Ptr A) (RIP.Ptr ty) where
 
-  type CFieldType A "a_c" = RIP.Ptr C
+  getField = HasCField.fromPtr (RIP.Proxy @"a_b")
+
+instance HasCField.HasCField A "a_b" where
+
+  type CFieldType A "a_b" = B
 
   offset# = \_ -> \_ -> 144
-
-instance (ty ~ RIP.Ptr C) => RIP.HasField "a_c" (RIP.Ptr A) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a_c")
 
 instance (ty ~ RIP.Ptr C) => RIP.CompatHasField.HasField "a_c" A ty where
 
@@ -501,6 +491,16 @@ instance (ty ~ RIP.Ptr C) => RIP.CompatHasField.HasField "a_c" A ty where
             }
       , RIP.getField @"a_c" x0
       )
+
+instance (ty ~ RIP.Ptr C) => RIP.HasField "a_c" (RIP.Ptr A) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"a_c")
+
+instance HasCField.HasCField A "a_c" where
+
+  type CFieldType A "a_c" = RIP.Ptr C
+
+  offset# = \_ -> \_ -> 144
 
 {-| __C declaration:__ @struct C@
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/bindingspec.yaml
@@ -39,11 +39,12 @@ hstypes:
       - a_b
       - a_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -72,11 +73,12 @@ hstypes:
       - cint16_T_re
       - cint16_T_im
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -92,7 +94,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -100,6 +101,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -122,7 +125,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -130,6 +132,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -152,7 +156,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -160,6 +163,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/spec_examples/th.txt
@@ -56,15 +56,15 @@ newtype Int16_T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CShort => HasField "unwrapInt16_T" Int16_T ty
+    where hasField = \x_0 -> (\y_1 -> Int16_T{unwrapInt16_T = y_1},
+                              getField @"unwrapInt16_T" x_0)
 instance (~) ty CShort =>
          HasField "unwrapInt16_T" (Ptr Int16_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt16_T")
 instance HasCField Int16_T "unwrapInt16_T"
     where type CFieldType Int16_T "unwrapInt16_T" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort => HasField "unwrapInt16_T" Int16_T ty
-    where hasField = \x_0 -> (\y_1 -> Int16_T{unwrapInt16_T = y_1},
-                              getField @"unwrapInt16_T" x_0)
 {-| __C declaration:__ @int32_T@
 
     __defined at:__ @edge-cases\/spec_examples.h 11:13@
@@ -89,15 +89,15 @@ newtype Int32_T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapInt32_T" Int32_T ty
+    where hasField = \x_0 -> (\y_1 -> Int32_T{unwrapInt32_T = y_1},
+                              getField @"unwrapInt32_T" x_0)
 instance (~) ty CInt =>
          HasField "unwrapInt32_T" (Ptr Int32_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt32_T")
 instance HasCField Int32_T "unwrapInt32_T"
     where type CFieldType Int32_T "unwrapInt32_T" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapInt32_T" Int32_T ty
-    where hasField = \x_0 -> (\y_1 -> Int32_T{unwrapInt32_T = y_1},
-                              getField @"unwrapInt32_T" x_0)
 {-| __C declaration:__ @int64_T@
 
     __defined at:__ @edge-cases\/spec_examples.h 12:19@
@@ -122,15 +122,15 @@ newtype Int64_T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CLLong => HasField "unwrapInt64_T" Int64_T ty
+    where hasField = \x_0 -> (\y_1 -> Int64_T{unwrapInt64_T = y_1},
+                              getField @"unwrapInt64_T" x_0)
 instance (~) ty CLLong =>
          HasField "unwrapInt64_T" (Ptr Int64_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt64_T")
 instance HasCField Int64_T "unwrapInt64_T"
     where type CFieldType Int64_T "unwrapInt64_T" = CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLLong => HasField "unwrapInt64_T" Int64_T ty
-    where hasField = \x_0 -> (\y_1 -> Int64_T{unwrapInt64_T = y_1},
-                              getField @"unwrapInt64_T" x_0)
 {-| __C declaration:__ @struct cint16_T@
 
     __defined at:__ @edge-cases\/spec_examples.h 14:9@
@@ -163,26 +163,26 @@ instance WriteRaw Cint16_T
                                        Cint16_T cint16_T_re_2
                                                 cint16_T_im_3 -> writeRaw (Proxy @"cint16_T_re") ptr_0 cint16_T_re_2 >> writeRaw (Proxy @"cint16_T_im") ptr_0 cint16_T_im_3
 deriving via (EquivStorable Cint16_T) instance Storable Cint16_T
-instance HasCField Cint16_T "cint16_T_re"
-    where type CFieldType Cint16_T "cint16_T_re" = Int16_T
-          offset# = \_ -> \_ -> 0
-instance (~) ty Int16_T =>
-         HasField "cint16_T_re" (Ptr Cint16_T) (Ptr ty)
-    where getField = fromPtr (Proxy @"cint16_T_re")
 instance (~) ty Int16_T => HasField "cint16_T_re" Cint16_T ty
     where hasField = \x_0 -> (\y_1 -> Cint16_T{cint16_T_re = y_1,
                                                cint16_T_im = getField @"cint16_T_im" x_0},
                               getField @"cint16_T_re" x_0)
-instance HasCField Cint16_T "cint16_T_im"
-    where type CFieldType Cint16_T "cint16_T_im" = Int16_T
-          offset# = \_ -> \_ -> 2
 instance (~) ty Int16_T =>
-         HasField "cint16_T_im" (Ptr Cint16_T) (Ptr ty)
-    where getField = fromPtr (Proxy @"cint16_T_im")
+         HasField "cint16_T_re" (Ptr Cint16_T) (Ptr ty)
+    where getField = fromPtr (Proxy @"cint16_T_re")
+instance HasCField Cint16_T "cint16_T_re"
+    where type CFieldType Cint16_T "cint16_T_re" = Int16_T
+          offset# = \_ -> \_ -> 0
 instance (~) ty Int16_T => HasField "cint16_T_im" Cint16_T ty
     where hasField = \x_0 -> (\y_1 -> Cint16_T{cint16_T_im = y_1,
                                                cint16_T_re = getField @"cint16_T_re" x_0},
                               getField @"cint16_T_im" x_0)
+instance (~) ty Int16_T =>
+         HasField "cint16_T_im" (Ptr Cint16_T) (Ptr ty)
+    where getField = fromPtr (Proxy @"cint16_T_im")
+instance HasCField Cint16_T "cint16_T_im"
+    where type CFieldType Cint16_T "cint16_T_im" = Int16_T
+          offset# = \_ -> \_ -> 2
 {-| __C declaration:__ @struct B@
 
     __defined at:__ @edge-cases\/spec_examples.h 19:8@
@@ -255,11 +255,6 @@ instance WriteRaw A
                                          a_b_5
                                          a_c_6 -> writeRaw (Proxy @"a_x") ptr_0 a_x_2 >> (writeRaw (Proxy @"a_label") ptr_0 a_label_3 >> (writeRaw (Proxy @"a_samples") ptr_0 a_samples_4 >> (writeRaw (Proxy @"a_b") ptr_0 a_b_5 >> writeRaw (Proxy @"a_c") ptr_0 a_c_6)))
 deriving via (EquivStorable A) instance Storable A
-instance HasCField A "a_x"
-    where type CFieldType A "a_x" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble => HasField "a_x" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_x")
 instance (~) ty CDouble => HasField "a_x" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_x = y_1,
                                         a_label = getField @"a_label" x_0,
@@ -267,11 +262,11 @@ instance (~) ty CDouble => HasField "a_x" A ty
                                         a_b = getField @"a_b" x_0,
                                         a_c = getField @"a_c" x_0},
                               getField @"a_x" x_0)
-instance HasCField A "a_label"
-    where type CFieldType A "a_label" = Ptr CChar
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CChar) => HasField "a_label" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_label")
+instance (~) ty CDouble => HasField "a_x" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_x")
+instance HasCField A "a_x"
+    where type CFieldType A "a_x" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr CChar) => HasField "a_label" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_label = y_1,
                                         a_x = getField @"a_x" x_0,
@@ -279,12 +274,11 @@ instance (~) ty (Ptr CChar) => HasField "a_label" A ty
                                         a_b = getField @"a_b" x_0,
                                         a_c = getField @"a_c" x_0},
                               getField @"a_label" x_0)
-instance HasCField A "a_samples"
-    where type CFieldType A "a_samples" = ConstantArray 128 CChar
-          offset# = \_ -> \_ -> 16
-instance (~) ty (ConstantArray 128 CChar) =>
-         HasField "a_samples" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_samples")
+instance (~) ty (Ptr CChar) => HasField "a_label" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_label")
+instance HasCField A "a_label"
+    where type CFieldType A "a_label" = Ptr CChar
+          offset# = \_ -> \_ -> 8
 instance (~) ty (ConstantArray 128 CChar) =>
          HasField "a_samples" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_samples = y_1,
@@ -293,11 +287,12 @@ instance (~) ty (ConstantArray 128 CChar) =>
                                         a_b = getField @"a_b" x_0,
                                         a_c = getField @"a_c" x_0},
                               getField @"a_samples" x_0)
-instance HasCField A "a_b"
-    where type CFieldType A "a_b" = B
-          offset# = \_ -> \_ -> 144
-instance (~) ty B => HasField "a_b" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_b")
+instance (~) ty (ConstantArray 128 CChar) =>
+         HasField "a_samples" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_samples")
+instance HasCField A "a_samples"
+    where type CFieldType A "a_samples" = ConstantArray 128 CChar
+          offset# = \_ -> \_ -> 16
 instance (~) ty B => HasField "a_b" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_b = y_1,
                                         a_x = getField @"a_x" x_0,
@@ -305,11 +300,11 @@ instance (~) ty B => HasField "a_b" A ty
                                         a_samples = getField @"a_samples" x_0,
                                         a_c = getField @"a_c" x_0},
                               getField @"a_b" x_0)
-instance HasCField A "a_c"
-    where type CFieldType A "a_c" = Ptr C
+instance (~) ty B => HasField "a_b" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_b")
+instance HasCField A "a_b"
+    where type CFieldType A "a_b" = B
           offset# = \_ -> \_ -> 144
-instance (~) ty (Ptr C) => HasField "a_c" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_c")
 instance (~) ty (Ptr C) => HasField "a_c" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_c = y_1,
                                         a_x = getField @"a_x" x_0,
@@ -317,6 +312,11 @@ instance (~) ty (Ptr C) => HasField "a_c" A ty
                                         a_samples = getField @"a_samples" x_0,
                                         a_b = getField @"a_b" x_0},
                               getField @"a_c" x_0)
+instance (~) ty (Ptr C) => HasField "a_c" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_c")
+instance HasCField A "a_c"
+    where type CFieldType A "a_c" = Ptr C
+          offset# = \_ -> \_ -> 144
 {-| __C declaration:__ @struct C@
 
     __defined at:__ @edge-cases\/spec_examples.h 28:10@

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/Example.hs
@@ -58,6 +58,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -68,14 +76,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @myUInt@
 
@@ -106,6 +106,14 @@ newtype MyUInt = MyUInt
     )
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapMyUInt" MyUInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyUInt {unwrapMyUInt = y1}, RIP.getField @"unwrapMyUInt" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapMyUInt" (RIP.Ptr MyUInt) (RIP.Ptr ty) where
 
   getField =
@@ -116,14 +124,6 @@ instance HasCField.HasCField MyUInt "unwrapMyUInt" where
   type CFieldType MyUInt "unwrapMyUInt" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapMyUInt" MyUInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyUInt {unwrapMyUInt = y1}, RIP.getField @"unwrapMyUInt" x0)
 
 {-| __C declaration:__ @myLong@
 
@@ -154,6 +154,14 @@ newtype MyLong = MyLong
     )
 
 instance ( ty ~ RIP.CLong
+         ) => RIP.CompatHasField.HasField "unwrapMyLong" MyLong ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyLong {unwrapMyLong = y1}, RIP.getField @"unwrapMyLong" x0)
+
+instance ( ty ~ RIP.CLong
          ) => RIP.HasField "unwrapMyLong" (RIP.Ptr MyLong) (RIP.Ptr ty) where
 
   getField =
@@ -164,14 +172,6 @@ instance HasCField.HasCField MyLong "unwrapMyLong" where
   type CFieldType MyLong "unwrapMyLong" = RIP.CLong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.CompatHasField.HasField "unwrapMyLong" MyLong ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyLong {unwrapMyLong = y1}, RIP.getField @"unwrapMyLong" x0)
 
 {-| __C declaration:__ @struct myStruct@
 
@@ -232,20 +232,6 @@ instance Marshal.WriteRaw MyStruct where
 
 deriving via Marshal.EquivStorable MyStruct instance RIP.Storable MyStruct
 
-instance HasCBitfield.HasCBitfield MyStruct "myStruct_x" where
-
-  type CBitfieldType MyStruct "myStruct_x" = MyInt
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 2
-
-instance ( ty ~ MyInt
-         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"myStruct_x")
-
 instance ( ty ~ MyInt
          ) => RIP.CompatHasField.HasField "myStruct_x" MyStruct ty where
 
@@ -259,19 +245,19 @@ instance ( ty ~ MyInt
       , RIP.getField @"myStruct_x" x0
       )
 
-instance HasCBitfield.HasCBitfield MyStruct "myStruct_y" where
-
-  type CBitfieldType MyStruct "myStruct_y" = MyUInt
-
-  bitfieldOffset# = \_ -> \_ -> 2
-
-  bitfieldWidth# = \_ -> \_ -> 4
-
-instance ( ty ~ MyUInt
-         ) => RIP.HasField "myStruct_y" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ MyInt
+         ) => RIP.HasField "myStruct_x" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"myStruct_y")
+    HasCBitfield.toPtr (RIP.Proxy @"myStruct_x")
+
+instance HasCBitfield.HasCBitfield MyStruct "myStruct_x" where
+
+  type CBitfieldType MyStruct "myStruct_x" = MyInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 2
 
 instance ( ty ~ MyUInt
          ) => RIP.CompatHasField.HasField "myStruct_y" MyStruct ty where
@@ -286,19 +272,19 @@ instance ( ty ~ MyUInt
       , RIP.getField @"myStruct_y" x0
       )
 
-instance HasCBitfield.HasCBitfield MyStruct "myStruct_z" where
-
-  type CBitfieldType MyStruct "myStruct_z" = MyLong
-
-  bitfieldOffset# = \_ -> \_ -> 6
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ MyLong
-         ) => RIP.HasField "myStruct_z" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ MyUInt
+         ) => RIP.HasField "myStruct_y" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"myStruct_z")
+    HasCBitfield.toPtr (RIP.Proxy @"myStruct_y")
+
+instance HasCBitfield.HasCBitfield MyStruct "myStruct_y" where
+
+  type CBitfieldType MyStruct "myStruct_y" = MyUInt
+
+  bitfieldOffset# = \_ -> \_ -> 2
+
+  bitfieldWidth# = \_ -> \_ -> 4
 
 instance ( ty ~ MyLong
          ) => RIP.CompatHasField.HasField "myStruct_z" MyStruct ty where
@@ -312,3 +298,17 @@ instance ( ty ~ MyLong
                    }
       , RIP.getField @"myStruct_z" x0
       )
+
+instance ( ty ~ MyLong
+         ) => RIP.HasField "myStruct_z" (RIP.Ptr MyStruct) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"myStruct_z")
+
+instance HasCBitfield.HasCBitfield MyStruct "myStruct_z" where
+
+  type CBitfieldType MyStruct "myStruct_z" = MyLong
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 3

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/bindingspec.yaml
@@ -26,7 +26,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -34,6 +33,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -56,7 +57,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -64,6 +64,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -85,11 +87,12 @@ hstypes:
       - myStruct_y
       - myStruct_z
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -105,7 +108,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -113,6 +115,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/typedef_bitfield/th.txt
@@ -23,14 +23,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @myUInt@
 
     __defined at:__ @edge-cases\/typedef_bitfield.h 3:22@
@@ -55,15 +55,15 @@ newtype MyUInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CUInt => HasField "unwrapMyUInt" MyUInt ty
+    where hasField = \x_0 -> (\y_1 -> MyUInt{unwrapMyUInt = y_1},
+                              getField @"unwrapMyUInt" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapMyUInt" (Ptr MyUInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyUInt")
 instance HasCField MyUInt "unwrapMyUInt"
     where type CFieldType MyUInt "unwrapMyUInt" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapMyUInt" MyUInt ty
-    where hasField = \x_0 -> (\y_1 -> MyUInt{unwrapMyUInt = y_1},
-                              getField @"unwrapMyUInt" x_0)
 {-| __C declaration:__ @myLong@
 
     __defined at:__ @edge-cases\/typedef_bitfield.h 4:14@
@@ -88,15 +88,15 @@ newtype MyLong
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CLong => HasField "unwrapMyLong" MyLong ty
+    where hasField = \x_0 -> (\y_1 -> MyLong{unwrapMyLong = y_1},
+                              getField @"unwrapMyLong" x_0)
 instance (~) ty CLong =>
          HasField "unwrapMyLong" (Ptr MyLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyLong")
 instance HasCField MyLong "unwrapMyLong"
     where type CFieldType MyLong "unwrapMyLong" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong => HasField "unwrapMyLong" MyLong ty
-    where hasField = \x_0 -> (\y_1 -> MyLong{unwrapMyLong = y_1},
-                              getField @"unwrapMyLong" x_0)
 {-| __C declaration:__ @struct myStruct@
 
     __defined at:__ @edge-cases\/typedef_bitfield.h 6:8@
@@ -137,39 +137,39 @@ instance WriteRaw MyStruct
                                                 myStruct_y_3
                                                 myStruct_z_4 -> poke (Proxy @"myStruct_x") ptr_0 myStruct_x_2 >> (poke (Proxy @"myStruct_y") ptr_0 myStruct_y_3 >> poke (Proxy @"myStruct_z") ptr_0 myStruct_z_4)
 deriving via (EquivStorable MyStruct) instance Storable MyStruct
-instance HasCBitfield MyStruct "myStruct_x"
-    where type CBitfieldType MyStruct "myStruct_x" = MyInt
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 2
-instance (~) ty MyInt =>
-         HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"myStruct_x")
 instance (~) ty MyInt => HasField "myStruct_x" MyStruct ty
     where hasField = \x_0 -> (\y_1 -> MyStruct{myStruct_x = y_1,
                                                myStruct_y = getField @"myStruct_y" x_0,
                                                myStruct_z = getField @"myStruct_z" x_0},
                               getField @"myStruct_x" x_0)
-instance HasCBitfield MyStruct "myStruct_y"
-    where type CBitfieldType MyStruct "myStruct_y" = MyUInt
-          bitfieldOffset# = \_ -> \_ -> 2
-          bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty MyUInt =>
-         HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"myStruct_y")
+instance (~) ty MyInt =>
+         HasField "myStruct_x" (Ptr MyStruct) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"myStruct_x")
+instance HasCBitfield MyStruct "myStruct_x"
+    where type CBitfieldType MyStruct "myStruct_x" = MyInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 2
 instance (~) ty MyUInt => HasField "myStruct_y" MyStruct ty
     where hasField = \x_0 -> (\y_1 -> MyStruct{myStruct_y = y_1,
                                                myStruct_x = getField @"myStruct_x" x_0,
                                                myStruct_z = getField @"myStruct_z" x_0},
                               getField @"myStruct_y" x_0)
-instance HasCBitfield MyStruct "myStruct_z"
-    where type CBitfieldType MyStruct "myStruct_z" = MyLong
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty MyLong =>
-         HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"myStruct_z")
+instance (~) ty MyUInt =>
+         HasField "myStruct_y" (Ptr MyStruct) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"myStruct_y")
+instance HasCBitfield MyStruct "myStruct_y"
+    where type CBitfieldType MyStruct "myStruct_y" = MyUInt
+          bitfieldOffset# = \_ -> \_ -> 2
+          bitfieldWidth# = \_ -> \_ -> 4
 instance (~) ty MyLong => HasField "myStruct_z" MyStruct ty
     where hasField = \x_0 -> (\y_1 -> MyStruct{myStruct_z = y_1,
                                                myStruct_x = getField @"myStruct_x" x_0,
                                                myStruct_y = getField @"myStruct_y" x_0},
                               getField @"myStruct_z" x_0)
+instance (~) ty MyLong =>
+         HasField "myStruct_z" (Ptr MyStruct) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"myStruct_z")
+instance HasCBitfield MyStruct "myStruct_z"
+    where type CBitfieldType MyStruct "myStruct_z" = MyLong
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 3

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/Example.hs
@@ -107,6 +107,14 @@ instance Read MyEnum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapMyEnum" (RIP.Ptr MyEnum) (RIP.Ptr ty) where
 
   getField =
@@ -117,14 +125,6 @@ instance HasCField.HasCField MyEnum "unwrapMyEnum" where
   type CFieldType MyEnum "unwrapMyEnum" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapMyEnum" MyEnum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyEnum {unwrapMyEnum = y1}, RIP.getField @"unwrapMyEnum" x0)
 
 {-| __C declaration:__ @Say你好@
 

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/bindingspec.yaml
@@ -15,12 +15,13 @@ hstypes:
       - unwrapMyEnum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/th.txt
@@ -39,15 +39,15 @@ instance Read MyEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
+    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
+                              getField @"unwrapMyEnum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapMyEnum" (Ptr MyEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyEnum")
 instance HasCField MyEnum "unwrapMyEnum"
     where type CFieldType MyEnum "unwrapMyEnum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapMyEnum" MyEnum ty
-    where hasField = \x_0 -> (\y_1 -> MyEnum{unwrapMyEnum = y_1},
-                              getField @"unwrapMyEnum" x_0)
 {-| __C declaration:__ @Say你好@
 
     __defined at:__ @edge-cases\/uses_utf8.h 5:9@

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/Example.hs
@@ -114,6 +114,16 @@ instance RIP.FromFunPtr FileOpenedNotification_Aux where
   fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 
 instance ( ty ~ IO ()
+         ) => RIP.CompatHasField.HasField "unwrapFileOpenedNotification_Aux" FileOpenedNotification_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          FileOpenedNotification_Aux {unwrapFileOpenedNotification_Aux = y1}
+      , RIP.getField @"unwrapFileOpenedNotification_Aux" x0
+      )
+
+instance ( ty ~ IO ()
          ) => RIP.HasField "unwrapFileOpenedNotification_Aux" (RIP.Ptr FileOpenedNotification_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -125,16 +135,6 @@ instance HasCField.HasCField FileOpenedNotification_Aux "unwrapFileOpenedNotific
     IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO ()
-         ) => RIP.CompatHasField.HasField "unwrapFileOpenedNotification_Aux" FileOpenedNotification_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          FileOpenedNotification_Aux {unwrapFileOpenedNotification_Aux = y1}
-      , RIP.getField @"unwrapFileOpenedNotification_Aux" x0
-      )
 
 {-| __C declaration:__ @FileOpenedNotification@
 
@@ -155,6 +155,16 @@ newtype FileOpenedNotification = FileOpenedNotification
     )
 
 instance ( ty ~ RIP.FunPtr FileOpenedNotification_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFileOpenedNotification" FileOpenedNotification ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          FileOpenedNotification {unwrapFileOpenedNotification = y1}
+      , RIP.getField @"unwrapFileOpenedNotification" x0
+      )
+
+instance ( ty ~ RIP.FunPtr FileOpenedNotification_Aux
          ) => RIP.HasField "unwrapFileOpenedNotification" (RIP.Ptr FileOpenedNotification) (RIP.Ptr ty) where
 
   getField =
@@ -166,16 +176,6 @@ instance HasCField.HasCField FileOpenedNotification "unwrapFileOpenedNotificatio
     RIP.FunPtr FileOpenedNotification_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr FileOpenedNotification_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFileOpenedNotification" FileOpenedNotification ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          FileOpenedNotification {unwrapFileOpenedNotification = y1}
-      , RIP.getField @"unwrapFileOpenedNotification" x0
-      )
 
 {-| Auxiliary type used by 'ProgressUpdate'
 
@@ -226,6 +226,16 @@ instance RIP.FromFunPtr ProgressUpdate_Aux where
   fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapProgressUpdate_Aux" ProgressUpdate_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          ProgressUpdate_Aux {unwrapProgressUpdate_Aux = y1}
+      , RIP.getField @"unwrapProgressUpdate_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapProgressUpdate_Aux" (RIP.Ptr ProgressUpdate_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -237,16 +247,6 @@ instance HasCField.HasCField ProgressUpdate_Aux "unwrapProgressUpdate_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapProgressUpdate_Aux" ProgressUpdate_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          ProgressUpdate_Aux {unwrapProgressUpdate_Aux = y1}
-      , RIP.getField @"unwrapProgressUpdate_Aux" x0
-      )
 
 {-| __C declaration:__ @ProgressUpdate@
 
@@ -267,6 +267,15 @@ newtype ProgressUpdate = ProgressUpdate
     )
 
 instance ( ty ~ RIP.FunPtr ProgressUpdate_Aux
+         ) => RIP.CompatHasField.HasField "unwrapProgressUpdate" ProgressUpdate ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> ProgressUpdate {unwrapProgressUpdate = y1}
+      , RIP.getField @"unwrapProgressUpdate" x0
+      )
+
+instance ( ty ~ RIP.FunPtr ProgressUpdate_Aux
          ) => RIP.HasField "unwrapProgressUpdate" (RIP.Ptr ProgressUpdate) (RIP.Ptr ty) where
 
   getField =
@@ -278,15 +287,6 @@ instance HasCField.HasCField ProgressUpdate "unwrapProgressUpdate" where
     RIP.FunPtr ProgressUpdate_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr ProgressUpdate_Aux
-         ) => RIP.CompatHasField.HasField "unwrapProgressUpdate" ProgressUpdate ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> ProgressUpdate {unwrapProgressUpdate = y1}
-      , RIP.getField @"unwrapProgressUpdate" x0
-      )
 
 {-| Auxiliary type used by 'DataValidator'
 
@@ -337,6 +337,16 @@ instance RIP.FromFunPtr DataValidator_Aux where
   fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapDataValidator_Aux" DataValidator_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          DataValidator_Aux {unwrapDataValidator_Aux = y1}
+      , RIP.getField @"unwrapDataValidator_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapDataValidator_Aux" (RIP.Ptr DataValidator_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -348,16 +358,6 @@ instance HasCField.HasCField DataValidator_Aux "unwrapDataValidator_Aux" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapDataValidator_Aux" DataValidator_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          DataValidator_Aux {unwrapDataValidator_Aux = y1}
-      , RIP.getField @"unwrapDataValidator_Aux" x0
-      )
 
 {-| __C declaration:__ @DataValidator@
 
@@ -378,6 +378,15 @@ newtype DataValidator = DataValidator
     )
 
 instance ( ty ~ RIP.FunPtr DataValidator_Aux
+         ) => RIP.CompatHasField.HasField "unwrapDataValidator" DataValidator ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> DataValidator {unwrapDataValidator = y1}
+      , RIP.getField @"unwrapDataValidator" x0
+      )
+
+instance ( ty ~ RIP.FunPtr DataValidator_Aux
          ) => RIP.HasField "unwrapDataValidator" (RIP.Ptr DataValidator) (RIP.Ptr ty) where
 
   getField =
@@ -389,15 +398,6 @@ instance HasCField.HasCField DataValidator "unwrapDataValidator" where
     RIP.FunPtr DataValidator_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr DataValidator_Aux
-         ) => RIP.CompatHasField.HasField "unwrapDataValidator" DataValidator ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> DataValidator {unwrapDataValidator = y1}
-      , RIP.getField @"unwrapDataValidator" x0
-      )
 
 {-| __C declaration:__ @struct Measurement@
 
@@ -449,19 +449,6 @@ instance Marshal.WriteRaw Measurement where
 
 deriving via Marshal.EquivStorable Measurement instance RIP.Storable Measurement
 
-instance HasCField.HasCField Measurement "measurement_value" where
-
-  type CFieldType Measurement "measurement_value" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "measurement_value" (RIP.Ptr Measurement) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"measurement_value")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "measurement_value" Measurement ty where
 
@@ -474,18 +461,18 @@ instance ( ty ~ RIP.CDouble
       , RIP.getField @"measurement_value" x0
       )
 
-instance HasCField.HasCField Measurement "measurement_timestamp" where
-
-  type CFieldType Measurement "measurement_timestamp" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "measurement_timestamp" (RIP.Ptr Measurement) (RIP.Ptr ty) where
+         ) => RIP.HasField "measurement_value" (RIP.Ptr Measurement) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"measurement_timestamp")
+    HasCField.fromPtr (RIP.Proxy @"measurement_value")
+
+instance HasCField.HasCField Measurement "measurement_value" where
+
+  type CFieldType Measurement "measurement_value" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "measurement_timestamp" Measurement ty where
@@ -498,6 +485,19 @@ instance ( ty ~ RIP.CDouble
                       }
       , RIP.getField @"measurement_timestamp" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "measurement_timestamp" (RIP.Ptr Measurement) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"measurement_timestamp")
+
+instance HasCField.HasCField Measurement "measurement_timestamp" where
+
+  type CFieldType Measurement "measurement_timestamp" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 8
 
 {-| Auxiliary type used by 'MeasurementReceived'
 
@@ -548,6 +548,16 @@ instance RIP.FromFunPtr MeasurementReceived_Aux where
   fromFunPtr = hs_bindgen_383c36bb22947621
 
 instance ( ty ~ (RIP.Ptr Measurement -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived_Aux" MeasurementReceived_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MeasurementReceived_Aux {unwrapMeasurementReceived_Aux = y1}
+      , RIP.getField @"unwrapMeasurementReceived_Aux" x0
+      )
+
+instance ( ty ~ (RIP.Ptr Measurement -> IO ())
          ) => RIP.HasField "unwrapMeasurementReceived_Aux" (RIP.Ptr MeasurementReceived_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -559,16 +569,6 @@ instance HasCField.HasCField MeasurementReceived_Aux "unwrapMeasurementReceived_
     RIP.Ptr Measurement -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.Ptr Measurement -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived_Aux" MeasurementReceived_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MeasurementReceived_Aux {unwrapMeasurementReceived_Aux = y1}
-      , RIP.getField @"unwrapMeasurementReceived_Aux" x0
-      )
 
 {-| __C declaration:__ @MeasurementReceived@
 
@@ -589,6 +589,16 @@ newtype MeasurementReceived = MeasurementReceived
     )
 
 instance ( ty ~ RIP.FunPtr MeasurementReceived_Aux
+         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived" MeasurementReceived ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MeasurementReceived {unwrapMeasurementReceived = y1}
+      , RIP.getField @"unwrapMeasurementReceived" x0
+      )
+
+instance ( ty ~ RIP.FunPtr MeasurementReceived_Aux
          ) => RIP.HasField "unwrapMeasurementReceived" (RIP.Ptr MeasurementReceived) (RIP.Ptr ty) where
 
   getField =
@@ -600,16 +610,6 @@ instance HasCField.HasCField MeasurementReceived "unwrapMeasurementReceived" whe
     RIP.FunPtr MeasurementReceived_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr MeasurementReceived_Aux
-         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived" MeasurementReceived ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MeasurementReceived {unwrapMeasurementReceived = y1}
-      , RIP.getField @"unwrapMeasurementReceived" x0
-      )
 
 {-| Auxiliary type used by 'MeasurementReceived2'
 
@@ -625,6 +625,16 @@ newtype MeasurementReceived2_Aux = MeasurementReceived2_Aux
   deriving stock (RIP.Generic)
 
 instance ( ty ~ (Measurement -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived2_Aux" MeasurementReceived2_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MeasurementReceived2_Aux {unwrapMeasurementReceived2_Aux = y1}
+      , RIP.getField @"unwrapMeasurementReceived2_Aux" x0
+      )
+
+instance ( ty ~ (Measurement -> IO ())
          ) => RIP.HasField "unwrapMeasurementReceived2_Aux" (RIP.Ptr MeasurementReceived2_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -636,16 +646,6 @@ instance HasCField.HasCField MeasurementReceived2_Aux "unwrapMeasurementReceived
     Measurement -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (Measurement -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived2_Aux" MeasurementReceived2_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MeasurementReceived2_Aux {unwrapMeasurementReceived2_Aux = y1}
-      , RIP.getField @"unwrapMeasurementReceived2_Aux" x0
-      )
 
 {-| __C declaration:__ @MeasurementReceived2@
 
@@ -666,6 +666,16 @@ newtype MeasurementReceived2 = MeasurementReceived2
     )
 
 instance ( ty ~ RIP.FunPtr MeasurementReceived2_Aux
+         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived2" MeasurementReceived2 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          MeasurementReceived2 {unwrapMeasurementReceived2 = y1}
+      , RIP.getField @"unwrapMeasurementReceived2" x0
+      )
+
+instance ( ty ~ RIP.FunPtr MeasurementReceived2_Aux
          ) => RIP.HasField "unwrapMeasurementReceived2" (RIP.Ptr MeasurementReceived2) (RIP.Ptr ty) where
 
   getField =
@@ -677,16 +687,6 @@ instance HasCField.HasCField MeasurementReceived2 "unwrapMeasurementReceived2" w
     RIP.FunPtr MeasurementReceived2_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr MeasurementReceived2_Aux
-         ) => RIP.CompatHasField.HasField "unwrapMeasurementReceived2" MeasurementReceived2 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          MeasurementReceived2 {unwrapMeasurementReceived2 = y1}
-      , RIP.getField @"unwrapMeasurementReceived2" x0
-      )
 
 {-| Auxiliary type used by 'SampleBufferFull'
 
@@ -737,6 +737,16 @@ instance RIP.FromFunPtr SampleBufferFull_Aux where
   fromFunPtr = hs_bindgen_2ab7ac6bb756ba7e
 
 instance ( ty ~ (RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapSampleBufferFull_Aux" SampleBufferFull_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          SampleBufferFull_Aux {unwrapSampleBufferFull_Aux = y1}
+      , RIP.getField @"unwrapSampleBufferFull_Aux" x0
+      )
+
+instance ( ty ~ (RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ())
          ) => RIP.HasField "unwrapSampleBufferFull_Aux" (RIP.Ptr SampleBufferFull_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -748,16 +758,6 @@ instance HasCField.HasCField SampleBufferFull_Aux "unwrapSampleBufferFull_Aux" w
     RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.Ptr (IsA.Elem (CA.ConstantArray 10 RIP.CInt)) -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapSampleBufferFull_Aux" SampleBufferFull_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          SampleBufferFull_Aux {unwrapSampleBufferFull_Aux = y1}
-      , RIP.getField @"unwrapSampleBufferFull_Aux" x0
-      )
 
 {-| __C declaration:__ @SampleBufferFull@
 
@@ -778,6 +778,16 @@ newtype SampleBufferFull = SampleBufferFull
     )
 
 instance ( ty ~ RIP.FunPtr SampleBufferFull_Aux
+         ) => RIP.CompatHasField.HasField "unwrapSampleBufferFull" SampleBufferFull ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          SampleBufferFull {unwrapSampleBufferFull = y1}
+      , RIP.getField @"unwrapSampleBufferFull" x0
+      )
+
+instance ( ty ~ RIP.FunPtr SampleBufferFull_Aux
          ) => RIP.HasField "unwrapSampleBufferFull" (RIP.Ptr SampleBufferFull) (RIP.Ptr ty) where
 
   getField =
@@ -789,16 +799,6 @@ instance HasCField.HasCField SampleBufferFull "unwrapSampleBufferFull" where
     RIP.FunPtr SampleBufferFull_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr SampleBufferFull_Aux
-         ) => RIP.CompatHasField.HasField "unwrapSampleBufferFull" SampleBufferFull ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          SampleBufferFull {unwrapSampleBufferFull = y1}
-      , RIP.getField @"unwrapSampleBufferFull" x0
-      )
 
 {-| __C declaration:__ @struct MeasurementHandler@
 
@@ -862,19 +862,6 @@ instance Marshal.WriteRaw MeasurementHandler where
 
 deriving via Marshal.EquivStorable MeasurementHandler instance RIP.Storable MeasurementHandler
 
-instance HasCField.HasCField MeasurementHandler "measurementHandler_onReceived" where
-
-  type CFieldType MeasurementHandler "measurementHandler_onReceived" =
-    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "measurementHandler_onReceived" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"measurementHandler_onReceived")
-
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
          ) => RIP.CompatHasField.HasField "measurementHandler_onReceived" MeasurementHandler ty where
 
@@ -888,18 +875,18 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
       , RIP.getField @"measurementHandler_onReceived" x0
       )
 
-instance HasCField.HasCField MeasurementHandler "measurementHandler_validate" where
-
-  type CFieldType MeasurementHandler "measurementHandler_validate" =
-    RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
-         ) => RIP.HasField "measurementHandler_validate" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
+         ) => RIP.HasField "measurementHandler_onReceived" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"measurementHandler_validate")
+    HasCField.fromPtr (RIP.Proxy @"measurementHandler_onReceived")
+
+instance HasCField.HasCField MeasurementHandler "measurementHandler_onReceived" where
+
+  type CFieldType MeasurementHandler "measurementHandler_onReceived" =
+    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
          ) => RIP.CompatHasField.HasField "measurementHandler_validate" MeasurementHandler ty where
@@ -914,18 +901,18 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
       , RIP.getField @"measurementHandler_validate" x0
       )
 
-instance HasCField.HasCField MeasurementHandler "measurementHandler_onError" where
-
-  type CFieldType MeasurementHandler "measurementHandler_onError" =
-    RIP.FunPtr (RIP.CInt -> IO ())
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
-         ) => RIP.HasField "measurementHandler_onError" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
+         ) => RIP.HasField "measurementHandler_validate" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"measurementHandler_onError")
+    HasCField.fromPtr (RIP.Proxy @"measurementHandler_validate")
+
+instance HasCField.HasCField MeasurementHandler "measurementHandler_validate" where
+
+  type CFieldType MeasurementHandler "measurementHandler_validate" =
+    RIP.FunPtr (RIP.Ptr Measurement -> IO RIP.CInt)
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
          ) => RIP.CompatHasField.HasField "measurementHandler_onError" MeasurementHandler ty where
@@ -939,6 +926,19 @@ instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
                              }
       , RIP.getField @"measurementHandler_onError" x0
       )
+
+instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
+         ) => RIP.HasField "measurementHandler_onError" (RIP.Ptr MeasurementHandler) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"measurementHandler_onError")
+
+instance HasCField.HasCField MeasurementHandler "measurementHandler_onError" where
+
+  type CFieldType MeasurementHandler "measurementHandler_onError" =
+    RIP.FunPtr (RIP.CInt -> IO ())
+
+  offset# = \_ -> \_ -> 16
 
 {-| __C declaration:__ @struct DataPipeline@
 
@@ -1002,19 +1002,6 @@ instance Marshal.WriteRaw DataPipeline where
 
 deriving via Marshal.EquivStorable DataPipeline instance RIP.Storable DataPipeline
 
-instance HasCField.HasCField DataPipeline "dataPipeline_preProcess" where
-
-  type CFieldType DataPipeline "dataPipeline_preProcess" =
-    RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
-         ) => RIP.HasField "dataPipeline_preProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"dataPipeline_preProcess")
-
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
          ) => RIP.CompatHasField.HasField "dataPipeline_preProcess" DataPipeline ty where
 
@@ -1028,18 +1015,18 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
       , RIP.getField @"dataPipeline_preProcess" x0
       )
 
-instance HasCField.HasCField DataPipeline "dataPipeline_process" where
-
-  type CFieldType DataPipeline "dataPipeline_process" =
-    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-         ) => RIP.HasField "dataPipeline_process" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
+         ) => RIP.HasField "dataPipeline_preProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"dataPipeline_process")
+    HasCField.fromPtr (RIP.Proxy @"dataPipeline_preProcess")
+
+instance HasCField.HasCField DataPipeline "dataPipeline_preProcess" where
+
+  type CFieldType DataPipeline "dataPipeline_preProcess" =
+    RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
          ) => RIP.CompatHasField.HasField "dataPipeline_process" DataPipeline ty where
@@ -1054,18 +1041,18 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
       , RIP.getField @"dataPipeline_process" x0
       )
 
-instance HasCField.HasCField DataPipeline "dataPipeline_postProcess" where
-
-  type CFieldType DataPipeline "dataPipeline_postProcess" =
-    RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
-         ) => RIP.HasField "dataPipeline_postProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
+         ) => RIP.HasField "dataPipeline_process" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"dataPipeline_postProcess")
+    HasCField.fromPtr (RIP.Proxy @"dataPipeline_process")
+
+instance HasCField.HasCField DataPipeline "dataPipeline_process" where
+
+  type CFieldType DataPipeline "dataPipeline_process" =
+    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
          ) => RIP.CompatHasField.HasField "dataPipeline_postProcess" DataPipeline ty where
@@ -1079,6 +1066,19 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
                        }
       , RIP.getField @"dataPipeline_postProcess" x0
       )
+
+instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
+         ) => RIP.HasField "dataPipeline_postProcess" (RIP.Ptr DataPipeline) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"dataPipeline_postProcess")
+
+instance HasCField.HasCField DataPipeline "dataPipeline_postProcess" where
+
+  type CFieldType DataPipeline "dataPipeline_postProcess" =
+    RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
+
+  offset# = \_ -> \_ -> 16
 
 {-| __C declaration:__ @union ProcessorCallback@
 
@@ -1178,23 +1178,16 @@ set_processorCallback_withProgress ::
 set_processorCallback_withProgress =
   RIP.setUnionPayload
 
-instance HasCField.HasCField ProcessorCallback "processorCallback_simple" where
-
-  type CFieldType ProcessorCallback "processorCallback_simple" =
-    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> IO ())
          ) => RIP.HasField "processorCallback_simple" (RIP.Ptr ProcessorCallback) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_simple")
 
-instance HasCField.HasCField ProcessorCallback "processorCallback_withValidator" where
+instance HasCField.HasCField ProcessorCallback "processorCallback_simple" where
 
-  type CFieldType ProcessorCallback "processorCallback_withValidator" =
-    RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
+  type CFieldType ProcessorCallback "processorCallback_simple" =
+    RIP.FunPtr (RIP.Ptr Measurement -> IO ())
 
   offset# = \_ -> \_ -> 0
 
@@ -1204,10 +1197,10 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_withValidator")
 
-instance HasCField.HasCField ProcessorCallback "processorCallback_withProgress" where
+instance HasCField.HasCField ProcessorCallback "processorCallback_withValidator" where
 
-  type CFieldType ProcessorCallback "processorCallback_withProgress" =
-    RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
+  type CFieldType ProcessorCallback "processorCallback_withValidator" =
+    RIP.FunPtr (RIP.Ptr Measurement -> DataValidator -> IO ())
 
   offset# = \_ -> \_ -> 0
 
@@ -1216,6 +1209,13 @@ instance ( ty ~ RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"processorCallback_withProgress")
+
+instance HasCField.HasCField ProcessorCallback "processorCallback_withProgress" where
+
+  type CFieldType ProcessorCallback "processorCallback_withProgress" =
+    RIP.FunPtr (RIP.Ptr Measurement -> ProgressUpdate -> IO ())
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @enum \@Processor_mode@
 
@@ -1299,6 +1299,15 @@ instance Read Processor_mode where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapProcessor_mode" Processor_mode ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Processor_mode {unwrapProcessor_mode = y1}
+      , RIP.getField @"unwrapProcessor_mode" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapProcessor_mode" (RIP.Ptr Processor_mode) (RIP.Ptr ty) where
 
   getField =
@@ -1310,15 +1319,6 @@ instance HasCField.HasCField Processor_mode "unwrapProcessor_mode" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapProcessor_mode" Processor_mode ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Processor_mode {unwrapProcessor_mode = y1}
-      , RIP.getField @"unwrapProcessor_mode" x0
-      )
 
 {-| __C declaration:__ @MODE_SIMPLE@
 
@@ -1397,19 +1397,6 @@ instance Marshal.WriteRaw Processor where
 
 deriving via Marshal.EquivStorable Processor instance RIP.Storable Processor
 
-instance HasCField.HasCField Processor "processor_mode" where
-
-  type CFieldType Processor "processor_mode" =
-    Processor_mode
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Processor_mode
-         ) => RIP.HasField "processor_mode" (RIP.Ptr Processor) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"processor_mode")
-
 instance ( ty ~ Processor_mode
          ) => RIP.CompatHasField.HasField "processor_mode" Processor ty where
 
@@ -1422,18 +1409,18 @@ instance ( ty ~ Processor_mode
       , RIP.getField @"processor_mode" x0
       )
 
-instance HasCField.HasCField Processor "processor_callback" where
-
-  type CFieldType Processor "processor_callback" =
-    ProcessorCallback
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ ProcessorCallback
-         ) => RIP.HasField "processor_callback" (RIP.Ptr Processor) (RIP.Ptr ty) where
+instance ( ty ~ Processor_mode
+         ) => RIP.HasField "processor_mode" (RIP.Ptr Processor) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"processor_callback")
+    HasCField.fromPtr (RIP.Proxy @"processor_mode")
+
+instance HasCField.HasCField Processor "processor_mode" where
+
+  type CFieldType Processor "processor_mode" =
+    Processor_mode
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ ProcessorCallback
          ) => RIP.CompatHasField.HasField "processor_callback" Processor ty where
@@ -1444,6 +1431,19 @@ instance ( ty ~ ProcessorCallback
           Processor {processor_callback = y1, processor_mode = RIP.getField @"processor_mode" x0}
       , RIP.getField @"processor_callback" x0
       )
+
+instance ( ty ~ ProcessorCallback
+         ) => RIP.HasField "processor_callback" (RIP.Ptr Processor) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"processor_callback")
+
+instance HasCField.HasCField Processor "processor_callback" where
+
+  type CFieldType Processor "processor_callback" =
+    ProcessorCallback
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @foo@
 
@@ -1473,6 +1473,13 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
@@ -1483,13 +1490,6 @@ instance HasCField.HasCField Foo "unwrapFoo" where
   type CFieldType Foo "unwrapFoo" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
 
 {-| __C declaration:__ @foo2@
 
@@ -1520,6 +1520,14 @@ newtype Foo2 = Foo2
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapFoo2" Foo2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo2 {unwrapFoo2 = y1}, RIP.getField @"unwrapFoo2" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapFoo2" (RIP.Ptr Foo2) (RIP.Ptr ty) where
 
   getField =
@@ -1530,14 +1538,6 @@ instance HasCField.HasCField Foo2 "unwrapFoo2" where
   type CFieldType Foo2 "unwrapFoo2" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapFoo2" Foo2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Foo2 {unwrapFoo2 = y1}, RIP.getField @"unwrapFoo2" x0)
 
 {-| __C declaration:__ @A@
 
@@ -1567,6 +1567,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -1577,12 +1583,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @B@
 
@@ -1612,6 +1612,12 @@ newtype B = B
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
@@ -1622,12 +1628,6 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
 
 {-| __C declaration:__ @struct S@
 
@@ -1670,23 +1670,23 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_fn" where
-
-  type CFieldType S "s_fn" = RIP.FunPtr (B -> IO ())
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr (B -> IO ())
-         ) => RIP.HasField "s_fn" (RIP.Ptr S) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s_fn")
-
 instance ( ty ~ RIP.FunPtr (B -> IO ())
          ) => RIP.CompatHasField.HasField "s_fn" S ty where
 
   hasField =
     \x0 ->
       (\y1 -> S {s_fn = y1}, RIP.getField @"s_fn" x0)
+
+instance ( ty ~ RIP.FunPtr (B -> IO ())
+         ) => RIP.HasField "s_fn" (RIP.Ptr S) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s_fn")
+
+instance HasCField.HasCField S "s_fn" where
+
+  type CFieldType S "s_fn" = RIP.FunPtr (B -> IO ())
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @C@
 
@@ -1716,6 +1716,12 @@ newtype C = C
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapC" C ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> C {unwrapC = y1}, RIP.getField @"unwrapC" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapC" (RIP.Ptr C) (RIP.Ptr ty) where
 
@@ -1726,12 +1732,6 @@ instance HasCField.HasCField C "unwrapC" where
   type CFieldType C "unwrapC" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapC" C ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> C {unwrapC = y1}, RIP.getField @"unwrapC" x0)
 
 {-| __C declaration:__ @union U@
 
@@ -1777,17 +1777,17 @@ set_u_fn ::
   -> U
 set_u_fn = RIP.setUnionPayload
 
+instance ( ty ~ CA.ConstantArray 3 (RIP.FunPtr (C -> IO ()))
+         ) => RIP.HasField "u_fn" (RIP.Ptr U) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u_fn")
+
 instance HasCField.HasCField U "u_fn" where
 
   type CFieldType U "u_fn" =
     CA.ConstantArray 3 (RIP.FunPtr (C -> IO ()))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 (RIP.FunPtr (C -> IO ()))
-         ) => RIP.HasField "u_fn" (RIP.Ptr U) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u_fn")
 
 {-| __C declaration:__ @D@
 
@@ -1817,6 +1817,12 @@ newtype D = D
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapD" D ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> D {unwrapD = y1}, RIP.getField @"unwrapD" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapD" (RIP.Ptr D) (RIP.Ptr ty) where
 
@@ -1827,12 +1833,6 @@ instance HasCField.HasCField D "unwrapD" where
   type CFieldType D "unwrapD" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapD" D ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> D {unwrapD = y1}, RIP.getField @"unwrapD" x0)
 
 {-| __C declaration:__ @T@
 
@@ -1881,6 +1881,13 @@ instance RIP.FromFunPtr T where
   fromFunPtr = hs_bindgen_8f830eadb43a6fe4
 
 instance ( ty ~ (RIP.FunPtr (D -> IO ()) -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ (RIP.FunPtr (D -> IO ()) -> IO ())
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -1891,13 +1898,6 @@ instance HasCField.HasCField T "unwrapT" where
     RIP.FunPtr (D -> IO ()) -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.FunPtr (D -> IO ()) -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 -- __unique:__ @instance ToFunPtr (A -> IO ())@
 foreign import ccall safe "wrapper" hs_bindgen_a46c670f88b5e6d2_base ::

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/bindingspec.yaml
@@ -77,7 +77,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -85,6 +84,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -107,7 +108,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -115,6 +115,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -137,7 +139,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -145,6 +146,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -167,7 +170,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -175,6 +177,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -196,11 +200,12 @@ hstypes:
       - dataPipeline_process
       - dataPipeline_postProcess
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -213,12 +218,13 @@ hstypes:
       fields:
       - unwrapDataValidator
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -232,12 +238,13 @@ hstypes:
       fields:
       - unwrapFileOpenedNotification
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -254,7 +261,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -262,6 +268,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -284,7 +292,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -292,6 +299,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -312,11 +321,12 @@ hstypes:
       - measurement_value
       - measurement_timestamp
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -331,11 +341,12 @@ hstypes:
       - measurementHandler_validate
       - measurementHandler_onError
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -348,12 +359,13 @@ hstypes:
       fields:
       - unwrapMeasurementReceived
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -367,12 +379,13 @@ hstypes:
       fields:
       - unwrapMeasurementReceived2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -387,10 +400,11 @@ hstypes:
       - processor_mode
       - processor_callback
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -404,7 +418,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -417,12 +431,13 @@ hstypes:
       - unwrapProcessor_mode
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -439,12 +454,13 @@ hstypes:
       fields:
       - unwrapProgressUpdate
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -458,11 +474,12 @@ hstypes:
       fields:
       - s_fn
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -475,12 +492,13 @@ hstypes:
       fields:
       - unwrapSampleBufferFull
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -494,12 +512,13 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr
 - hsname: U
   representation:
@@ -510,7 +529,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/th.txt
@@ -466,6 +466,12 @@ instance FromFunPtr FileOpenedNotification_Aux
     where fromFunPtr = hs_bindgen_f3ba5920f34c7f6a
 instance (~) ty (IO ()) =>
          HasField "unwrapFileOpenedNotification_Aux"
+                  FileOpenedNotification_Aux
+                  ty
+    where hasField = \x_0 -> (\y_1 -> FileOpenedNotification_Aux{unwrapFileOpenedNotification_Aux = y_1},
+                              getField @"unwrapFileOpenedNotification_Aux" x_0)
+instance (~) ty (IO ()) =>
+         HasField "unwrapFileOpenedNotification_Aux"
                   (Ptr FileOpenedNotification_Aux)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFileOpenedNotification_Aux")
@@ -474,12 +480,6 @@ instance HasCField FileOpenedNotification_Aux
     where type CFieldType FileOpenedNotification_Aux
                           "unwrapFileOpenedNotification_Aux" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) =>
-         HasField "unwrapFileOpenedNotification_Aux"
-                  FileOpenedNotification_Aux
-                  ty
-    where hasField = \x_0 -> (\y_1 -> FileOpenedNotification_Aux{unwrapFileOpenedNotification_Aux = y_1},
-                              getField @"unwrapFileOpenedNotification_Aux" x_0)
 {-| __C declaration:__ @FileOpenedNotification@
 
     __defined at:__ @functions\/callbacks.h 10:16@
@@ -495,6 +495,10 @@ newtype FileOpenedNotification
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr FileOpenedNotification_Aux) =>
+         HasField "unwrapFileOpenedNotification" FileOpenedNotification ty
+    where hasField = \x_0 -> (\y_1 -> FileOpenedNotification{unwrapFileOpenedNotification = y_1},
+                              getField @"unwrapFileOpenedNotification" x_0)
+instance (~) ty (FunPtr FileOpenedNotification_Aux) =>
          HasField "unwrapFileOpenedNotification"
                   (Ptr FileOpenedNotification)
                   (Ptr ty)
@@ -504,10 +508,6 @@ instance HasCField FileOpenedNotification
     where type CFieldType FileOpenedNotification
                           "unwrapFileOpenedNotification" = FunPtr FileOpenedNotification_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr FileOpenedNotification_Aux) =>
-         HasField "unwrapFileOpenedNotification" FileOpenedNotification ty
-    where hasField = \x_0 -> (\y_1 -> FileOpenedNotification{unwrapFileOpenedNotification = y_1},
-                              getField @"unwrapFileOpenedNotification" x_0)
 {-| Auxiliary type used by 'ProgressUpdate'
 
     __C declaration:__ @ProgressUpdate@
@@ -544,6 +544,10 @@ instance ToFunPtr ProgressUpdate_Aux
 instance FromFunPtr ProgressUpdate_Aux
     where fromFunPtr = hs_bindgen_ccf7f4b62a839a04
 instance (~) ty (CInt -> IO ()) =>
+         HasField "unwrapProgressUpdate_Aux" ProgressUpdate_Aux ty
+    where hasField = \x_0 -> (\y_1 -> ProgressUpdate_Aux{unwrapProgressUpdate_Aux = y_1},
+                              getField @"unwrapProgressUpdate_Aux" x_0)
+instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapProgressUpdate_Aux"
                   (Ptr ProgressUpdate_Aux)
                   (Ptr ty)
@@ -552,10 +556,6 @@ instance HasCField ProgressUpdate_Aux "unwrapProgressUpdate_Aux"
     where type CFieldType ProgressUpdate_Aux
                           "unwrapProgressUpdate_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) =>
-         HasField "unwrapProgressUpdate_Aux" ProgressUpdate_Aux ty
-    where hasField = \x_0 -> (\y_1 -> ProgressUpdate_Aux{unwrapProgressUpdate_Aux = y_1},
-                              getField @"unwrapProgressUpdate_Aux" x_0)
 {-| __C declaration:__ @ProgressUpdate@
 
     __defined at:__ @functions\/callbacks.h 11:16@
@@ -571,16 +571,16 @@ newtype ProgressUpdate
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr ProgressUpdate_Aux) =>
+         HasField "unwrapProgressUpdate" ProgressUpdate ty
+    where hasField = \x_0 -> (\y_1 -> ProgressUpdate{unwrapProgressUpdate = y_1},
+                              getField @"unwrapProgressUpdate" x_0)
+instance (~) ty (FunPtr ProgressUpdate_Aux) =>
          HasField "unwrapProgressUpdate" (Ptr ProgressUpdate) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProgressUpdate")
 instance HasCField ProgressUpdate "unwrapProgressUpdate"
     where type CFieldType ProgressUpdate
                           "unwrapProgressUpdate" = FunPtr ProgressUpdate_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr ProgressUpdate_Aux) =>
-         HasField "unwrapProgressUpdate" ProgressUpdate ty
-    where hasField = \x_0 -> (\y_1 -> ProgressUpdate{unwrapProgressUpdate = y_1},
-                              getField @"unwrapProgressUpdate" x_0)
 {-| Auxiliary type used by 'DataValidator'
 
     __C declaration:__ @DataValidator@
@@ -617,16 +617,16 @@ instance ToFunPtr DataValidator_Aux
 instance FromFunPtr DataValidator_Aux
     where fromFunPtr = hs_bindgen_c1e79a4c11ca4033
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapDataValidator_Aux" DataValidator_Aux ty
+    where hasField = \x_0 -> (\y_1 -> DataValidator_Aux{unwrapDataValidator_Aux = y_1},
+                              getField @"unwrapDataValidator_Aux" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapDataValidator_Aux" (Ptr DataValidator_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapDataValidator_Aux")
 instance HasCField DataValidator_Aux "unwrapDataValidator_Aux"
     where type CFieldType DataValidator_Aux
                           "unwrapDataValidator_Aux" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapDataValidator_Aux" DataValidator_Aux ty
-    where hasField = \x_0 -> (\y_1 -> DataValidator_Aux{unwrapDataValidator_Aux = y_1},
-                              getField @"unwrapDataValidator_Aux" x_0)
 {-| __C declaration:__ @DataValidator@
 
     __defined at:__ @functions\/callbacks.h 12:15@
@@ -642,16 +642,16 @@ newtype DataValidator
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr DataValidator_Aux) =>
+         HasField "unwrapDataValidator" DataValidator ty
+    where hasField = \x_0 -> (\y_1 -> DataValidator{unwrapDataValidator = y_1},
+                              getField @"unwrapDataValidator" x_0)
+instance (~) ty (FunPtr DataValidator_Aux) =>
          HasField "unwrapDataValidator" (Ptr DataValidator) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapDataValidator")
 instance HasCField DataValidator "unwrapDataValidator"
     where type CFieldType DataValidator
                           "unwrapDataValidator" = FunPtr DataValidator_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr DataValidator_Aux) =>
-         HasField "unwrapDataValidator" DataValidator ty
-    where hasField = \x_0 -> (\y_1 -> DataValidator{unwrapDataValidator = y_1},
-                              getField @"unwrapDataValidator" x_0)
 {-| __C declaration:__ @struct Measurement@
 
     __defined at:__ @functions\/callbacks.h 21:8@
@@ -684,28 +684,28 @@ instance WriteRaw Measurement
                                        Measurement measurement_value_2
                                                    measurement_timestamp_3 -> writeRaw (Proxy @"measurement_value") ptr_0 measurement_value_2 >> writeRaw (Proxy @"measurement_timestamp") ptr_0 measurement_timestamp_3
 deriving via (EquivStorable Measurement) instance Storable Measurement
-instance HasCField Measurement "measurement_value"
-    where type CFieldType Measurement "measurement_value" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "measurement_value" (Ptr Measurement) (Ptr ty)
-    where getField = fromPtr (Proxy @"measurement_value")
 instance (~) ty CDouble =>
          HasField "measurement_value" Measurement ty
     where hasField = \x_0 -> (\y_1 -> Measurement{measurement_value = y_1,
                                                   measurement_timestamp = getField @"measurement_timestamp" x_0},
                               getField @"measurement_value" x_0)
-instance HasCField Measurement "measurement_timestamp"
-    where type CFieldType Measurement "measurement_timestamp" = CDouble
-          offset# = \_ -> \_ -> 8
 instance (~) ty CDouble =>
-         HasField "measurement_timestamp" (Ptr Measurement) (Ptr ty)
-    where getField = fromPtr (Proxy @"measurement_timestamp")
+         HasField "measurement_value" (Ptr Measurement) (Ptr ty)
+    where getField = fromPtr (Proxy @"measurement_value")
+instance HasCField Measurement "measurement_value"
+    where type CFieldType Measurement "measurement_value" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty CDouble =>
          HasField "measurement_timestamp" Measurement ty
     where hasField = \x_0 -> (\y_1 -> Measurement{measurement_timestamp = y_1,
                                                   measurement_value = getField @"measurement_value" x_0},
                               getField @"measurement_timestamp" x_0)
+instance (~) ty CDouble =>
+         HasField "measurement_timestamp" (Ptr Measurement) (Ptr ty)
+    where getField = fromPtr (Proxy @"measurement_timestamp")
+instance HasCField Measurement "measurement_timestamp"
+    where type CFieldType Measurement "measurement_timestamp" = CDouble
+          offset# = \_ -> \_ -> 8
 {-| Auxiliary type used by 'MeasurementReceived'
 
     __C declaration:__ @MeasurementReceived@
@@ -743,6 +743,10 @@ instance ToFunPtr MeasurementReceived_Aux
 instance FromFunPtr MeasurementReceived_Aux
     where fromFunPtr = hs_bindgen_383c36bb22947621
 instance (~) ty (Ptr Measurement -> IO ()) =>
+         HasField "unwrapMeasurementReceived_Aux" MeasurementReceived_Aux ty
+    where hasField = \x_0 -> (\y_1 -> MeasurementReceived_Aux{unwrapMeasurementReceived_Aux = y_1},
+                              getField @"unwrapMeasurementReceived_Aux" x_0)
+instance (~) ty (Ptr Measurement -> IO ()) =>
          HasField "unwrapMeasurementReceived_Aux"
                   (Ptr MeasurementReceived_Aux)
                   (Ptr ty)
@@ -752,10 +756,6 @@ instance HasCField MeasurementReceived_Aux
     where type CFieldType MeasurementReceived_Aux
                           "unwrapMeasurementReceived_Aux" = Ptr Measurement -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Measurement -> IO ()) =>
-         HasField "unwrapMeasurementReceived_Aux" MeasurementReceived_Aux ty
-    where hasField = \x_0 -> (\y_1 -> MeasurementReceived_Aux{unwrapMeasurementReceived_Aux = y_1},
-                              getField @"unwrapMeasurementReceived_Aux" x_0)
 {-| __C declaration:__ @MeasurementReceived@
 
     __defined at:__ @functions\/callbacks.h 26:16@
@@ -771,6 +771,10 @@ newtype MeasurementReceived
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr MeasurementReceived_Aux) =>
+         HasField "unwrapMeasurementReceived" MeasurementReceived ty
+    where hasField = \x_0 -> (\y_1 -> MeasurementReceived{unwrapMeasurementReceived = y_1},
+                              getField @"unwrapMeasurementReceived" x_0)
+instance (~) ty (FunPtr MeasurementReceived_Aux) =>
          HasField "unwrapMeasurementReceived"
                   (Ptr MeasurementReceived)
                   (Ptr ty)
@@ -779,10 +783,6 @@ instance HasCField MeasurementReceived "unwrapMeasurementReceived"
     where type CFieldType MeasurementReceived
                           "unwrapMeasurementReceived" = FunPtr MeasurementReceived_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr MeasurementReceived_Aux) =>
-         HasField "unwrapMeasurementReceived" MeasurementReceived ty
-    where hasField = \x_0 -> (\y_1 -> MeasurementReceived{unwrapMeasurementReceived = y_1},
-                              getField @"unwrapMeasurementReceived" x_0)
 {-| Auxiliary type used by 'MeasurementReceived2'
 
     __C declaration:__ @MeasurementReceived2@
@@ -797,6 +797,12 @@ newtype MeasurementReceived2_Aux
     deriving stock Generic
 instance (~) ty (Measurement -> IO ()) =>
          HasField "unwrapMeasurementReceived2_Aux"
+                  MeasurementReceived2_Aux
+                  ty
+    where hasField = \x_0 -> (\y_1 -> MeasurementReceived2_Aux{unwrapMeasurementReceived2_Aux = y_1},
+                              getField @"unwrapMeasurementReceived2_Aux" x_0)
+instance (~) ty (Measurement -> IO ()) =>
+         HasField "unwrapMeasurementReceived2_Aux"
                   (Ptr MeasurementReceived2_Aux)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMeasurementReceived2_Aux")
@@ -805,12 +811,6 @@ instance HasCField MeasurementReceived2_Aux
     where type CFieldType MeasurementReceived2_Aux
                           "unwrapMeasurementReceived2_Aux" = Measurement -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (Measurement -> IO ()) =>
-         HasField "unwrapMeasurementReceived2_Aux"
-                  MeasurementReceived2_Aux
-                  ty
-    where hasField = \x_0 -> (\y_1 -> MeasurementReceived2_Aux{unwrapMeasurementReceived2_Aux = y_1},
-                              getField @"unwrapMeasurementReceived2_Aux" x_0)
 {-| __C declaration:__ @MeasurementReceived2@
 
     __defined at:__ @functions\/callbacks.h 29:16@
@@ -826,6 +826,10 @@ newtype MeasurementReceived2
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr MeasurementReceived2_Aux) =>
+         HasField "unwrapMeasurementReceived2" MeasurementReceived2 ty
+    where hasField = \x_0 -> (\y_1 -> MeasurementReceived2{unwrapMeasurementReceived2 = y_1},
+                              getField @"unwrapMeasurementReceived2" x_0)
+instance (~) ty (FunPtr MeasurementReceived2_Aux) =>
          HasField "unwrapMeasurementReceived2"
                   (Ptr MeasurementReceived2)
                   (Ptr ty)
@@ -835,10 +839,6 @@ instance HasCField MeasurementReceived2
     where type CFieldType MeasurementReceived2
                           "unwrapMeasurementReceived2" = FunPtr MeasurementReceived2_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr MeasurementReceived2_Aux) =>
-         HasField "unwrapMeasurementReceived2" MeasurementReceived2 ty
-    where hasField = \x_0 -> (\y_1 -> MeasurementReceived2{unwrapMeasurementReceived2 = y_1},
-                              getField @"unwrapMeasurementReceived2" x_0)
 {-| Auxiliary type used by 'SampleBufferFull'
 
     __C declaration:__ @SampleBufferFull@
@@ -877,6 +877,10 @@ instance ToFunPtr SampleBufferFull_Aux
 instance FromFunPtr SampleBufferFull_Aux
     where fromFunPtr = hs_bindgen_2ab7ac6bb756ba7e
 instance (~) ty (Ptr (Elem (ConstantArray 10 CInt)) -> IO ()) =>
+         HasField "unwrapSampleBufferFull_Aux" SampleBufferFull_Aux ty
+    where hasField = \x_0 -> (\y_1 -> SampleBufferFull_Aux{unwrapSampleBufferFull_Aux = y_1},
+                              getField @"unwrapSampleBufferFull_Aux" x_0)
+instance (~) ty (Ptr (Elem (ConstantArray 10 CInt)) -> IO ()) =>
          HasField "unwrapSampleBufferFull_Aux"
                   (Ptr SampleBufferFull_Aux)
                   (Ptr ty)
@@ -888,10 +892,6 @@ instance HasCField SampleBufferFull_Aux
                                                                                   CInt)) ->
                                                          IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Elem (ConstantArray 10 CInt)) -> IO ()) =>
-         HasField "unwrapSampleBufferFull_Aux" SampleBufferFull_Aux ty
-    where hasField = \x_0 -> (\y_1 -> SampleBufferFull_Aux{unwrapSampleBufferFull_Aux = y_1},
-                              getField @"unwrapSampleBufferFull_Aux" x_0)
 {-| __C declaration:__ @SampleBufferFull@
 
     __defined at:__ @functions\/callbacks.h 32:16@
@@ -907,16 +907,16 @@ newtype SampleBufferFull
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr SampleBufferFull_Aux) =>
+         HasField "unwrapSampleBufferFull" SampleBufferFull ty
+    where hasField = \x_0 -> (\y_1 -> SampleBufferFull{unwrapSampleBufferFull = y_1},
+                              getField @"unwrapSampleBufferFull" x_0)
+instance (~) ty (FunPtr SampleBufferFull_Aux) =>
          HasField "unwrapSampleBufferFull" (Ptr SampleBufferFull) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSampleBufferFull")
 instance HasCField SampleBufferFull "unwrapSampleBufferFull"
     where type CFieldType SampleBufferFull
                           "unwrapSampleBufferFull" = FunPtr SampleBufferFull_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr SampleBufferFull_Aux) =>
-         HasField "unwrapSampleBufferFull" SampleBufferFull ty
-    where hasField = \x_0 -> (\y_1 -> SampleBufferFull{unwrapSampleBufferFull = y_1},
-                              getField @"unwrapSampleBufferFull" x_0)
 {-| __C declaration:__ @struct MeasurementHandler@
 
     __defined at:__ @functions\/callbacks.h 50:8@
@@ -959,52 +959,52 @@ instance WriteRaw MeasurementHandler
                                                           measurementHandler_validate_3
                                                           measurementHandler_onError_4 -> writeRaw (Proxy @"measurementHandler_onReceived") ptr_0 measurementHandler_onReceived_2 >> (writeRaw (Proxy @"measurementHandler_validate") ptr_0 measurementHandler_validate_3 >> writeRaw (Proxy @"measurementHandler_onError") ptr_0 measurementHandler_onError_4)
 deriving via (EquivStorable MeasurementHandler) instance Storable MeasurementHandler
-instance HasCField MeasurementHandler
-                   "measurementHandler_onReceived"
-    where type CFieldType MeasurementHandler
-                          "measurementHandler_onReceived" = FunPtr (Ptr Measurement -> IO ())
-          offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
-         HasField "measurementHandler_onReceived"
-                  (Ptr MeasurementHandler)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"measurementHandler_onReceived")
 instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
          HasField "measurementHandler_onReceived" MeasurementHandler ty
     where hasField = \x_0 -> (\y_1 -> MeasurementHandler{measurementHandler_onReceived = y_1,
                                                          measurementHandler_validate = getField @"measurementHandler_validate" x_0,
                                                          measurementHandler_onError = getField @"measurementHandler_onError" x_0},
                               getField @"measurementHandler_onReceived" x_0)
-instance HasCField MeasurementHandler "measurementHandler_validate"
-    where type CFieldType MeasurementHandler
-                          "measurementHandler_validate" = FunPtr (Ptr Measurement -> IO CInt)
-          offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Measurement -> IO CInt)) =>
-         HasField "measurementHandler_validate"
+instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
+         HasField "measurementHandler_onReceived"
                   (Ptr MeasurementHandler)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"measurementHandler_validate")
+    where getField = fromPtr (Proxy @"measurementHandler_onReceived")
+instance HasCField MeasurementHandler
+                   "measurementHandler_onReceived"
+    where type CFieldType MeasurementHandler
+                          "measurementHandler_onReceived" = FunPtr (Ptr Measurement -> IO ())
+          offset# = \_ -> \_ -> 0
 instance (~) ty (FunPtr (Ptr Measurement -> IO CInt)) =>
          HasField "measurementHandler_validate" MeasurementHandler ty
     where hasField = \x_0 -> (\y_1 -> MeasurementHandler{measurementHandler_validate = y_1,
                                                          measurementHandler_onReceived = getField @"measurementHandler_onReceived" x_0,
                                                          measurementHandler_onError = getField @"measurementHandler_onError" x_0},
                               getField @"measurementHandler_validate" x_0)
-instance HasCField MeasurementHandler "measurementHandler_onError"
-    where type CFieldType MeasurementHandler
-                          "measurementHandler_onError" = FunPtr (CInt -> IO ())
-          offset# = \_ -> \_ -> 16
-instance (~) ty (FunPtr (CInt -> IO ())) =>
-         HasField "measurementHandler_onError"
+instance (~) ty (FunPtr (Ptr Measurement -> IO CInt)) =>
+         HasField "measurementHandler_validate"
                   (Ptr MeasurementHandler)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"measurementHandler_onError")
+    where getField = fromPtr (Proxy @"measurementHandler_validate")
+instance HasCField MeasurementHandler "measurementHandler_validate"
+    where type CFieldType MeasurementHandler
+                          "measurementHandler_validate" = FunPtr (Ptr Measurement -> IO CInt)
+          offset# = \_ -> \_ -> 8
 instance (~) ty (FunPtr (CInt -> IO ())) =>
          HasField "measurementHandler_onError" MeasurementHandler ty
     where hasField = \x_0 -> (\y_1 -> MeasurementHandler{measurementHandler_onError = y_1,
                                                          measurementHandler_onReceived = getField @"measurementHandler_onReceived" x_0,
                                                          measurementHandler_validate = getField @"measurementHandler_validate" x_0},
                               getField @"measurementHandler_onError" x_0)
+instance (~) ty (FunPtr (CInt -> IO ())) =>
+         HasField "measurementHandler_onError"
+                  (Ptr MeasurementHandler)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"measurementHandler_onError")
+instance HasCField MeasurementHandler "measurementHandler_onError"
+    where type CFieldType MeasurementHandler
+                          "measurementHandler_onError" = FunPtr (CInt -> IO ())
+          offset# = \_ -> \_ -> 16
 {-| __C declaration:__ @struct DataPipeline@
 
     __defined at:__ @functions\/callbacks.h 58:8@
@@ -1047,15 +1047,6 @@ instance WriteRaw DataPipeline
                                                     dataPipeline_process_3
                                                     dataPipeline_postProcess_4 -> writeRaw (Proxy @"dataPipeline_preProcess") ptr_0 dataPipeline_preProcess_2 >> (writeRaw (Proxy @"dataPipeline_process") ptr_0 dataPipeline_process_3 >> writeRaw (Proxy @"dataPipeline_postProcess") ptr_0 dataPipeline_postProcess_4)
 deriving via (EquivStorable DataPipeline) instance Storable DataPipeline
-instance HasCField DataPipeline "dataPipeline_preProcess"
-    where type CFieldType DataPipeline
-                          "dataPipeline_preProcess" = FunPtr (Ptr Measurement ->
-                                                              DataValidator -> IO ())
-          offset# = \_ -> \_ -> 0
-instance (~) ty
-             (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
-         HasField "dataPipeline_preProcess" (Ptr DataPipeline) (Ptr ty)
-    where getField = fromPtr (Proxy @"dataPipeline_preProcess")
 instance (~) ty
              (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
          HasField "dataPipeline_preProcess" DataPipeline ty
@@ -1063,28 +1054,28 @@ instance (~) ty
                                                    dataPipeline_process = getField @"dataPipeline_process" x_0,
                                                    dataPipeline_postProcess = getField @"dataPipeline_postProcess" x_0},
                               getField @"dataPipeline_preProcess" x_0)
-instance HasCField DataPipeline "dataPipeline_process"
+instance (~) ty
+             (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
+         HasField "dataPipeline_preProcess" (Ptr DataPipeline) (Ptr ty)
+    where getField = fromPtr (Proxy @"dataPipeline_preProcess")
+instance HasCField DataPipeline "dataPipeline_preProcess"
     where type CFieldType DataPipeline
-                          "dataPipeline_process" = FunPtr (Ptr Measurement -> IO ())
-          offset# = \_ -> \_ -> 8
-instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
-         HasField "dataPipeline_process" (Ptr DataPipeline) (Ptr ty)
-    where getField = fromPtr (Proxy @"dataPipeline_process")
+                          "dataPipeline_preProcess" = FunPtr (Ptr Measurement ->
+                                                              DataValidator -> IO ())
+          offset# = \_ -> \_ -> 0
 instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
          HasField "dataPipeline_process" DataPipeline ty
     where hasField = \x_0 -> (\y_1 -> DataPipeline{dataPipeline_process = y_1,
                                                    dataPipeline_preProcess = getField @"dataPipeline_preProcess" x_0,
                                                    dataPipeline_postProcess = getField @"dataPipeline_postProcess" x_0},
                               getField @"dataPipeline_process" x_0)
-instance HasCField DataPipeline "dataPipeline_postProcess"
+instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
+         HasField "dataPipeline_process" (Ptr DataPipeline) (Ptr ty)
+    where getField = fromPtr (Proxy @"dataPipeline_process")
+instance HasCField DataPipeline "dataPipeline_process"
     where type CFieldType DataPipeline
-                          "dataPipeline_postProcess" = FunPtr (Ptr Measurement ->
-                                                               ProgressUpdate -> IO ())
-          offset# = \_ -> \_ -> 16
-instance (~) ty
-             (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
-         HasField "dataPipeline_postProcess" (Ptr DataPipeline) (Ptr ty)
-    where getField = fromPtr (Proxy @"dataPipeline_postProcess")
+                          "dataPipeline_process" = FunPtr (Ptr Measurement -> IO ())
+          offset# = \_ -> \_ -> 8
 instance (~) ty
              (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
          HasField "dataPipeline_postProcess" DataPipeline ty
@@ -1092,6 +1083,15 @@ instance (~) ty
                                                    dataPipeline_preProcess = getField @"dataPipeline_preProcess" x_0,
                                                    dataPipeline_process = getField @"dataPipeline_process" x_0},
                               getField @"dataPipeline_postProcess" x_0)
+instance (~) ty
+             (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
+         HasField "dataPipeline_postProcess" (Ptr DataPipeline) (Ptr ty)
+    where getField = fromPtr (Proxy @"dataPipeline_postProcess")
+instance HasCField DataPipeline "dataPipeline_postProcess"
+    where type CFieldType DataPipeline
+                          "dataPipeline_postProcess" = FunPtr (Ptr Measurement ->
+                                                               ProgressUpdate -> IO ())
+          offset# = \_ -> \_ -> 16
 {-| __C declaration:__ @union ProcessorCallback@
 
     __defined at:__ @functions\/callbacks.h 69:7@
@@ -1219,20 +1219,14 @@ set_processorCallback_withProgress :: FunPtr (Ptr Measurement ->
 
 -}
 set_processorCallback_withProgress = setUnionPayload
-instance HasCField ProcessorCallback "processorCallback_simple"
-    where type CFieldType ProcessorCallback
-                          "processorCallback_simple" = FunPtr (Ptr Measurement -> IO ())
-          offset# = \_ -> \_ -> 0
 instance (~) ty (FunPtr (Ptr Measurement -> IO ())) =>
          HasField "processorCallback_simple"
                   (Ptr ProcessorCallback)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_simple")
-instance HasCField ProcessorCallback
-                   "processorCallback_withValidator"
+instance HasCField ProcessorCallback "processorCallback_simple"
     where type CFieldType ProcessorCallback
-                          "processorCallback_withValidator" = FunPtr (Ptr Measurement ->
-                                                                      DataValidator -> IO ())
+                          "processorCallback_simple" = FunPtr (Ptr Measurement -> IO ())
           offset# = \_ -> \_ -> 0
 instance (~) ty
              (FunPtr (Ptr Measurement -> DataValidator -> IO ())) =>
@@ -1241,10 +1235,10 @@ instance (~) ty
                   (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_withValidator")
 instance HasCField ProcessorCallback
-                   "processorCallback_withProgress"
+                   "processorCallback_withValidator"
     where type CFieldType ProcessorCallback
-                          "processorCallback_withProgress" = FunPtr (Ptr Measurement ->
-                                                                     ProgressUpdate -> IO ())
+                          "processorCallback_withValidator" = FunPtr (Ptr Measurement ->
+                                                                      DataValidator -> IO ())
           offset# = \_ -> \_ -> 0
 instance (~) ty
              (FunPtr (Ptr Measurement -> ProgressUpdate -> IO ())) =>
@@ -1252,6 +1246,12 @@ instance (~) ty
                   (Ptr ProcessorCallback)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"processorCallback_withProgress")
+instance HasCField ProcessorCallback
+                   "processorCallback_withProgress"
+    where type CFieldType ProcessorCallback
+                          "processorCallback_withProgress" = FunPtr (Ptr Measurement ->
+                                                                     ProgressUpdate -> IO ())
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @enum \@Processor_mode@
 
     __defined at:__ @functions\/callbacks.h 76:3@
@@ -1294,15 +1294,15 @@ instance Read Processor_mode
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CUInt =>
+         HasField "unwrapProcessor_mode" Processor_mode ty
+    where hasField = \x_0 -> (\y_1 -> Processor_mode{unwrapProcessor_mode = y_1},
+                              getField @"unwrapProcessor_mode" x_0)
+instance (~) ty CUInt =>
          HasField "unwrapProcessor_mode" (Ptr Processor_mode) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapProcessor_mode")
 instance HasCField Processor_mode "unwrapProcessor_mode"
     where type CFieldType Processor_mode "unwrapProcessor_mode" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unwrapProcessor_mode" Processor_mode ty
-    where hasField = \x_0 -> (\y_1 -> Processor_mode{unwrapProcessor_mode = y_1},
-                              getField @"unwrapProcessor_mode" x_0)
 {-| __C declaration:__ @MODE_SIMPLE@
 
     __defined at:__ @functions\/callbacks.h 76:10@
@@ -1359,29 +1359,29 @@ instance WriteRaw Processor
                                        Processor processor_mode_2
                                                  processor_callback_3 -> writeRaw (Proxy @"processor_mode") ptr_0 processor_mode_2 >> writeRaw (Proxy @"processor_callback") ptr_0 processor_callback_3
 deriving via (EquivStorable Processor) instance Storable Processor
-instance HasCField Processor "processor_mode"
-    where type CFieldType Processor "processor_mode" = Processor_mode
-          offset# = \_ -> \_ -> 0
-instance (~) ty Processor_mode =>
-         HasField "processor_mode" (Ptr Processor) (Ptr ty)
-    where getField = fromPtr (Proxy @"processor_mode")
 instance (~) ty Processor_mode =>
          HasField "processor_mode" Processor ty
     where hasField = \x_0 -> (\y_1 -> Processor{processor_mode = y_1,
                                                 processor_callback = getField @"processor_callback" x_0},
                               getField @"processor_mode" x_0)
-instance HasCField Processor "processor_callback"
-    where type CFieldType Processor
-                          "processor_callback" = ProcessorCallback
-          offset# = \_ -> \_ -> 8
-instance (~) ty ProcessorCallback =>
-         HasField "processor_callback" (Ptr Processor) (Ptr ty)
-    where getField = fromPtr (Proxy @"processor_callback")
+instance (~) ty Processor_mode =>
+         HasField "processor_mode" (Ptr Processor) (Ptr ty)
+    where getField = fromPtr (Proxy @"processor_mode")
+instance HasCField Processor "processor_mode"
+    where type CFieldType Processor "processor_mode" = Processor_mode
+          offset# = \_ -> \_ -> 0
 instance (~) ty ProcessorCallback =>
          HasField "processor_callback" Processor ty
     where hasField = \x_0 -> (\y_1 -> Processor{processor_callback = y_1,
                                                 processor_mode = getField @"processor_mode" x_0},
                               getField @"processor_callback" x_0)
+instance (~) ty ProcessorCallback =>
+         HasField "processor_callback" (Ptr Processor) (Ptr ty)
+    where getField = fromPtr (Proxy @"processor_callback")
+instance HasCField Processor "processor_callback"
+    where type CFieldType Processor
+                          "processor_callback" = ProcessorCallback
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @foo@
 
     __defined at:__ @functions\/callbacks.h 94:13@
@@ -1406,14 +1406,14 @@ newtype Foo
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapFoo" Foo ty
+    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
+                              getField @"unwrapFoo" x_0)
 instance (~) ty CInt => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapFoo" Foo ty
-    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
-                              getField @"unwrapFoo" x_0)
 {-| __C declaration:__ @foo2@
 
     __defined at:__ @functions\/callbacks.h 95:13@
@@ -1438,14 +1438,14 @@ newtype Foo2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapFoo2" Foo2 ty
+    where hasField = \x_0 -> (\y_1 -> Foo2{unwrapFoo2 = y_1},
+                              getField @"unwrapFoo2" x_0)
 instance (~) ty CInt => HasField "unwrapFoo2" (Ptr Foo2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo2")
 instance HasCField Foo2 "unwrapFoo2"
     where type CFieldType Foo2 "unwrapFoo2" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapFoo2" Foo2 ty
-    where hasField = \x_0 -> (\y_1 -> Foo2{unwrapFoo2 = y_1},
-                              getField @"unwrapFoo2" x_0)
 {-| __C declaration:__ @A@
 
     __defined at:__ @functions\/callbacks.h 102:13@
@@ -1470,14 +1470,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @B@
 
     __defined at:__ @functions\/callbacks.h 108:13@
@@ -1502,14 +1502,14 @@ newtype B
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty CInt => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 {-| __C declaration:__ @struct S@
 
     __defined at:__ @functions\/callbacks.h 109:8@
@@ -1534,15 +1534,15 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_fn_2 -> writeRaw (Proxy @"s_fn") ptr_0 s_fn_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_fn"
-    where type CFieldType S "s_fn" = FunPtr (B -> IO ())
-          offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (B -> IO ())) =>
-         HasField "s_fn" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_fn")
 instance (~) ty (FunPtr (B -> IO ())) => HasField "s_fn" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_fn = y_1},
                               getField @"s_fn" x_0)
+instance (~) ty (FunPtr (B -> IO ())) =>
+         HasField "s_fn" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_fn")
+instance HasCField S "s_fn"
+    where type CFieldType S "s_fn" = FunPtr (B -> IO ())
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @C@
 
     __defined at:__ @functions\/callbacks.h 116:13@
@@ -1567,14 +1567,14 @@ newtype C
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapC" C ty
+    where hasField = \x_0 -> (\y_1 -> C{unwrapC = y_1},
+                              getField @"unwrapC" x_0)
 instance (~) ty CInt => HasField "unwrapC" (Ptr C) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapC")
 instance HasCField C "unwrapC"
     where type CFieldType C "unwrapC" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapC" C ty
-    where hasField = \x_0 -> (\y_1 -> C{unwrapC = y_1},
-                              getField @"unwrapC" x_0)
 {-| __C declaration:__ @union U@
 
     __defined at:__ @functions\/callbacks.h 117:7@
@@ -1620,13 +1620,13 @@ set_u_fn :: ConstantArray 3 (FunPtr (C -> IO ())) -> U
 
 -}
 set_u_fn = setUnionPayload
+instance (~) ty (ConstantArray 3 (FunPtr (C -> IO ()))) =>
+         HasField "u_fn" (Ptr U) (Ptr ty)
+    where getField = fromPtr (Proxy @"u_fn")
 instance HasCField U "u_fn"
     where type CFieldType U "u_fn" = ConstantArray 3
                                                    (FunPtr (C -> IO ()))
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 (FunPtr (C -> IO ()))) =>
-         HasField "u_fn" (Ptr U) (Ptr ty)
-    where getField = fromPtr (Proxy @"u_fn")
 {-| __C declaration:__ @D@
 
     __defined at:__ @functions\/callbacks.h 124:13@
@@ -1651,14 +1651,14 @@ newtype D
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapD" D ty
+    where hasField = \x_0 -> (\y_1 -> D{unwrapD = y_1},
+                              getField @"unwrapD" x_0)
 instance (~) ty CInt => HasField "unwrapD" (Ptr D) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapD")
 instance HasCField D "unwrapD"
     where type CFieldType D "unwrapD" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapD" D ty
-    where hasField = \x_0 -> (\y_1 -> D{unwrapD = y_1},
-                              getField @"unwrapD" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @functions\/callbacks.h 125:15@
@@ -1691,15 +1691,15 @@ instance ToFunPtr T
 instance FromFunPtr T
     where fromFunPtr = hs_bindgen_8f830eadb43a6fe4
 instance (~) ty (FunPtr (D -> IO ()) -> IO ()) =>
+         HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
+instance (~) ty (FunPtr (D -> IO ()) -> IO ()) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = FunPtr (D -> IO ()) -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (D -> IO ()) -> IO ()) =>
-         HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 -- __unique:__ @instance ToFunPtr (A -> IO ())@
 foreign import ccall safe "wrapper" hs_bindgen_a46c670f88b5e6d2_base ::
     Int32 -> IO ()

--- a/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/Example.hs
@@ -74,6 +74,15 @@ instance RIP.FromFunPtr Fun_ptr_Aux where
   fromFunPtr = hs_bindgen_f8391e85af67fcb6
 
 instance ( ty ~ (RIP.Ptr Forward_declaration -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapFun_ptr_Aux" Fun_ptr_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Fun_ptr_Aux {unwrapFun_ptr_Aux = y1}
+      , RIP.getField @"unwrapFun_ptr_Aux" x0
+      )
+
+instance ( ty ~ (RIP.Ptr Forward_declaration -> IO ())
          ) => RIP.HasField "unwrapFun_ptr_Aux" (RIP.Ptr Fun_ptr_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -85,15 +94,6 @@ instance HasCField.HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux" where
     RIP.Ptr Forward_declaration -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.Ptr Forward_declaration -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapFun_ptr_Aux" Fun_ptr_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Fun_ptr_Aux {unwrapFun_ptr_Aux = y1}
-      , RIP.getField @"unwrapFun_ptr_Aux" x0
-      )
 
 {-| __C declaration:__ @fun_ptr@
 
@@ -114,6 +114,14 @@ newtype Fun_ptr = Fun_ptr
     )
 
 instance ( ty ~ RIP.FunPtr Fun_ptr_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFun_ptr" Fun_ptr ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Fun_ptr {unwrapFun_ptr = y1}, RIP.getField @"unwrapFun_ptr" x0)
+
+instance ( ty ~ RIP.FunPtr Fun_ptr_Aux
          ) => RIP.HasField "unwrapFun_ptr" (RIP.Ptr Fun_ptr) (RIP.Ptr ty) where
 
   getField =
@@ -125,14 +133,6 @@ instance HasCField.HasCField Fun_ptr "unwrapFun_ptr" where
     RIP.FunPtr Fun_ptr_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Fun_ptr_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFun_ptr" Fun_ptr ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Fun_ptr {unwrapFun_ptr = y1}, RIP.getField @"unwrapFun_ptr" x0)
 
 {-| __C declaration:__ @struct forward_declaration@
 
@@ -175,19 +175,6 @@ instance Marshal.WriteRaw Forward_declaration where
 
 deriving via Marshal.EquivStorable Forward_declaration instance RIP.Storable Forward_declaration
 
-instance HasCField.HasCField Forward_declaration "forward_declaration_f" where
-
-  type CFieldType Forward_declaration "forward_declaration_f" =
-    Fun_ptr
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Fun_ptr
-         ) => RIP.HasField "forward_declaration_f" (RIP.Ptr Forward_declaration) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"forward_declaration_f")
-
 instance ( ty ~ Fun_ptr
          ) => RIP.CompatHasField.HasField "forward_declaration_f" Forward_declaration ty where
 
@@ -197,3 +184,16 @@ instance ( ty ~ Fun_ptr
           Forward_declaration {forward_declaration_f = y1}
       , RIP.getField @"forward_declaration_f" x0
       )
+
+instance ( ty ~ Fun_ptr
+         ) => RIP.HasField "forward_declaration_f" (RIP.Ptr Forward_declaration) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"forward_declaration_f")
+
+instance HasCField.HasCField Forward_declaration "forward_declaration_f" where
+
+  type CFieldType Forward_declaration "forward_declaration_f" =
+    Fun_ptr
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - forward_declaration_f
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,12 +35,13 @@ hstypes:
       fields:
       - unwrapFun_ptr
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/circular_dependency_fun/th.txt
@@ -35,16 +35,16 @@ instance ToFunPtr Fun_ptr_Aux
 instance FromFunPtr Fun_ptr_Aux
     where fromFunPtr = hs_bindgen_f8391e85af67fcb6
 instance (~) ty (Ptr Forward_declaration -> IO ()) =>
+         HasField "unwrapFun_ptr_Aux" Fun_ptr_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Fun_ptr_Aux{unwrapFun_ptr_Aux = y_1},
+                              getField @"unwrapFun_ptr_Aux" x_0)
+instance (~) ty (Ptr Forward_declaration -> IO ()) =>
          HasField "unwrapFun_ptr_Aux" (Ptr Fun_ptr_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFun_ptr_Aux")
 instance HasCField Fun_ptr_Aux "unwrapFun_ptr_Aux"
     where type CFieldType Fun_ptr_Aux
                           "unwrapFun_ptr_Aux" = Ptr Forward_declaration -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Forward_declaration -> IO ()) =>
-         HasField "unwrapFun_ptr_Aux" Fun_ptr_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Fun_ptr_Aux{unwrapFun_ptr_Aux = y_1},
-                              getField @"unwrapFun_ptr_Aux" x_0)
 {-| __C declaration:__ @fun_ptr@
 
     __defined at:__ @functions\/circular_dependency_fun.h 3:16@
@@ -60,15 +60,15 @@ newtype Fun_ptr
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Fun_ptr_Aux) =>
+         HasField "unwrapFun_ptr" Fun_ptr ty
+    where hasField = \x_0 -> (\y_1 -> Fun_ptr{unwrapFun_ptr = y_1},
+                              getField @"unwrapFun_ptr" x_0)
+instance (~) ty (FunPtr Fun_ptr_Aux) =>
          HasField "unwrapFun_ptr" (Ptr Fun_ptr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFun_ptr")
 instance HasCField Fun_ptr "unwrapFun_ptr"
     where type CFieldType Fun_ptr "unwrapFun_ptr" = FunPtr Fun_ptr_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Fun_ptr_Aux) =>
-         HasField "unwrapFun_ptr" Fun_ptr ty
-    where hasField = \x_0 -> (\y_1 -> Fun_ptr{unwrapFun_ptr = y_1},
-                              getField @"unwrapFun_ptr" x_0)
 {-| __C declaration:__ @struct forward_declaration@
 
     __defined at:__ @functions\/circular_dependency_fun.h 5:8@
@@ -93,14 +93,14 @@ instance WriteRaw Forward_declaration
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Forward_declaration forward_declaration_f_2 -> writeRaw (Proxy @"forward_declaration_f") ptr_0 forward_declaration_f_2
 deriving via (EquivStorable Forward_declaration) instance Storable Forward_declaration
-instance HasCField Forward_declaration "forward_declaration_f"
-    where type CFieldType Forward_declaration
-                          "forward_declaration_f" = Fun_ptr
-          offset# = \_ -> \_ -> 0
-instance (~) ty Fun_ptr =>
-         HasField "forward_declaration_f" (Ptr Forward_declaration) (Ptr ty)
-    where getField = fromPtr (Proxy @"forward_declaration_f")
 instance (~) ty Fun_ptr =>
          HasField "forward_declaration_f" Forward_declaration ty
     where hasField = \x_0 -> (\y_1 -> Forward_declaration{forward_declaration_f = y_1},
                               getField @"forward_declaration_f" x_0)
+instance (~) ty Fun_ptr =>
+         HasField "forward_declaration_f" (Ptr Forward_declaration) (Ptr ty)
+    where getField = fromPtr (Proxy @"forward_declaration_f")
+instance HasCField Forward_declaration "forward_declaration_f"
+    where type CFieldType Forward_declaration
+                          "forward_declaration_f" = Fun_ptr
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/Example.hs
@@ -82,17 +82,6 @@ instance Marshal.WriteRaw Outside where
 
 deriving via Marshal.EquivStorable Outside instance RIP.Storable Outside
 
-instance HasCField.HasCField Outside "outside_x" where
-
-  type CFieldType Outside "outside_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outside_x" (RIP.Ptr Outside) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"outside_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outside_x" Outside ty where
 
@@ -103,16 +92,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"outside_x" x0
       )
 
-instance HasCField.HasCField Outside "outside_y" where
-
-  type CFieldType Outside "outside_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outside_y" (RIP.Ptr Outside) (RIP.Ptr ty) where
+         ) => RIP.HasField "outside_x" (RIP.Ptr Outside) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"outside_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"outside_x")
+
+instance HasCField.HasCField Outside "outside_x" where
+
+  type CFieldType Outside "outside_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outside_y" Outside ty where
@@ -123,3 +112,14 @@ instance ( ty ~ RIP.CInt
           Outside {outside_y = y1, outside_x = RIP.getField @"outside_x" x0}
       , RIP.getField @"outside_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outside_y" (RIP.Ptr Outside) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"outside_y")
+
+instance HasCField.HasCField Outside "outside_y" where
+
+  type CFieldType Outside "outside_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       - outside_x
       - outside_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/decls_in_signature/th.txt
@@ -65,24 +65,24 @@ instance WriteRaw Outside
                                        Outside outside_x_2
                                                outside_y_3 -> writeRaw (Proxy @"outside_x") ptr_0 outside_x_2 >> writeRaw (Proxy @"outside_y") ptr_0 outside_y_3
 deriving via (EquivStorable Outside) instance Storable Outside
-instance HasCField Outside "outside_x"
-    where type CFieldType Outside "outside_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "outside_x" (Ptr Outside) (Ptr ty)
-    where getField = fromPtr (Proxy @"outside_x")
 instance (~) ty CInt => HasField "outside_x" Outside ty
     where hasField = \x_0 -> (\y_1 -> Outside{outside_x = y_1,
                                               outside_y = getField @"outside_y" x_0},
                               getField @"outside_x" x_0)
-instance HasCField Outside "outside_y"
-    where type CFieldType Outside "outside_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "outside_y" (Ptr Outside) (Ptr ty)
-    where getField = fromPtr (Proxy @"outside_y")
+instance (~) ty CInt => HasField "outside_x" (Ptr Outside) (Ptr ty)
+    where getField = fromPtr (Proxy @"outside_x")
+instance HasCField Outside "outside_x"
+    where type CFieldType Outside "outside_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "outside_y" Outside ty
     where hasField = \x_0 -> (\y_1 -> Outside{outside_y = y_1,
                                               outside_x = getField @"outside_x" x_0},
                               getField @"outside_y" x_0)
+instance (~) ty CInt => HasField "outside_y" (Ptr Outside) (Ptr ty)
+    where getField = fromPtr (Proxy @"outside_y")
+instance HasCField Outside "outside_y"
+    where type CFieldType Outside "outside_y" = CInt
+          offset# = \_ -> \_ -> 4
 -- __unique:__ @test_functionsdecls_in_signature_Example_Safe_normal@
 foreign import ccall safe "hs_bindgen_920e5c20f770432b" hs_bindgen_920e5c20f770432b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/Example.hs
@@ -84,6 +84,14 @@ newtype Size_t = Size_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapSize_t" Size_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Size_t {unwrapSize_t = y1}, RIP.getField @"unwrapSize_t" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapSize_t" (RIP.Ptr Size_t) (RIP.Ptr ty) where
 
   getField =
@@ -94,11 +102,3 @@ instance HasCField.HasCField Size_t "unwrapSize_t" where
   type CFieldType Size_t "unwrapSize_t" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapSize_t" Size_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Size_t {unwrapSize_t = y1}, RIP.getField @"unwrapSize_t" x0)

--- a/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/bindingspec.yaml
@@ -36,7 +36,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -44,6 +43,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/fun_attributes/th.txt
@@ -469,15 +469,15 @@ newtype Size_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapSize_t" Size_t ty
+    where hasField = \x_0 -> (\y_1 -> Size_t{unwrapSize_t = y_1},
+                              getField @"unwrapSize_t" x_0)
 instance (~) ty CInt =>
          HasField "unwrapSize_t" (Ptr Size_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSize_t")
 instance HasCField Size_t "unwrapSize_t"
     where type CFieldType Size_t "unwrapSize_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapSize_t" Size_t ty
-    where hasField = \x_0 -> (\y_1 -> Size_t{unwrapSize_t = y_1},
-                              getField @"unwrapSize_t" x_0)
 -- __unique:__ @test_functionsfun_attributes_Example_Safe___f1@
 foreign import ccall safe "hs_bindgen_0560fe42a40f777f" hs_bindgen_0560fe42a40f777f_base ::
     IO ()

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/Example.hs
@@ -63,17 +63,17 @@ instance Marshal.WriteRaw T where
 
 deriving via Marshal.EquivStorable T instance RIP.Storable T
 
-instance HasCField.HasCField T "t_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
 
-  type CFieldType T "t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
+instance HasCField.HasCField T "t_x" where
 
-  hasField =
-    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
+  type CFieldType T "t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - t_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct/th.txt
@@ -126,14 +126,14 @@ instance WriteRaw T
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
 deriving via (EquivStorable T) instance Storable T
-instance HasCField T "t_x"
-    where type CFieldType T "t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 instance (~) ty CInt => HasField "t_x" T ty
     where hasField = \x_0 -> (\y_1 -> T{t_x = y_1},
                               getField @"t_x" x_0)
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_functionsheap_typesstruct_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_a5d53f538e59b1fc" hs_bindgen_a5d53f538e59b1fc_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/Example.hs
@@ -63,17 +63,17 @@ instance Marshal.WriteRaw T where
 
 deriving via Marshal.EquivStorable T instance RIP.Storable T
 
-instance HasCField.HasCField T "t_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
 
-  type CFieldType T "t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
+instance HasCField.HasCField T "t_x" where
 
-  hasField =
-    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
+  type CFieldType T "t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - t_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const/th.txt
@@ -46,14 +46,14 @@ instance WriteRaw T
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
 deriving via (EquivStorable T) instance Storable T
-instance HasCField T "t_x"
-    where type CFieldType T "t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 instance (~) ty CInt => HasField "t_x" T ty
     where hasField = \x_0 -> (\y_1 -> T{t_x = y_1},
                               getField @"t_x" x_0)
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/Example.hs
@@ -63,17 +63,17 @@ instance Marshal.WriteRaw T where
 
 deriving via Marshal.EquivStorable T instance RIP.Storable T
 
-instance HasCField.HasCField T "t_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
 
-  type CFieldType T "t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "t_x" T ty where
+instance HasCField.HasCField T "t_x" where
 
-  hasField =
-    \x0 -> (\y1 -> T {t_x = y1}, RIP.getField @"t_x" x0)
+  type CFieldType T "t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - t_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_member/th.txt
@@ -46,14 +46,14 @@ instance WriteRaw T
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T t_x_2 -> writeRaw (Proxy @"t_x") ptr_0 t_x_2
 deriving via (EquivStorable T) instance Storable T
-instance HasCField T "t_x"
-    where type CFieldType T "t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 instance (~) ty CInt => HasField "t_x" T ty
     where hasField = \x_0 -> (\y_1 -> T{t_x = y_1},
                               getField @"t_x" x_0)
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
+instance HasCField T "t_x"
+    where type CFieldType T "t_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/Example.hs
@@ -65,20 +65,20 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s_x" S ty where
 
-  type CFieldType S "s_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s_x" S ty where
+instance HasCField.HasCField S "s_x" where
 
-  hasField =
-    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
+  type CFieldType S "s_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @T@
 
@@ -97,6 +97,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -106,9 +112,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = S
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - s_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/struct_const_typedef/th.txt
@@ -46,14 +46,14 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_x_2 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_x"
-    where type CFieldType S "s_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_x")
 instance (~) ty CInt => HasField "s_x" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_x = y_1},
                               getField @"s_x" x_0)
+instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_x")
+instance HasCField S "s_x"
+    where type CFieldType S "s_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @T@
 
     __defined at:__ @functions\/heap_types\/struct_const_typedef.h 7:24@
@@ -64,14 +64,14 @@ newtype T
     = T {unwrapT :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty S => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S
           offset# = \_ -> \_ -> 0
-instance (~) ty S => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 -- __unique:__ @test_functionsheap_typesstruct_co_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_67465eb5641985dc" hs_bindgen_67465eb5641985dc_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/Example.hs
@@ -67,12 +67,12 @@ set_t_x ::
   -> T
 set_t_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")
+
 instance HasCField.HasCField T "t_x" where
 
   type CFieldType T "t_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/bindingspec.yaml
@@ -19,7 +19,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union/th.txt
@@ -67,11 +67,11 @@ set_t_x :: CInt -> T
 
 -}
 set_t_x = setUnionPayload
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_9fc5746860ab93cb" hs_bindgen_9fc5746860ab93cb_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/Example.hs
@@ -67,12 +67,12 @@ set_t_x ::
   -> T
 set_t_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")
+
 instance HasCField.HasCField T "t_x" where
 
   type CFieldType T "t_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/bindingspec.yaml
@@ -19,7 +19,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const/th.txt
@@ -67,11 +67,11 @@ set_t_x :: CInt -> T
 
 -}
 set_t_x = setUnionPayload
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/Example.hs
@@ -67,12 +67,12 @@ set_t_x ::
   -> T
 set_t_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t_x")
+
 instance HasCField.HasCField T "t_x" where
 
   type CFieldType T "t_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "t_x" (RIP.Ptr T) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t_x")

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/bindingspec.yaml
@@ -19,7 +19,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_member/th.txt
@@ -67,11 +67,11 @@ set_t_x :: CInt -> T
 
 -}
 set_t_x = setUnionPayload
+instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"t_x")
 instance HasCField T "t_x"
     where type CFieldType T "t_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "t_x" (Ptr T) (Ptr ty)
-    where getField = fromPtr (Proxy @"t_x")
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/Example.hs
@@ -70,15 +70,15 @@ set_u_x ::
   -> U
 set_u_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"u_x")
+
 instance HasCField.HasCField U "u_x" where
 
   type CFieldType U "u_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "u_x" (RIP.Ptr U) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"u_x")
 
 {-| __C declaration:__ @T@
 
@@ -97,6 +97,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ U) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance (ty ~ U) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -106,9 +112,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = U
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ U) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/bindingspec.yaml
@@ -17,10 +17,11 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -34,7 +35,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/heap_types/union_const_typedef/th.txt
@@ -67,11 +67,11 @@ set_u_x :: CInt -> U
 
 -}
 set_u_x = setUnionPayload
+instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
+    where getField = fromPtr (Proxy @"u_x")
 instance HasCField U "u_x"
     where type CFieldType U "u_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "u_x" (Ptr U) (Ptr ty)
-    where getField = fromPtr (Proxy @"u_x")
 {-| __C declaration:__ @T@
 
     __defined at:__ @functions\/heap_types\/union_const_typedef.h 7:23@
@@ -82,14 +82,14 @@ newtype T
     = T {unwrapT :: U}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty U => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty U => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = U
           offset# = \_ -> \_ -> 0
-instance (~) ty U => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 -- __unique:__ @test_functionsheap_typesunion_con_Example_Safe_fun@
 foreign import ccall safe "hs_bindgen_8a303cd5b4f7787b" hs_bindgen_8a303cd5b4f7787b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/Example.hs
@@ -75,6 +75,15 @@ instance RIP.FromFunPtr RunDriver_Aux where
   fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 
 instance ( ty ~ (RIP.Ptr Driver -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapRunDriver_Aux" RunDriver_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> RunDriver_Aux {unwrapRunDriver_Aux = y1}
+      , RIP.getField @"unwrapRunDriver_Aux" x0
+      )
+
+instance ( ty ~ (RIP.Ptr Driver -> IO RIP.CInt)
          ) => RIP.HasField "unwrapRunDriver_Aux" (RIP.Ptr RunDriver_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -86,15 +95,6 @@ instance HasCField.HasCField RunDriver_Aux "unwrapRunDriver_Aux" where
     RIP.Ptr Driver -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.Ptr Driver -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapRunDriver_Aux" RunDriver_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> RunDriver_Aux {unwrapRunDriver_Aux = y1}
-      , RIP.getField @"unwrapRunDriver_Aux" x0
-      )
 
 {-| __C declaration:__ @RunDriver@
 
@@ -115,6 +115,14 @@ newtype RunDriver = RunDriver
     )
 
 instance ( ty ~ RIP.FunPtr RunDriver_Aux
+         ) => RIP.CompatHasField.HasField "unwrapRunDriver" RunDriver ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         RunDriver {unwrapRunDriver = y1}, RIP.getField @"unwrapRunDriver" x0)
+
+instance ( ty ~ RIP.FunPtr RunDriver_Aux
          ) => RIP.HasField "unwrapRunDriver" (RIP.Ptr RunDriver) (RIP.Ptr ty) where
 
   getField =
@@ -126,14 +134,6 @@ instance HasCField.HasCField RunDriver "unwrapRunDriver" where
     RIP.FunPtr RunDriver_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr RunDriver_Aux
-         ) => RIP.CompatHasField.HasField "unwrapRunDriver" RunDriver ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         RunDriver {unwrapRunDriver = y1}, RIP.getField @"unwrapRunDriver" x0)
 
 {-| __C declaration:__ @struct Driver@
 
@@ -176,18 +176,6 @@ instance Marshal.WriteRaw Driver where
 
 deriving via Marshal.EquivStorable Driver instance RIP.Storable Driver
 
-instance HasCField.HasCField Driver "driver_run" where
-
-  type CFieldType Driver "driver_run" = RunDriver
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RunDriver
-         ) => RIP.HasField "driver_run" (RIP.Ptr Driver) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"driver_run")
-
 instance ( ty ~ RunDriver
          ) => RIP.CompatHasField.HasField "driver_run" Driver ty where
 
@@ -195,6 +183,18 @@ instance ( ty ~ RunDriver
     \x0 ->
       (\y1 ->
          Driver {driver_run = y1}, RIP.getField @"driver_run" x0)
+
+instance ( ty ~ RunDriver
+         ) => RIP.HasField "driver_run" (RIP.Ptr Driver) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"driver_run")
+
+instance HasCField.HasCField Driver "driver_run" where
+
+  type CFieldType Driver "driver_run" = RunDriver
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct Bare@
 
@@ -237,19 +237,6 @@ instance Marshal.WriteRaw Bare where
 
 deriving via Marshal.EquivStorable Bare instance RIP.Storable Bare
 
-instance HasCField.HasCField Bare "bare_callback" where
-
-  type CFieldType Bare "bare_callback" =
-    RIP.FunPtr (RIP.CInt -> IO ())
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
-         ) => RIP.HasField "bare_callback" (RIP.Ptr Bare) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"bare_callback")
-
 instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
          ) => RIP.CompatHasField.HasField "bare_callback" Bare ty where
 
@@ -257,3 +244,16 @@ instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
     \x0 ->
       (\y1 ->
          Bare {bare_callback = y1}, RIP.getField @"bare_callback" x0)
+
+instance ( ty ~ RIP.FunPtr (RIP.CInt -> IO ())
+         ) => RIP.HasField "bare_callback" (RIP.Ptr Bare) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"bare_callback")
+
+instance HasCField.HasCField Bare "bare_callback" where
+
+  type CFieldType Bare "bare_callback" =
+    RIP.FunPtr (RIP.CInt -> IO ())
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - bare_callback
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       fields:
       - driver_run
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,12 +56,13 @@ hstypes:
       fields:
       - unwrapRunDriver
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/typedef_funptr/th.txt
@@ -35,16 +35,16 @@ instance ToFunPtr RunDriver_Aux
 instance FromFunPtr RunDriver_Aux
     where fromFunPtr = hs_bindgen_6520ae39b50ffb4e
 instance (~) ty (Ptr Driver -> IO CInt) =>
+         HasField "unwrapRunDriver_Aux" RunDriver_Aux ty
+    where hasField = \x_0 -> (\y_1 -> RunDriver_Aux{unwrapRunDriver_Aux = y_1},
+                              getField @"unwrapRunDriver_Aux" x_0)
+instance (~) ty (Ptr Driver -> IO CInt) =>
          HasField "unwrapRunDriver_Aux" (Ptr RunDriver_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapRunDriver_Aux")
 instance HasCField RunDriver_Aux "unwrapRunDriver_Aux"
     where type CFieldType RunDriver_Aux
                           "unwrapRunDriver_Aux" = Ptr Driver -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Driver -> IO CInt) =>
-         HasField "unwrapRunDriver_Aux" RunDriver_Aux ty
-    where hasField = \x_0 -> (\y_1 -> RunDriver_Aux{unwrapRunDriver_Aux = y_1},
-                              getField @"unwrapRunDriver_Aux" x_0)
 {-| __C declaration:__ @RunDriver@
 
     __defined at:__ @functions\/typedef_funptr.h 12:15@
@@ -60,16 +60,16 @@ newtype RunDriver
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr RunDriver_Aux) =>
+         HasField "unwrapRunDriver" RunDriver ty
+    where hasField = \x_0 -> (\y_1 -> RunDriver{unwrapRunDriver = y_1},
+                              getField @"unwrapRunDriver" x_0)
+instance (~) ty (FunPtr RunDriver_Aux) =>
          HasField "unwrapRunDriver" (Ptr RunDriver) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapRunDriver")
 instance HasCField RunDriver "unwrapRunDriver"
     where type CFieldType RunDriver
                           "unwrapRunDriver" = FunPtr RunDriver_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr RunDriver_Aux) =>
-         HasField "unwrapRunDriver" RunDriver ty
-    where hasField = \x_0 -> (\y_1 -> RunDriver{unwrapRunDriver = y_1},
-                              getField @"unwrapRunDriver" x_0)
 {-| __C declaration:__ @struct Driver@
 
     __defined at:__ @functions\/typedef_funptr.h 13:8@
@@ -94,15 +94,15 @@ instance WriteRaw Driver
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Driver driver_run_2 -> writeRaw (Proxy @"driver_run") ptr_0 driver_run_2
 deriving via (EquivStorable Driver) instance Storable Driver
-instance HasCField Driver "driver_run"
-    where type CFieldType Driver "driver_run" = RunDriver
-          offset# = \_ -> \_ -> 0
-instance (~) ty RunDriver =>
-         HasField "driver_run" (Ptr Driver) (Ptr ty)
-    where getField = fromPtr (Proxy @"driver_run")
 instance (~) ty RunDriver => HasField "driver_run" Driver ty
     where hasField = \x_0 -> (\y_1 -> Driver{driver_run = y_1},
                               getField @"driver_run" x_0)
+instance (~) ty RunDriver =>
+         HasField "driver_run" (Ptr Driver) (Ptr ty)
+    where getField = fromPtr (Proxy @"driver_run")
+instance HasCField Driver "driver_run"
+    where type CFieldType Driver "driver_run" = RunDriver
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct Bare@
 
     __defined at:__ @functions\/typedef_funptr.h 20:8@
@@ -127,13 +127,13 @@ instance WriteRaw Bare
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Bare bare_callback_2 -> writeRaw (Proxy @"bare_callback") ptr_0 bare_callback_2
 deriving via (EquivStorable Bare) instance Storable Bare
-instance HasCField Bare "bare_callback"
-    where type CFieldType Bare "bare_callback" = FunPtr (CInt -> IO ())
-          offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr (CInt -> IO ())) =>
-         HasField "bare_callback" (Ptr Bare) (Ptr ty)
-    where getField = fromPtr (Proxy @"bare_callback")
 instance (~) ty (FunPtr (CInt -> IO ())) =>
          HasField "bare_callback" Bare ty
     where hasField = \x_0 -> (\y_1 -> Bare{bare_callback = y_1},
                               getField @"bare_callback" x_0)
+instance (~) ty (FunPtr (CInt -> IO ())) =>
+         HasField "bare_callback" (Ptr Bare) (Ptr ty)
+    where getField = fromPtr (Proxy @"bare_callback")
+instance HasCField Bare "bare_callback"
+    where type CFieldType Bare "bare_callback" = FunPtr (CInt -> IO ())
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/globals/globals/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/globals/globals/Example.hs
@@ -77,17 +77,6 @@ instance Marshal.WriteRaw Config where
 
 deriving via Marshal.EquivStorable Config instance RIP.Storable Config
 
-instance HasCField.HasCField Config "config_x" where
-
-  type CFieldType Config "config_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "config_x" (RIP.Ptr Config) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"config_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "config_x" Config ty where
 
@@ -98,16 +87,16 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"config_x" x0
       )
 
-instance HasCField.HasCField Config "config_y" where
-
-  type CFieldType Config "config_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "config_y" (RIP.Ptr Config) (RIP.Ptr ty) where
+         ) => RIP.HasField "config_x" (RIP.Ptr Config) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"config_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"config_x")
+
+instance HasCField.HasCField Config "config_x" where
+
+  type CFieldType Config "config_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "config_y" Config ty where
@@ -118,6 +107,17 @@ instance ( ty ~ RIP.CInt
           Config {config_y = y1, config_x = RIP.getField @"config_x" x0}
       , RIP.getField @"config_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "config_y" (RIP.Ptr Config) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"config_y")
+
+instance HasCField.HasCField Config "config_y" where
+
+  type CFieldType Config "config_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct inline_struct@
 
@@ -169,19 +169,6 @@ instance Marshal.WriteRaw Inline_struct where
 
 deriving via Marshal.EquivStorable Inline_struct instance RIP.Storable Inline_struct
 
-instance HasCField.HasCField Inline_struct "inline_struct_x" where
-
-  type CFieldType Inline_struct "inline_struct_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inline_struct_x" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"inline_struct_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inline_struct_x" Inline_struct ty where
 
@@ -192,18 +179,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"inline_struct_x" x0
       )
 
-instance HasCField.HasCField Inline_struct "inline_struct_y" where
-
-  type CFieldType Inline_struct "inline_struct_y" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inline_struct_y" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
+         ) => RIP.HasField "inline_struct_x" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"inline_struct_y")
+    HasCField.fromPtr (RIP.Proxy @"inline_struct_x")
+
+instance HasCField.HasCField Inline_struct "inline_struct_x" where
+
+  type CFieldType Inline_struct "inline_struct_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inline_struct_y" Inline_struct ty where
@@ -214,6 +201,19 @@ instance ( ty ~ RIP.CInt
           Inline_struct {inline_struct_y = y1, inline_struct_x = RIP.getField @"inline_struct_x" x0}
       , RIP.getField @"inline_struct_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "inline_struct_y" (RIP.Ptr Inline_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"inline_struct_y")
+
+instance HasCField.HasCField Inline_struct "inline_struct_y" where
+
+  type CFieldType Inline_struct "inline_struct_y" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct version_t@
 
@@ -274,19 +274,6 @@ instance Marshal.WriteRaw Version_t where
 
 deriving via Marshal.EquivStorable Version_t instance RIP.Storable Version_t
 
-instance HasCField.HasCField Version_t "version_t_major" where
-
-  type CFieldType Version_t "version_t_major" =
-    HsBindgen.Runtime.LibC.Word8
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "version_t_major" (RIP.Ptr Version_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"version_t_major")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.CompatHasField.HasField "version_t_major" Version_t ty where
 
@@ -300,18 +287,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word8
       , RIP.getField @"version_t_major" x0
       )
 
-instance HasCField.HasCField Version_t "version_t_minor" where
-
-  type CFieldType Version_t "version_t_minor" =
-    HsBindgen.Runtime.LibC.Word16
-
-  offset# = \_ -> \_ -> 2
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "version_t_minor" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.HasField "version_t_major" (RIP.Ptr Version_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"version_t_minor")
+    HasCField.fromPtr (RIP.Proxy @"version_t_major")
+
+instance HasCField.HasCField Version_t "version_t_major" where
+
+  type CFieldType Version_t "version_t_major" =
+    HsBindgen.Runtime.LibC.Word8
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.CompatHasField.HasField "version_t_minor" Version_t ty where
@@ -326,18 +313,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word16
       , RIP.getField @"version_t_minor" x0
       )
 
-instance HasCField.HasCField Version_t "version_t_patch" where
-
-  type CFieldType Version_t "version_t_patch" =
-    HsBindgen.Runtime.LibC.Word8
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.HasField "version_t_patch" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.HasField "version_t_minor" (RIP.Ptr Version_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"version_t_patch")
+    HasCField.fromPtr (RIP.Proxy @"version_t_minor")
+
+instance HasCField.HasCField Version_t "version_t_minor" where
+
+  type CFieldType Version_t "version_t_minor" =
+    HsBindgen.Runtime.LibC.Word16
+
+  offset# = \_ -> \_ -> 2
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.CompatHasField.HasField "version_t_patch" Version_t ty where
@@ -351,6 +338,19 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word8
                     }
       , RIP.getField @"version_t_patch" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.HasField "version_t_patch" (RIP.Ptr Version_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"version_t_patch")
+
+instance HasCField.HasCField Version_t "version_t_patch" where
+
+  type CFieldType Version_t "version_t_patch" =
+    HsBindgen.Runtime.LibC.Word8
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct struct1_t@
 
@@ -411,19 +411,6 @@ instance Marshal.WriteRaw Struct1_t where
 
 deriving via Marshal.EquivStorable Struct1_t instance RIP.Storable Struct1_t
 
-instance HasCField.HasCField Struct1_t "struct1_t_x" where
-
-  type CFieldType Struct1_t "struct1_t_x" =
-    HsBindgen.Runtime.LibC.Word16
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.HasField "struct1_t_x" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"struct1_t_x")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.CompatHasField.HasField "struct1_t_x" Struct1_t ty where
 
@@ -437,17 +424,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word16
       , RIP.getField @"struct1_t_x" x0
       )
 
-instance HasCField.HasCField Struct1_t "struct1_t_y" where
-
-  type CFieldType Struct1_t "struct1_t_y" = RIP.CBool
-
-  offset# = \_ -> \_ -> 2
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "struct1_t_y" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.HasField "struct1_t_x" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"struct1_t_y")
+    HasCField.fromPtr (RIP.Proxy @"struct1_t_x")
+
+instance HasCField.HasCField Struct1_t "struct1_t_x" where
+
+  type CFieldType Struct1_t "struct1_t_x" =
+    HsBindgen.Runtime.LibC.Word16
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "struct1_t_y" Struct1_t ty where
@@ -462,18 +450,17 @@ instance ( ty ~ RIP.CBool
       , RIP.getField @"struct1_t_y" x0
       )
 
-instance HasCField.HasCField Struct1_t "struct1_t_version" where
-
-  type CFieldType Struct1_t "struct1_t_version" =
-    Version_t
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Version_t
-         ) => RIP.HasField "struct1_t_version" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CBool
+         ) => RIP.HasField "struct1_t_y" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"struct1_t_version")
+    HasCField.fromPtr (RIP.Proxy @"struct1_t_y")
+
+instance HasCField.HasCField Struct1_t "struct1_t_y" where
+
+  type CFieldType Struct1_t "struct1_t_y" = RIP.CBool
+
+  offset# = \_ -> \_ -> 2
 
 instance ( ty ~ Version_t
          ) => RIP.CompatHasField.HasField "struct1_t_version" Struct1_t ty where
@@ -487,6 +474,19 @@ instance ( ty ~ Version_t
                     }
       , RIP.getField @"struct1_t_version" x0
       )
+
+instance ( ty ~ Version_t
+         ) => RIP.HasField "struct1_t_version" (RIP.Ptr Struct1_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"struct1_t_version")
+
+instance HasCField.HasCField Struct1_t "struct1_t_version" where
+
+  type CFieldType Struct1_t "struct1_t_version" =
+    Version_t
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct struct2_t@
 
@@ -529,19 +529,6 @@ instance Marshal.WriteRaw Struct2_t where
 
 deriving via Marshal.EquivStorable Struct2_t instance RIP.Storable Struct2_t
 
-instance HasCField.HasCField Struct2_t "struct2_t_field1" where
-
-  type CFieldType Struct2_t "struct2_t_field1" =
-    Struct1_t
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct1_t
-         ) => RIP.HasField "struct2_t_field1" (RIP.Ptr Struct2_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"struct2_t_field1")
-
 instance ( ty ~ Struct1_t
          ) => RIP.CompatHasField.HasField "struct2_t_field1" Struct2_t ty where
 
@@ -550,3 +537,16 @@ instance ( ty ~ Struct1_t
       ( \y1 -> Struct2_t {struct2_t_field1 = y1}
       , RIP.getField @"struct2_t_field1" x0
       )
+
+instance ( ty ~ Struct1_t
+         ) => RIP.HasField "struct2_t_field1" (RIP.Ptr Struct2_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"struct2_t_field1")
+
+instance HasCField.HasCField Struct2_t "struct2_t_field1" where
+
+  type CFieldType Struct2_t "struct2_t_field1" =
+    Struct1_t
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/globals/globals/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/globals/globals/bindingspec.yaml
@@ -36,11 +36,12 @@ hstypes:
       - config_x
       - config_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,11 +55,12 @@ hstypes:
       - inline_struct_x
       - inline_struct_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,11 +75,12 @@ hstypes:
       - struct1_t_y
       - struct1_t_version
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +93,12 @@ hstypes:
       fields:
       - struct2_t_field1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,11 +113,12 @@ hstypes:
       - version_t_minor
       - version_t_patch
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/globals/globals/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/globals/globals/th.txt
@@ -157,24 +157,24 @@ instance WriteRaw Config
                                        Config config_x_2
                                               config_y_3 -> writeRaw (Proxy @"config_x") ptr_0 config_x_2 >> writeRaw (Proxy @"config_y") ptr_0 config_y_3
 deriving via (EquivStorable Config) instance Storable Config
-instance HasCField Config "config_x"
-    where type CFieldType Config "config_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "config_x" (Ptr Config) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_x")
 instance (~) ty CInt => HasField "config_x" Config ty
     where hasField = \x_0 -> (\y_1 -> Config{config_x = y_1,
                                              config_y = getField @"config_y" x_0},
                               getField @"config_x" x_0)
-instance HasCField Config "config_y"
-    where type CFieldType Config "config_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "config_y" (Ptr Config) (Ptr ty)
-    where getField = fromPtr (Proxy @"config_y")
+instance (~) ty CInt => HasField "config_x" (Ptr Config) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_x")
+instance HasCField Config "config_x"
+    where type CFieldType Config "config_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "config_y" Config ty
     where hasField = \x_0 -> (\y_1 -> Config{config_y = y_1,
                                              config_x = getField @"config_x" x_0},
                               getField @"config_y" x_0)
+instance (~) ty CInt => HasField "config_y" (Ptr Config) (Ptr ty)
+    where getField = fromPtr (Proxy @"config_y")
+instance HasCField Config "config_y"
+    where type CFieldType Config "config_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct inline_struct@
 
     __defined at:__ @globals\/globals.h 20:15@
@@ -207,26 +207,26 @@ instance WriteRaw Inline_struct
                                        Inline_struct inline_struct_x_2
                                                      inline_struct_y_3 -> writeRaw (Proxy @"inline_struct_x") ptr_0 inline_struct_x_2 >> writeRaw (Proxy @"inline_struct_y") ptr_0 inline_struct_y_3
 deriving via (EquivStorable Inline_struct) instance Storable Inline_struct
-instance HasCField Inline_struct "inline_struct_x"
-    where type CFieldType Inline_struct "inline_struct_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inline_struct_x" (Ptr Inline_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"inline_struct_x")
 instance (~) ty CInt => HasField "inline_struct_x" Inline_struct ty
     where hasField = \x_0 -> (\y_1 -> Inline_struct{inline_struct_x = y_1,
                                                     inline_struct_y = getField @"inline_struct_y" x_0},
                               getField @"inline_struct_x" x_0)
-instance HasCField Inline_struct "inline_struct_y"
-    where type CFieldType Inline_struct "inline_struct_y" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "inline_struct_y" (Ptr Inline_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"inline_struct_y")
+         HasField "inline_struct_x" (Ptr Inline_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"inline_struct_x")
+instance HasCField Inline_struct "inline_struct_x"
+    where type CFieldType Inline_struct "inline_struct_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "inline_struct_y" Inline_struct ty
     where hasField = \x_0 -> (\y_1 -> Inline_struct{inline_struct_y = y_1,
                                                     inline_struct_x = getField @"inline_struct_x" x_0},
                               getField @"inline_struct_y" x_0)
+instance (~) ty CInt =>
+         HasField "inline_struct_y" (Ptr Inline_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"inline_struct_y")
+instance HasCField Inline_struct "inline_struct_y"
+    where type CFieldType Inline_struct "inline_struct_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct version_t@
 
     __defined at:__ @globals\/globals.h 407:9@
@@ -267,45 +267,45 @@ instance WriteRaw Version_t
                                                  version_t_minor_3
                                                  version_t_patch_4 -> writeRaw (Proxy @"version_t_major") ptr_0 version_t_major_2 >> (writeRaw (Proxy @"version_t_minor") ptr_0 version_t_minor_3 >> writeRaw (Proxy @"version_t_patch") ptr_0 version_t_patch_4)
 deriving via (EquivStorable Version_t) instance Storable Version_t
-instance HasCField Version_t "version_t_major"
-    where type CFieldType Version_t
-                          "version_t_major" = HsBindgen.Runtime.LibC.Word8
-          offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "version_t_major" (Ptr Version_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"version_t_major")
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "version_t_major" Version_t ty
     where hasField = \x_0 -> (\y_1 -> Version_t{version_t_major = y_1,
                                                 version_t_minor = getField @"version_t_minor" x_0,
                                                 version_t_patch = getField @"version_t_patch" x_0},
                               getField @"version_t_major" x_0)
-instance HasCField Version_t "version_t_minor"
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "version_t_major" (Ptr Version_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"version_t_major")
+instance HasCField Version_t "version_t_major"
     where type CFieldType Version_t
-                          "version_t_minor" = HsBindgen.Runtime.LibC.Word16
-          offset# = \_ -> \_ -> 2
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "version_t_minor" (Ptr Version_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"version_t_minor")
+                          "version_t_major" = HsBindgen.Runtime.LibC.Word8
+          offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "version_t_minor" Version_t ty
     where hasField = \x_0 -> (\y_1 -> Version_t{version_t_minor = y_1,
                                                 version_t_major = getField @"version_t_major" x_0,
                                                 version_t_patch = getField @"version_t_patch" x_0},
                               getField @"version_t_minor" x_0)
-instance HasCField Version_t "version_t_patch"
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "version_t_minor" (Ptr Version_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"version_t_minor")
+instance HasCField Version_t "version_t_minor"
     where type CFieldType Version_t
-                          "version_t_patch" = HsBindgen.Runtime.LibC.Word8
-          offset# = \_ -> \_ -> 4
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "version_t_patch" (Ptr Version_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"version_t_patch")
+                          "version_t_minor" = HsBindgen.Runtime.LibC.Word16
+          offset# = \_ -> \_ -> 2
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "version_t_patch" Version_t ty
     where hasField = \x_0 -> (\y_1 -> Version_t{version_t_patch = y_1,
                                                 version_t_major = getField @"version_t_major" x_0,
                                                 version_t_minor = getField @"version_t_minor" x_0},
                               getField @"version_t_patch" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "version_t_patch" (Ptr Version_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"version_t_patch")
+instance HasCField Version_t "version_t_patch"
+    where type CFieldType Version_t
+                          "version_t_patch" = HsBindgen.Runtime.LibC.Word8
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct struct1_t@
 
     __defined at:__ @globals\/globals.h 414:9@
@@ -346,42 +346,42 @@ instance WriteRaw Struct1_t
                                                  struct1_t_y_3
                                                  struct1_t_version_4 -> writeRaw (Proxy @"struct1_t_x") ptr_0 struct1_t_x_2 >> (writeRaw (Proxy @"struct1_t_y") ptr_0 struct1_t_y_3 >> writeRaw (Proxy @"struct1_t_version") ptr_0 struct1_t_version_4)
 deriving via (EquivStorable Struct1_t) instance Storable Struct1_t
-instance HasCField Struct1_t "struct1_t_x"
-    where type CFieldType Struct1_t
-                          "struct1_t_x" = HsBindgen.Runtime.LibC.Word16
-          offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "struct1_t_x" (Ptr Struct1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct1_t_x")
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "struct1_t_x" Struct1_t ty
     where hasField = \x_0 -> (\y_1 -> Struct1_t{struct1_t_x = y_1,
                                                 struct1_t_y = getField @"struct1_t_y" x_0,
                                                 struct1_t_version = getField @"struct1_t_version" x_0},
                               getField @"struct1_t_x" x_0)
-instance HasCField Struct1_t "struct1_t_y"
-    where type CFieldType Struct1_t "struct1_t_y" = CBool
-          offset# = \_ -> \_ -> 2
-instance (~) ty CBool =>
-         HasField "struct1_t_y" (Ptr Struct1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct1_t_y")
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "struct1_t_x" (Ptr Struct1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct1_t_x")
+instance HasCField Struct1_t "struct1_t_x"
+    where type CFieldType Struct1_t
+                          "struct1_t_x" = HsBindgen.Runtime.LibC.Word16
+          offset# = \_ -> \_ -> 0
 instance (~) ty CBool => HasField "struct1_t_y" Struct1_t ty
     where hasField = \x_0 -> (\y_1 -> Struct1_t{struct1_t_y = y_1,
                                                 struct1_t_x = getField @"struct1_t_x" x_0,
                                                 struct1_t_version = getField @"struct1_t_version" x_0},
                               getField @"struct1_t_y" x_0)
-instance HasCField Struct1_t "struct1_t_version"
-    where type CFieldType Struct1_t "struct1_t_version" = Version_t
-          offset# = \_ -> \_ -> 4
-instance (~) ty Version_t =>
-         HasField "struct1_t_version" (Ptr Struct1_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct1_t_version")
+instance (~) ty CBool =>
+         HasField "struct1_t_y" (Ptr Struct1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct1_t_y")
+instance HasCField Struct1_t "struct1_t_y"
+    where type CFieldType Struct1_t "struct1_t_y" = CBool
+          offset# = \_ -> \_ -> 2
 instance (~) ty Version_t =>
          HasField "struct1_t_version" Struct1_t ty
     where hasField = \x_0 -> (\y_1 -> Struct1_t{struct1_t_version = y_1,
                                                 struct1_t_x = getField @"struct1_t_x" x_0,
                                                 struct1_t_y = getField @"struct1_t_y" x_0},
                               getField @"struct1_t_version" x_0)
+instance (~) ty Version_t =>
+         HasField "struct1_t_version" (Ptr Struct1_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct1_t_version")
+instance HasCField Struct1_t "struct1_t_version"
+    where type CFieldType Struct1_t "struct1_t_version" = Version_t
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct struct2_t@
 
     __defined at:__ @globals\/globals.h 421:9@
@@ -406,16 +406,16 @@ instance WriteRaw Struct2_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct2_t struct2_t_field1_2 -> writeRaw (Proxy @"struct2_t_field1") ptr_0 struct2_t_field1_2
 deriving via (EquivStorable Struct2_t) instance Storable Struct2_t
-instance HasCField Struct2_t "struct2_t_field1"
-    where type CFieldType Struct2_t "struct2_t_field1" = Struct1_t
-          offset# = \_ -> \_ -> 0
-instance (~) ty Struct1_t =>
-         HasField "struct2_t_field1" (Ptr Struct2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct2_t_field1")
 instance (~) ty Struct1_t =>
          HasField "struct2_t_field1" Struct2_t ty
     where hasField = \x_0 -> (\y_1 -> Struct2_t{struct2_t_field1 = y_1},
                               getField @"struct2_t_field1" x_0)
+instance (~) ty Struct1_t =>
+         HasField "struct2_t_field1" (Ptr Struct2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct2_t_field1")
+instance HasCField Struct2_t "struct2_t_field1"
+    where type CFieldType Struct2_t "struct2_t_field1" = Struct1_t
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_globalsglobals_Example_get_simpleGlobal@
 foreign import ccall unsafe "hs_bindgen_4f8e7b3d91414aa8" hs_bindgen_4f8e7b3d91414aa8_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/Example.hs
@@ -90,18 +90,6 @@ instance Marshal.WriteRaw AnonPoint where
 
 deriving via Marshal.EquivStorable AnonPoint instance RIP.Storable AnonPoint
 
-instance HasCField.HasCField AnonPoint "anonPoint_x" where
-
-  type CFieldType AnonPoint "anonPoint_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPoint_x" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"anonPoint_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "anonPoint_x" AnonPoint ty where
 
@@ -112,17 +100,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"anonPoint_x" x0
       )
 
-instance HasCField.HasCField AnonPoint "anonPoint_y" where
-
-  type CFieldType AnonPoint "anonPoint_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPoint_y" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
+         ) => RIP.HasField "anonPoint_x" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"anonPoint_y")
+    HasCField.fromPtr (RIP.Proxy @"anonPoint_x")
+
+instance HasCField.HasCField AnonPoint "anonPoint_x" where
+
+  type CFieldType AnonPoint "anonPoint_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "anonPoint_y" AnonPoint ty where
@@ -133,6 +121,18 @@ instance ( ty ~ RIP.CInt
           AnonPoint {anonPoint_y = y1, anonPoint_x = RIP.getField @"anonPoint_x" x0}
       , RIP.getField @"anonPoint_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "anonPoint_y" (RIP.Ptr AnonPoint) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anonPoint_y")
+
+instance HasCField.HasCField AnonPoint "anonPoint_y" where
+
+  type CFieldType AnonPoint "anonPoint_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@anonPair@
 
@@ -184,18 +184,6 @@ instance Marshal.WriteRaw AnonPair where
 
 deriving via Marshal.EquivStorable AnonPair instance RIP.Storable AnonPair
 
-instance HasCField.HasCField AnonPair "anonPair_a" where
-
-  type CFieldType AnonPair "anonPair_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPair_a" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"anonPair_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "anonPair_a" AnonPair ty where
 
@@ -206,17 +194,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"anonPair_a" x0
       )
 
-instance HasCField.HasCField AnonPair "anonPair_b" where
-
-  type CFieldType AnonPair "anonPair_b" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "anonPair_b" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
+         ) => RIP.HasField "anonPair_a" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"anonPair_b")
+    HasCField.fromPtr (RIP.Proxy @"anonPair_a")
+
+instance HasCField.HasCField AnonPair "anonPair_a" where
+
+  type CFieldType AnonPair "anonPair_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "anonPair_b" AnonPair ty where
@@ -227,6 +215,18 @@ instance ( ty ~ RIP.CInt
           AnonPair {anonPair_b = y1, anonPair_a = RIP.getField @"anonPair_a" x0}
       , RIP.getField @"anonPair_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "anonPair_b" (RIP.Ptr AnonPair) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anonPair_b")
+
+instance HasCField.HasCField AnonPair "anonPair_b" where
+
+  type CFieldType AnonPair "anonPair_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @enum \@anonEnum@
 
@@ -307,6 +307,14 @@ instance Read AnonEnum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapAnonEnum" AnonEnum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         AnonEnum {unwrapAnonEnum = y1}, RIP.getField @"unwrapAnonEnum" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapAnonEnum" (RIP.Ptr AnonEnum) (RIP.Ptr ty) where
 
   getField =
@@ -317,14 +325,6 @@ instance HasCField.HasCField AnonEnum "unwrapAnonEnum" where
   type CFieldType AnonEnum "unwrapAnonEnum" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapAnonEnum" AnonEnum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         AnonEnum {unwrapAnonEnum = y1}, RIP.getField @"unwrapAnonEnum" x0)
 
 {-| __C declaration:__ @VAL_A@
 
@@ -413,6 +413,15 @@ instance Read AnonEnumCoords where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapAnonEnumCoords" AnonEnumCoords ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> AnonEnumCoords {unwrapAnonEnumCoords = y1}
+      , RIP.getField @"unwrapAnonEnumCoords" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapAnonEnumCoords" (RIP.Ptr AnonEnumCoords) (RIP.Ptr ty) where
 
   getField =
@@ -424,15 +433,6 @@ instance HasCField.HasCField AnonEnumCoords "unwrapAnonEnumCoords" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapAnonEnumCoords" AnonEnumCoords ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> AnonEnumCoords {unwrapAnonEnumCoords = y1}
-      , RIP.getField @"unwrapAnonEnumCoords" x0
-      )
 
 {-| __C declaration:__ @X@
 
@@ -538,6 +538,12 @@ instance Read A where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -548,12 +554,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @a1@
 
@@ -608,15 +608,15 @@ set_b_x ::
   -> B
 set_b_x = RIP.setUnionPayload
 
+instance (ty ~ RIP.CInt) => RIP.HasField "b_x" (RIP.Ptr B) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b_x")
+
 instance HasCField.HasCField B "b_x" where
 
   type CFieldType B "b_x" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "b_x" (RIP.Ptr B) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"b_x")
 
 {-| __C declaration:__ @struct \@C@
 
@@ -659,17 +659,17 @@ instance Marshal.WriteRaw C where
 
 deriving via Marshal.EquivStorable C instance RIP.Storable C
 
-instance HasCField.HasCField C "c_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "c_x" C ty where
 
-  type CFieldType C "c_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> C {c_x = y1}, RIP.getField @"c_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "c_x" (RIP.Ptr C) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"c_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "c_x" C ty where
+instance HasCField.HasCField C "c_x" where
 
-  hasField =
-    \x0 -> (\y1 -> C {c_x = y1}, RIP.getField @"c_x" x0)
+  type CFieldType C "c_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/bindingspec.yaml
@@ -33,12 +33,13 @@ hstypes:
       - unwrapA
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -56,12 +57,13 @@ hstypes:
       - unwrapAnonEnum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -79,12 +81,13 @@ hstypes:
       - unwrapAnonEnumCoords
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -101,11 +104,12 @@ hstypes:
       - anonPair_a
       - anonPair_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -119,11 +123,12 @@ hstypes:
       - anonPoint_x
       - anonPoint_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -138,7 +143,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -150,11 +155,12 @@ hstypes:
       fields:
       - c_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/th.txt
@@ -74,26 +74,26 @@ instance WriteRaw AnonPoint
                                        AnonPoint anonPoint_x_2
                                                  anonPoint_y_3 -> writeRaw (Proxy @"anonPoint_x") ptr_0 anonPoint_x_2 >> writeRaw (Proxy @"anonPoint_y") ptr_0 anonPoint_y_3
 deriving via (EquivStorable AnonPoint) instance Storable AnonPoint
-instance HasCField AnonPoint "anonPoint_x"
-    where type CFieldType AnonPoint "anonPoint_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "anonPoint_x" (Ptr AnonPoint) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonPoint_x")
 instance (~) ty CInt => HasField "anonPoint_x" AnonPoint ty
     where hasField = \x_0 -> (\y_1 -> AnonPoint{anonPoint_x = y_1,
                                                 anonPoint_y = getField @"anonPoint_y" x_0},
                               getField @"anonPoint_x" x_0)
-instance HasCField AnonPoint "anonPoint_y"
-    where type CFieldType AnonPoint "anonPoint_y" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "anonPoint_y" (Ptr AnonPoint) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonPoint_y")
+         HasField "anonPoint_x" (Ptr AnonPoint) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonPoint_x")
+instance HasCField AnonPoint "anonPoint_x"
+    where type CFieldType AnonPoint "anonPoint_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "anonPoint_y" AnonPoint ty
     where hasField = \x_0 -> (\y_1 -> AnonPoint{anonPoint_y = y_1,
                                                 anonPoint_x = getField @"anonPoint_x" x_0},
                               getField @"anonPoint_y" x_0)
+instance (~) ty CInt =>
+         HasField "anonPoint_y" (Ptr AnonPoint) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonPoint_y")
+instance HasCField AnonPoint "anonPoint_y"
+    where type CFieldType AnonPoint "anonPoint_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@anonPair@
 
     __defined at:__ @globals\/untagged.h 14:1@
@@ -126,26 +126,26 @@ instance WriteRaw AnonPair
                                        AnonPair anonPair_a_2
                                                 anonPair_b_3 -> writeRaw (Proxy @"anonPair_a") ptr_0 anonPair_a_2 >> writeRaw (Proxy @"anonPair_b") ptr_0 anonPair_b_3
 deriving via (EquivStorable AnonPair) instance Storable AnonPair
-instance HasCField AnonPair "anonPair_a"
-    where type CFieldType AnonPair "anonPair_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "anonPair_a" (Ptr AnonPair) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonPair_a")
 instance (~) ty CInt => HasField "anonPair_a" AnonPair ty
     where hasField = \x_0 -> (\y_1 -> AnonPair{anonPair_a = y_1,
                                                anonPair_b = getField @"anonPair_b" x_0},
                               getField @"anonPair_a" x_0)
-instance HasCField AnonPair "anonPair_b"
-    where type CFieldType AnonPair "anonPair_b" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "anonPair_b" (Ptr AnonPair) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonPair_b")
+         HasField "anonPair_a" (Ptr AnonPair) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonPair_a")
+instance HasCField AnonPair "anonPair_a"
+    where type CFieldType AnonPair "anonPair_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "anonPair_b" AnonPair ty
     where hasField = \x_0 -> (\y_1 -> AnonPair{anonPair_b = y_1,
                                                anonPair_a = getField @"anonPair_a" x_0},
                               getField @"anonPair_b" x_0)
+instance (~) ty CInt =>
+         HasField "anonPair_b" (Ptr AnonPair) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonPair_b")
+instance HasCField AnonPair "anonPair_b"
+    where type CFieldType AnonPair "anonPair_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @enum \@anonEnum@
 
     __defined at:__ @globals\/untagged.h 16:1@
@@ -186,15 +186,15 @@ instance Read AnonEnum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapAnonEnum" AnonEnum ty
+    where hasField = \x_0 -> (\y_1 -> AnonEnum{unwrapAnonEnum = y_1},
+                              getField @"unwrapAnonEnum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapAnonEnum" (Ptr AnonEnum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapAnonEnum")
 instance HasCField AnonEnum "unwrapAnonEnum"
     where type CFieldType AnonEnum "unwrapAnonEnum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapAnonEnum" AnonEnum ty
-    where hasField = \x_0 -> (\y_1 -> AnonEnum{unwrapAnonEnum = y_1},
-                              getField @"unwrapAnonEnum" x_0)
 {-| __C declaration:__ @VAL_A@
 
     __defined at:__ @globals\/untagged.h 16:8@
@@ -247,15 +247,15 @@ instance Read AnonEnumCoords
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CUInt =>
+         HasField "unwrapAnonEnumCoords" AnonEnumCoords ty
+    where hasField = \x_0 -> (\y_1 -> AnonEnumCoords{unwrapAnonEnumCoords = y_1},
+                              getField @"unwrapAnonEnumCoords" x_0)
+instance (~) ty CUInt =>
          HasField "unwrapAnonEnumCoords" (Ptr AnonEnumCoords) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapAnonEnumCoords")
 instance HasCField AnonEnumCoords "unwrapAnonEnumCoords"
     where type CFieldType AnonEnumCoords "unwrapAnonEnumCoords" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unwrapAnonEnumCoords" AnonEnumCoords ty
-    where hasField = \x_0 -> (\y_1 -> AnonEnumCoords{unwrapAnonEnumCoords = y_1},
-                              getField @"unwrapAnonEnumCoords" x_0)
 {-| __C declaration:__ @X@
 
     __defined at:__ @globals\/untagged.h 18:8@
@@ -318,14 +318,14 @@ instance Read A
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CUInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @a1@
 
     __defined at:__ @globals\/untagged.h 24:8@
@@ -379,11 +379,11 @@ set_b_x :: CInt -> B
 
 -}
 set_b_x = setUnionPayload
+instance (~) ty CInt => HasField "b_x" (Ptr B) (Ptr ty)
+    where getField = fromPtr (Proxy @"b_x")
 instance HasCField B "b_x"
     where type CFieldType B "b_x" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "b_x" (Ptr B) (Ptr ty)
-    where getField = fromPtr (Proxy @"b_x")
 {-| __C declaration:__ @struct \@C@
 
     __defined at:__ @globals\/untagged.h 30:1@
@@ -408,14 +408,14 @@ instance WriteRaw C
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        C c_x_2 -> writeRaw (Proxy @"c_x") ptr_0 c_x_2
 deriving via (EquivStorable C) instance Storable C
-instance HasCField C "c_x"
-    where type CFieldType C "c_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "c_x" (Ptr C) (Ptr ty)
-    where getField = fromPtr (Proxy @"c_x")
 instance (~) ty CInt => HasField "c_x" C ty
     where hasField = \x_0 -> (\y_1 -> C{c_x = y_1},
                               getField @"c_x" x_0)
+instance (~) ty CInt => HasField "c_x" (Ptr C) (Ptr ty)
+    where getField = fromPtr (Proxy @"c_x")
+instance HasCField C "c_x"
+    where type CFieldType C "c_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_globalsuntagged_Example_get_anonPoint@
 foreign import ccall unsafe "hs_bindgen_6629eeb3c2ffd60b" hs_bindgen_6629eeb3c2ffd60b_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/Example.hs
@@ -31,6 +31,12 @@ newtype B = B
   }
   deriving stock (RIP.Generic)
 
+instance (ty ~ M.A) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
 instance (ty ~ M.A) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
@@ -40,9 +46,3 @@ instance HasCField.HasCField B "unwrapB" where
   type CFieldType B "unwrapB" = M.A
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M.A) => RIP.CompatHasField.HasField "unwrapB" B ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/bindingspec.yaml
@@ -14,7 +14,8 @@ hstypes:
       fields:
       - unwrapB
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_ext_binding_dep/th.txt
@@ -27,14 +27,14 @@
     __exported by:__ @macros\/macro_ext_binding_dep.h@
 -}
 newtype B = B {unwrapB :: M.A} deriving stock Generic
+instance (~) ty M.A => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
 instance (~) ty M.A => HasField "unwrapB" (Ptr B) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapB")
 instance HasCField B "unwrapB"
     where type CFieldType B "unwrapB" = M.A
           offset# = \_ -> \_ -> 0
-instance (~) ty M.A => HasField "unwrapB" B ty
-    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
-                              getField @"unwrapB" x_0)
 -- __unique:__ @test_macrosmacro_ext_binding_dep_Example_Safe_use_b@
 foreign import ccall safe "hs_bindgen_f70130e6504e0e5e" hs_bindgen_f70130e6504e0e5e_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/Example.hs
@@ -54,6 +54,12 @@ newtype I = I
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapI" I ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> I {unwrapI = y1}, RIP.getField @"unwrapI" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr ty) where
 
@@ -64,12 +70,6 @@ instance HasCField.HasCField I "unwrapI" where
   type CFieldType I "unwrapI" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapI" I ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> I {unwrapI = y1}, RIP.getField @"unwrapI" x0)
 
 {-| __C declaration:__ @macro C@
 
@@ -99,6 +99,12 @@ newtype C = C
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapC" C ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> C {unwrapC = y1}, RIP.getField @"unwrapC" x0)
+
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapC" (RIP.Ptr C) (RIP.Ptr ty) where
 
@@ -109,12 +115,6 @@ instance HasCField.HasCField C "unwrapC" where
   type CFieldType C "unwrapC" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapC" C ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> C {unwrapC = y1}, RIP.getField @"unwrapC" x0)
 
 {-| __C declaration:__ @macro F@
 
@@ -142,6 +142,12 @@ newtype F = F
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "unwrapF" F ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> F {unwrapF = y1}, RIP.getField @"unwrapF" x0)
+
 instance ( ty ~ RIP.CFloat
          ) => RIP.HasField "unwrapF" (RIP.Ptr F) (RIP.Ptr ty) where
 
@@ -152,12 +158,6 @@ instance HasCField.HasCField F "unwrapF" where
   type CFieldType F "unwrapF" = RIP.CFloat
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "unwrapF" F ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> F {unwrapF = y1}, RIP.getField @"unwrapF" x0)
 
 {-| __C declaration:__ @macro L@
 
@@ -187,6 +187,12 @@ newtype L = L
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CLong) => RIP.CompatHasField.HasField "unwrapL" L ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> L {unwrapL = y1}, RIP.getField @"unwrapL" x0)
+
 instance ( ty ~ RIP.CLong
          ) => RIP.HasField "unwrapL" (RIP.Ptr L) (RIP.Ptr ty) where
 
@@ -197,12 +203,6 @@ instance HasCField.HasCField L "unwrapL" where
   type CFieldType L "unwrapL" = RIP.CLong
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CLong) => RIP.CompatHasField.HasField "unwrapL" L ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> L {unwrapL = y1}, RIP.getField @"unwrapL" x0)
 
 {-| __C declaration:__ @macro S@
 
@@ -232,6 +232,12 @@ newtype S = S
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CShort) => RIP.CompatHasField.HasField "unwrapS" S ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> S {unwrapS = y1}, RIP.getField @"unwrapS" x0)
+
 instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapS" (RIP.Ptr S) (RIP.Ptr ty) where
 
@@ -242,12 +248,6 @@ instance HasCField.HasCField S "unwrapS" where
   type CFieldType S "unwrapS" = RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CShort) => RIP.CompatHasField.HasField "unwrapS" S ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> S {unwrapS = y1}, RIP.getField @"unwrapS" x0)
 
 -- __unique:__ @instance ToFunPtr (RIP.CShort -> IO I)@
 foreign import ccall safe "wrapper" hs_bindgen_25a28556cfbbf031_base ::

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/bindingspec.yaml
@@ -29,7 +29,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -37,6 +36,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -56,7 +57,6 @@ hstypes:
       fields:
       - unwrapF
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -65,6 +65,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -87,7 +89,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -95,6 +96,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -117,7 +120,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -125,6 +127,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -147,7 +151,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -155,6 +158,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl/th.txt
@@ -335,14 +335,14 @@ newtype I
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapI" I ty
+    where hasField = \x_0 -> (\y_1 -> I{unwrapI = y_1},
+                              getField @"unwrapI" x_0)
 instance (~) ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapI" I ty
-    where hasField = \x_0 -> (\y_1 -> I{unwrapI = y_1},
-                              getField @"unwrapI" x_0)
 {-| __C declaration:__ @macro C@
 
     __defined at:__ @macros\/macro_in_fundecl.h 6:9@
@@ -367,14 +367,14 @@ newtype C
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapC" C ty
+    where hasField = \x_0 -> (\y_1 -> C{unwrapC = y_1},
+                              getField @"unwrapC" x_0)
 instance (~) ty CChar => HasField "unwrapC" (Ptr C) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapC")
 instance HasCField C "unwrapC"
     where type CFieldType C "unwrapC" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapC" C ty
-    where hasField = \x_0 -> (\y_1 -> C{unwrapC = y_1},
-                              getField @"unwrapC" x_0)
 {-| __C declaration:__ @macro F@
 
     __defined at:__ @macros\/macro_in_fundecl.h 7:9@
@@ -397,14 +397,14 @@ newtype F
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CFloat => HasField "unwrapF" F ty
+    where hasField = \x_0 -> (\y_1 -> F{unwrapF = y_1},
+                              getField @"unwrapF" x_0)
 instance (~) ty CFloat => HasField "unwrapF" (Ptr F) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF")
 instance HasCField F "unwrapF"
     where type CFieldType F "unwrapF" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat => HasField "unwrapF" F ty
-    where hasField = \x_0 -> (\y_1 -> F{unwrapF = y_1},
-                              getField @"unwrapF" x_0)
 {-| __C declaration:__ @macro L@
 
     __defined at:__ @macros\/macro_in_fundecl.h 8:9@
@@ -429,14 +429,14 @@ newtype L
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CLong => HasField "unwrapL" L ty
+    where hasField = \x_0 -> (\y_1 -> L{unwrapL = y_1},
+                              getField @"unwrapL" x_0)
 instance (~) ty CLong => HasField "unwrapL" (Ptr L) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapL")
 instance HasCField L "unwrapL"
     where type CFieldType L "unwrapL" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong => HasField "unwrapL" L ty
-    where hasField = \x_0 -> (\y_1 -> L{unwrapL = y_1},
-                              getField @"unwrapL" x_0)
 {-| __C declaration:__ @macro S@
 
     __defined at:__ @macros\/macro_in_fundecl.h 9:9@
@@ -461,14 +461,14 @@ newtype S
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CShort => HasField "unwrapS" S ty
+    where hasField = \x_0 -> (\y_1 -> S{unwrapS = y_1},
+                              getField @"unwrapS" x_0)
 instance (~) ty CShort => HasField "unwrapS" (Ptr S) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS")
 instance HasCField S "unwrapS"
     where type CFieldType S "unwrapS" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort => HasField "unwrapS" S ty
-    where hasField = \x_0 -> (\y_1 -> S{unwrapS = y_1},
-                              getField @"unwrapS" x_0)
 -- __unique:__ @instance ToFunPtr (RIP.CShort -> IO I)@
 foreign import ccall safe "wrapper" hs_bindgen_25a28556cfbbf031_base ::
     Int16 -> IO Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/Example.hs
@@ -58,6 +58,13 @@ newtype MC = MC
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapMC" MC ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MC {unwrapMC = y1}, RIP.getField @"unwrapMC" x0)
+
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapMC" (RIP.Ptr MC) (RIP.Ptr ty) where
 
@@ -68,13 +75,6 @@ instance HasCField.HasCField MC "unwrapMC" where
   type CFieldType MC "unwrapMC" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapMC" MC ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MC {unwrapMC = y1}, RIP.getField @"unwrapMC" x0)
 
 {-| __C declaration:__ @TC@
 
@@ -104,6 +104,13 @@ newtype TC = TC
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapTC" TC ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TC {unwrapTC = y1}, RIP.getField @"unwrapTC" x0)
+
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapTC" (RIP.Ptr TC) (RIP.Ptr ty) where
 
@@ -114,13 +121,6 @@ instance HasCField.HasCField TC "unwrapTC" where
   type CFieldType TC "unwrapTC" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapTC" TC ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TC {unwrapTC = y1}, RIP.getField @"unwrapTC" x0)
 
 {-| __C declaration:__ @struct struct1@
 
@@ -163,17 +163,6 @@ instance Marshal.WriteRaw Struct1 where
 
 deriving via Marshal.EquivStorable Struct1 instance RIP.Storable Struct1
 
-instance HasCField.HasCField Struct1 "struct1_a" where
-
-  type CFieldType Struct1 "struct1_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct1_a" (RIP.Ptr Struct1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"struct1_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct1_a" Struct1 ty where
 
@@ -181,6 +170,17 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Struct1 {struct1_a = y1}, RIP.getField @"struct1_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct1_a" (RIP.Ptr Struct1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"struct1_a")
+
+instance HasCField.HasCField Struct1 "struct1_a" where
+
+  type CFieldType Struct1 "struct1_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct struct2@
 
@@ -223,17 +223,6 @@ instance Marshal.WriteRaw Struct2 where
 
 deriving via Marshal.EquivStorable Struct2 instance RIP.Storable Struct2
 
-instance HasCField.HasCField Struct2 "struct2_a" where
-
-  type CFieldType Struct2 "struct2_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct2_a" (RIP.Ptr Struct2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"struct2_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct2_a" Struct2 ty where
 
@@ -241,6 +230,17 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Struct2 {struct2_a = y1}, RIP.getField @"struct2_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct2_a" (RIP.Ptr Struct2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"struct2_a")
+
+instance HasCField.HasCField Struct2 "struct2_a" where
+
+  type CFieldType Struct2 "struct2_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct struct3@
 
@@ -283,17 +283,6 @@ instance Marshal.WriteRaw Struct3 where
 
 deriving via Marshal.EquivStorable Struct3 instance RIP.Storable Struct3
 
-instance HasCField.HasCField Struct3 "struct3_a" where
-
-  type CFieldType Struct3 "struct3_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct3_a" (RIP.Ptr Struct3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"struct3_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct3_a" Struct3 ty where
 
@@ -301,6 +290,17 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Struct3 {struct3_a = y1}, RIP.getField @"struct3_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct3_a" (RIP.Ptr Struct3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"struct3_a")
+
+instance HasCField.HasCField Struct3 "struct3_a" where
+
+  type CFieldType Struct3 "struct3_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct3_t@
 
@@ -320,6 +320,14 @@ newtype Struct3_t = Struct3_t
     )
 
 instance ( ty ~ Struct3
+         ) => RIP.CompatHasField.HasField "unwrapStruct3_t" Struct3_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct3_t {unwrapStruct3_t = y1}, RIP.getField @"unwrapStruct3_t" x0)
+
+instance ( ty ~ Struct3
          ) => RIP.HasField "unwrapStruct3_t" (RIP.Ptr Struct3_t) (RIP.Ptr ty) where
 
   getField =
@@ -330,14 +338,6 @@ instance HasCField.HasCField Struct3_t "unwrapStruct3_t" where
   type CFieldType Struct3_t "unwrapStruct3_t" = Struct3
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct3
-         ) => RIP.CompatHasField.HasField "unwrapStruct3_t" Struct3_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct3_t {unwrapStruct3_t = y1}, RIP.getField @"unwrapStruct3_t" x0)
 
 {-| __C declaration:__ @struct struct4@
 
@@ -380,17 +380,6 @@ instance Marshal.WriteRaw Struct4 where
 
 deriving via Marshal.EquivStorable Struct4 instance RIP.Storable Struct4
 
-instance HasCField.HasCField Struct4 "struct4_a" where
-
-  type CFieldType Struct4 "struct4_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct4_a" (RIP.Ptr Struct4) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"struct4_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct4_a" Struct4 ty where
 
@@ -398,3 +387,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Struct4 {struct4_a = y1}, RIP.getField @"struct4_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct4_a" (RIP.Ptr Struct4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"struct4_a")
+
+instance HasCField.HasCField Struct4 "struct4_a" where
+
+  type CFieldType Struct4 "struct4_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/bindingspec.yaml
@@ -41,7 +41,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -49,6 +48,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -68,11 +69,12 @@ hstypes:
       fields:
       - struct1_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -85,11 +87,12 @@ hstypes:
       fields:
       - struct2_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -102,11 +105,12 @@ hstypes:
       fields:
       - struct3_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -119,11 +123,12 @@ hstypes:
       fields:
       - unwrapStruct3_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -136,11 +141,12 @@ hstypes:
       fields:
       - struct4_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -156,7 +162,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -164,6 +169,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_in_fundecl_vs_typedef/th.txt
@@ -254,14 +254,14 @@ newtype MC
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapMC" MC ty
+    where hasField = \x_0 -> (\y_1 -> MC{unwrapMC = y_1},
+                              getField @"unwrapMC" x_0)
 instance (~) ty CChar => HasField "unwrapMC" (Ptr MC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMC")
 instance HasCField MC "unwrapMC"
     where type CFieldType MC "unwrapMC" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapMC" MC ty
-    where hasField = \x_0 -> (\y_1 -> MC{unwrapMC = y_1},
-                              getField @"unwrapMC" x_0)
 {-| __C declaration:__ @TC@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 5:14@
@@ -286,14 +286,14 @@ newtype TC
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapTC" TC ty
+    where hasField = \x_0 -> (\y_1 -> TC{unwrapTC = y_1},
+                              getField @"unwrapTC" x_0)
 instance (~) ty CChar => HasField "unwrapTC" (Ptr TC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTC")
 instance HasCField TC "unwrapTC"
     where type CFieldType TC "unwrapTC" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapTC" TC ty
-    where hasField = \x_0 -> (\y_1 -> TC{unwrapTC = y_1},
-                              getField @"unwrapTC" x_0)
 {-| __C declaration:__ @struct struct1@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 18:16@
@@ -318,14 +318,14 @@ instance WriteRaw Struct1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct1 struct1_a_2 -> writeRaw (Proxy @"struct1_a") ptr_0 struct1_a_2
 deriving via (EquivStorable Struct1) instance Storable Struct1
-instance HasCField Struct1 "struct1_a"
-    where type CFieldType Struct1 "struct1_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct1_a" (Ptr Struct1) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct1_a")
 instance (~) ty CInt => HasField "struct1_a" Struct1 ty
     where hasField = \x_0 -> (\y_1 -> Struct1{struct1_a = y_1},
                               getField @"struct1_a" x_0)
+instance (~) ty CInt => HasField "struct1_a" (Ptr Struct1) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct1_a")
+instance HasCField Struct1 "struct1_a"
+    where type CFieldType Struct1 "struct1_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct2@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 19:9@
@@ -350,14 +350,14 @@ instance WriteRaw Struct2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct2 struct2_a_2 -> writeRaw (Proxy @"struct2_a") ptr_0 struct2_a_2
 deriving via (EquivStorable Struct2) instance Storable Struct2
-instance HasCField Struct2 "struct2_a"
-    where type CFieldType Struct2 "struct2_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct2_a" (Ptr Struct2) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct2_a")
 instance (~) ty CInt => HasField "struct2_a" Struct2 ty
     where hasField = \x_0 -> (\y_1 -> Struct2{struct2_a = y_1},
                               getField @"struct2_a" x_0)
+instance (~) ty CInt => HasField "struct2_a" (Ptr Struct2) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct2_a")
+instance HasCField Struct2 "struct2_a"
+    where type CFieldType Struct2 "struct2_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct struct3@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 20:16@
@@ -382,14 +382,14 @@ instance WriteRaw Struct3
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct3 struct3_a_2 -> writeRaw (Proxy @"struct3_a") ptr_0 struct3_a_2
 deriving via (EquivStorable Struct3) instance Storable Struct3
-instance HasCField Struct3 "struct3_a"
-    where type CFieldType Struct3 "struct3_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct3_a" (Ptr Struct3) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct3_a")
 instance (~) ty CInt => HasField "struct3_a" Struct3 ty
     where hasField = \x_0 -> (\y_1 -> Struct3{struct3_a = y_1},
                               getField @"struct3_a" x_0)
+instance (~) ty CInt => HasField "struct3_a" (Ptr Struct3) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct3_a")
+instance HasCField Struct3 "struct3_a"
+    where type CFieldType Struct3 "struct3_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct3_t@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 20:35@
@@ -400,15 +400,15 @@ newtype Struct3_t
     = Struct3_t {unwrapStruct3_t :: Struct3}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Struct3 => HasField "unwrapStruct3_t" Struct3_t ty
+    where hasField = \x_0 -> (\y_1 -> Struct3_t{unwrapStruct3_t = y_1},
+                              getField @"unwrapStruct3_t" x_0)
 instance (~) ty Struct3 =>
          HasField "unwrapStruct3_t" (Ptr Struct3_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct3_t")
 instance HasCField Struct3_t "unwrapStruct3_t"
     where type CFieldType Struct3_t "unwrapStruct3_t" = Struct3
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct3 => HasField "unwrapStruct3_t" Struct3_t ty
-    where hasField = \x_0 -> (\y_1 -> Struct3_t{unwrapStruct3_t = y_1},
-                              getField @"unwrapStruct3_t" x_0)
 {-| __C declaration:__ @struct struct4@
 
     __defined at:__ @macros\/macro_in_fundecl_vs_typedef.h 21:16@
@@ -433,14 +433,14 @@ instance WriteRaw Struct4
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct4 struct4_a_2 -> writeRaw (Proxy @"struct4_a") ptr_0 struct4_a_2
 deriving via (EquivStorable Struct4) instance Storable Struct4
-instance HasCField Struct4 "struct4_a"
-    where type CFieldType Struct4 "struct4_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct4_a" (Ptr Struct4) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct4_a")
 instance (~) ty CInt => HasField "struct4_a" Struct4 ty
     where hasField = \x_0 -> (\y_1 -> Struct4{struct4_a = y_1},
                               getField @"struct4_a" x_0)
+instance (~) ty CInt => HasField "struct4_a" (Ptr Struct4) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct4_a")
+instance HasCField Struct4 "struct4_a"
+    where type CFieldType Struct4 "struct4_a" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_macrosmacro_in_fundecl_vs_typ_Example_Safe_quux1@
 foreign import ccall safe "hs_bindgen_02e0e3b28d470fd4" hs_bindgen_02e0e3b28d470fd4_base ::
     Int8

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/Example.hs
@@ -51,6 +51,14 @@ newtype FILE = FILE
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapFILE" FILE ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         FILE {unwrapFILE = y1}, RIP.getField @"unwrapFILE" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapFILE" (RIP.Ptr FILE) (RIP.Ptr ty) where
 
   getField =
@@ -61,11 +69,3 @@ instance HasCField.HasCField FILE "unwrapFILE" where
   type CFieldType FILE "unwrapFILE" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapFILE" FILE ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         FILE {unwrapFILE = y1}, RIP.getField @"unwrapFILE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_redefines_global/th.txt
@@ -23,11 +23,11 @@ newtype FILE
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapFILE" FILE ty
+    where hasField = \x_0 -> (\y_1 -> FILE{unwrapFILE = y_1},
+                              getField @"unwrapFILE" x_0)
 instance (~) ty CInt => HasField "unwrapFILE" (Ptr FILE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFILE")
 instance HasCField FILE "unwrapFILE"
     where type CFieldType FILE "unwrapFILE" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapFILE" FILE ty
-    where hasField = \x_0 -> (\y_1 -> FILE{unwrapFILE = y_1},
-                              getField @"unwrapFILE" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/Example.hs
@@ -46,6 +46,14 @@ newtype PtrToVoid = PtrToVoid
     )
 
 instance ( ty ~ RIP.Ptr RIP.Void
+         ) => RIP.CompatHasField.HasField "unwrapPtrToVoid" PtrToVoid ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         PtrToVoid {unwrapPtrToVoid = y1}, RIP.getField @"unwrapPtrToVoid" x0)
+
+instance ( ty ~ RIP.Ptr RIP.Void
          ) => RIP.HasField "unwrapPtrToVoid" (RIP.Ptr PtrToVoid) (RIP.Ptr ty) where
 
   getField =
@@ -57,14 +65,6 @@ instance HasCField.HasCField PtrToVoid "unwrapPtrToVoid" where
     RIP.Ptr RIP.Void
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.Void
-         ) => RIP.CompatHasField.HasField "unwrapPtrToVoid" PtrToVoid ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         PtrToVoid {unwrapPtrToVoid = y1}, RIP.getField @"unwrapPtrToVoid" x0)
 
 {-| __C declaration:__ @macro PtrToConstVoidL@
 
@@ -85,6 +85,15 @@ newtype PtrToConstVoidL = PtrToConstVoidL
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.Void
+         ) => RIP.CompatHasField.HasField "unwrapPtrToConstVoidL" PtrToConstVoidL ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> PtrToConstVoidL {unwrapPtrToConstVoidL = y1}
+      , RIP.getField @"unwrapPtrToConstVoidL" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst RIP.Void
          ) => RIP.HasField "unwrapPtrToConstVoidL" (RIP.Ptr PtrToConstVoidL) (RIP.Ptr ty) where
 
   getField =
@@ -96,15 +105,6 @@ instance HasCField.HasCField PtrToConstVoidL "unwrapPtrToConstVoidL" where
     PtrConst.PtrConst RIP.Void
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.Void
-         ) => RIP.CompatHasField.HasField "unwrapPtrToConstVoidL" PtrToConstVoidL ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> PtrToConstVoidL {unwrapPtrToConstVoidL = y1}
-      , RIP.getField @"unwrapPtrToConstVoidL" x0
-      )
 
 {-| __C declaration:__ @macro PtrToConstVoidR@
 
@@ -125,6 +125,15 @@ newtype PtrToConstVoidR = PtrToConstVoidR
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.Void
+         ) => RIP.CompatHasField.HasField "unwrapPtrToConstVoidR" PtrToConstVoidR ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> PtrToConstVoidR {unwrapPtrToConstVoidR = y1}
+      , RIP.getField @"unwrapPtrToConstVoidR" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst RIP.Void
          ) => RIP.HasField "unwrapPtrToConstVoidR" (RIP.Ptr PtrToConstVoidR) (RIP.Ptr ty) where
 
   getField =
@@ -136,15 +145,6 @@ instance HasCField.HasCField PtrToConstVoidR "unwrapPtrToConstVoidR" where
     PtrConst.PtrConst RIP.Void
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.Void
-         ) => RIP.CompatHasField.HasField "unwrapPtrToConstVoidR" PtrToConstVoidR ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> PtrToConstVoidR {unwrapPtrToConstVoidR = y1}
-      , RIP.getField @"unwrapPtrToConstVoidR" x0
-      )
 
 {-| __C declaration:__ @macro PtrToConstIntL@
 
@@ -165,6 +165,15 @@ newtype PtrToConstIntL = PtrToConstIntL
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapPtrToConstIntL" PtrToConstIntL ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> PtrToConstIntL {unwrapPtrToConstIntL = y1}
+      , RIP.getField @"unwrapPtrToConstIntL" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst RIP.CInt
          ) => RIP.HasField "unwrapPtrToConstIntL" (RIP.Ptr PtrToConstIntL) (RIP.Ptr ty) where
 
   getField =
@@ -176,15 +185,6 @@ instance HasCField.HasCField PtrToConstIntL "unwrapPtrToConstIntL" where
     PtrConst.PtrConst RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapPtrToConstIntL" PtrToConstIntL ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> PtrToConstIntL {unwrapPtrToConstIntL = y1}
-      , RIP.getField @"unwrapPtrToConstIntL" x0
-      )
 
 {-| __C declaration:__ @macro PtrToConstIntR@
 
@@ -205,6 +205,15 @@ newtype PtrToConstIntR = PtrToConstIntR
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapPtrToConstIntR" PtrToConstIntR ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> PtrToConstIntR {unwrapPtrToConstIntR = y1}
+      , RIP.getField @"unwrapPtrToConstIntR" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst RIP.CInt
          ) => RIP.HasField "unwrapPtrToConstIntR" (RIP.Ptr PtrToConstIntR) (RIP.Ptr ty) where
 
   getField =
@@ -216,15 +225,6 @@ instance HasCField.HasCField PtrToConstIntR "unwrapPtrToConstIntR" where
     PtrConst.PtrConst RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapPtrToConstIntR" PtrToConstIntR ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> PtrToConstIntR {unwrapPtrToConstIntR = y1}
-      , RIP.getField @"unwrapPtrToConstIntR" x0
-      )
 
 {-| __C declaration:__ @macro ConstPtrToInt@
 
@@ -245,6 +245,15 @@ newtype ConstPtrToInt = ConstPtrToInt
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapConstPtrToInt" ConstPtrToInt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> ConstPtrToInt {unwrapConstPtrToInt = y1}
+      , RIP.getField @"unwrapConstPtrToInt" x0
+      )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrapConstPtrToInt" (RIP.Ptr ConstPtrToInt) (RIP.Ptr ty) where
 
   getField =
@@ -256,12 +265,3 @@ instance HasCField.HasCField ConstPtrToInt "unwrapConstPtrToInt" where
     RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapConstPtrToInt" ConstPtrToInt ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> ConstPtrToInt {unwrapConstPtrToInt = y1}
-      , RIP.getField @"unwrapConstPtrToInt" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/bindingspec.yaml
@@ -29,12 +29,13 @@ hstypes:
       fields:
       - unwrapConstPtrToInt
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -48,12 +49,13 @@ hstypes:
       fields:
       - unwrapPtrToConstIntL
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -67,12 +69,13 @@ hstypes:
       fields:
       - unwrapPtrToConstIntR
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -86,12 +89,13 @@ hstypes:
       fields:
       - unwrapPtrToConstVoidL
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -105,12 +109,13 @@ hstypes:
       fields:
       - unwrapPtrToConstVoidR
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -124,12 +129,13 @@ hstypes:
       fields:
       - unwrapPtrToVoid
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_type_ptr_qualifiers/th.txt
@@ -14,15 +14,15 @@ newtype PtrToVoid
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Void) =>
+         HasField "unwrapPtrToVoid" PtrToVoid ty
+    where hasField = \x_0 -> (\y_1 -> PtrToVoid{unwrapPtrToVoid = y_1},
+                              getField @"unwrapPtrToVoid" x_0)
+instance (~) ty (Ptr Void) =>
          HasField "unwrapPtrToVoid" (Ptr PtrToVoid) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrToVoid")
 instance HasCField PtrToVoid "unwrapPtrToVoid"
     where type CFieldType PtrToVoid "unwrapPtrToVoid" = Ptr Void
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Void) =>
-         HasField "unwrapPtrToVoid" PtrToVoid ty
-    where hasField = \x_0 -> (\y_1 -> PtrToVoid{unwrapPtrToVoid = y_1},
-                              getField @"unwrapPtrToVoid" x_0)
 {-| __C declaration:__ @macro PtrToConstVoidL@
 
     __defined at:__ @macros\/macro_type_ptr_qualifiers.h 5:9@
@@ -38,16 +38,16 @@ newtype PtrToConstVoidL
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst Void) =>
+         HasField "unwrapPtrToConstVoidL" PtrToConstVoidL ty
+    where hasField = \x_0 -> (\y_1 -> PtrToConstVoidL{unwrapPtrToConstVoidL = y_1},
+                              getField @"unwrapPtrToConstVoidL" x_0)
+instance (~) ty (PtrConst Void) =>
          HasField "unwrapPtrToConstVoidL" (Ptr PtrToConstVoidL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrToConstVoidL")
 instance HasCField PtrToConstVoidL "unwrapPtrToConstVoidL"
     where type CFieldType PtrToConstVoidL
                           "unwrapPtrToConstVoidL" = PtrConst Void
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst Void) =>
-         HasField "unwrapPtrToConstVoidL" PtrToConstVoidL ty
-    where hasField = \x_0 -> (\y_1 -> PtrToConstVoidL{unwrapPtrToConstVoidL = y_1},
-                              getField @"unwrapPtrToConstVoidL" x_0)
 {-| __C declaration:__ @macro PtrToConstVoidR@
 
     __defined at:__ @macros\/macro_type_ptr_qualifiers.h 8:9@
@@ -63,16 +63,16 @@ newtype PtrToConstVoidR
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst Void) =>
+         HasField "unwrapPtrToConstVoidR" PtrToConstVoidR ty
+    where hasField = \x_0 -> (\y_1 -> PtrToConstVoidR{unwrapPtrToConstVoidR = y_1},
+                              getField @"unwrapPtrToConstVoidR" x_0)
+instance (~) ty (PtrConst Void) =>
          HasField "unwrapPtrToConstVoidR" (Ptr PtrToConstVoidR) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrToConstVoidR")
 instance HasCField PtrToConstVoidR "unwrapPtrToConstVoidR"
     where type CFieldType PtrToConstVoidR
                           "unwrapPtrToConstVoidR" = PtrConst Void
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst Void) =>
-         HasField "unwrapPtrToConstVoidR" PtrToConstVoidR ty
-    where hasField = \x_0 -> (\y_1 -> PtrToConstVoidR{unwrapPtrToConstVoidR = y_1},
-                              getField @"unwrapPtrToConstVoidR" x_0)
 {-| __C declaration:__ @macro PtrToConstIntL@
 
     __defined at:__ @macros\/macro_type_ptr_qualifiers.h 11:9@
@@ -88,16 +88,16 @@ newtype PtrToConstIntL
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst CInt) =>
+         HasField "unwrapPtrToConstIntL" PtrToConstIntL ty
+    where hasField = \x_0 -> (\y_1 -> PtrToConstIntL{unwrapPtrToConstIntL = y_1},
+                              getField @"unwrapPtrToConstIntL" x_0)
+instance (~) ty (PtrConst CInt) =>
          HasField "unwrapPtrToConstIntL" (Ptr PtrToConstIntL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrToConstIntL")
 instance HasCField PtrToConstIntL "unwrapPtrToConstIntL"
     where type CFieldType PtrToConstIntL
                           "unwrapPtrToConstIntL" = PtrConst CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrapPtrToConstIntL" PtrToConstIntL ty
-    where hasField = \x_0 -> (\y_1 -> PtrToConstIntL{unwrapPtrToConstIntL = y_1},
-                              getField @"unwrapPtrToConstIntL" x_0)
 {-| __C declaration:__ @macro PtrToConstIntR@
 
     __defined at:__ @macros\/macro_type_ptr_qualifiers.h 14:9@
@@ -113,16 +113,16 @@ newtype PtrToConstIntR
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst CInt) =>
+         HasField "unwrapPtrToConstIntR" PtrToConstIntR ty
+    where hasField = \x_0 -> (\y_1 -> PtrToConstIntR{unwrapPtrToConstIntR = y_1},
+                              getField @"unwrapPtrToConstIntR" x_0)
+instance (~) ty (PtrConst CInt) =>
          HasField "unwrapPtrToConstIntR" (Ptr PtrToConstIntR) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrToConstIntR")
 instance HasCField PtrToConstIntR "unwrapPtrToConstIntR"
     where type CFieldType PtrToConstIntR
                           "unwrapPtrToConstIntR" = PtrConst CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst CInt) =>
-         HasField "unwrapPtrToConstIntR" PtrToConstIntR ty
-    where hasField = \x_0 -> (\y_1 -> PtrToConstIntR{unwrapPtrToConstIntR = y_1},
-                              getField @"unwrapPtrToConstIntR" x_0)
 {-| __C declaration:__ @macro ConstPtrToInt@
 
     __defined at:__ @macros\/macro_type_ptr_qualifiers.h 17:9@
@@ -138,13 +138,13 @@ newtype ConstPtrToInt
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr CInt) =>
+         HasField "unwrapConstPtrToInt" ConstPtrToInt ty
+    where hasField = \x_0 -> (\y_1 -> ConstPtrToInt{unwrapConstPtrToInt = y_1},
+                              getField @"unwrapConstPtrToInt" x_0)
+instance (~) ty (Ptr CInt) =>
          HasField "unwrapConstPtrToInt" (Ptr ConstPtrToInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConstPtrToInt")
 instance HasCField ConstPtrToInt "unwrapConstPtrToInt"
     where type CFieldType ConstPtrToInt
                           "unwrapConstPtrToInt" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) =>
-         HasField "unwrapConstPtrToInt" ConstPtrToInt ty
-    where hasField = \x_0 -> (\y_1 -> ConstPtrToInt{unwrapConstPtrToInt = y_1},
-                              getField @"unwrapConstPtrToInt" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/Example.hs
@@ -54,6 +54,14 @@ newtype MY_TYPE = MY_TYPE
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMY_TYPE" MY_TYPE ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MY_TYPE {unwrapMY_TYPE = y1}, RIP.getField @"unwrapMY_TYPE" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMY_TYPE" (RIP.Ptr MY_TYPE) (RIP.Ptr ty) where
 
   getField =
@@ -64,14 +72,6 @@ instance HasCField.HasCField MY_TYPE "unwrapMY_TYPE" where
   type CFieldType MY_TYPE "unwrapMY_TYPE" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMY_TYPE" MY_TYPE ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MY_TYPE {unwrapMY_TYPE = y1}, RIP.getField @"unwrapMY_TYPE" x0)
 
 {-| __C declaration:__ @struct bar@
 
@@ -123,17 +123,6 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCField.HasCField Bar "bar_x" where
-
-  type CFieldType Bar "bar_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "bar_x" Bar ty where
 
   hasField =
@@ -143,15 +132,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "bar_x" Bar ty where
       , RIP.getField @"bar_x" x0
       )
 
-instance HasCField.HasCField Bar "bar_y" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (RIP.Ptr ty) where
 
-  type CFieldType Bar "bar_y" = MY_TYPE
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_x")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField Bar "bar_x" where
 
-instance (ty ~ MY_TYPE) => RIP.HasField "bar_y" (RIP.Ptr Bar) (RIP.Ptr ty) where
+  type CFieldType Bar "bar_x" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_y")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ MY_TYPE) => RIP.CompatHasField.HasField "bar_y" Bar ty where
 
@@ -161,3 +151,13 @@ instance (ty ~ MY_TYPE) => RIP.CompatHasField.HasField "bar_y" Bar ty where
           Bar {bar_y = y1, bar_x = RIP.getField @"bar_x" x0}
       , RIP.getField @"bar_y" x0
       )
+
+instance (ty ~ MY_TYPE) => RIP.HasField "bar_y" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_y")
+
+instance HasCField.HasCField Bar "bar_y" where
+
+  type CFieldType Bar "bar_y" = MY_TYPE
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/bindingspec.yaml
@@ -21,11 +21,12 @@ hstypes:
       - bar_x
       - bar_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -41,7 +42,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -49,6 +49,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_typedef_struct/th.txt
@@ -23,15 +23,15 @@ newtype MY_TYPE
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMY_TYPE" MY_TYPE ty
+    where hasField = \x_0 -> (\y_1 -> MY_TYPE{unwrapMY_TYPE = y_1},
+                              getField @"unwrapMY_TYPE" x_0)
 instance (~) ty CInt =>
          HasField "unwrapMY_TYPE" (Ptr MY_TYPE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMY_TYPE")
 instance HasCField MY_TYPE "unwrapMY_TYPE"
     where type CFieldType MY_TYPE "unwrapMY_TYPE" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMY_TYPE" MY_TYPE ty
-    where hasField = \x_0 -> (\y_1 -> MY_TYPE{unwrapMY_TYPE = y_1},
-                              getField @"unwrapMY_TYPE" x_0)
 {-| __C declaration:__ @struct bar@
 
     __defined at:__ @macros\/macro_typedef_struct.h 3:9@
@@ -64,21 +64,21 @@ instance WriteRaw Bar
                                        Bar bar_x_2
                                            bar_y_3 -> writeRaw (Proxy @"bar_x") ptr_0 bar_x_2 >> writeRaw (Proxy @"bar_y") ptr_0 bar_y_3
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCField Bar "bar_x"
-    where type CFieldType Bar "bar_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "bar_x" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_x")
 instance (~) ty CInt => HasField "bar_x" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_x = y_1,
                                           bar_y = getField @"bar_y" x_0},
                               getField @"bar_x" x_0)
-instance HasCField Bar "bar_y"
-    where type CFieldType Bar "bar_y" = MY_TYPE
-          offset# = \_ -> \_ -> 4
-instance (~) ty MY_TYPE => HasField "bar_y" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_y")
+instance (~) ty CInt => HasField "bar_x" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_x")
+instance HasCField Bar "bar_x"
+    where type CFieldType Bar "bar_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty MY_TYPE => HasField "bar_y" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_y = y_1,
                                           bar_x = getField @"bar_x" x_0},
                               getField @"bar_y" x_0)
+instance (~) ty MY_TYPE => HasField "bar_y" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_y")
+instance HasCField Bar "bar_y"
+    where type CFieldType Bar "bar_y" = MY_TYPE
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_types/Example.hs
@@ -50,6 +50,14 @@ newtype PtrInt = PtrInt
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapPtrInt" PtrInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         PtrInt {unwrapPtrInt = y1}, RIP.getField @"unwrapPtrInt" x0)
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrapPtrInt" (RIP.Ptr PtrInt) (RIP.Ptr ty) where
 
   getField =
@@ -61,14 +69,6 @@ instance HasCField.HasCField PtrInt "unwrapPtrInt" where
     RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapPtrInt" PtrInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         PtrInt {unwrapPtrInt = y1}, RIP.getField @"unwrapPtrInt" x0)
 
 {-| __C declaration:__ @macro ShortInt@
 
@@ -99,6 +99,14 @@ newtype ShortInt = ShortInt
     )
 
 instance ( ty ~ RIP.CShort
+         ) => RIP.CompatHasField.HasField "unwrapShortInt" ShortInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         ShortInt {unwrapShortInt = y1}, RIP.getField @"unwrapShortInt" x0)
+
+instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapShortInt" (RIP.Ptr ShortInt) (RIP.Ptr ty) where
 
   getField =
@@ -110,14 +118,6 @@ instance HasCField.HasCField ShortInt "unwrapShortInt" where
     RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.CompatHasField.HasField "unwrapShortInt" ShortInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         ShortInt {unwrapShortInt = y1}, RIP.getField @"unwrapShortInt" x0)
 
 {-| __C declaration:__ @macro SignedShortInt@
 
@@ -148,6 +148,15 @@ newtype SignedShortInt = SignedShortInt
     )
 
 instance ( ty ~ RIP.CShort
+         ) => RIP.CompatHasField.HasField "unwrapSignedShortInt" SignedShortInt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> SignedShortInt {unwrapSignedShortInt = y1}
+      , RIP.getField @"unwrapSignedShortInt" x0
+      )
+
+instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapSignedShortInt" (RIP.Ptr SignedShortInt) (RIP.Ptr ty) where
 
   getField =
@@ -159,15 +168,6 @@ instance HasCField.HasCField SignedShortInt "unwrapSignedShortInt" where
     RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.CompatHasField.HasField "unwrapSignedShortInt" SignedShortInt ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> SignedShortInt {unwrapSignedShortInt = y1}
-      , RIP.getField @"unwrapSignedShortInt" x0
-      )
 
 {-| __C declaration:__ @macro UnsignedShortInt@
 
@@ -198,6 +198,16 @@ newtype UnsignedShortInt = UnsignedShortInt
     )
 
 instance ( ty ~ RIP.CUShort
+         ) => RIP.CompatHasField.HasField "unwrapUnsignedShortInt" UnsignedShortInt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          UnsignedShortInt {unwrapUnsignedShortInt = y1}
+      , RIP.getField @"unwrapUnsignedShortInt" x0
+      )
+
+instance ( ty ~ RIP.CUShort
          ) => RIP.HasField "unwrapUnsignedShortInt" (RIP.Ptr UnsignedShortInt) (RIP.Ptr ty) where
 
   getField =
@@ -209,16 +219,6 @@ instance HasCField.HasCField UnsignedShortInt "unwrapUnsignedShortInt" where
     RIP.CUShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUShort
-         ) => RIP.CompatHasField.HasField "unwrapUnsignedShortInt" UnsignedShortInt ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          UnsignedShortInt {unwrapUnsignedShortInt = y1}
-      , RIP.getField @"unwrapUnsignedShortInt" x0
-      )
 
 {-| __C declaration:__ @macro PtrPtrChar@
 
@@ -239,6 +239,15 @@ newtype PtrPtrChar = PtrPtrChar
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr RIP.CChar)
+         ) => RIP.CompatHasField.HasField "unwrapPtrPtrChar" PtrPtrChar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> PtrPtrChar {unwrapPtrPtrChar = y1}
+      , RIP.getField @"unwrapPtrPtrChar" x0
+      )
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr RIP.CChar)
          ) => RIP.HasField "unwrapPtrPtrChar" (RIP.Ptr PtrPtrChar) (RIP.Ptr ty) where
 
   getField =
@@ -250,15 +259,6 @@ instance HasCField.HasCField PtrPtrChar "unwrapPtrPtrChar" where
     RIP.Ptr (RIP.Ptr RIP.CChar)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr RIP.CChar)
-         ) => RIP.CompatHasField.HasField "unwrapPtrPtrChar" PtrPtrChar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> PtrPtrChar {unwrapPtrPtrChar = y1}
-      , RIP.getField @"unwrapPtrPtrChar" x0
-      )
 
 {-| __C declaration:__ @macro MTy@
 
@@ -287,6 +287,14 @@ newtype MTy = MTy
     )
 
 instance ( ty ~ RIP.CFloat
+         ) => RIP.CompatHasField.HasField "unwrapMTy" MTy ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MTy {unwrapMTy = y1}, RIP.getField @"unwrapMTy" x0)
+
+instance ( ty ~ RIP.CFloat
          ) => RIP.HasField "unwrapMTy" (RIP.Ptr MTy) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapMTy")
@@ -296,14 +304,6 @@ instance HasCField.HasCField MTy "unwrapMTy" where
   type CFieldType MTy "unwrapMTy" = RIP.CFloat
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.CompatHasField.HasField "unwrapMTy" MTy ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MTy {unwrapMTy = y1}, RIP.getField @"unwrapMTy" x0)
 
 {-| __C declaration:__ @tty@
 
@@ -331,6 +331,13 @@ newtype Tty = Tty
     , Marshal.WriteRaw
     )
 
+instance (ty ~ MTy) => RIP.CompatHasField.HasField "unwrapTty" Tty ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Tty {unwrapTty = y1}, RIP.getField @"unwrapTty" x0)
+
 instance (ty ~ MTy) => RIP.HasField "unwrapTty" (RIP.Ptr Tty) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTty")
@@ -340,13 +347,6 @@ instance HasCField.HasCField Tty "unwrapTty" where
   type CFieldType Tty "unwrapTty" = MTy
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MTy) => RIP.CompatHasField.HasField "unwrapTty" Tty ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Tty {unwrapTty = y1}, RIP.getField @"unwrapTty" x0)
 
 {-| __C declaration:__ @macro UINT8_T@
 
@@ -377,6 +377,14 @@ newtype UINT8_T = UINT8_T
     )
 
 instance ( ty ~ RIP.CUChar
+         ) => RIP.CompatHasField.HasField "unwrapUINT8_T" UINT8_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         UINT8_T {unwrapUINT8_T = y1}, RIP.getField @"unwrapUINT8_T" x0)
+
+instance ( ty ~ RIP.CUChar
          ) => RIP.HasField "unwrapUINT8_T" (RIP.Ptr UINT8_T) (RIP.Ptr ty) where
 
   getField =
@@ -387,14 +395,6 @@ instance HasCField.HasCField UINT8_T "unwrapUINT8_T" where
   type CFieldType UINT8_T "unwrapUINT8_T" = RIP.CUChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.CompatHasField.HasField "unwrapUINT8_T" UINT8_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         UINT8_T {unwrapUINT8_T = y1}, RIP.getField @"unwrapUINT8_T" x0)
 
 {-| __C declaration:__ @macro BOOLEAN_T@
 
@@ -425,6 +425,14 @@ newtype BOOLEAN_T = BOOLEAN_T
     )
 
 instance ( ty ~ UINT8_T
+         ) => RIP.CompatHasField.HasField "unwrapBOOLEAN_T" BOOLEAN_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BOOLEAN_T {unwrapBOOLEAN_T = y1}, RIP.getField @"unwrapBOOLEAN_T" x0)
+
+instance ( ty ~ UINT8_T
          ) => RIP.HasField "unwrapBOOLEAN_T" (RIP.Ptr BOOLEAN_T) (RIP.Ptr ty) where
 
   getField =
@@ -435,14 +443,6 @@ instance HasCField.HasCField BOOLEAN_T "unwrapBOOLEAN_T" where
   type CFieldType BOOLEAN_T "unwrapBOOLEAN_T" = UINT8_T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UINT8_T
-         ) => RIP.CompatHasField.HasField "unwrapBOOLEAN_T" BOOLEAN_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         BOOLEAN_T {unwrapBOOLEAN_T = y1}, RIP.getField @"unwrapBOOLEAN_T" x0)
 
 {-| __C declaration:__ @boolean_T@
 
@@ -473,6 +473,14 @@ newtype Boolean_T = Boolean_T
     )
 
 instance ( ty ~ BOOLEAN_T
+         ) => RIP.CompatHasField.HasField "unwrapBoolean_T" Boolean_T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Boolean_T {unwrapBoolean_T = y1}, RIP.getField @"unwrapBoolean_T" x0)
+
+instance ( ty ~ BOOLEAN_T
          ) => RIP.HasField "unwrapBoolean_T" (RIP.Ptr Boolean_T) (RIP.Ptr ty) where
 
   getField =
@@ -484,11 +492,3 @@ instance HasCField.HasCField Boolean_T "unwrapBoolean_T" where
     BOOLEAN_T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ BOOLEAN_T
-         ) => RIP.CompatHasField.HasField "unwrapBoolean_T" Boolean_T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Boolean_T {unwrapBoolean_T = y1}, RIP.getField @"unwrapBoolean_T" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_types/bindingspec.yaml
@@ -44,7 +44,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -52,6 +51,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -74,7 +75,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -82,6 +82,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -101,7 +103,6 @@ hstypes:
       fields:
       - unwrapMTy
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -110,6 +111,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -129,12 +132,13 @@ hstypes:
       fields:
       - unwrapPtrInt
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -148,12 +152,13 @@ hstypes:
       fields:
       - unwrapPtrPtrChar
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -170,7 +175,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -178,6 +182,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -200,7 +206,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -208,6 +213,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -227,7 +234,6 @@ hstypes:
       fields:
       - unwrapTty
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -236,6 +242,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -258,7 +266,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -266,6 +273,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -288,7 +297,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -296,6 +304,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_types/th.txt
@@ -13,15 +13,15 @@ newtype PtrInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr CInt) => HasField "unwrapPtrInt" PtrInt ty
+    where hasField = \x_0 -> (\y_1 -> PtrInt{unwrapPtrInt = y_1},
+                              getField @"unwrapPtrInt" x_0)
 instance (~) ty (Ptr CInt) =>
          HasField "unwrapPtrInt" (Ptr PtrInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrInt")
 instance HasCField PtrInt "unwrapPtrInt"
     where type CFieldType PtrInt "unwrapPtrInt" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) => HasField "unwrapPtrInt" PtrInt ty
-    where hasField = \x_0 -> (\y_1 -> PtrInt{unwrapPtrInt = y_1},
-                              getField @"unwrapPtrInt" x_0)
 {-| __C declaration:__ @macro ShortInt@
 
     __defined at:__ @macros\/macro_types.h 3:9@
@@ -46,15 +46,15 @@ newtype ShortInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CShort => HasField "unwrapShortInt" ShortInt ty
+    where hasField = \x_0 -> (\y_1 -> ShortInt{unwrapShortInt = y_1},
+                              getField @"unwrapShortInt" x_0)
 instance (~) ty CShort =>
          HasField "unwrapShortInt" (Ptr ShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapShortInt")
 instance HasCField ShortInt "unwrapShortInt"
     where type CFieldType ShortInt "unwrapShortInt" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort => HasField "unwrapShortInt" ShortInt ty
-    where hasField = \x_0 -> (\y_1 -> ShortInt{unwrapShortInt = y_1},
-                              getField @"unwrapShortInt" x_0)
 {-| __C declaration:__ @macro SignedShortInt@
 
     __defined at:__ @macros\/macro_types.h 4:9@
@@ -80,16 +80,16 @@ newtype SignedShortInt
                       Storable,
                       WriteRaw)
 instance (~) ty CShort =>
+         HasField "unwrapSignedShortInt" SignedShortInt ty
+    where hasField = \x_0 -> (\y_1 -> SignedShortInt{unwrapSignedShortInt = y_1},
+                              getField @"unwrapSignedShortInt" x_0)
+instance (~) ty CShort =>
          HasField "unwrapSignedShortInt" (Ptr SignedShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSignedShortInt")
 instance HasCField SignedShortInt "unwrapSignedShortInt"
     where type CFieldType SignedShortInt
                           "unwrapSignedShortInt" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "unwrapSignedShortInt" SignedShortInt ty
-    where hasField = \x_0 -> (\y_1 -> SignedShortInt{unwrapSignedShortInt = y_1},
-                              getField @"unwrapSignedShortInt" x_0)
 {-| __C declaration:__ @macro UnsignedShortInt@
 
     __defined at:__ @macros\/macro_types.h 5:9@
@@ -115,16 +115,16 @@ newtype UnsignedShortInt
                       Storable,
                       WriteRaw)
 instance (~) ty CUShort =>
+         HasField "unwrapUnsignedShortInt" UnsignedShortInt ty
+    where hasField = \x_0 -> (\y_1 -> UnsignedShortInt{unwrapUnsignedShortInt = y_1},
+                              getField @"unwrapUnsignedShortInt" x_0)
+instance (~) ty CUShort =>
          HasField "unwrapUnsignedShortInt" (Ptr UnsignedShortInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUnsignedShortInt")
 instance HasCField UnsignedShortInt "unwrapUnsignedShortInt"
     where type CFieldType UnsignedShortInt
                           "unwrapUnsignedShortInt" = CUShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CUShort =>
-         HasField "unwrapUnsignedShortInt" UnsignedShortInt ty
-    where hasField = \x_0 -> (\y_1 -> UnsignedShortInt{unwrapUnsignedShortInt = y_1},
-                              getField @"unwrapUnsignedShortInt" x_0)
 {-| __C declaration:__ @macro PtrPtrChar@
 
     __defined at:__ @macros\/macro_types.h 8:9@
@@ -140,16 +140,16 @@ newtype PtrPtrChar
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr CChar)) =>
+         HasField "unwrapPtrPtrChar" PtrPtrChar ty
+    where hasField = \x_0 -> (\y_1 -> PtrPtrChar{unwrapPtrPtrChar = y_1},
+                              getField @"unwrapPtrPtrChar" x_0)
+instance (~) ty (Ptr (Ptr CChar)) =>
          HasField "unwrapPtrPtrChar" (Ptr PtrPtrChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPtrPtrChar")
 instance HasCField PtrPtrChar "unwrapPtrPtrChar"
     where type CFieldType PtrPtrChar
                           "unwrapPtrPtrChar" = Ptr (Ptr CChar)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr CChar)) =>
-         HasField "unwrapPtrPtrChar" PtrPtrChar ty
-    where hasField = \x_0 -> (\y_1 -> PtrPtrChar{unwrapPtrPtrChar = y_1},
-                              getField @"unwrapPtrPtrChar" x_0)
 {-| __C declaration:__ @macro MTy@
 
     __defined at:__ @macros\/macro_types.h 11:9@
@@ -172,14 +172,14 @@ newtype MTy
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CFloat => HasField "unwrapMTy" MTy ty
+    where hasField = \x_0 -> (\y_1 -> MTy{unwrapMTy = y_1},
+                              getField @"unwrapMTy" x_0)
 instance (~) ty CFloat => HasField "unwrapMTy" (Ptr MTy) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMTy")
 instance HasCField MTy "unwrapMTy"
     where type CFieldType MTy "unwrapMTy" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat => HasField "unwrapMTy" MTy ty
-    where hasField = \x_0 -> (\y_1 -> MTy{unwrapMTy = y_1},
-                              getField @"unwrapMTy" x_0)
 {-| __C declaration:__ @tty@
 
     __defined at:__ @macros\/macro_types.h 12:13@
@@ -202,14 +202,14 @@ newtype Tty
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty MTy => HasField "unwrapTty" Tty ty
+    where hasField = \x_0 -> (\y_1 -> Tty{unwrapTty = y_1},
+                              getField @"unwrapTty" x_0)
 instance (~) ty MTy => HasField "unwrapTty" (Ptr Tty) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTty")
 instance HasCField Tty "unwrapTty"
     where type CFieldType Tty "unwrapTty" = MTy
           offset# = \_ -> \_ -> 0
-instance (~) ty MTy => HasField "unwrapTty" Tty ty
-    where hasField = \x_0 -> (\y_1 -> Tty{unwrapTty = y_1},
-                              getField @"unwrapTty" x_0)
 {-| __C declaration:__ @macro UINT8_T@
 
     __defined at:__ @macros\/macro_types.h 14:9@
@@ -234,15 +234,15 @@ newtype UINT8_T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CUChar => HasField "unwrapUINT8_T" UINT8_T ty
+    where hasField = \x_0 -> (\y_1 -> UINT8_T{unwrapUINT8_T = y_1},
+                              getField @"unwrapUINT8_T" x_0)
 instance (~) ty CUChar =>
          HasField "unwrapUINT8_T" (Ptr UINT8_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUINT8_T")
 instance HasCField UINT8_T "unwrapUINT8_T"
     where type CFieldType UINT8_T "unwrapUINT8_T" = CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CUChar => HasField "unwrapUINT8_T" UINT8_T ty
-    where hasField = \x_0 -> (\y_1 -> UINT8_T{unwrapUINT8_T = y_1},
-                              getField @"unwrapUINT8_T" x_0)
 {-| __C declaration:__ @macro BOOLEAN_T@
 
     __defined at:__ @macros\/macro_types.h 15:9@
@@ -267,15 +267,15 @@ newtype BOOLEAN_T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty UINT8_T => HasField "unwrapBOOLEAN_T" BOOLEAN_T ty
+    where hasField = \x_0 -> (\y_1 -> BOOLEAN_T{unwrapBOOLEAN_T = y_1},
+                              getField @"unwrapBOOLEAN_T" x_0)
 instance (~) ty UINT8_T =>
          HasField "unwrapBOOLEAN_T" (Ptr BOOLEAN_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOLEAN_T")
 instance HasCField BOOLEAN_T "unwrapBOOLEAN_T"
     where type CFieldType BOOLEAN_T "unwrapBOOLEAN_T" = UINT8_T
           offset# = \_ -> \_ -> 0
-instance (~) ty UINT8_T => HasField "unwrapBOOLEAN_T" BOOLEAN_T ty
-    where hasField = \x_0 -> (\y_1 -> BOOLEAN_T{unwrapBOOLEAN_T = y_1},
-                              getField @"unwrapBOOLEAN_T" x_0)
 {-| __C declaration:__ @boolean_T@
 
     __defined at:__ @macros\/macro_types.h 16:19@
@@ -301,12 +301,12 @@ newtype Boolean_T
                       Storable,
                       WriteRaw)
 instance (~) ty BOOLEAN_T =>
+         HasField "unwrapBoolean_T" Boolean_T ty
+    where hasField = \x_0 -> (\y_1 -> Boolean_T{unwrapBoolean_T = y_1},
+                              getField @"unwrapBoolean_T" x_0)
+instance (~) ty BOOLEAN_T =>
          HasField "unwrapBoolean_T" (Ptr Boolean_T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBoolean_T")
 instance HasCField Boolean_T "unwrapBoolean_T"
     where type CFieldType Boolean_T "unwrapBoolean_T" = BOOLEAN_T
           offset# = \_ -> \_ -> 0
-instance (~) ty BOOLEAN_T =>
-         HasField "unwrapBoolean_T" Boolean_T ty
-    where hasField = \x_0 -> (\y_1 -> Boolean_T{unwrapBoolean_T = y_1},
-                              getField @"unwrapBoolean_T" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/Example.hs
@@ -85,6 +85,14 @@ newtype Outer_int = Outer_int
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapOuter_int" Outer_int ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Outer_int {unwrapOuter_int = y1}, RIP.getField @"unwrapOuter_int" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapOuter_int" (RIP.Ptr Outer_int) (RIP.Ptr ty) where
 
   getField =
@@ -96,14 +104,6 @@ instance HasCField.HasCField Outer_int "unwrapOuter_int" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapOuter_int" Outer_int ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Outer_int {unwrapOuter_int = y1}, RIP.getField @"unwrapOuter_int" x0)
 
 {-| __C declaration:__ @inner_int@
 
@@ -134,6 +134,14 @@ newtype Inner_int = Inner_int
     )
 
 instance ( ty ~ Outer_int
+         ) => RIP.CompatHasField.HasField "unwrapInner_int" Inner_int ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Inner_int {unwrapInner_int = y1}, RIP.getField @"unwrapInner_int" x0)
+
+instance ( ty ~ Outer_int
          ) => RIP.HasField "unwrapInner_int" (RIP.Ptr Inner_int) (RIP.Ptr ty) where
 
   getField =
@@ -145,14 +153,6 @@ instance HasCField.HasCField Inner_int "unwrapInner_int" where
     Outer_int
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Outer_int
-         ) => RIP.CompatHasField.HasField "unwrapInner_int" Inner_int ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Inner_int {unwrapInner_int = y1}, RIP.getField @"unwrapInner_int" x0)
 
 {-| __C declaration:__ @macro OUTER_B@
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/elaborate/th.txt
@@ -66,15 +66,15 @@ newtype Outer_int
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapOuter_int" Outer_int ty
+    where hasField = \x_0 -> (\y_1 -> Outer_int{unwrapOuter_int = y_1},
+                              getField @"unwrapOuter_int" x_0)
 instance (~) ty CInt =>
          HasField "unwrapOuter_int" (Ptr Outer_int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapOuter_int")
 instance HasCField Outer_int "unwrapOuter_int"
     where type CFieldType Outer_int "unwrapOuter_int" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapOuter_int" Outer_int ty
-    where hasField = \x_0 -> (\y_1 -> Outer_int{unwrapOuter_int = y_1},
-                              getField @"unwrapOuter_int" x_0)
 {-| __C declaration:__ @inner_int@
 
     __defined at:__ @elaborate_inner.h 3:19@
@@ -100,15 +100,15 @@ newtype Inner_int
                       Storable,
                       WriteRaw)
 instance (~) ty Outer_int =>
+         HasField "unwrapInner_int" Inner_int ty
+    where hasField = \x_0 -> (\y_1 -> Inner_int{unwrapInner_int = y_1},
+                              getField @"unwrapInner_int" x_0)
+instance (~) ty Outer_int =>
          HasField "unwrapInner_int" (Ptr Inner_int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInner_int")
 instance HasCField Inner_int "unwrapInner_int"
     where type CFieldType Inner_int "unwrapInner_int" = Outer_int
           offset# = \_ -> \_ -> 0
-instance (~) ty Outer_int =>
-         HasField "unwrapInner_int" Inner_int ty
-    where hasField = \x_0 -> (\y_1 -> Inner_int{unwrapInner_int = y_1},
-                              getField @"unwrapInner_int" x_0)
 {-| __C declaration:__ @macro OUTER_B@
 
     __defined at:__ @macros\/parse\/elaborate.h 12:9@

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/Example.hs
@@ -73,6 +73,14 @@ newtype TypeA = TypeA
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapTypeA" TypeA ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TypeA {unwrapTypeA = y1}, RIP.getField @"unwrapTypeA" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapTypeA" (RIP.Ptr TypeA) (RIP.Ptr ty) where
 
   getField =
@@ -83,14 +91,6 @@ instance HasCField.HasCField TypeA "unwrapTypeA" where
   type CFieldType TypeA "unwrapTypeA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapTypeA" TypeA ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TypeA {unwrapTypeA = y1}, RIP.getField @"unwrapTypeA" x0)
 
 {-| __C declaration:__ @macro TypeB@
 
@@ -121,6 +121,14 @@ newtype TypeB = TypeB
     )
 
 instance ( ty ~ TypeA
+         ) => RIP.CompatHasField.HasField "unwrapTypeB" TypeB ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TypeB {unwrapTypeB = y1}, RIP.getField @"unwrapTypeB" x0)
+
+instance ( ty ~ TypeA
          ) => RIP.HasField "unwrapTypeB" (RIP.Ptr TypeB) (RIP.Ptr ty) where
 
   getField =
@@ -131,11 +139,3 @@ instance HasCField.HasCField TypeB "unwrapTypeB" where
   type CFieldType TypeB "unwrapTypeB" = TypeA
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ TypeA
-         ) => RIP.CompatHasField.HasField "unwrapTypeB" TypeB ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TypeB {unwrapTypeB = y1}, RIP.getField @"unwrapTypeB" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/first_parse_then_typecheck/th.txt
@@ -51,14 +51,14 @@ newtype TypeA
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapTypeA" TypeA ty
+    where hasField = \x_0 -> (\y_1 -> TypeA{unwrapTypeA = y_1},
+                              getField @"unwrapTypeA" x_0)
 instance (~) ty CInt => HasField "unwrapTypeA" (Ptr TypeA) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypeA")
 instance HasCField TypeA "unwrapTypeA"
     where type CFieldType TypeA "unwrapTypeA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapTypeA" TypeA ty
-    where hasField = \x_0 -> (\y_1 -> TypeA{unwrapTypeA = y_1},
-                              getField @"unwrapTypeA" x_0)
 {-| __C declaration:__ @macro TypeB@
 
     __defined at:__ @macros\/parse\/first_parse_then_typecheck.h 9:9@
@@ -83,12 +83,12 @@ newtype TypeB
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty TypeA => HasField "unwrapTypeB" TypeB ty
+    where hasField = \x_0 -> (\y_1 -> TypeB{unwrapTypeB = y_1},
+                              getField @"unwrapTypeB" x_0)
 instance (~) ty TypeA =>
          HasField "unwrapTypeB" (Ptr TypeB) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypeB")
 instance HasCField TypeB "unwrapTypeB"
     where type CFieldType TypeB "unwrapTypeB" = TypeA
           offset# = \_ -> \_ -> 0
-instance (~) ty TypeA => HasField "unwrapTypeB" TypeB ty
-    where hasField = \x_0 -> (\y_1 -> TypeB{unwrapTypeB = y_1},
-                              getField @"unwrapTypeB" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/Example.hs
@@ -57,6 +57,13 @@ newtype Ta = Ta
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapTa" Ta ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Ta {unwrapTa = y1}, RIP.getField @"unwrapTa" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapTa" (RIP.Ptr Ta) (RIP.Ptr ty) where
 
@@ -67,13 +74,6 @@ instance HasCField.HasCField Ta "unwrapTa" where
   type CFieldType Ta "unwrapTa" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapTa" Ta ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Ta {unwrapTa = y1}, RIP.getField @"unwrapTa" x0)
 
 {-| __C declaration:__ @macro Ma@
 
@@ -103,6 +103,13 @@ newtype Ma = Ma
     , Marshal.WriteRaw
     )
 
+instance (ty ~ Ta) => RIP.CompatHasField.HasField "unwrapMa" Ma ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Ma {unwrapMa = y1}, RIP.getField @"unwrapMa" x0)
+
 instance (ty ~ Ta) => RIP.HasField "unwrapMa" (RIP.Ptr Ma) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapMa")
@@ -112,13 +119,6 @@ instance HasCField.HasCField Ma "unwrapMa" where
   type CFieldType Ma "unwrapMa" = Ta
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ Ta) => RIP.CompatHasField.HasField "unwrapMa" Ma ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Ma {unwrapMa = y1}, RIP.getField @"unwrapMa" x0)
 
 {-| __C declaration:__ @T1@
 
@@ -148,6 +148,13 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
 
@@ -158,13 +165,6 @@ instance HasCField.HasCField T1 "unwrapT1" where
   type CFieldType T1 "unwrapT1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
 
 {-| __C declaration:__ @macro M1@
 
@@ -194,6 +194,13 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T1) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
+
 instance (ty ~ T1) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM1")
@@ -203,13 +210,6 @@ instance HasCField.HasCField M1 "unwrapM1" where
   type CFieldType M1 "unwrapM1" = T1
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
 
 {-| __C declaration:__ @macro M2@
 
@@ -239,6 +239,13 @@ newtype M2 = M2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T1) => RIP.CompatHasField.HasField "unwrapM2" M2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M2 {unwrapM2 = y1}, RIP.getField @"unwrapM2" x0)
+
 instance (ty ~ T1) => RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM2")
@@ -248,13 +255,6 @@ instance HasCField.HasCField M2 "unwrapM2" where
   type CFieldType M2 "unwrapM2" = T1
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1) => RIP.CompatHasField.HasField "unwrapM2" M2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M2 {unwrapM2 = y1}, RIP.getField @"unwrapM2" x0)
 
 {-| __C declaration:__ @T2@
 
@@ -284,6 +284,13 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
@@ -294,13 +301,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @macro M3@
 
@@ -330,6 +330,13 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
+
 instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
@@ -339,13 +346,6 @@ instance HasCField.HasCField M3 "unwrapM3" where
   type CFieldType M3 "unwrapM3" = T2
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
 
 {-| __C declaration:__ @macro M4@
 
@@ -375,6 +375,13 @@ newtype M4 = M4
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM4" M4 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M4 {unwrapM4 = y1}, RIP.getField @"unwrapM4" x0)
+
 instance (ty ~ T2) => RIP.HasField "unwrapM4" (RIP.Ptr M4) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM4")
@@ -384,10 +391,3 @@ instance HasCField.HasCField M4 "unwrapM4" where
   type CFieldType M4 "unwrapM4" = T2
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM4" M4 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M4 {unwrapM4 = y1}, RIP.getField @"unwrapM4" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/bindingspec.yaml
@@ -38,7 +38,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -46,6 +45,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -68,7 +69,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -76,6 +76,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -98,7 +100,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -106,6 +107,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -128,7 +131,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -136,6 +138,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -158,7 +162,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -166,6 +169,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -188,7 +193,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -196,6 +200,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -218,7 +224,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -226,6 +231,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -248,7 +255,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -256,6 +262,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include/th.txt
@@ -24,14 +24,14 @@ newtype Ta
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapTa" Ta ty
+    where hasField = \x_0 -> (\y_1 -> Ta{unwrapTa = y_1},
+                              getField @"unwrapTa" x_0)
 instance (~) ty CInt => HasField "unwrapTa" (Ptr Ta) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTa")
 instance HasCField Ta "unwrapTa"
     where type CFieldType Ta "unwrapTa" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapTa" Ta ty
-    where hasField = \x_0 -> (\y_1 -> Ta{unwrapTa = y_1},
-                              getField @"unwrapTa" x_0)
 {-| __C declaration:__ @macro Ma@
 
     __defined at:__ @intermittent_include_inner.h 1:9@
@@ -56,14 +56,14 @@ newtype Ma
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty Ta => HasField "unwrapMa" Ma ty
+    where hasField = \x_0 -> (\y_1 -> Ma{unwrapMa = y_1},
+                              getField @"unwrapMa" x_0)
 instance (~) ty Ta => HasField "unwrapMa" (Ptr Ma) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMa")
 instance HasCField Ma "unwrapMa"
     where type CFieldType Ma "unwrapMa" = Ta
           offset# = \_ -> \_ -> 0
-instance (~) ty Ta => HasField "unwrapMa" Ma ty
-    where hasField = \x_0 -> (\y_1 -> Ma{unwrapMa = y_1},
-                              getField @"unwrapMa" x_0)
 {-| __C declaration:__ @T1@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 9:13@
@@ -88,14 +88,14 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT1" T1 ty
+    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
+                              getField @"unwrapT1" x_0)
 instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT1" T1 ty
-    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
-                              getField @"unwrapT1" x_0)
 {-| __C declaration:__ @macro M1@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 7:9@
@@ -120,14 +120,14 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T1 => HasField "unwrapM1" M1 ty
+    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
+                              getField @"unwrapM1" x_0)
 instance (~) ty T1 => HasField "unwrapM1" (Ptr M1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = T1
           offset# = \_ -> \_ -> 0
-instance (~) ty T1 => HasField "unwrapM1" M1 ty
-    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
-                              getField @"unwrapM1" x_0)
 {-| __C declaration:__ @macro M2@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 11:9@
@@ -152,14 +152,14 @@ newtype M2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T1 => HasField "unwrapM2" M2 ty
+    where hasField = \x_0 -> (\y_1 -> M2{unwrapM2 = y_1},
+                              getField @"unwrapM2" x_0)
 instance (~) ty T1 => HasField "unwrapM2" (Ptr M2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = T1
           offset# = \_ -> \_ -> 0
-instance (~) ty T1 => HasField "unwrapM2" M2 ty
-    where hasField = \x_0 -> (\y_1 -> M2{unwrapM2 = y_1},
-                              getField @"unwrapM2" x_0)
 {-| __C declaration:__ @T2@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 17:13@
@@ -184,14 +184,14 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty CInt => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @macro M3@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 15:9@
@@ -216,14 +216,14 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T2 => HasField "unwrapM3" M3 ty
+    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
+                              getField @"unwrapM3" x_0)
 instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
           offset# = \_ -> \_ -> 0
-instance (~) ty T2 => HasField "unwrapM3" M3 ty
-    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
-                              getField @"unwrapM3" x_0)
 {-| __C declaration:__ @macro M4@
 
     __defined at:__ @macros\/parse\/intermittent_include.h 19:9@
@@ -248,11 +248,11 @@ newtype M4
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T2 => HasField "unwrapM4" M4 ty
+    where hasField = \x_0 -> (\y_1 -> M4{unwrapM4 = y_1},
+                              getField @"unwrapM4" x_0)
 instance (~) ty T2 => HasField "unwrapM4" (Ptr M4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM4")
 instance HasCField M4 "unwrapM4"
     where type CFieldType M4 "unwrapM4" = T2
           offset# = \_ -> \_ -> 0
-instance (~) ty T2 => HasField "unwrapM4" M4 ty
-    where hasField = \x_0 -> (\y_1 -> M4{unwrapM4 = y_1},
-                              getField @"unwrapM4" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/Example.hs
@@ -52,6 +52,13 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
 instance ( ty ~ RIP.CFloat
          ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
@@ -62,13 +69,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = RIP.CFloat
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @T4@
 
@@ -97,6 +97,14 @@ newtype T4 = T4
     )
 
 instance ( ty ~ RIP.CDouble
+         ) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)
+
+instance ( ty ~ RIP.CDouble
          ) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
@@ -106,14 +114,6 @@ instance HasCField.HasCField T4 "unwrapT4" where
   type CFieldType T4 "unwrapT4" = RIP.CDouble
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)
 
 {-| __C declaration:__ @T1@
 
@@ -143,6 +143,13 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
 
@@ -153,13 +160,6 @@ instance HasCField.HasCField T1 "unwrapT1" where
   type CFieldType T1 "unwrapT1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
 
 {-| __C declaration:__ @T3@
 
@@ -189,6 +189,13 @@ newtype T3 = T3
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
 
@@ -199,13 +206,6 @@ instance HasCField.HasCField T3 "unwrapT3" where
   type CFieldType T3 "unwrapT3" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)
 
 {-| __C declaration:__ @T5@
 
@@ -235,6 +235,13 @@ newtype T5 = T5
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT5" T5 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T5 {unwrapT5 = y1}, RIP.getField @"unwrapT5" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT5" (RIP.Ptr T5) (RIP.Ptr ty) where
 
@@ -245,10 +252,3 @@ instance HasCField.HasCField T5 "unwrapT5" where
   type CFieldType T5 "unwrapT5" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT5" T5 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T5 {unwrapT5 = y1}, RIP.getField @"unwrapT5" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/bindingspec.yaml
@@ -29,7 +29,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -37,6 +36,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -56,7 +57,6 @@ hstypes:
       fields:
       - unwrapT2
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -65,6 +65,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -87,7 +89,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -95,6 +96,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -114,7 +117,6 @@ hstypes:
       fields:
       - unwrapT4
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -123,6 +125,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -145,7 +149,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -153,6 +156,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/intermittent_include_conditional/th.txt
@@ -22,14 +22,14 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CFloat => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty CFloat => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @T4@
 
     __defined at:__ @intermittent_include_conditional_inner.h 6:16@
@@ -52,14 +52,14 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CDouble => HasField "unwrapT4" T4 ty
+    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
+                              getField @"unwrapT4" x_0)
 instance (~) ty CDouble => HasField "unwrapT4" (Ptr T4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble => HasField "unwrapT4" T4 ty
-    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
-                              getField @"unwrapT4" x_0)
 {-| __C declaration:__ @T1@
 
     __defined at:__ @macros\/parse\/intermittent_include_conditional.h 1:13@
@@ -84,14 +84,14 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT1" T1 ty
+    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
+                              getField @"unwrapT1" x_0)
 instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT1" T1 ty
-    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
-                              getField @"unwrapT1" x_0)
 {-| __C declaration:__ @T3@
 
     __defined at:__ @macros\/parse\/intermittent_include_conditional.h 6:13@
@@ -116,14 +116,14 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT3" T3 ty
+    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
+                              getField @"unwrapT3" x_0)
 instance (~) ty CInt => HasField "unwrapT3" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT3" T3 ty
-    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
-                              getField @"unwrapT3" x_0)
 {-| __C declaration:__ @T5@
 
     __defined at:__ @macros\/parse\/intermittent_include_conditional.h 11:13@
@@ -148,11 +148,11 @@ newtype T5
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT5" T5 ty
+    where hasField = \x_0 -> (\y_1 -> T5{unwrapT5 = y_1},
+                              getField @"unwrapT5" x_0)
 instance (~) ty CInt => HasField "unwrapT5" (Ptr T5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT5")
 instance HasCField T5 "unwrapT5"
     where type CFieldType T5 "unwrapT5" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT5" T5 ty
-    where hasField = \x_0 -> (\y_1 -> T5{unwrapT5 = y_1},
-                              getField @"unwrapT5" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/Example.hs
@@ -53,6 +53,13 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
 
@@ -63,13 +70,6 @@ instance HasCField.HasCField M1 "unwrapM1" where
   type CFieldType M1 "unwrapM1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
 
 {-| __C declaration:__ @T2@
 
@@ -99,6 +99,13 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ M1) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
 instance (ty ~ M1) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
@@ -108,13 +115,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = M1
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M1) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @macro M3@
 
@@ -144,6 +144,13 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
+
 instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
@@ -153,13 +160,6 @@ instance HasCField.HasCField M3 "unwrapM3" where
   type CFieldType M3 "unwrapM3" = T2
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
 
 {-| __C declaration:__ @T4@
 
@@ -189,6 +189,13 @@ newtype T4 = T4
     , Marshal.WriteRaw
     )
 
+instance (ty ~ M3) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)
+
 instance (ty ~ M3) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
@@ -198,10 +205,3 @@ instance HasCField.HasCField T4 "unwrapT4" where
   type CFieldType T4 "unwrapT4" = M3
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M3) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/bindingspec.yaml
@@ -26,7 +26,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -34,6 +33,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -56,7 +57,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -64,6 +64,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -86,7 +88,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -94,6 +95,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -116,7 +119,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -124,6 +126,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope/th.txt
@@ -23,14 +23,14 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapM1" M1 ty
+    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
+                              getField @"unwrapM1" x_0)
 instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapM1" M1 ty
-    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
-                              getField @"unwrapM1" x_0)
 {-| __C declaration:__ @T2@
 
     __defined at:__ @macros\/parse\/macro_typedef_scope.h 5:12@
@@ -55,14 +55,14 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty M1 => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty M1 => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = M1
           offset# = \_ -> \_ -> 0
-instance (~) ty M1 => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @macro M3@
 
     __defined at:__ @macros\/parse\/macro_typedef_scope.h 6:9@
@@ -87,14 +87,14 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T2 => HasField "unwrapM3" M3 ty
+    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
+                              getField @"unwrapM3" x_0)
 instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
           offset# = \_ -> \_ -> 0
-instance (~) ty T2 => HasField "unwrapM3" M3 ty
-    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
-                              getField @"unwrapM3" x_0)
 {-| __C declaration:__ @T4@
 
     __defined at:__ @macros\/parse\/macro_typedef_scope.h 7:12@
@@ -119,11 +119,11 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty M3 => HasField "unwrapT4" T4 ty
+    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
+                              getField @"unwrapT4" x_0)
 instance (~) ty M3 => HasField "unwrapT4" (Ptr T4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = M3
           offset# = \_ -> \_ -> 0
-instance (~) ty M3 => HasField "unwrapT4" T4 ty
-    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
-                              getField @"unwrapT4" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/Example.hs
@@ -53,6 +53,13 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
 
@@ -63,13 +70,6 @@ instance HasCField.HasCField M1 "unwrapM1" where
   type CFieldType M1 "unwrapM1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
 
 {-| __C declaration:__ @T2@
 
@@ -99,6 +99,13 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ M1) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
 instance (ty ~ M1) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
@@ -108,13 +115,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = M1
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M1) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @macro M3@
 
@@ -144,6 +144,13 @@ newtype M3 = M3
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
+
 instance (ty ~ T2) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
@@ -153,13 +160,6 @@ instance HasCField.HasCField M3 "unwrapM3" where
   type CFieldType M3 "unwrapM3" = T2
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T2) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
 
 {-| __C declaration:__ @T4@
 
@@ -189,6 +189,13 @@ newtype T4 = T4
     , Marshal.WriteRaw
     )
 
+instance (ty ~ M3) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)
+
 instance (ty ~ M3) => RIP.HasField "unwrapT4" (RIP.Ptr T4) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT4")
@@ -198,10 +205,3 @@ instance HasCField.HasCField T4 "unwrapT4" where
   type CFieldType T4 "unwrapT4" = M3
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ M3) => RIP.CompatHasField.HasField "unwrapT4" T4 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T4 {unwrapT4 = y1}, RIP.getField @"unwrapT4" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/bindingspec.yaml
@@ -26,7 +26,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -34,6 +33,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -56,7 +57,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -64,6 +64,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -86,7 +88,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -94,6 +95,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -116,7 +119,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -124,6 +126,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/parse/macro_typedef_scope_multiple/th.txt
@@ -25,14 +25,14 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapM1" M1 ty
+    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
+                              getField @"unwrapM1" x_0)
 instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapM1" M1 ty
-    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
-                              getField @"unwrapM1" x_0)
 {-| __C declaration:__ @T2@
 
     __defined at:__ @macro_typedef_scope_multiple_inner1.h 2:12@
@@ -57,14 +57,14 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty M1 => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty M1 => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = M1
           offset# = \_ -> \_ -> 0
-instance (~) ty M1 => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @macro M3@
 
     __defined at:__ @macro_typedef_scope_multiple_inner2.h 1:9@
@@ -89,14 +89,14 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty T2 => HasField "unwrapM3" M3 ty
+    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
+                              getField @"unwrapM3" x_0)
 instance (~) ty T2 => HasField "unwrapM3" (Ptr M3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = T2
           offset# = \_ -> \_ -> 0
-instance (~) ty T2 => HasField "unwrapM3" M3 ty
-    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
-                              getField @"unwrapM3" x_0)
 {-| __C declaration:__ @T4@
 
     __defined at:__ @macro_typedef_scope_multiple_inner2.h 2:12@
@@ -121,11 +121,11 @@ newtype T4
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty M3 => HasField "unwrapT4" T4 ty
+    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
+                              getField @"unwrapT4" x_0)
 instance (~) ty M3 => HasField "unwrapT4" (Ptr T4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT4")
 instance HasCField T4 "unwrapT4"
     where type CFieldType T4 "unwrapT4" = M3
           offset# = \_ -> \_ -> 0
-instance (~) ty M3 => HasField "unwrapT4" T4 ty
-    where hasField = \x_0 -> (\y_1 -> T4{unwrapT4 = y_1},
-                              getField @"unwrapT4" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/Example.hs
@@ -107,6 +107,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -117,12 +123,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @struct some_struct@
 
@@ -252,6 +252,14 @@ instance Read Some_enum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapSome_enum" Some_enum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Some_enum {unwrapSome_enum = y1}, RIP.getField @"unwrapSome_enum" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapSome_enum" (RIP.Ptr Some_enum) (RIP.Ptr ty) where
 
   getField =
@@ -263,14 +271,6 @@ instance HasCField.HasCField Some_enum "unwrapSome_enum" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapSome_enum" Some_enum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Some_enum {unwrapSome_enum = y1}, RIP.getField @"unwrapSome_enum" x0)
 
 {-| __C declaration:__ @ENUM_A@
 
@@ -294,6 +294,15 @@ newtype Arr_typedef1 = Arr_typedef1
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray A
+         ) => RIP.CompatHasField.HasField "unwrapArr_typedef1" Arr_typedef1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Arr_typedef1 {unwrapArr_typedef1 = y1}
+      , RIP.getField @"unwrapArr_typedef1" x0
+      )
+
+instance ( ty ~ IA.IncompleteArray A
          ) => RIP.HasField "unwrapArr_typedef1" (RIP.Ptr Arr_typedef1) (RIP.Ptr ty) where
 
   getField =
@@ -305,15 +314,6 @@ instance HasCField.HasCField Arr_typedef1 "unwrapArr_typedef1" where
     IA.IncompleteArray A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray A
-         ) => RIP.CompatHasField.HasField "unwrapArr_typedef1" Arr_typedef1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Arr_typedef1 {unwrapArr_typedef1 = y1}
-      , RIP.getField @"unwrapArr_typedef1" x0
-      )
 
 {-| __C declaration:__ @arr_typedef2@
 
@@ -328,6 +328,15 @@ newtype Arr_typedef2 = Arr_typedef2
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray (RIP.Ptr A)
+         ) => RIP.CompatHasField.HasField "unwrapArr_typedef2" Arr_typedef2 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Arr_typedef2 {unwrapArr_typedef2 = y1}
+      , RIP.getField @"unwrapArr_typedef2" x0
+      )
+
+instance ( ty ~ IA.IncompleteArray (RIP.Ptr A)
          ) => RIP.HasField "unwrapArr_typedef2" (RIP.Ptr Arr_typedef2) (RIP.Ptr ty) where
 
   getField =
@@ -339,15 +348,6 @@ instance HasCField.HasCField Arr_typedef2 "unwrapArr_typedef2" where
     IA.IncompleteArray (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray (RIP.Ptr A)
-         ) => RIP.CompatHasField.HasField "unwrapArr_typedef2" Arr_typedef2 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Arr_typedef2 {unwrapArr_typedef2 = y1}
-      , RIP.getField @"unwrapArr_typedef2" x0
-      )
 
 {-| __C declaration:__ @arr_typedef3@
 
@@ -368,6 +368,15 @@ newtype Arr_typedef3 = Arr_typedef3
     )
 
 instance ( ty ~ CA.ConstantArray 5 A
+         ) => RIP.CompatHasField.HasField "unwrapArr_typedef3" Arr_typedef3 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Arr_typedef3 {unwrapArr_typedef3 = y1}
+      , RIP.getField @"unwrapArr_typedef3" x0
+      )
+
+instance ( ty ~ CA.ConstantArray 5 A
          ) => RIP.HasField "unwrapArr_typedef3" (RIP.Ptr Arr_typedef3) (RIP.Ptr ty) where
 
   getField =
@@ -379,15 +388,6 @@ instance HasCField.HasCField Arr_typedef3 "unwrapArr_typedef3" where
     CA.ConstantArray 5 A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 5 A
-         ) => RIP.CompatHasField.HasField "unwrapArr_typedef3" Arr_typedef3 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Arr_typedef3 {unwrapArr_typedef3 = y1}
-      , RIP.getField @"unwrapArr_typedef3" x0
-      )
 
 {-| __C declaration:__ @arr_typedef4@
 
@@ -408,6 +408,15 @@ newtype Arr_typedef4 = Arr_typedef4
     )
 
 instance ( ty ~ CA.ConstantArray 5 (RIP.Ptr A)
+         ) => RIP.CompatHasField.HasField "unwrapArr_typedef4" Arr_typedef4 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Arr_typedef4 {unwrapArr_typedef4 = y1}
+      , RIP.getField @"unwrapArr_typedef4" x0
+      )
+
+instance ( ty ~ CA.ConstantArray 5 (RIP.Ptr A)
          ) => RIP.HasField "unwrapArr_typedef4" (RIP.Ptr Arr_typedef4) (RIP.Ptr ty) where
 
   getField =
@@ -419,15 +428,6 @@ instance HasCField.HasCField Arr_typedef4 "unwrapArr_typedef4" where
     CA.ConstantArray 5 (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 5 (RIP.Ptr A)
-         ) => RIP.CompatHasField.HasField "unwrapArr_typedef4" Arr_typedef4 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Arr_typedef4 {unwrapArr_typedef4 = y1}
-      , RIP.getField @"unwrapArr_typedef4" x0
-      )
 
 {-| Typedefs
 
@@ -460,6 +460,14 @@ newtype Typedef1 = Typedef1
     )
 
 instance ( ty ~ A
+         ) => RIP.CompatHasField.HasField "unwrapTypedef1" Typedef1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Typedef1 {unwrapTypedef1 = y1}, RIP.getField @"unwrapTypedef1" x0)
+
+instance ( ty ~ A
          ) => RIP.HasField "unwrapTypedef1" (RIP.Ptr Typedef1) (RIP.Ptr ty) where
 
   getField =
@@ -470,14 +478,6 @@ instance HasCField.HasCField Typedef1 "unwrapTypedef1" where
   type CFieldType Typedef1 "unwrapTypedef1" = A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.CompatHasField.HasField "unwrapTypedef1" Typedef1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Typedef1 {unwrapTypedef1 = y1}, RIP.getField @"unwrapTypedef1" x0)
 
 {-| __C declaration:__ @typedef2@
 
@@ -498,6 +498,14 @@ newtype Typedef2 = Typedef2
     )
 
 instance ( ty ~ RIP.Ptr A
+         ) => RIP.CompatHasField.HasField "unwrapTypedef2" Typedef2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Typedef2 {unwrapTypedef2 = y1}, RIP.getField @"unwrapTypedef2" x0)
+
+instance ( ty ~ RIP.Ptr A
          ) => RIP.HasField "unwrapTypedef2" (RIP.Ptr Typedef2) (RIP.Ptr ty) where
 
   getField =
@@ -508,14 +516,6 @@ instance HasCField.HasCField Typedef2 "unwrapTypedef2" where
   type CFieldType Typedef2 "unwrapTypedef2" = RIP.Ptr A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.CompatHasField.HasField "unwrapTypedef2" Typedef2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Typedef2 {unwrapTypedef2 = y1}, RIP.getField @"unwrapTypedef2" x0)
 
 {-| __C declaration:__ @typedef3@
 
@@ -536,6 +536,14 @@ newtype Typedef3 = Typedef3
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr A)
+         ) => RIP.CompatHasField.HasField "unwrapTypedef3" Typedef3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Typedef3 {unwrapTypedef3 = y1}, RIP.getField @"unwrapTypedef3" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr A)
          ) => RIP.HasField "unwrapTypedef3" (RIP.Ptr Typedef3) (RIP.Ptr ty) where
 
   getField =
@@ -547,14 +555,6 @@ instance HasCField.HasCField Typedef3 "unwrapTypedef3" where
     RIP.Ptr (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr A)
-         ) => RIP.CompatHasField.HasField "unwrapTypedef3" Typedef3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Typedef3 {unwrapTypedef3 = y1}, RIP.getField @"unwrapTypedef3" x0)
 
 {-| Auxiliary type used by 'Funptr_typedef1'
 
@@ -605,6 +605,16 @@ instance RIP.FromFunPtr Funptr_typedef1_Aux where
   fromFunPtr = hs_bindgen_806a46dc418a062c
 
 instance ( ty ~ IO A
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef1_Aux" Funptr_typedef1_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Funptr_typedef1_Aux {unwrapFunptr_typedef1_Aux = y1}
+      , RIP.getField @"unwrapFunptr_typedef1_Aux" x0
+      )
+
+instance ( ty ~ IO A
          ) => RIP.HasField "unwrapFunptr_typedef1_Aux" (RIP.Ptr Funptr_typedef1_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -616,16 +626,6 @@ instance HasCField.HasCField Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux" whe
     IO A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO A
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef1_Aux" Funptr_typedef1_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Funptr_typedef1_Aux {unwrapFunptr_typedef1_Aux = y1}
-      , RIP.getField @"unwrapFunptr_typedef1_Aux" x0
-      )
 
 {-| __C declaration:__ @funptr_typedef1@
 
@@ -646,6 +646,15 @@ newtype Funptr_typedef1 = Funptr_typedef1
     )
 
 instance ( ty ~ RIP.FunPtr Funptr_typedef1_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef1" Funptr_typedef1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Funptr_typedef1 {unwrapFunptr_typedef1 = y1}
+      , RIP.getField @"unwrapFunptr_typedef1" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Funptr_typedef1_Aux
          ) => RIP.HasField "unwrapFunptr_typedef1" (RIP.Ptr Funptr_typedef1) (RIP.Ptr ty) where
 
   getField =
@@ -657,15 +666,6 @@ instance HasCField.HasCField Funptr_typedef1 "unwrapFunptr_typedef1" where
     RIP.FunPtr Funptr_typedef1_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Funptr_typedef1_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef1" Funptr_typedef1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Funptr_typedef1 {unwrapFunptr_typedef1 = y1}
-      , RIP.getField @"unwrapFunptr_typedef1" x0
-      )
 
 {-| Auxiliary type used by 'Funptr_typedef2'
 
@@ -716,6 +716,16 @@ instance RIP.FromFunPtr Funptr_typedef2_Aux where
   fromFunPtr = hs_bindgen_323d07dff85b802c
 
 instance ( ty ~ IO (RIP.Ptr A)
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef2_Aux" Funptr_typedef2_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Funptr_typedef2_Aux {unwrapFunptr_typedef2_Aux = y1}
+      , RIP.getField @"unwrapFunptr_typedef2_Aux" x0
+      )
+
+instance ( ty ~ IO (RIP.Ptr A)
          ) => RIP.HasField "unwrapFunptr_typedef2_Aux" (RIP.Ptr Funptr_typedef2_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -727,16 +737,6 @@ instance HasCField.HasCField Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux" whe
     IO (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO (RIP.Ptr A)
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef2_Aux" Funptr_typedef2_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Funptr_typedef2_Aux {unwrapFunptr_typedef2_Aux = y1}
-      , RIP.getField @"unwrapFunptr_typedef2_Aux" x0
-      )
 
 {-| __C declaration:__ @funptr_typedef2@
 
@@ -757,6 +757,15 @@ newtype Funptr_typedef2 = Funptr_typedef2
     )
 
 instance ( ty ~ RIP.FunPtr Funptr_typedef2_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef2" Funptr_typedef2 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Funptr_typedef2 {unwrapFunptr_typedef2 = y1}
+      , RIP.getField @"unwrapFunptr_typedef2" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Funptr_typedef2_Aux
          ) => RIP.HasField "unwrapFunptr_typedef2" (RIP.Ptr Funptr_typedef2) (RIP.Ptr ty) where
 
   getField =
@@ -768,15 +777,6 @@ instance HasCField.HasCField Funptr_typedef2 "unwrapFunptr_typedef2" where
     RIP.FunPtr Funptr_typedef2_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Funptr_typedef2_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef2" Funptr_typedef2 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Funptr_typedef2 {unwrapFunptr_typedef2 = y1}
-      , RIP.getField @"unwrapFunptr_typedef2" x0
-      )
 
 {-| Auxiliary type used by 'Funptr_typedef3'
 
@@ -827,6 +827,16 @@ instance RIP.FromFunPtr Funptr_typedef3_Aux where
   fromFunPtr = hs_bindgen_82dc7b932974117e
 
 instance ( ty ~ IO (RIP.Ptr (RIP.Ptr A))
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef3_Aux" Funptr_typedef3_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Funptr_typedef3_Aux {unwrapFunptr_typedef3_Aux = y1}
+      , RIP.getField @"unwrapFunptr_typedef3_Aux" x0
+      )
+
+instance ( ty ~ IO (RIP.Ptr (RIP.Ptr A))
          ) => RIP.HasField "unwrapFunptr_typedef3_Aux" (RIP.Ptr Funptr_typedef3_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -838,16 +848,6 @@ instance HasCField.HasCField Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux" whe
     IO (RIP.Ptr (RIP.Ptr A))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO (RIP.Ptr (RIP.Ptr A))
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef3_Aux" Funptr_typedef3_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Funptr_typedef3_Aux {unwrapFunptr_typedef3_Aux = y1}
-      , RIP.getField @"unwrapFunptr_typedef3_Aux" x0
-      )
 
 {-| __C declaration:__ @funptr_typedef3@
 
@@ -868,6 +868,15 @@ newtype Funptr_typedef3 = Funptr_typedef3
     )
 
 instance ( ty ~ RIP.FunPtr Funptr_typedef3_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef3" Funptr_typedef3 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Funptr_typedef3 {unwrapFunptr_typedef3 = y1}
+      , RIP.getField @"unwrapFunptr_typedef3" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Funptr_typedef3_Aux
          ) => RIP.HasField "unwrapFunptr_typedef3" (RIP.Ptr Funptr_typedef3) (RIP.Ptr ty) where
 
   getField =
@@ -879,15 +888,6 @@ instance HasCField.HasCField Funptr_typedef3 "unwrapFunptr_typedef3" where
     RIP.FunPtr Funptr_typedef3_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Funptr_typedef3_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef3" Funptr_typedef3 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Funptr_typedef3 {unwrapFunptr_typedef3 = y1}
-      , RIP.getField @"unwrapFunptr_typedef3" x0
-      )
 
 {-| Auxiliary type used by 'Funptr_typedef4'
 
@@ -938,6 +938,16 @@ instance RIP.FromFunPtr Funptr_typedef4_Aux where
   fromFunPtr = hs_bindgen_d4a97954476da161
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef4_Aux" Funptr_typedef4_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Funptr_typedef4_Aux {unwrapFunptr_typedef4_Aux = y1}
+      , RIP.getField @"unwrapFunptr_typedef4_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
          ) => RIP.HasField "unwrapFunptr_typedef4_Aux" (RIP.Ptr Funptr_typedef4_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -949,16 +959,6 @@ instance HasCField.HasCField Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux" whe
     RIP.CInt -> RIP.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef4_Aux" Funptr_typedef4_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Funptr_typedef4_Aux {unwrapFunptr_typedef4_Aux = y1}
-      , RIP.getField @"unwrapFunptr_typedef4_Aux" x0
-      )
 
 {-| __C declaration:__ @funptr_typedef4@
 
@@ -979,6 +979,15 @@ newtype Funptr_typedef4 = Funptr_typedef4
     )
 
 instance ( ty ~ RIP.FunPtr Funptr_typedef4_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef4" Funptr_typedef4 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Funptr_typedef4 {unwrapFunptr_typedef4 = y1}
+      , RIP.getField @"unwrapFunptr_typedef4" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Funptr_typedef4_Aux
          ) => RIP.HasField "unwrapFunptr_typedef4" (RIP.Ptr Funptr_typedef4) (RIP.Ptr ty) where
 
   getField =
@@ -990,15 +999,6 @@ instance HasCField.HasCField Funptr_typedef4 "unwrapFunptr_typedef4" where
     RIP.FunPtr Funptr_typedef4_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Funptr_typedef4_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef4" Funptr_typedef4 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Funptr_typedef4 {unwrapFunptr_typedef4 = y1}
-      , RIP.getField @"unwrapFunptr_typedef4" x0
-      )
 
 {-| Auxiliary type used by 'Funptr_typedef5'
 
@@ -1049,6 +1049,16 @@ instance RIP.FromFunPtr Funptr_typedef5_Aux where
   fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef5_Aux" Funptr_typedef5_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Funptr_typedef5_Aux {unwrapFunptr_typedef5_Aux = y1}
+      , RIP.getField @"unwrapFunptr_typedef5_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
          ) => RIP.HasField "unwrapFunptr_typedef5_Aux" (RIP.Ptr Funptr_typedef5_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -1060,16 +1070,6 @@ instance HasCField.HasCField Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux" whe
     RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef5_Aux" Funptr_typedef5_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Funptr_typedef5_Aux {unwrapFunptr_typedef5_Aux = y1}
-      , RIP.getField @"unwrapFunptr_typedef5_Aux" x0
-      )
 
 {-| __C declaration:__ @funptr_typedef5@
 
@@ -1090,6 +1090,15 @@ newtype Funptr_typedef5 = Funptr_typedef5
     )
 
 instance ( ty ~ RIP.FunPtr Funptr_typedef5_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef5" Funptr_typedef5 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Funptr_typedef5 {unwrapFunptr_typedef5 = y1}
+      , RIP.getField @"unwrapFunptr_typedef5" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Funptr_typedef5_Aux
          ) => RIP.HasField "unwrapFunptr_typedef5" (RIP.Ptr Funptr_typedef5) (RIP.Ptr ty) where
 
   getField =
@@ -1101,15 +1110,6 @@ instance HasCField.HasCField Funptr_typedef5 "unwrapFunptr_typedef5" where
     RIP.FunPtr Funptr_typedef5_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Funptr_typedef5_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunptr_typedef5" Funptr_typedef5 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Funptr_typedef5 {unwrapFunptr_typedef5 = y1}
-      , RIP.getField @"unwrapFunptr_typedef5" x0
-      )
 
 {-| __C declaration:__ @comments2@
 
@@ -1140,6 +1140,14 @@ newtype Comments2 = Comments2
     )
 
 instance ( ty ~ A
+         ) => RIP.CompatHasField.HasField "unwrapComments2" Comments2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Comments2 {unwrapComments2 = y1}, RIP.getField @"unwrapComments2" x0)
+
+instance ( ty ~ A
          ) => RIP.HasField "unwrapComments2" (RIP.Ptr Comments2) (RIP.Ptr ty) where
 
   getField =
@@ -1150,14 +1158,6 @@ instance HasCField.HasCField Comments2 "unwrapComments2" where
   type CFieldType Comments2 "unwrapComments2" = A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.CompatHasField.HasField "unwrapComments2" Comments2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Comments2 {unwrapComments2 = y1}, RIP.getField @"unwrapComments2" x0)
 
 {-| Struct fields
 
@@ -1223,19 +1223,6 @@ instance Marshal.WriteRaw Example_struct where
 
 deriving via Marshal.EquivStorable Example_struct instance RIP.Storable Example_struct
 
-instance HasCField.HasCField Example_struct "example_struct_field1" where
-
-  type CFieldType Example_struct "example_struct_field1" =
-    A
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.HasField "example_struct_field1" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_field1")
-
 instance ( ty ~ A
          ) => RIP.CompatHasField.HasField "example_struct_field1" Example_struct ty where
 
@@ -1249,18 +1236,18 @@ instance ( ty ~ A
       , RIP.getField @"example_struct_field1" x0
       )
 
-instance HasCField.HasCField Example_struct "example_struct_field2" where
-
-  type CFieldType Example_struct "example_struct_field2" =
-    RIP.Ptr A
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "example_struct_field2" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+instance ( ty ~ A
+         ) => RIP.HasField "example_struct_field1" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_field2")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_field1")
+
+instance HasCField.HasCField Example_struct "example_struct_field1" where
+
+  type CFieldType Example_struct "example_struct_field1" =
+    A
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr A
          ) => RIP.CompatHasField.HasField "example_struct_field2" Example_struct ty where
@@ -1275,18 +1262,18 @@ instance ( ty ~ RIP.Ptr A
       , RIP.getField @"example_struct_field2" x0
       )
 
-instance HasCField.HasCField Example_struct "example_struct_field3" where
-
-  type CFieldType Example_struct "example_struct_field3" =
-    RIP.Ptr (RIP.Ptr A)
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr A)
-         ) => RIP.HasField "example_struct_field3" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr A
+         ) => RIP.HasField "example_struct_field2" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_field3")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_field2")
+
+instance HasCField.HasCField Example_struct "example_struct_field2" where
+
+  type CFieldType Example_struct "example_struct_field2" =
+    RIP.Ptr A
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr A)
          ) => RIP.CompatHasField.HasField "example_struct_field3" Example_struct ty where
@@ -1300,6 +1287,19 @@ instance ( ty ~ RIP.Ptr (RIP.Ptr A)
                          }
       , RIP.getField @"example_struct_field3" x0
       )
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr A)
+         ) => RIP.HasField "example_struct_field3" (RIP.Ptr Example_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"example_struct_field3")
+
+instance HasCField.HasCField Example_struct "example_struct_field3" where
+
+  type CFieldType Example_struct "example_struct_field3" =
+    RIP.Ptr (RIP.Ptr A)
+
+  offset# = \_ -> \_ -> 16
 
 {-| __C declaration:__ @const_typedef1@
 
@@ -1330,6 +1330,15 @@ newtype Const_typedef1 = Const_typedef1
     )
 
 instance ( ty ~ A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef1" Const_typedef1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef1 {unwrapConst_typedef1 = y1}
+      , RIP.getField @"unwrapConst_typedef1" x0
+      )
+
+instance ( ty ~ A
          ) => RIP.HasField "unwrapConst_typedef1" (RIP.Ptr Const_typedef1) (RIP.Ptr ty) where
 
   getField =
@@ -1341,15 +1350,6 @@ instance HasCField.HasCField Const_typedef1 "unwrapConst_typedef1" where
     A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef1" Const_typedef1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef1 {unwrapConst_typedef1 = y1}
-      , RIP.getField @"unwrapConst_typedef1" x0
-      )
 
 {-| __C declaration:__ @const_typedef2@
 
@@ -1380,6 +1380,15 @@ newtype Const_typedef2 = Const_typedef2
     )
 
 instance ( ty ~ A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef2" Const_typedef2 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef2 {unwrapConst_typedef2 = y1}
+      , RIP.getField @"unwrapConst_typedef2" x0
+      )
+
+instance ( ty ~ A
          ) => RIP.HasField "unwrapConst_typedef2" (RIP.Ptr Const_typedef2) (RIP.Ptr ty) where
 
   getField =
@@ -1391,15 +1400,6 @@ instance HasCField.HasCField Const_typedef2 "unwrapConst_typedef2" where
     A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef2" Const_typedef2 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef2 {unwrapConst_typedef2 = y1}
-      , RIP.getField @"unwrapConst_typedef2" x0
-      )
 
 {-| __C declaration:__ @const_typedef3@
 
@@ -1420,6 +1420,15 @@ newtype Const_typedef3 = Const_typedef3
     )
 
 instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef3" Const_typedef3 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef3 {unwrapConst_typedef3 = y1}
+      , RIP.getField @"unwrapConst_typedef3" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.HasField "unwrapConst_typedef3" (RIP.Ptr Const_typedef3) (RIP.Ptr ty) where
 
   getField =
@@ -1431,15 +1440,6 @@ instance HasCField.HasCField Const_typedef3 "unwrapConst_typedef3" where
     PtrConst.PtrConst A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef3" Const_typedef3 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef3 {unwrapConst_typedef3 = y1}
-      , RIP.getField @"unwrapConst_typedef3" x0
-      )
 
 {-| __C declaration:__ @const_typedef4@
 
@@ -1460,6 +1460,15 @@ newtype Const_typedef4 = Const_typedef4
     )
 
 instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef4" Const_typedef4 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef4 {unwrapConst_typedef4 = y1}
+      , RIP.getField @"unwrapConst_typedef4" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.HasField "unwrapConst_typedef4" (RIP.Ptr Const_typedef4) (RIP.Ptr ty) where
 
   getField =
@@ -1471,15 +1480,6 @@ instance HasCField.HasCField Const_typedef4 "unwrapConst_typedef4" where
     PtrConst.PtrConst A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef4" Const_typedef4 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef4 {unwrapConst_typedef4 = y1}
-      , RIP.getField @"unwrapConst_typedef4" x0
-      )
 
 {-| __C declaration:__ @const_typedef5@
 
@@ -1500,6 +1500,15 @@ newtype Const_typedef5 = Const_typedef5
     )
 
 instance ( ty ~ RIP.Ptr A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef5" Const_typedef5 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef5 {unwrapConst_typedef5 = y1}
+      , RIP.getField @"unwrapConst_typedef5" x0
+      )
+
+instance ( ty ~ RIP.Ptr A
          ) => RIP.HasField "unwrapConst_typedef5" (RIP.Ptr Const_typedef5) (RIP.Ptr ty) where
 
   getField =
@@ -1511,15 +1520,6 @@ instance HasCField.HasCField Const_typedef5 "unwrapConst_typedef5" where
     RIP.Ptr A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef5" Const_typedef5 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef5 {unwrapConst_typedef5 = y1}
-      , RIP.getField @"unwrapConst_typedef5" x0
-      )
 
 {-| __C declaration:__ @const_typedef6@
 
@@ -1540,6 +1540,15 @@ newtype Const_typedef6 = Const_typedef6
     )
 
 instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef6" Const_typedef6 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef6 {unwrapConst_typedef6 = y1}
+      , RIP.getField @"unwrapConst_typedef6" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.HasField "unwrapConst_typedef6" (RIP.Ptr Const_typedef6) (RIP.Ptr ty) where
 
   getField =
@@ -1551,15 +1560,6 @@ instance HasCField.HasCField Const_typedef6 "unwrapConst_typedef6" where
     PtrConst.PtrConst A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef6" Const_typedef6 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef6 {unwrapConst_typedef6 = y1}
-      , RIP.getField @"unwrapConst_typedef6" x0
-      )
 
 {-| __C declaration:__ @const_typedef7@
 
@@ -1580,6 +1580,15 @@ newtype Const_typedef7 = Const_typedef7
     )
 
 instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.CompatHasField.HasField "unwrapConst_typedef7" Const_typedef7 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_typedef7 {unwrapConst_typedef7 = y1}
+      , RIP.getField @"unwrapConst_typedef7" x0
+      )
+
+instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.HasField "unwrapConst_typedef7" (RIP.Ptr Const_typedef7) (RIP.Ptr ty) where
 
   getField =
@@ -1591,15 +1600,6 @@ instance HasCField.HasCField Const_typedef7 "unwrapConst_typedef7" where
     PtrConst.PtrConst A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.CompatHasField.HasField "unwrapConst_typedef7" Const_typedef7 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_typedef7 {unwrapConst_typedef7 = y1}
-      , RIP.getField @"unwrapConst_typedef7" x0
-      )
 
 {-| __C declaration:__ @struct example_struct_with_const@
 
@@ -1703,19 +1703,6 @@ instance Marshal.WriteRaw Example_struct_with_const where
 
 deriving via Marshal.EquivStorable Example_struct_with_const instance RIP.Storable Example_struct_with_const
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field1" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field1" =
-    A
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ A
-         ) => RIP.HasField "example_struct_with_const_const_field1" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field1")
-
 instance ( ty ~ A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field1" Example_struct_with_const ty where
 
@@ -1733,18 +1720,18 @@ instance ( ty ~ A
       , RIP.getField @"example_struct_with_const_const_field1" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field2" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field2" =
-    A
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ A
-         ) => RIP.HasField "example_struct_with_const_const_field2" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+         ) => RIP.HasField "example_struct_with_const_const_field1" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field2")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field1")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field1" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field1" =
+    A
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field2" Example_struct_with_const ty where
@@ -1763,18 +1750,18 @@ instance ( ty ~ A
       , RIP.getField @"example_struct_with_const_const_field2" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field3" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field3" =
-    PtrConst.PtrConst A
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field3" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance ( ty ~ A
+         ) => RIP.HasField "example_struct_with_const_const_field2" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field3")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field2")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field2" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field2" =
+    A
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field3" Example_struct_with_const ty where
@@ -1793,18 +1780,18 @@ instance ( ty ~ PtrConst.PtrConst A
       , RIP.getField @"example_struct_with_const_const_field3" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field4" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field4" =
-    PtrConst.PtrConst A
-
-  offset# = \_ -> \_ -> 16
-
 instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field4" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+         ) => RIP.HasField "example_struct_with_const_const_field3" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field4")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field3")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field3" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field3" =
+    PtrConst.PtrConst A
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field4" Example_struct_with_const ty where
@@ -1823,18 +1810,18 @@ instance ( ty ~ PtrConst.PtrConst A
       , RIP.getField @"example_struct_with_const_const_field4" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field5" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field5" =
-    RIP.Ptr A
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ RIP.Ptr A
-         ) => RIP.HasField "example_struct_with_const_const_field5" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.HasField "example_struct_with_const_const_field4" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field5")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field4")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field4" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field4" =
+    PtrConst.PtrConst A
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ RIP.Ptr A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field5" Example_struct_with_const ty where
@@ -1853,18 +1840,18 @@ instance ( ty ~ RIP.Ptr A
       , RIP.getField @"example_struct_with_const_const_field5" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field6" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field6" =
-    PtrConst.PtrConst A
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field6" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr A
+         ) => RIP.HasField "example_struct_with_const_const_field5" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field6")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field5")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field5" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field5" =
+    RIP.Ptr A
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field6" Example_struct_with_const ty where
@@ -1883,18 +1870,18 @@ instance ( ty ~ PtrConst.PtrConst A
       , RIP.getField @"example_struct_with_const_const_field6" x0
       )
 
-instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field7" where
-
-  type CFieldType Example_struct_with_const "example_struct_with_const_const_field7" =
-    PtrConst.PtrConst A
-
-  offset# = \_ -> \_ -> 40
-
 instance ( ty ~ PtrConst.PtrConst A
-         ) => RIP.HasField "example_struct_with_const_const_field7" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+         ) => RIP.HasField "example_struct_with_const_const_field6" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field7")
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field6")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field6" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field6" =
+    PtrConst.PtrConst A
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ PtrConst.PtrConst A
          ) => RIP.CompatHasField.HasField "example_struct_with_const_const_field7" Example_struct_with_const ty where
@@ -1912,6 +1899,19 @@ instance ( ty ~ PtrConst.PtrConst A
                                     }
       , RIP.getField @"example_struct_with_const_const_field7" x0
       )
+
+instance ( ty ~ PtrConst.PtrConst A
+         ) => RIP.HasField "example_struct_with_const_const_field7" (RIP.Ptr Example_struct_with_const) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"example_struct_with_const_const_field7")
+
+instance HasCField.HasCField Example_struct_with_const "example_struct_with_const_const_field7" where
+
+  type CFieldType Example_struct_with_const "example_struct_with_const_const_field7" =
+    PtrConst.PtrConst A
+
+  offset# = \_ -> \_ -> 40
 
 {-| Auxiliary type used by 'Const_funptr1'
 
@@ -1962,6 +1962,16 @@ instance RIP.FromFunPtr Const_funptr1_Aux where
   fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr1_Aux" Const_funptr1_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr1_Aux {unwrapConst_funptr1_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr1_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
          ) => RIP.HasField "unwrapConst_funptr1_Aux" (RIP.Ptr Const_funptr1_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -1973,16 +1983,6 @@ instance HasCField.HasCField Const_funptr1_Aux "unwrapConst_funptr1_Aux" where
     RIP.CInt -> RIP.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr1_Aux" Const_funptr1_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr1_Aux {unwrapConst_funptr1_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr1_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr1@
 
@@ -2003,6 +2003,15 @@ newtype Const_funptr1 = Const_funptr1
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr1_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr1" Const_funptr1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr1 {unwrapConst_funptr1 = y1}
+      , RIP.getField @"unwrapConst_funptr1" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr1_Aux
          ) => RIP.HasField "unwrapConst_funptr1" (RIP.Ptr Const_funptr1) (RIP.Ptr ty) where
 
   getField =
@@ -2014,15 +2023,6 @@ instance HasCField.HasCField Const_funptr1 "unwrapConst_funptr1" where
     RIP.FunPtr Const_funptr1_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr1_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr1" Const_funptr1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr1 {unwrapConst_funptr1 = y1}
-      , RIP.getField @"unwrapConst_funptr1" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr2'
 
@@ -2073,6 +2073,16 @@ instance RIP.FromFunPtr Const_funptr2_Aux where
   fromFunPtr = hs_bindgen_352cebf463125ca9
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr2_Aux" Const_funptr2_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr2_Aux {unwrapConst_funptr2_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr2_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
          ) => RIP.HasField "unwrapConst_funptr2_Aux" (RIP.Ptr Const_funptr2_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2084,16 +2094,6 @@ instance HasCField.HasCField Const_funptr2_Aux "unwrapConst_funptr2_Aux" where
     RIP.CInt -> RIP.CDouble -> IO A
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO A)
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr2_Aux" Const_funptr2_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr2_Aux {unwrapConst_funptr2_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr2_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr2@
 
@@ -2114,6 +2114,15 @@ newtype Const_funptr2 = Const_funptr2
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr2_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr2" Const_funptr2 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr2 {unwrapConst_funptr2 = y1}
+      , RIP.getField @"unwrapConst_funptr2" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr2_Aux
          ) => RIP.HasField "unwrapConst_funptr2" (RIP.Ptr Const_funptr2) (RIP.Ptr ty) where
 
   getField =
@@ -2125,15 +2134,6 @@ instance HasCField.HasCField Const_funptr2 "unwrapConst_funptr2" where
     RIP.FunPtr Const_funptr2_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr2_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr2" Const_funptr2 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr2 {unwrapConst_funptr2 = y1}
-      , RIP.getField @"unwrapConst_funptr2" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr3'
 
@@ -2184,6 +2184,16 @@ instance RIP.FromFunPtr Const_funptr3_Aux where
   fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr3_Aux" Const_funptr3_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr3_Aux {unwrapConst_funptr3_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr3_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
          ) => RIP.HasField "unwrapConst_funptr3_Aux" (RIP.Ptr Const_funptr3_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2195,16 +2205,6 @@ instance HasCField.HasCField Const_funptr3_Aux "unwrapConst_funptr3_Aux" where
     RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr3_Aux" Const_funptr3_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr3_Aux {unwrapConst_funptr3_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr3_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr3@
 
@@ -2225,6 +2225,15 @@ newtype Const_funptr3 = Const_funptr3
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr3_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr3" Const_funptr3 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr3 {unwrapConst_funptr3 = y1}
+      , RIP.getField @"unwrapConst_funptr3" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr3_Aux
          ) => RIP.HasField "unwrapConst_funptr3" (RIP.Ptr Const_funptr3) (RIP.Ptr ty) where
 
   getField =
@@ -2236,15 +2245,6 @@ instance HasCField.HasCField Const_funptr3 "unwrapConst_funptr3" where
     RIP.FunPtr Const_funptr3_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr3_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr3" Const_funptr3 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr3 {unwrapConst_funptr3 = y1}
-      , RIP.getField @"unwrapConst_funptr3" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr4'
 
@@ -2295,6 +2295,16 @@ instance RIP.FromFunPtr Const_funptr4_Aux where
   fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr4_Aux" Const_funptr4_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr4_Aux {unwrapConst_funptr4_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr4_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
          ) => RIP.HasField "unwrapConst_funptr4_Aux" (RIP.Ptr Const_funptr4_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2306,16 +2316,6 @@ instance HasCField.HasCField Const_funptr4_Aux "unwrapConst_funptr4_Aux" where
     RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr4_Aux" Const_funptr4_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr4_Aux {unwrapConst_funptr4_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr4_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr4@
 
@@ -2336,6 +2336,15 @@ newtype Const_funptr4 = Const_funptr4
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr4_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr4" Const_funptr4 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr4 {unwrapConst_funptr4 = y1}
+      , RIP.getField @"unwrapConst_funptr4" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr4_Aux
          ) => RIP.HasField "unwrapConst_funptr4" (RIP.Ptr Const_funptr4) (RIP.Ptr ty) where
 
   getField =
@@ -2347,15 +2356,6 @@ instance HasCField.HasCField Const_funptr4 "unwrapConst_funptr4" where
     RIP.FunPtr Const_funptr4_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr4_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr4" Const_funptr4 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr4 {unwrapConst_funptr4 = y1}
-      , RIP.getField @"unwrapConst_funptr4" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr5'
 
@@ -2406,6 +2406,16 @@ instance RIP.FromFunPtr Const_funptr5_Aux where
   fromFunPtr = hs_bindgen_38a21d84bb7115b5
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr5_Aux" Const_funptr5_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr5_Aux {unwrapConst_funptr5_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr5_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
          ) => RIP.HasField "unwrapConst_funptr5_Aux" (RIP.Ptr Const_funptr5_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2417,16 +2427,6 @@ instance HasCField.HasCField Const_funptr5_Aux "unwrapConst_funptr5_Aux" where
     RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (RIP.Ptr A))
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr5_Aux" Const_funptr5_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr5_Aux {unwrapConst_funptr5_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr5_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr5@
 
@@ -2447,6 +2447,15 @@ newtype Const_funptr5 = Const_funptr5
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr5_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr5" Const_funptr5 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr5 {unwrapConst_funptr5 = y1}
+      , RIP.getField @"unwrapConst_funptr5" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr5_Aux
          ) => RIP.HasField "unwrapConst_funptr5" (RIP.Ptr Const_funptr5) (RIP.Ptr ty) where
 
   getField =
@@ -2458,15 +2467,6 @@ instance HasCField.HasCField Const_funptr5 "unwrapConst_funptr5" where
     RIP.FunPtr Const_funptr5_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr5_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr5" Const_funptr5 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr5 {unwrapConst_funptr5 = y1}
-      , RIP.getField @"unwrapConst_funptr5" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr6'
 
@@ -2517,6 +2517,16 @@ instance RIP.FromFunPtr Const_funptr6_Aux where
   fromFunPtr = hs_bindgen_45251216b04aa8b5
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr6_Aux" Const_funptr6_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr6_Aux {unwrapConst_funptr6_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr6_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
          ) => RIP.HasField "unwrapConst_funptr6_Aux" (RIP.Ptr Const_funptr6_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2528,16 +2538,6 @@ instance HasCField.HasCField Const_funptr6_Aux "unwrapConst_funptr6_Aux" where
     RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr6_Aux" Const_funptr6_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr6_Aux {unwrapConst_funptr6_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr6_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr6@
 
@@ -2558,6 +2558,15 @@ newtype Const_funptr6 = Const_funptr6
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr6_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr6" Const_funptr6 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr6 {unwrapConst_funptr6 = y1}
+      , RIP.getField @"unwrapConst_funptr6" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr6_Aux
          ) => RIP.HasField "unwrapConst_funptr6" (RIP.Ptr Const_funptr6) (RIP.Ptr ty) where
 
   getField =
@@ -2569,15 +2578,6 @@ instance HasCField.HasCField Const_funptr6 "unwrapConst_funptr6" where
     RIP.FunPtr Const_funptr6_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr6_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr6" Const_funptr6 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr6 {unwrapConst_funptr6 = y1}
-      , RIP.getField @"unwrapConst_funptr6" x0
-      )
 
 {-| Auxiliary type used by 'Const_funptr7'
 
@@ -2628,6 +2628,16 @@ instance RIP.FromFunPtr Const_funptr7_Aux where
   fromFunPtr = hs_bindgen_42fbcebf75a973ba
 
 instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr7_Aux" Const_funptr7_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Const_funptr7_Aux {unwrapConst_funptr7_Aux = y1}
+      , RIP.getField @"unwrapConst_funptr7_Aux" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
          ) => RIP.HasField "unwrapConst_funptr7_Aux" (RIP.Ptr Const_funptr7_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -2639,16 +2649,6 @@ instance HasCField.HasCField Const_funptr7_Aux "unwrapConst_funptr7_Aux" where
     RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CDouble -> IO (PtrConst.PtrConst A))
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr7_Aux" Const_funptr7_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Const_funptr7_Aux {unwrapConst_funptr7_Aux = y1}
-      , RIP.getField @"unwrapConst_funptr7_Aux" x0
-      )
 
 {-| __C declaration:__ @const_funptr7@
 
@@ -2669,6 +2669,15 @@ newtype Const_funptr7 = Const_funptr7
     )
 
 instance ( ty ~ RIP.FunPtr Const_funptr7_Aux
+         ) => RIP.CompatHasField.HasField "unwrapConst_funptr7" Const_funptr7 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Const_funptr7 {unwrapConst_funptr7 = y1}
+      , RIP.getField @"unwrapConst_funptr7" x0
+      )
+
+instance ( ty ~ RIP.FunPtr Const_funptr7_Aux
          ) => RIP.HasField "unwrapConst_funptr7" (RIP.Ptr Const_funptr7) (RIP.Ptr ty) where
 
   getField =
@@ -2680,15 +2689,6 @@ instance HasCField.HasCField Const_funptr7 "unwrapConst_funptr7" where
     RIP.FunPtr Const_funptr7_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr Const_funptr7_Aux
-         ) => RIP.CompatHasField.HasField "unwrapConst_funptr7" Const_funptr7 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Const_funptr7 {unwrapConst_funptr7 = y1}
-      , RIP.getField @"unwrapConst_funptr7" x0
-      )
 
 {-| Macro-defined types
 
@@ -2721,6 +2721,14 @@ newtype BOOL = BOOL
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
 
   getField =
@@ -2731,14 +2739,6 @@ instance HasCField.HasCField BOOL "unwrapBOOL" where
   type CFieldType BOOL "unwrapBOOL" = RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
 
 {-| __C declaration:__ @macro INT@
 
@@ -2768,6 +2768,13 @@ newtype INT = INT
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapINT" INT ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         INT {unwrapINT = y1}, RIP.getField @"unwrapINT" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapINT" (RIP.Ptr INT) (RIP.Ptr ty) where
 
@@ -2778,13 +2785,6 @@ instance HasCField.HasCField INT "unwrapINT" where
   type CFieldType INT "unwrapINT" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapINT" INT ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         INT {unwrapINT = y1}, RIP.getField @"unwrapINT" x0)
 
 {-| __C declaration:__ @macro INTP@
 
@@ -2805,6 +2805,14 @@ newtype INTP = INTP
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapINTP" INTP ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         INTP {unwrapINTP = y1}, RIP.getField @"unwrapINTP" x0)
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrapINTP" (RIP.Ptr INTP) (RIP.Ptr ty) where
 
   getField =
@@ -2815,14 +2823,6 @@ instance HasCField.HasCField INTP "unwrapINTP" where
   type CFieldType INTP "unwrapINTP" = RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapINTP" INTP ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         INTP {unwrapINTP = y1}, RIP.getField @"unwrapINTP" x0)
 
 {-| __C declaration:__ @macro INTCP@
 
@@ -2843,6 +2843,14 @@ newtype INTCP = INTCP
     )
 
 instance ( ty ~ PtrConst.PtrConst RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapINTCP" INTCP ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         INTCP {unwrapINTCP = y1}, RIP.getField @"unwrapINTCP" x0)
+
+instance ( ty ~ PtrConst.PtrConst RIP.CInt
          ) => RIP.HasField "unwrapINTCP" (RIP.Ptr INTCP) (RIP.Ptr ty) where
 
   getField =
@@ -2854,11 +2862,3 @@ instance HasCField.HasCField INTCP "unwrapINTCP" where
     PtrConst.PtrConst RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ PtrConst.PtrConst RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapINTCP" INTCP ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         INTCP {unwrapINTCP = y1}, RIP.getField @"unwrapINTCP" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/Example.hs
@@ -50,6 +50,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -60,9 +66,3 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/arithmetic_types/th.txt
@@ -584,14 +584,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 -- __unique:__ @test_macrosreparsearithmetic_type_Example_Safe_f1@
 foreign import ccall safe "hs_bindgen_7e7e01d691b1fb2a" hs_bindgen_7e7e01d691b1fb2a_base ::
     Int8

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/bindingspec.yaml
@@ -125,7 +125,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -133,6 +132,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -152,11 +153,12 @@ hstypes:
       fields:
       - unwrapArr_typedef1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: Arr_typedef2
@@ -166,11 +168,12 @@ hstypes:
       fields:
       - unwrapArr_typedef2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: Arr_typedef3
@@ -180,11 +183,12 @@ hstypes:
       fields:
       - unwrapArr_typedef3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -198,11 +202,12 @@ hstypes:
       fields:
       - unwrapArr_typedef4
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show
@@ -219,7 +224,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -227,6 +231,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -249,7 +255,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -257,6 +262,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -276,12 +283,13 @@ hstypes:
       fields:
       - unwrapConst_funptr1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -295,12 +303,13 @@ hstypes:
       fields:
       - unwrapConst_funptr2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -314,12 +323,13 @@ hstypes:
       fields:
       - unwrapConst_funptr3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -333,12 +343,13 @@ hstypes:
       fields:
       - unwrapConst_funptr4
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -352,12 +363,13 @@ hstypes:
       fields:
       - unwrapConst_funptr5
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -371,12 +383,13 @@ hstypes:
       fields:
       - unwrapConst_funptr6
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -390,12 +403,13 @@ hstypes:
       fields:
       - unwrapConst_funptr7
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -412,7 +426,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -420,6 +433,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -442,7 +457,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -450,6 +464,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -469,12 +485,13 @@ hstypes:
       fields:
       - unwrapConst_typedef3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -488,12 +505,13 @@ hstypes:
       fields:
       - unwrapConst_typedef4
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -507,12 +525,13 @@ hstypes:
       fields:
       - unwrapConst_typedef5
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -526,12 +545,13 @@ hstypes:
       fields:
       - unwrapConst_typedef6
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -545,12 +565,13 @@ hstypes:
       fields:
       - unwrapConst_typedef7
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -566,11 +587,12 @@ hstypes:
       - example_struct_field2
       - example_struct_field3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -589,11 +611,12 @@ hstypes:
       - example_struct_with_const_const_field6
       - example_struct_with_const_const_field7
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -606,12 +629,13 @@ hstypes:
       fields:
       - unwrapFunptr_typedef1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -625,12 +649,13 @@ hstypes:
       fields:
       - unwrapFunptr_typedef2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -644,12 +669,13 @@ hstypes:
       fields:
       - unwrapFunptr_typedef3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -663,12 +689,13 @@ hstypes:
       fields:
       - unwrapFunptr_typedef4
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -682,12 +709,13 @@ hstypes:
       fields:
       - unwrapFunptr_typedef5
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -704,7 +732,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -712,6 +739,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -731,12 +760,13 @@ hstypes:
       fields:
       - unwrapINTCP
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -750,12 +780,13 @@ hstypes:
       fields:
       - unwrapINTP
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -770,12 +801,13 @@ hstypes:
       - unwrapSome_enum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -820,7 +852,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -828,6 +859,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -847,12 +880,13 @@ hstypes:
       fields:
       - unwrapTypedef2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -866,12 +900,13 @@ hstypes:
       fields:
       - unwrapTypedef3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/Example.hs
@@ -51,6 +51,14 @@ newtype BOOL = BOOL
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
 
   getField =
@@ -61,11 +69,3 @@ instance HasCField.HasCField BOOL "unwrapBOOL" where
   type CFieldType BOOL "unwrapBOOL" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/cref_attributes/th.txt
@@ -84,14 +84,14 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapBOOL" BOOL ty
+    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
+                              getField @"unwrapBOOL" x_0)
 instance (~) ty CInt => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapBOOL" BOOL ty
-    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
-                              getField @"unwrapBOOL" x_0)
 -- __unique:__ @test_macrosreparsecref_attributes_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_9f4b1c3748016429" hs_bindgen_9f4b1c3748016429_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/Example.hs
@@ -67,20 +67,20 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_x" where
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s_x" S ty where
 
-  type CFieldType S "s_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
 
 instance (ty ~ RIP.CInt) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s_x" S ty where
+instance HasCField.HasCField S "s_x" where
 
-  hasField =
-    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
+  type CFieldType S "s_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @macro T@
 
@@ -99,6 +99,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance (ty ~ S) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -108,12 +114,6 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = S
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 {-| __C declaration:__ @foo@
 
@@ -132,6 +132,13 @@ newtype Foo = Foo
     , Marshal.WriteRaw
     )
 
+instance (ty ~ T) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
+
 instance (ty ~ T) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
@@ -141,13 +148,6 @@ instance HasCField.HasCField Foo "unwrapFoo" where
   type CFieldType Foo "unwrapFoo" = T
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
 
 {-| __C declaration:__ @bar@
 
@@ -168,6 +168,14 @@ newtype Bar = Bar
     )
 
 instance ( ty ~ RIP.Ptr T
+         ) => RIP.CompatHasField.HasField "unwrapBar" Bar ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bar {unwrapBar = y1}, RIP.getField @"unwrapBar" x0)
+
+instance ( ty ~ RIP.Ptr T
          ) => RIP.HasField "unwrapBar" (RIP.Ptr Bar) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapBar")
@@ -177,11 +185,3 @@ instance HasCField.HasCField Bar "unwrapBar" where
   type CFieldType Bar "unwrapBar" = RIP.Ptr T
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr T
-         ) => RIP.CompatHasField.HasField "unwrapBar" Bar ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bar {unwrapBar = y1}, RIP.getField @"unwrapBar" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/bindingspec.yaml
@@ -23,12 +23,13 @@ hstypes:
       fields:
       - unwrapBar
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -42,11 +43,12 @@ hstypes:
       fields:
       - unwrapFoo
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -59,11 +61,12 @@ hstypes:
       fields:
       - s_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -76,11 +79,12 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/defer_wrong/th.txt
@@ -23,14 +23,14 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_x_2 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_x"
-    where type CFieldType S "s_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_x")
 instance (~) ty CInt => HasField "s_x" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_x = y_1},
                               getField @"s_x" x_0)
+instance (~) ty CInt => HasField "s_x" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_x")
+instance HasCField S "s_x"
+    where type CFieldType S "s_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @macro T@
 
     __defined at:__ @macros\/reparse\/defer_wrong.h 13:9@
@@ -41,14 +41,14 @@ newtype T
     = T {unwrapT :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty S => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty S => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = S
           offset# = \_ -> \_ -> 0
-instance (~) ty S => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 {-| __C declaration:__ @foo@
 
     __defined at:__ @macros\/reparse\/defer_wrong.h 15:11@
@@ -59,14 +59,14 @@ newtype Foo
     = Foo {unwrapFoo :: T}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty T => HasField "unwrapFoo" Foo ty
+    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
+                              getField @"unwrapFoo" x_0)
 instance (~) ty T => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo")
 instance HasCField Foo "unwrapFoo"
     where type CFieldType Foo "unwrapFoo" = T
           offset# = \_ -> \_ -> 0
-instance (~) ty T => HasField "unwrapFoo" Foo ty
-    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
-                              getField @"unwrapFoo" x_0)
 {-| __C declaration:__ @bar@
 
     __defined at:__ @macros\/reparse\/defer_wrong.h 16:13@
@@ -81,11 +81,11 @@ newtype Bar
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr T) => HasField "unwrapBar" Bar ty
+    where hasField = \x_0 -> (\y_1 -> Bar{unwrapBar = y_1},
+                              getField @"unwrapBar" x_0)
 instance (~) ty (Ptr T) => HasField "unwrapBar" (Ptr Bar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBar")
 instance HasCField Bar "unwrapBar"
     where type CFieldType Bar "unwrapBar" = Ptr T
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T) => HasField "unwrapBar" Bar ty
-    where hasField = \x_0 -> (\y_1 -> Bar{unwrapBar = y_1},
-                              getField @"unwrapBar" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/Example.hs
@@ -63,6 +63,14 @@ newtype MY_INT = MY_INT
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMY_INT" MY_INT ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MY_INT {unwrapMY_INT = y1}, RIP.getField @"unwrapMY_INT" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMY_INT" (RIP.Ptr MY_INT) (RIP.Ptr ty) where
 
   getField =
@@ -73,14 +81,6 @@ instance HasCField.HasCField MY_INT "unwrapMY_INT" where
   type CFieldType MY_INT "unwrapMY_INT" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMY_INT" MY_INT ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MY_INT {unwrapMY_INT = y1}, RIP.getField @"unwrapMY_INT" x0)
 
 {-| __C declaration:__ @my_int_t@
 
@@ -111,6 +111,14 @@ newtype My_int_t = My_int_t
     )
 
 instance ( ty ~ MY_INT
+         ) => RIP.CompatHasField.HasField "unwrapMy_int_t" My_int_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         My_int_t {unwrapMy_int_t = y1}, RIP.getField @"unwrapMy_int_t" x0)
+
+instance ( ty ~ MY_INT
          ) => RIP.HasField "unwrapMy_int_t" (RIP.Ptr My_int_t) (RIP.Ptr ty) where
 
   getField =
@@ -121,11 +129,3 @@ instance HasCField.HasCField My_int_t "unwrapMy_int_t" where
   type CFieldType My_int_t "unwrapMy_int_t" = MY_INT
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MY_INT
-         ) => RIP.CompatHasField.HasField "unwrapMy_int_t" My_int_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         My_int_t {unwrapMy_int_t = y1}, RIP.getField @"unwrapMy_int_t" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/functions/th.txt
@@ -98,15 +98,15 @@ newtype MY_INT
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMY_INT" MY_INT ty
+    where hasField = \x_0 -> (\y_1 -> MY_INT{unwrapMY_INT = y_1},
+                              getField @"unwrapMY_INT" x_0)
 instance (~) ty CInt =>
          HasField "unwrapMY_INT" (Ptr MY_INT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMY_INT")
 instance HasCField MY_INT "unwrapMY_INT"
     where type CFieldType MY_INT "unwrapMY_INT" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMY_INT" MY_INT ty
-    where hasField = \x_0 -> (\y_1 -> MY_INT{unwrapMY_INT = y_1},
-                              getField @"unwrapMY_INT" x_0)
 {-| __C declaration:__ @my_int_t@
 
     __defined at:__ @macros\/reparse\/functions.h 19:16@
@@ -131,15 +131,15 @@ newtype My_int_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty MY_INT => HasField "unwrapMy_int_t" My_int_t ty
+    where hasField = \x_0 -> (\y_1 -> My_int_t{unwrapMy_int_t = y_1},
+                              getField @"unwrapMy_int_t" x_0)
 instance (~) ty MY_INT =>
          HasField "unwrapMy_int_t" (Ptr My_int_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMy_int_t")
 instance HasCField My_int_t "unwrapMy_int_t"
     where type CFieldType My_int_t "unwrapMy_int_t" = MY_INT
           offset# = \_ -> \_ -> 0
-instance (~) ty MY_INT => HasField "unwrapMy_int_t" My_int_t ty
-    where hasField = \x_0 -> (\y_1 -> My_int_t{unwrapMy_int_t = y_1},
-                              getField @"unwrapMy_int_t" x_0)
 -- __unique:__ @test_macrosreparsefunctions_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_b6e9ae739486d53b" hs_bindgen_b6e9ae739486d53b_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/Example.hs
@@ -51,6 +51,14 @@ newtype BOOL = BOOL
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
 
   getField =
@@ -61,11 +69,3 @@ instance HasCField.HasCField BOOL "unwrapBOOL" where
   type CFieldType BOOL "unwrapBOOL" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/gnu_attributes/th.txt
@@ -124,14 +124,14 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapBOOL" BOOL ty
+    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
+                              getField @"unwrapBOOL" x_0)
 instance (~) ty CInt => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapBOOL" BOOL ty
-    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
-                              getField @"unwrapBOOL" x_0)
 -- __unique:__ @test_macrosreparsegnu_attributes_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_702437d53bf7e32f" hs_bindgen_702437d53bf7e32f_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/Example.hs
@@ -56,6 +56,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -66,14 +74,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @struct TS1@
 
@@ -116,21 +116,21 @@ instance Marshal.WriteRaw T2 where
 
 deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
 
-instance HasCField.HasCField T2 "t2_x" where
-
-  type CFieldType T2 "t2_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t2_x" T2 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T2 {t2_x = y1}, RIP.getField @"t2_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
+instance HasCField.HasCField T2 "t2_x" where
+
+  type CFieldType T2 "t2_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct TS3@
 
@@ -173,21 +173,21 @@ instance Marshal.WriteRaw T3 where
 
 deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
 
-instance HasCField.HasCField T3 "t3_x" where
-
-  type CFieldType T3 "t3_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t3_x" T3 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T3 {t3_x = y1}, RIP.getField @"t3_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct T4@
 
@@ -230,18 +230,18 @@ instance Marshal.WriteRaw T4 where
 
 deriving via Marshal.EquivStorable T4 instance RIP.Storable T4
 
-instance HasCField.HasCField T4 "t4_x" where
-
-  type CFieldType T4 "t4_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t4_x" (RIP.Ptr T4) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t4_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t4_x" T4 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T4 {t4_x = y1}, RIP.getField @"t4_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t4_x" (RIP.Ptr T4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t4_x")
+
+instance HasCField.HasCField T4 "t4_x" where
+
+  type CFieldType T4 "t4_x" = MyInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -62,11 +63,12 @@ hstypes:
       fields:
       - t2_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -79,11 +81,12 @@ hstypes:
       fields:
       - t3_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -96,11 +99,12 @@ hstypes:
       fields:
       - t4_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/Example.hs
@@ -59,6 +59,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -69,14 +77,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @struct \@T1_x@
 
@@ -119,22 +119,22 @@ instance Marshal.WriteRaw T1_x where
 
 deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
 
-instance HasCField.HasCField T1_x "t1_x_x" where
-
-  type CFieldType T1_x "t1_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t1_x_x" T1_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T1_x {t1_x_x = y1}, RIP.getField @"t1_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T1@
 
@@ -177,21 +177,21 @@ instance Marshal.WriteRaw T1 where
 
 deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
 
-instance HasCField.HasCField T1 "t1_x" where
-
-  type CFieldType T1 "t1_x" = T1_x
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
-
 instance (ty ~ T1_x) => RIP.CompatHasField.HasField "t1_x" T1 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T1 {t1_x = y1}, RIP.getField @"t1_x" x0)
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T2@
 
@@ -234,22 +234,22 @@ instance Marshal.WriteRaw T2 where
 
 deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
 
-instance HasCField.HasCField T2 "t2_x" where
+instance (ty ~ RIP.Ptr T2_x) => RIP.CompatHasField.HasField "t2_x" T2 ty where
 
-  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> T2 {t2_x = y1}, RIP.getField @"t2_x" x0)
 
 instance ( ty ~ RIP.Ptr T2_x
          ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
-instance (ty ~ RIP.Ptr T2_x) => RIP.CompatHasField.HasField "t2_x" T2 ty where
+instance HasCField.HasCField T2 "t2_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> T2 {t2_x = y1}, RIP.getField @"t2_x" x0)
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T2_x@
 
@@ -292,22 +292,22 @@ instance Marshal.WriteRaw T2_x where
 
 deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
 
-instance HasCField.HasCField T2_x "t2_x_x" where
-
-  type CFieldType T2_x "t2_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t2_x_x" T2_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T2_x {t2_x_x = y1}, RIP.getField @"t2_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T3@
 
@@ -350,23 +350,23 @@ instance Marshal.WriteRaw T3 where
 
 deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
 
-instance HasCField.HasCField T3 "t3_x" where
-
-  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
-
 instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
          ) => RIP.CompatHasField.HasField "t3_x" T3 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T3 {t3_x = y1}, RIP.getField @"t3_x" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T3_x@
 
@@ -409,19 +409,19 @@ instance Marshal.WriteRaw T3_x where
 
 deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
 
-instance HasCField.HasCField T3_x "t3_x_x" where
-
-  type CFieldType T3_x "t3_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t3_x_x" T3_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T3_x {t3_x_x = y1}, RIP.getField @"t3_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -62,11 +63,12 @@ hstypes:
       fields:
       - t1_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -79,11 +81,12 @@ hstypes:
       fields:
       - t1_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -96,11 +99,12 @@ hstypes:
       fields:
       - t2_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -113,11 +117,12 @@ hstypes:
       fields:
       - t2_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -130,11 +135,12 @@ hstypes:
       fields:
       - t3_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -147,11 +153,12 @@ hstypes:
       fields:
       - t3_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_struct/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @struct \@T1_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:10@
@@ -74,14 +74,14 @@ instance WriteRaw T1_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T1_x t1_x_x_2 -> writeRaw (Proxy @"t1_x_x") ptr_0 t1_x_x_2
 deriving via (EquivStorable T1_x) instance Storable T1_x
-instance HasCField T1_x "t1_x_x"
-    where type CFieldType T1_x "t1_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x_x")
 instance (~) ty MyInt => HasField "t1_x_x" T1_x ty
     where hasField = \x_0 -> (\y_1 -> T1_x{t1_x_x = y_1},
                               getField @"t1_x_x" x_0)
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T1@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 3:1@
@@ -106,14 +106,14 @@ instance WriteRaw T1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
 deriving via (EquivStorable T1) instance Storable T1
-instance HasCField T1 "t1_x"
-    where type CFieldType T1 "t1_x" = T1_x
-          offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 instance (~) ty T1_x => HasField "t1_x" T1 ty
     where hasField = \x_0 -> (\y_1 -> T1{t1_x = y_1},
                               getField @"t1_x" x_0)
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T2@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:1@
@@ -138,14 +138,14 @@ instance WriteRaw T2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
 deriving via (EquivStorable T2) instance Storable T2
-instance HasCField T2 "t2_x"
-    where type CFieldType T2 "t2_x" = Ptr T2_x
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x")
 instance (~) ty (Ptr T2_x) => HasField "t2_x" T2 ty
     where hasField = \x_0 -> (\y_1 -> T2{t2_x = y_1},
                               getField @"t2_x" x_0)
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T2_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 4:10@
@@ -170,14 +170,14 @@ instance WriteRaw T2_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2_x t2_x_x_2 -> writeRaw (Proxy @"t2_x_x") ptr_0 t2_x_x_2
 deriving via (EquivStorable T2_x) instance Storable T2_x
-instance HasCField T2_x "t2_x_x"
-    where type CFieldType T2_x "t2_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x_x")
 instance (~) ty MyInt => HasField "t2_x_x" T2_x ty
     where hasField = \x_0 -> (\y_1 -> T2_x{t2_x_x = y_1},
                               getField @"t2_x_x" x_0)
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T3@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:1@
@@ -202,15 +202,15 @@ instance WriteRaw T3
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
 deriving via (EquivStorable T3) instance Storable T3
-instance HasCField T3 "t3_x"
-    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x")
 instance (~) ty (Ptr (Ptr T3_x)) => HasField "t3_x" T3 ty
     where hasField = \x_0 -> (\y_1 -> T3{t3_x = y_1},
                               getField @"t3_x" x_0)
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T3_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_struct.h 5:10@
@@ -235,14 +235,14 @@ instance WriteRaw T3_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3_x t3_x_x_2 -> writeRaw (Proxy @"t3_x_x") ptr_0 t3_x_x_2
 deriving via (EquivStorable T3_x) instance Storable T3_x
-instance HasCField T3_x "t3_x_x"
-    where type CFieldType T3_x "t3_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x_x")
 instance (~) ty MyInt => HasField "t3_x_x" T3_x ty
     where hasField = \x_0 -> (\y_1 -> T3_x{t3_x_x = y_1},
                               getField @"t3_x_x" x_0)
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/Example.hs
@@ -58,6 +58,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -68,14 +76,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @struct T1@
 
@@ -118,21 +118,21 @@ instance Marshal.WriteRaw T1 where
 
 deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
 
-instance HasCField.HasCField T1 "t1_x" where
-
-  type CFieldType T1 "t1_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t1_x" T1 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T1 {t1_x = y1}, RIP.getField @"t1_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T2_Aux@
 
@@ -175,23 +175,23 @@ instance Marshal.WriteRaw T2_Aux where
 
 deriving via Marshal.EquivStorable T2_Aux instance RIP.Storable T2_Aux
 
-instance HasCField.HasCField T2_Aux "t2_Aux_x" where
-
-  type CFieldType T2_Aux "t2_Aux_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t2_Aux_x" T2_Aux ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T2_Aux {t2_Aux_x = y1}, RIP.getField @"t2_Aux_x" x0)
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
+
+instance HasCField.HasCField T2_Aux "t2_Aux_x" where
+
+  type CFieldType T2_Aux "t2_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @T2@
 
@@ -212,6 +212,14 @@ newtype T2 = T2
     )
 
 instance ( ty ~ RIP.Ptr T2_Aux
+         ) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
+instance ( ty ~ RIP.Ptr T2_Aux
          ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
@@ -221,14 +229,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = RIP.Ptr T2_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr T2_Aux
-         ) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @struct \@T3_Aux@
 
@@ -271,23 +271,23 @@ instance Marshal.WriteRaw T3_Aux where
 
 deriving via Marshal.EquivStorable T3_Aux instance RIP.Storable T3_Aux
 
-instance HasCField.HasCField T3_Aux "t3_Aux_x" where
-
-  type CFieldType T3_Aux "t3_Aux_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t3_Aux_x" T3_Aux ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T3_Aux {t3_Aux_x = y1}, RIP.getField @"t3_Aux_x" x0)
+
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
+
+instance HasCField.HasCField T3_Aux "t3_Aux_x" where
+
+  type CFieldType T3_Aux "t3_Aux_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @T3@
 
@@ -308,6 +308,14 @@ newtype T3 = T3
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
          ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
@@ -318,11 +326,3 @@ instance HasCField.HasCField T3 "unwrapT3" where
     RIP.Ptr (RIP.Ptr T3_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -62,11 +63,12 @@ hstypes:
       fields:
       - t1_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -79,12 +81,13 @@ hstypes:
       fields:
       - unwrapT2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -98,11 +101,12 @@ hstypes:
       fields:
       - t2_Aux_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -115,12 +119,13 @@ hstypes:
       fields:
       - unwrapT3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -134,11 +139,12 @@ hstypes:
       fields:
       - t3_Aux_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_typedef/th.txt
@@ -23,14 +23,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @struct T1@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 3:9@
@@ -55,14 +55,14 @@ instance WriteRaw T1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
 deriving via (EquivStorable T1) instance Storable T1
-instance HasCField T1 "t1_x"
-    where type CFieldType T1 "t1_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 instance (~) ty MyInt => HasField "t1_x" T1 ty
     where hasField = \x_0 -> (\y_1 -> T1{t1_x = y_1},
                               getField @"t1_x" x_0)
+instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T2_Aux@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:9@
@@ -87,14 +87,14 @@ instance WriteRaw T2_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2_Aux t2_Aux_x_2 -> writeRaw (Proxy @"t2_Aux_x") ptr_0 t2_Aux_x_2
 deriving via (EquivStorable T2_Aux) instance Storable T2_Aux
-instance HasCField T2_Aux "t2_Aux_x"
-    where type CFieldType T2_Aux "t2_Aux_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_Aux_x")
 instance (~) ty MyInt => HasField "t2_Aux_x" T2_Aux ty
     where hasField = \x_0 -> (\y_1 -> T2_Aux{t2_Aux_x = y_1},
                               getField @"t2_Aux_x" x_0)
+instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_Aux_x")
+instance HasCField T2_Aux "t2_Aux_x"
+    where type CFieldType T2_Aux "t2_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @T2@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 4:32@
@@ -109,15 +109,15 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr T2_Aux) => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty (Ptr T2_Aux) =>
          HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_Aux) => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @struct \@T3_Aux@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:9@
@@ -142,14 +142,14 @@ instance WriteRaw T3_Aux
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3_Aux t3_Aux_x_2 -> writeRaw (Proxy @"t3_Aux_x") ptr_0 t3_Aux_x_2
 deriving via (EquivStorable T3_Aux) instance Storable T3_Aux
-instance HasCField T3_Aux "t3_Aux_x"
-    where type CFieldType T3_Aux "t3_Aux_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_Aux_x")
 instance (~) ty MyInt => HasField "t3_Aux_x" T3_Aux ty
     where hasField = \x_0 -> (\y_1 -> T3_Aux{t3_Aux_x = y_1},
                               getField @"t3_Aux_x" x_0)
+instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_Aux_x")
+instance HasCField T3_Aux "t3_Aux_x"
+    where type CFieldType T3_Aux "t3_Aux_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @T3@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_typedef.h 5:32@
@@ -164,12 +164,12 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (Ptr T3_Aux)) => HasField "unwrapT3" T3 ty
+    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
+                              getField @"unwrapT3" x_0)
 instance (~) ty (Ptr (Ptr T3_Aux)) =>
          HasField "unwrapT3" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_Aux)) => HasField "unwrapT3" T3 ty
-    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
-                              getField @"unwrapT3" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/Example.hs
@@ -65,6 +65,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -75,14 +83,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @struct \@T1_x@
 
@@ -125,22 +125,22 @@ instance Marshal.WriteRaw T1_x where
 
 deriving via Marshal.EquivStorable T1_x instance RIP.Storable T1_x
 
-instance HasCField.HasCField T1_x "t1_x_x" where
-
-  type CFieldType T1_x "t1_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t1_x_x" T1_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T1_x {t1_x_x = y1}, RIP.getField @"t1_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
+instance HasCField.HasCField T1_x "t1_x_x" where
+
+  type CFieldType T1_x "t1_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@T1@
 
@@ -186,15 +186,15 @@ set_t1_x ::
   -> T1
 set_t1_x = RIP.setUnionPayload
 
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
 instance HasCField.HasCField T1 "t1_x" where
 
   type CFieldType T1 "t1_x" = T1_x
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
 {-| __C declaration:__ @union \@T2@
 
@@ -240,16 +240,16 @@ set_t2_x ::
   -> T2
 set_t2_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
 instance HasCField.HasCField T2 "t2_x" where
 
   type CFieldType T2 "t2_x" = RIP.Ptr T2_x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
 {-| __C declaration:__ @struct \@T2_x@
 
@@ -292,22 +292,22 @@ instance Marshal.WriteRaw T2_x where
 
 deriving via Marshal.EquivStorable T2_x instance RIP.Storable T2_x
 
-instance HasCField.HasCField T2_x "t2_x_x" where
-
-  type CFieldType T2_x "t2_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t2_x_x" T2_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T2_x {t2_x_x = y1}, RIP.getField @"t2_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
+instance HasCField.HasCField T2_x "t2_x_x" where
+
+  type CFieldType T2_x "t2_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@T3@
 
@@ -353,16 +353,16 @@ set_t3_x ::
   -> T3
 set_t3_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
 instance HasCField.HasCField T3 "t3_x" where
 
   type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
 {-| __C declaration:__ @struct \@T3_x@
 
@@ -405,19 +405,19 @@ instance Marshal.WriteRaw T3_x where
 
 deriving via Marshal.EquivStorable T3_x instance RIP.Storable T3_x
 
-instance HasCField.HasCField T3_x "t3_x_x" where
-
-  type CFieldType T3_x "t3_x_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "t3_x_x" T3_x ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          T3_x {t3_x_x = y1}, RIP.getField @"t3_x_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
+
+instance HasCField.HasCField T3_x "t3_x_x" where
+
+  type CFieldType T3_x "t3_x_x" = MyInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -64,7 +65,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -76,11 +77,12 @@ hstypes:
       fields:
       - t1_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -95,7 +97,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -107,11 +109,12 @@ hstypes:
       fields:
       - t2_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -126,7 +129,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -138,11 +141,12 @@ hstypes:
       fields:
       - t3_x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_union/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @struct \@T1_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:9@
@@ -74,14 +74,14 @@ instance WriteRaw T1_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T1_x t1_x_x_2 -> writeRaw (Proxy @"t1_x_x") ptr_0 t1_x_x_2
 deriving via (EquivStorable T1_x) instance Storable T1_x
-instance HasCField T1_x "t1_x_x"
-    where type CFieldType T1_x "t1_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x_x")
 instance (~) ty MyInt => HasField "t1_x_x" T1_x ty
     where hasField = \x_0 -> (\y_1 -> T1_x{t1_x_x = y_1},
                               getField @"t1_x_x" x_0)
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
+instance HasCField T1_x "t1_x_x"
+    where type CFieldType T1_x "t1_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@T1@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 3:1@
@@ -127,11 +127,11 @@ set_t1_x :: T1_x -> T1
 
 -}
 set_t1_x = setUnionPayload
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:1@
@@ -177,11 +177,11 @@ set_t2_x :: Ptr T2_x -> T2
 
 -}
 set_t2_x = setUnionPayload
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @struct \@T2_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 4:9@
@@ -206,14 +206,14 @@ instance WriteRaw T2_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2_x t2_x_x_2 -> writeRaw (Proxy @"t2_x_x") ptr_0 t2_x_x_2
 deriving via (EquivStorable T2_x) instance Storable T2_x
-instance HasCField T2_x "t2_x_x"
-    where type CFieldType T2_x "t2_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x_x")
 instance (~) ty MyInt => HasField "t2_x_x" T2_x ty
     where hasField = \x_0 -> (\y_1 -> T2_x{t2_x_x = y_1},
                               getField @"t2_x_x" x_0)
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
+instance HasCField T2_x "t2_x_x"
+    where type CFieldType T2_x "t2_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@T3@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:1@
@@ -259,12 +259,12 @@ set_t3_x :: Ptr (Ptr T3_x) -> T3
 
 -}
 set_t3_x = setUnionPayload
-instance HasCField T3 "t3_x"
-    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
-          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr (Ptr T3_x)) =>
          HasField "t3_x" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"t3_x")
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T3_x@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_union.h 5:9@
@@ -289,14 +289,14 @@ instance WriteRaw T3_x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3_x t3_x_x_2 -> writeRaw (Proxy @"t3_x_x") ptr_0 t3_x_x_2
 deriving via (EquivStorable T3_x) instance Storable T3_x
-instance HasCField T3_x "t3_x_x"
-    where type CFieldType T3_x "t3_x_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x_x")
 instance (~) ty MyInt => HasField "t3_x_x" T3_x ty
     where hasField = \x_0 -> (\y_1 -> T3_x{t3_x_x = y_1},
                               getField @"t3_x_x" x_0)
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
+instance HasCField T3_x "t3_x_x"
+    where type CFieldType T3_x "t3_x_x" = MyInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_2ac02abef90be65b" hs_bindgen_2ac02abef90be65b_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/Example.hs
@@ -56,6 +56,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -66,14 +74,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @struct \@G1@
 
@@ -116,21 +116,21 @@ instance Marshal.WriteRaw G1 where
 
 deriving via Marshal.EquivStorable G1 instance RIP.Storable G1
 
-instance HasCField.HasCField G1 "g1_x" where
-
-  type CFieldType G1 "g1_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "g1_x" G1 ty where
 
   hasField =
     \x0 ->
       (\y1 -> G1 {g1_x = y1}, RIP.getField @"g1_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
+
+instance HasCField.HasCField G1 "g1_x" where
+
+  type CFieldType G1 "g1_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@G2@
 
@@ -173,21 +173,21 @@ instance Marshal.WriteRaw G2 where
 
 deriving via Marshal.EquivStorable G2 instance RIP.Storable G2
 
-instance HasCField.HasCField G2 "g2_x" where
-
-  type CFieldType G2 "g2_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "g2_x" G2 ty where
 
   hasField =
     \x0 ->
       (\y1 -> G2 {g2_x = y1}, RIP.getField @"g2_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
+
+instance HasCField.HasCField G2 "g2_x" where
+
+  type CFieldType G2 "g2_x" = MyInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@G3@
 
@@ -230,18 +230,18 @@ instance Marshal.WriteRaw G3 where
 
 deriving via Marshal.EquivStorable G3 instance RIP.Storable G3
 
-instance HasCField.HasCField G3 "g3_x" where
-
-  type CFieldType G3 "g3_x" = MyInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")
-
 instance (ty ~ MyInt) => RIP.CompatHasField.HasField "g3_x" G3 ty where
 
   hasField =
     \x0 ->
       (\y1 -> G3 {g3_x = y1}, RIP.getField @"g3_x" x0)
+
+instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")
+
+instance HasCField.HasCField G3 "g3_x" where
+
+  type CFieldType G3 "g3_x" = MyInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/bindingspec.yaml
@@ -23,11 +23,12 @@ hstypes:
       fields:
       - g1_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -40,11 +41,12 @@ hstypes:
       fields:
       - g2_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -57,11 +59,12 @@ hstypes:
       fields:
       - g3_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -77,7 +80,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -85,6 +87,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/struct_in_variable/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @struct \@G1@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 3:1@
@@ -74,14 +74,14 @@ instance WriteRaw G1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        G1 g1_x_2 -> writeRaw (Proxy @"g1_x") ptr_0 g1_x_2
 deriving via (EquivStorable G1) instance Storable G1
-instance HasCField G1 "g1_x"
-    where type CFieldType G1 "g1_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
-    where getField = fromPtr (Proxy @"g1_x")
 instance (~) ty MyInt => HasField "g1_x" G1 ty
     where hasField = \x_0 -> (\y_1 -> G1{g1_x = y_1},
                               getField @"g1_x" x_0)
+instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+    where getField = fromPtr (Proxy @"g1_x")
+instance HasCField G1 "g1_x"
+    where type CFieldType G1 "g1_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@G2@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 4:1@
@@ -106,14 +106,14 @@ instance WriteRaw G2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        G2 g2_x_2 -> writeRaw (Proxy @"g2_x") ptr_0 g2_x_2
 deriving via (EquivStorable G2) instance Storable G2
-instance HasCField G2 "g2_x"
-    where type CFieldType G2 "g2_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
-    where getField = fromPtr (Proxy @"g2_x")
 instance (~) ty MyInt => HasField "g2_x" G2 ty
     where hasField = \x_0 -> (\y_1 -> G2{g2_x = y_1},
                               getField @"g2_x" x_0)
+instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+    where getField = fromPtr (Proxy @"g2_x")
+instance HasCField G2 "g2_x"
+    where type CFieldType G2 "g2_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@G3@
 
     __defined at:__ @macros\/reparse\/nesting\/struct_in_variable.h 5:1@
@@ -138,14 +138,14 @@ instance WriteRaw G3
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        G3 g3_x_2 -> writeRaw (Proxy @"g3_x") ptr_0 g3_x_2
 deriving via (EquivStorable G3) instance Storable G3
-instance HasCField G3 "g3_x"
-    where type CFieldType G3 "g3_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
-    where getField = fromPtr (Proxy @"g3_x")
 instance (~) ty MyInt => HasField "g3_x" G3 ty
     where hasField = \x_0 -> (\y_1 -> G3{g3_x = y_1},
                               getField @"g3_x" x_0)
+instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+    where getField = fromPtr (Proxy @"g3_x")
+instance HasCField G3 "g3_x"
+    where type CFieldType G3 "g3_x" = MyInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_macrosreparsenestingstruct__Example_get_G1@
 foreign import ccall unsafe "hs_bindgen_7b488cf23d974403" hs_bindgen_7b488cf23d974403_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/th.txt
@@ -23,14 +23,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @struct TS1@
 
     __defined at:__ @macros\/reparse\/nesting.h 5:16@
@@ -55,14 +55,14 @@ instance WriteRaw T2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
 deriving via (EquivStorable T2) instance Storable T2
-instance HasCField T2 "t2_x"
-    where type CFieldType T2 "t2_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x" (Ptr T2) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x")
 instance (~) ty MyInt => HasField "t2_x" T2 ty
     where hasField = \x_0 -> (\y_1 -> T2{t2_x = y_1},
                               getField @"t2_x" x_0)
+instance (~) ty MyInt => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct TS3@
 
     __defined at:__ @macros\/reparse\/nesting.h 6:16@
@@ -87,14 +87,14 @@ instance WriteRaw T3
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
 deriving via (EquivStorable T3) instance Storable T3
-instance HasCField T3 "t3_x"
-    where type CFieldType T3 "t3_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x" (Ptr T3) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x")
 instance (~) ty MyInt => HasField "t3_x" T3 ty
     where hasField = \x_0 -> (\y_1 -> T3{t3_x = y_1},
                               getField @"t3_x" x_0)
+instance (~) ty MyInt => HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = MyInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct T4@
 
     __defined at:__ @macros\/reparse\/nesting.h 7:9@
@@ -119,11 +119,11 @@ instance WriteRaw T4
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T4 t4_x_2 -> writeRaw (Proxy @"t4_x") ptr_0 t4_x_2
 deriving via (EquivStorable T4) instance Storable T4
-instance HasCField T4 "t4_x"
-    where type CFieldType T4 "t4_x" = MyInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t4_x" (Ptr T4) (Ptr ty)
-    where getField = fromPtr (Proxy @"t4_x")
 instance (~) ty MyInt => HasField "t4_x" T4 ty
     where hasField = \x_0 -> (\y_1 -> T4{t4_x = y_1},
                               getField @"t4_x" x_0)
+instance (~) ty MyInt => HasField "t4_x" (Ptr T4) (Ptr ty)
+    where getField = fromPtr (Proxy @"t4_x")
+instance HasCField T4 "t4_x"
+    where type CFieldType T4 "t4_x" = MyInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/Example.hs
@@ -65,6 +65,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -75,14 +83,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @union \@T1_x@
 
@@ -128,15 +128,15 @@ set_t1_x_x ::
   -> T1_x
 set_t1_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
 instance HasCField.HasCField T1_x "t1_x_x" where
 
   type CFieldType T1_x "t1_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
 {-| __C declaration:__ @struct \@T1@
 
@@ -179,21 +179,21 @@ instance Marshal.WriteRaw T1 where
 
 deriving via Marshal.EquivStorable T1 instance RIP.Storable T1
 
-instance HasCField.HasCField T1 "t1_x" where
-
-  type CFieldType T1 "t1_x" = T1_x
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
-
 instance (ty ~ T1_x) => RIP.CompatHasField.HasField "t1_x" T1 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T1 {t1_x = y1}, RIP.getField @"t1_x" x0)
+
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
+instance HasCField.HasCField T1 "t1_x" where
+
+  type CFieldType T1 "t1_x" = T1_x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@T2@
 
@@ -236,22 +236,22 @@ instance Marshal.WriteRaw T2 where
 
 deriving via Marshal.EquivStorable T2 instance RIP.Storable T2
 
-instance HasCField.HasCField T2 "t2_x" where
+instance (ty ~ RIP.Ptr T2_x) => RIP.CompatHasField.HasField "t2_x" T2 ty where
 
-  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 -> T2 {t2_x = y1}, RIP.getField @"t2_x" x0)
 
 instance ( ty ~ RIP.Ptr T2_x
          ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
-instance (ty ~ RIP.Ptr T2_x) => RIP.CompatHasField.HasField "t2_x" T2 ty where
+instance HasCField.HasCField T2 "t2_x" where
 
-  hasField =
-    \x0 ->
-      (\y1 -> T2 {t2_x = y1}, RIP.getField @"t2_x" x0)
+  type CFieldType T2 "t2_x" = RIP.Ptr T2_x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@T2_x@
 
@@ -297,15 +297,15 @@ set_t2_x_x ::
   -> T2_x
 set_t2_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
 instance HasCField.HasCField T2_x "t2_x_x" where
 
   type CFieldType T2_x "t2_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
 {-| __C declaration:__ @struct \@T3@
 
@@ -348,23 +348,23 @@ instance Marshal.WriteRaw T3 where
 
 deriving via Marshal.EquivStorable T3 instance RIP.Storable T3
 
-instance HasCField.HasCField T3 "t3_x" where
-
-  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
-
 instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
          ) => RIP.CompatHasField.HasField "t3_x" T3 ty where
 
   hasField =
     \x0 ->
       (\y1 -> T3 {t3_x = y1}, RIP.getField @"t3_x" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
+instance HasCField.HasCField T3 "t3_x" where
+
+  type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@T3_x@
 
@@ -410,12 +410,12 @@ set_t3_x_x ::
   -> T3_x
 set_t3_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
+
 instance HasCField.HasCField T3_x "t3_x_x" where
 
   type CFieldType T3_x "t3_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -62,10 +63,11 @@ hstypes:
       fields:
       - t1_x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -79,7 +81,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -91,11 +93,12 @@ hstypes:
       fields:
       - t2_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -110,7 +113,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -122,11 +125,12 @@ hstypes:
       fields:
       - t3_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -141,7 +145,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_struct/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @union \@T1_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:10@
@@ -97,11 +97,11 @@ set_t1_x_x :: MyInt -> T1_x
 
 -}
 set_t1_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @struct \@T1@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 3:1@
@@ -126,14 +126,14 @@ instance WriteRaw T1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T1 t1_x_2 -> writeRaw (Proxy @"t1_x") ptr_0 t1_x_2
 deriving via (EquivStorable T1) instance Storable T1
-instance HasCField T1 "t1_x"
-    where type CFieldType T1 "t1_x" = T1_x
-          offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 instance (~) ty T1_x => HasField "t1_x" T1 ty
     where hasField = \x_0 -> (\y_1 -> T1{t1_x = y_1},
                               getField @"t1_x" x_0)
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
+instance HasCField T1 "t1_x"
+    where type CFieldType T1 "t1_x" = T1_x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@T2@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:1@
@@ -158,14 +158,14 @@ instance WriteRaw T2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T2 t2_x_2 -> writeRaw (Proxy @"t2_x") ptr_0 t2_x_2
 deriving via (EquivStorable T2) instance Storable T2
-instance HasCField T2 "t2_x"
-    where type CFieldType T2 "t2_x" = Ptr T2_x
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x")
 instance (~) ty (Ptr T2_x) => HasField "t2_x" T2 ty
     where hasField = \x_0 -> (\y_1 -> T2{t2_x = y_1},
                               getField @"t2_x" x_0)
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
+instance HasCField T2 "t2_x"
+    where type CFieldType T2 "t2_x" = Ptr T2_x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@T2_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 4:10@
@@ -213,11 +213,11 @@ set_t2_x_x :: MyInt -> T2_x
 
 -}
 set_t2_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @struct \@T3@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:1@
@@ -242,15 +242,15 @@ instance WriteRaw T3
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        T3 t3_x_2 -> writeRaw (Proxy @"t3_x") ptr_0 t3_x_2
 deriving via (EquivStorable T3) instance Storable T3
-instance HasCField T3 "t3_x"
-    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_x)) =>
-         HasField "t3_x" (Ptr T3) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x")
 instance (~) ty (Ptr (Ptr T3_x)) => HasField "t3_x" T3 ty
     where hasField = \x_0 -> (\y_1 -> T3{t3_x = y_1},
                               getField @"t3_x" x_0)
+instance (~) ty (Ptr (Ptr T3_x)) =>
+         HasField "t3_x" (Ptr T3) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x")
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@T3_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_struct.h 5:10@
@@ -298,11 +298,11 @@ set_t3_x_x :: MyInt -> T3_x
 
 -}
 set_t3_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/Example.hs
@@ -64,6 +64,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -74,14 +82,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @union T1@
 
@@ -127,15 +127,15 @@ set_t1_x ::
   -> T1
 set_t1_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
 instance HasCField.HasCField T1 "t1_x" where
 
   type CFieldType T1 "t1_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
 {-| __C declaration:__ @union \@T2_Aux@
 
@@ -181,16 +181,16 @@ set_t2_Aux_x ::
   -> T2_Aux
 set_t2_Aux_x = RIP.setUnionPayload
 
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
+
 instance HasCField.HasCField T2_Aux "t2_Aux_x" where
 
   type CFieldType T2_Aux "t2_Aux_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t2_Aux_x" (RIP.Ptr T2_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_Aux_x")
 
 {-| __C declaration:__ @T2@
 
@@ -211,6 +211,14 @@ newtype T2 = T2
     )
 
 instance ( ty ~ RIP.Ptr T2_Aux
+         ) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
+instance ( ty ~ RIP.Ptr T2_Aux
          ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT2")
@@ -220,14 +228,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = RIP.Ptr T2_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr T2_Aux
-         ) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @union \@T3_Aux@
 
@@ -273,16 +273,16 @@ set_t3_Aux_x ::
   -> T3_Aux
 set_t3_Aux_x = RIP.setUnionPayload
 
+instance ( ty ~ MyInt
+         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
+
 instance HasCField.HasCField T3_Aux "t3_Aux_x" where
 
   type CFieldType T3_Aux "t3_Aux_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ MyInt
-         ) => RIP.HasField "t3_Aux_x" (RIP.Ptr T3_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_Aux_x")
 
 {-| __C declaration:__ @T3@
 
@@ -303,6 +303,14 @@ newtype T3 = T3
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
          ) => RIP.HasField "unwrapT3" (RIP.Ptr T3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT3")
@@ -313,11 +321,3 @@ instance HasCField.HasCField T3 "unwrapT3" where
     RIP.Ptr (RIP.Ptr T3_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapT3" T3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T3 {unwrapT3 = y1}, RIP.getField @"unwrapT3" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -64,7 +65,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -76,12 +77,13 @@ hstypes:
       fields:
       - unwrapT2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -97,7 +99,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -109,12 +111,13 @@ hstypes:
       fields:
       - unwrapT3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -130,7 +133,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_typedef/th.txt
@@ -23,14 +23,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @union T1@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 3:9@
@@ -76,11 +76,11 @@ set_t1_x :: MyInt -> T1
 
 -}
 set_t1_x = setUnionPayload
+instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2_Aux@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:9@
@@ -128,11 +128,11 @@ set_t2_Aux_x :: MyInt -> T2_Aux
 
 -}
 set_t2_Aux_x = setUnionPayload
+instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_Aux_x")
 instance HasCField T2_Aux "t2_Aux_x"
     where type CFieldType T2_Aux "t2_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_Aux_x" (Ptr T2_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_Aux_x")
 {-| __C declaration:__ @T2@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 4:31@
@@ -147,15 +147,15 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr T2_Aux) => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty (Ptr T2_Aux) =>
          HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = Ptr T2_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_Aux) => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @union \@T3_Aux@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:9@
@@ -203,11 +203,11 @@ set_t3_Aux_x :: MyInt -> T3_Aux
 
 -}
 set_t3_Aux_x = setUnionPayload
+instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_Aux_x")
 instance HasCField T3_Aux "t3_Aux_x"
     where type CFieldType T3_Aux "t3_Aux_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_Aux_x" (Ptr T3_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_Aux_x")
 {-| __C declaration:__ @T3@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_typedef.h 5:31@
@@ -222,12 +222,12 @@ newtype T3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (Ptr T3_Aux)) => HasField "unwrapT3" T3 ty
+    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
+                              getField @"unwrapT3" x_0)
 instance (~) ty (Ptr (Ptr T3_Aux)) =>
          HasField "unwrapT3" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT3")
 instance HasCField T3 "unwrapT3"
     where type CFieldType T3 "unwrapT3" = Ptr (Ptr T3_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr T3_Aux)) => HasField "unwrapT3" T3 ty
-    where hasField = \x_0 -> (\y_1 -> T3{unwrapT3 = y_1},
-                              getField @"unwrapT3" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/Example.hs
@@ -71,6 +71,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -81,14 +89,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @union \@T1_x@
 
@@ -134,15 +134,15 @@ set_t1_x_x ::
   -> T1_x
 set_t1_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
+
 instance HasCField.HasCField T1_x "t1_x_x" where
 
   type CFieldType T1_x "t1_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t1_x_x" (RIP.Ptr T1_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x_x")
 
 {-| __C declaration:__ @union \@T1@
 
@@ -188,15 +188,15 @@ set_t1_x ::
   -> T1
 set_t1_x = RIP.setUnionPayload
 
+instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
+
 instance HasCField.HasCField T1 "t1_x" where
 
   type CFieldType T1 "t1_x" = T1_x
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ T1_x) => RIP.HasField "t1_x" (RIP.Ptr T1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t1_x")
 
 {-| __C declaration:__ @union \@T2@
 
@@ -242,16 +242,16 @@ set_t2_x ::
   -> T2
 set_t2_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.Ptr T2_x
+         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
+
 instance HasCField.HasCField T2 "t2_x" where
 
   type CFieldType T2 "t2_x" = RIP.Ptr T2_x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr T2_x
-         ) => RIP.HasField "t2_x" (RIP.Ptr T2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x")
 
 {-| __C declaration:__ @union \@T2_x@
 
@@ -297,15 +297,15 @@ set_t2_x_x ::
   -> T2_x
 set_t2_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
+
 instance HasCField.HasCField T2_x "t2_x_x" where
 
   type CFieldType T2_x "t2_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t2_x_x" (RIP.Ptr T2_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t2_x_x")
 
 {-| __C declaration:__ @union \@T3@
 
@@ -351,16 +351,16 @@ set_t3_x ::
   -> T3
 set_t3_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
+         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
+
 instance HasCField.HasCField T3 "t3_x" where
 
   type CFieldType T3 "t3_x" = RIP.Ptr (RIP.Ptr T3_x)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr T3_x)
-         ) => RIP.HasField "t3_x" (RIP.Ptr T3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x")
 
 {-| __C declaration:__ @union \@T3_x@
 
@@ -406,12 +406,12 @@ set_t3_x_x ::
   -> T3_x
 set_t3_x_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")
+
 instance HasCField.HasCField T3_x "t3_x_x" where
 
   type CFieldType T3_x "t3_x_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "t3_x_x" (RIP.Ptr T3_x) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"t3_x_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/bindingspec.yaml
@@ -35,7 +35,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +42,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -64,7 +65,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -78,7 +79,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -92,7 +93,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -106,7 +107,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -120,7 +121,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -134,7 +135,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_union/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @union \@T1_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:9@
@@ -97,11 +97,11 @@ set_t1_x_x :: MyInt -> T1_x
 
 -}
 set_t1_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x_x")
 instance HasCField T1_x "t1_x_x"
     where type CFieldType T1_x "t1_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t1_x_x" (Ptr T1_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x_x")
 {-| __C declaration:__ @union \@T1@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 3:1@
@@ -147,11 +147,11 @@ set_t1_x :: T1_x -> T1
 
 -}
 set_t1_x = setUnionPayload
+instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
+    where getField = fromPtr (Proxy @"t1_x")
 instance HasCField T1 "t1_x"
     where type CFieldType T1 "t1_x" = T1_x
           offset# = \_ -> \_ -> 0
-instance (~) ty T1_x => HasField "t1_x" (Ptr T1) (Ptr ty)
-    where getField = fromPtr (Proxy @"t1_x")
 {-| __C declaration:__ @union \@T2@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:1@
@@ -197,11 +197,11 @@ set_t2_x :: Ptr T2_x -> T2
 
 -}
 set_t2_x = setUnionPayload
+instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x")
 instance HasCField T2 "t2_x"
     where type CFieldType T2 "t2_x" = Ptr T2_x
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr T2_x) => HasField "t2_x" (Ptr T2) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x")
 {-| __C declaration:__ @union \@T2_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 4:9@
@@ -249,11 +249,11 @@ set_t2_x_x :: MyInt -> T2_x
 
 -}
 set_t2_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t2_x_x")
 instance HasCField T2_x "t2_x_x"
     where type CFieldType T2_x "t2_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t2_x_x" (Ptr T2_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t2_x_x")
 {-| __C declaration:__ @union \@T3@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:1@
@@ -299,12 +299,12 @@ set_t3_x :: Ptr (Ptr T3_x) -> T3
 
 -}
 set_t3_x = setUnionPayload
-instance HasCField T3 "t3_x"
-    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
-          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr (Ptr T3_x)) =>
          HasField "t3_x" (Ptr T3) (Ptr ty)
     where getField = fromPtr (Proxy @"t3_x")
+instance HasCField T3 "t3_x"
+    where type CFieldType T3 "t3_x" = Ptr (Ptr T3_x)
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@T3_x@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_union.h 5:9@
@@ -352,11 +352,11 @@ set_t3_x_x :: MyInt -> T3_x
 
 -}
 set_t3_x_x = setUnionPayload
+instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
+    where getField = fromPtr (Proxy @"t3_x_x")
 instance HasCField T3_x "t3_x_x"
     where type CFieldType T3_x "t3_x_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "t3_x_x" (Ptr T3_x) (Ptr ty)
-    where getField = fromPtr (Proxy @"t3_x_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_T1@
 foreign import ccall unsafe "hs_bindgen_44a1ef54c1044601" hs_bindgen_44a1ef54c1044601_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/Example.hs
@@ -62,6 +62,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -72,14 +80,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| __C declaration:__ @union \@G1@
 
@@ -125,15 +125,15 @@ set_g1_x ::
   -> G1
 set_g1_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
+
 instance HasCField.HasCField G1 "g1_x" where
 
   type CFieldType G1 "g1_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g1_x" (RIP.Ptr G1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g1_x")
 
 {-| __C declaration:__ @union \@G2@
 
@@ -179,15 +179,15 @@ set_g2_x ::
   -> G2
 set_g2_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
+
 instance HasCField.HasCField G2 "g2_x" where
 
   type CFieldType G2 "g2_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g2_x" (RIP.Ptr G2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g2_x")
 
 {-| __C declaration:__ @union \@G3@
 
@@ -233,12 +233,12 @@ set_g3_x ::
   -> G3
 set_g3_x = RIP.setUnionPayload
 
+instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")
+
 instance HasCField.HasCField G3 "g3_x" where
 
   type CFieldType G3 "g3_x" = MyInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ MyInt) => RIP.HasField "g3_x" (RIP.Ptr G3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"g3_x")

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/bindingspec.yaml
@@ -25,7 +25,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -39,7 +39,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -53,7 +53,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -68,7 +68,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -76,6 +75,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/nesting/union_in_variable/th.txt
@@ -42,14 +42,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| __C declaration:__ @union \@G1@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 3:1@
@@ -95,11 +95,11 @@ set_g1_x :: MyInt -> G1
 
 -}
 set_g1_x = setUnionPayload
+instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
+    where getField = fromPtr (Proxy @"g1_x")
 instance HasCField G1 "g1_x"
     where type CFieldType G1 "g1_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g1_x" (Ptr G1) (Ptr ty)
-    where getField = fromPtr (Proxy @"g1_x")
 {-| __C declaration:__ @union \@G2@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 4:1@
@@ -145,11 +145,11 @@ set_g2_x :: MyInt -> G2
 
 -}
 set_g2_x = setUnionPayload
+instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
+    where getField = fromPtr (Proxy @"g2_x")
 instance HasCField G2 "g2_x"
     where type CFieldType G2 "g2_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g2_x" (Ptr G2) (Ptr ty)
-    where getField = fromPtr (Proxy @"g2_x")
 {-| __C declaration:__ @union \@G3@
 
     __defined at:__ @macros\/reparse\/nesting\/union_in_variable.h 5:1@
@@ -195,11 +195,11 @@ set_g3_x :: MyInt -> G3
 
 -}
 set_g3_x = setUnionPayload
+instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
+    where getField = fromPtr (Proxy @"g3_x")
 instance HasCField G3 "g3_x"
     where type CFieldType G3 "g3_x" = MyInt
           offset# = \_ -> \_ -> 0
-instance (~) ty MyInt => HasField "g3_x" (Ptr G3) (Ptr ty)
-    where getField = fromPtr (Proxy @"g3_x")
 -- __unique:__ @test_macrosreparsenestingunion_i_Example_get_G1@
 foreign import ccall unsafe "hs_bindgen_4b01ee4d60407c60" hs_bindgen_4b01ee4d60407c60_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/th.txt
@@ -2533,14 +2533,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @struct some_struct@
 
     __defined at:__ @macros\/reparse.h 7:8@
@@ -2611,15 +2611,15 @@ instance Read Some_enum
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapSome_enum" Some_enum ty
+    where hasField = \x_0 -> (\y_1 -> Some_enum{unwrapSome_enum = y_1},
+                              getField @"unwrapSome_enum" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapSome_enum" (Ptr Some_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSome_enum")
 instance HasCField Some_enum "unwrapSome_enum"
     where type CFieldType Some_enum "unwrapSome_enum" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapSome_enum" Some_enum ty
-    where hasField = \x_0 -> (\y_1 -> Some_enum{unwrapSome_enum = y_1},
-                              getField @"unwrapSome_enum" x_0)
 {-| __C declaration:__ @ENUM_A@
 
     __defined at:__ @macros\/reparse.h 9:18@
@@ -2639,16 +2639,16 @@ newtype Arr_typedef1
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray A) =>
+         HasField "unwrapArr_typedef1" Arr_typedef1 ty
+    where hasField = \x_0 -> (\y_1 -> Arr_typedef1{unwrapArr_typedef1 = y_1},
+                              getField @"unwrapArr_typedef1" x_0)
+instance (~) ty (IncompleteArray A) =>
          HasField "unwrapArr_typedef1" (Ptr Arr_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef1")
 instance HasCField Arr_typedef1 "unwrapArr_typedef1"
     where type CFieldType Arr_typedef1
                           "unwrapArr_typedef1" = IncompleteArray A
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray A) =>
-         HasField "unwrapArr_typedef1" Arr_typedef1 ty
-    where hasField = \x_0 -> (\y_1 -> Arr_typedef1{unwrapArr_typedef1 = y_1},
-                              getField @"unwrapArr_typedef1" x_0)
 {-| __C declaration:__ @arr_typedef2@
 
     __defined at:__ @macros\/reparse.h 110:13@
@@ -2660,16 +2660,16 @@ newtype Arr_typedef2
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray (Ptr A)) =>
+         HasField "unwrapArr_typedef2" Arr_typedef2 ty
+    where hasField = \x_0 -> (\y_1 -> Arr_typedef2{unwrapArr_typedef2 = y_1},
+                              getField @"unwrapArr_typedef2" x_0)
+instance (~) ty (IncompleteArray (Ptr A)) =>
          HasField "unwrapArr_typedef2" (Ptr Arr_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef2")
 instance HasCField Arr_typedef2 "unwrapArr_typedef2"
     where type CFieldType Arr_typedef2
                           "unwrapArr_typedef2" = IncompleteArray (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray (Ptr A)) =>
-         HasField "unwrapArr_typedef2" Arr_typedef2 ty
-    where hasField = \x_0 -> (\y_1 -> Arr_typedef2{unwrapArr_typedef2 = y_1},
-                              getField @"unwrapArr_typedef2" x_0)
 {-| __C declaration:__ @arr_typedef3@
 
     __defined at:__ @macros\/reparse.h 111:13@
@@ -2681,16 +2681,16 @@ newtype Arr_typedef3
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 5 A) =>
+         HasField "unwrapArr_typedef3" Arr_typedef3 ty
+    where hasField = \x_0 -> (\y_1 -> Arr_typedef3{unwrapArr_typedef3 = y_1},
+                              getField @"unwrapArr_typedef3" x_0)
+instance (~) ty (ConstantArray 5 A) =>
          HasField "unwrapArr_typedef3" (Ptr Arr_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef3")
 instance HasCField Arr_typedef3 "unwrapArr_typedef3"
     where type CFieldType Arr_typedef3
                           "unwrapArr_typedef3" = ConstantArray 5 A
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 5 A) =>
-         HasField "unwrapArr_typedef3" Arr_typedef3 ty
-    where hasField = \x_0 -> (\y_1 -> Arr_typedef3{unwrapArr_typedef3 = y_1},
-                              getField @"unwrapArr_typedef3" x_0)
 {-| __C declaration:__ @arr_typedef4@
 
     __defined at:__ @macros\/reparse.h 112:13@
@@ -2702,16 +2702,16 @@ newtype Arr_typedef4
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 5 (Ptr A)) =>
+         HasField "unwrapArr_typedef4" Arr_typedef4 ty
+    where hasField = \x_0 -> (\y_1 -> Arr_typedef4{unwrapArr_typedef4 = y_1},
+                              getField @"unwrapArr_typedef4" x_0)
+instance (~) ty (ConstantArray 5 (Ptr A)) =>
          HasField "unwrapArr_typedef4" (Ptr Arr_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapArr_typedef4")
 instance HasCField Arr_typedef4 "unwrapArr_typedef4"
     where type CFieldType Arr_typedef4
                           "unwrapArr_typedef4" = ConstantArray 5 (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 5 (Ptr A)) =>
-         HasField "unwrapArr_typedef4" Arr_typedef4 ty
-    where hasField = \x_0 -> (\y_1 -> Arr_typedef4{unwrapArr_typedef4 = y_1},
-                              getField @"unwrapArr_typedef4" x_0)
 {-| Typedefs
 
     __C declaration:__ @typedef1@
@@ -2738,15 +2738,15 @@ newtype Typedef1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapTypedef1" Typedef1 ty
+    where hasField = \x_0 -> (\y_1 -> Typedef1{unwrapTypedef1 = y_1},
+                              getField @"unwrapTypedef1" x_0)
 instance (~) ty A =>
          HasField "unwrapTypedef1" (Ptr Typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef1")
 instance HasCField Typedef1 "unwrapTypedef1"
     where type CFieldType Typedef1 "unwrapTypedef1" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapTypedef1" Typedef1 ty
-    where hasField = \x_0 -> (\y_1 -> Typedef1{unwrapTypedef1 = y_1},
-                              getField @"unwrapTypedef1" x_0)
 {-| __C declaration:__ @typedef2@
 
     __defined at:__ @macros\/reparse.h 119:14@
@@ -2761,15 +2761,15 @@ newtype Typedef2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr A) => HasField "unwrapTypedef2" Typedef2 ty
+    where hasField = \x_0 -> (\y_1 -> Typedef2{unwrapTypedef2 = y_1},
+                              getField @"unwrapTypedef2" x_0)
 instance (~) ty (Ptr A) =>
          HasField "unwrapTypedef2" (Ptr Typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef2")
 instance HasCField Typedef2 "unwrapTypedef2"
     where type CFieldType Typedef2 "unwrapTypedef2" = Ptr A
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr A) => HasField "unwrapTypedef2" Typedef2 ty
-    where hasField = \x_0 -> (\y_1 -> Typedef2{unwrapTypedef2 = y_1},
-                              getField @"unwrapTypedef2" x_0)
 {-| __C declaration:__ @typedef3@
 
     __defined at:__ @macros\/reparse.h 120:14@
@@ -2785,15 +2785,15 @@ newtype Typedef3
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr A)) =>
+         HasField "unwrapTypedef3" Typedef3 ty
+    where hasField = \x_0 -> (\y_1 -> Typedef3{unwrapTypedef3 = y_1},
+                              getField @"unwrapTypedef3" x_0)
+instance (~) ty (Ptr (Ptr A)) =>
          HasField "unwrapTypedef3" (Ptr Typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTypedef3")
 instance HasCField Typedef3 "unwrapTypedef3"
     where type CFieldType Typedef3 "unwrapTypedef3" = Ptr (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr A)) =>
-         HasField "unwrapTypedef3" Typedef3 ty
-    where hasField = \x_0 -> (\y_1 -> Typedef3{unwrapTypedef3 = y_1},
-                              getField @"unwrapTypedef3" x_0)
 {-| Auxiliary type used by 'Funptr_typedef1'
 
     __C declaration:__ @funptr_typedef1@
@@ -2829,6 +2829,10 @@ instance ToFunPtr Funptr_typedef1_Aux
 instance FromFunPtr Funptr_typedef1_Aux
     where fromFunPtr = hs_bindgen_806a46dc418a062c
 instance (~) ty (IO A) =>
+         HasField "unwrapFunptr_typedef1_Aux" Funptr_typedef1_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef1_Aux{unwrapFunptr_typedef1_Aux = y_1},
+                              getField @"unwrapFunptr_typedef1_Aux" x_0)
+instance (~) ty (IO A) =>
          HasField "unwrapFunptr_typedef1_Aux"
                   (Ptr Funptr_typedef1_Aux)
                   (Ptr ty)
@@ -2837,10 +2841,6 @@ instance HasCField Funptr_typedef1_Aux "unwrapFunptr_typedef1_Aux"
     where type CFieldType Funptr_typedef1_Aux
                           "unwrapFunptr_typedef1_Aux" = IO A
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO A) =>
-         HasField "unwrapFunptr_typedef1_Aux" Funptr_typedef1_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef1_Aux{unwrapFunptr_typedef1_Aux = y_1},
-                              getField @"unwrapFunptr_typedef1_Aux" x_0)
 {-| __C declaration:__ @funptr_typedef1@
 
     __defined at:__ @macros\/reparse.h 132:16@
@@ -2856,16 +2856,16 @@ newtype Funptr_typedef1
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Funptr_typedef1_Aux) =>
+         HasField "unwrapFunptr_typedef1" Funptr_typedef1 ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef1{unwrapFunptr_typedef1 = y_1},
+                              getField @"unwrapFunptr_typedef1" x_0)
+instance (~) ty (FunPtr Funptr_typedef1_Aux) =>
          HasField "unwrapFunptr_typedef1" (Ptr Funptr_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef1")
 instance HasCField Funptr_typedef1 "unwrapFunptr_typedef1"
     where type CFieldType Funptr_typedef1
                           "unwrapFunptr_typedef1" = FunPtr Funptr_typedef1_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Funptr_typedef1_Aux) =>
-         HasField "unwrapFunptr_typedef1" Funptr_typedef1 ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef1{unwrapFunptr_typedef1 = y_1},
-                              getField @"unwrapFunptr_typedef1" x_0)
 {-| Auxiliary type used by 'Funptr_typedef2'
 
     __C declaration:__ @funptr_typedef2@
@@ -2901,6 +2901,10 @@ instance ToFunPtr Funptr_typedef2_Aux
 instance FromFunPtr Funptr_typedef2_Aux
     where fromFunPtr = hs_bindgen_323d07dff85b802c
 instance (~) ty (IO (Ptr A)) =>
+         HasField "unwrapFunptr_typedef2_Aux" Funptr_typedef2_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef2_Aux{unwrapFunptr_typedef2_Aux = y_1},
+                              getField @"unwrapFunptr_typedef2_Aux" x_0)
+instance (~) ty (IO (Ptr A)) =>
          HasField "unwrapFunptr_typedef2_Aux"
                   (Ptr Funptr_typedef2_Aux)
                   (Ptr ty)
@@ -2909,10 +2913,6 @@ instance HasCField Funptr_typedef2_Aux "unwrapFunptr_typedef2_Aux"
     where type CFieldType Funptr_typedef2_Aux
                           "unwrapFunptr_typedef2_Aux" = IO (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO (Ptr A)) =>
-         HasField "unwrapFunptr_typedef2_Aux" Funptr_typedef2_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef2_Aux{unwrapFunptr_typedef2_Aux = y_1},
-                              getField @"unwrapFunptr_typedef2_Aux" x_0)
 {-| __C declaration:__ @funptr_typedef2@
 
     __defined at:__ @macros\/reparse.h 133:16@
@@ -2928,16 +2928,16 @@ newtype Funptr_typedef2
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Funptr_typedef2_Aux) =>
+         HasField "unwrapFunptr_typedef2" Funptr_typedef2 ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef2{unwrapFunptr_typedef2 = y_1},
+                              getField @"unwrapFunptr_typedef2" x_0)
+instance (~) ty (FunPtr Funptr_typedef2_Aux) =>
          HasField "unwrapFunptr_typedef2" (Ptr Funptr_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef2")
 instance HasCField Funptr_typedef2 "unwrapFunptr_typedef2"
     where type CFieldType Funptr_typedef2
                           "unwrapFunptr_typedef2" = FunPtr Funptr_typedef2_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Funptr_typedef2_Aux) =>
-         HasField "unwrapFunptr_typedef2" Funptr_typedef2 ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef2{unwrapFunptr_typedef2 = y_1},
-                              getField @"unwrapFunptr_typedef2" x_0)
 {-| Auxiliary type used by 'Funptr_typedef3'
 
     __C declaration:__ @funptr_typedef3@
@@ -2973,6 +2973,10 @@ instance ToFunPtr Funptr_typedef3_Aux
 instance FromFunPtr Funptr_typedef3_Aux
     where fromFunPtr = hs_bindgen_82dc7b932974117e
 instance (~) ty (IO (Ptr (Ptr A))) =>
+         HasField "unwrapFunptr_typedef3_Aux" Funptr_typedef3_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef3_Aux{unwrapFunptr_typedef3_Aux = y_1},
+                              getField @"unwrapFunptr_typedef3_Aux" x_0)
+instance (~) ty (IO (Ptr (Ptr A))) =>
          HasField "unwrapFunptr_typedef3_Aux"
                   (Ptr Funptr_typedef3_Aux)
                   (Ptr ty)
@@ -2981,10 +2985,6 @@ instance HasCField Funptr_typedef3_Aux "unwrapFunptr_typedef3_Aux"
     where type CFieldType Funptr_typedef3_Aux
                           "unwrapFunptr_typedef3_Aux" = IO (Ptr (Ptr A))
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO (Ptr (Ptr A))) =>
-         HasField "unwrapFunptr_typedef3_Aux" Funptr_typedef3_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef3_Aux{unwrapFunptr_typedef3_Aux = y_1},
-                              getField @"unwrapFunptr_typedef3_Aux" x_0)
 {-| __C declaration:__ @funptr_typedef3@
 
     __defined at:__ @macros\/reparse.h 134:16@
@@ -3000,16 +3000,16 @@ newtype Funptr_typedef3
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Funptr_typedef3_Aux) =>
+         HasField "unwrapFunptr_typedef3" Funptr_typedef3 ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef3{unwrapFunptr_typedef3 = y_1},
+                              getField @"unwrapFunptr_typedef3" x_0)
+instance (~) ty (FunPtr Funptr_typedef3_Aux) =>
          HasField "unwrapFunptr_typedef3" (Ptr Funptr_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef3")
 instance HasCField Funptr_typedef3 "unwrapFunptr_typedef3"
     where type CFieldType Funptr_typedef3
                           "unwrapFunptr_typedef3" = FunPtr Funptr_typedef3_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Funptr_typedef3_Aux) =>
-         HasField "unwrapFunptr_typedef3" Funptr_typedef3 ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef3{unwrapFunptr_typedef3 = y_1},
-                              getField @"unwrapFunptr_typedef3" x_0)
 {-| Auxiliary type used by 'Funptr_typedef4'
 
     __C declaration:__ @funptr_typedef4@
@@ -3048,6 +3048,10 @@ instance ToFunPtr Funptr_typedef4_Aux
 instance FromFunPtr Funptr_typedef4_Aux
     where fromFunPtr = hs_bindgen_d4a97954476da161
 instance (~) ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapFunptr_typedef4_Aux" Funptr_typedef4_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef4_Aux{unwrapFunptr_typedef4_Aux = y_1},
+                              getField @"unwrapFunptr_typedef4_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO A) =>
          HasField "unwrapFunptr_typedef4_Aux"
                   (Ptr Funptr_typedef4_Aux)
                   (Ptr ty)
@@ -3056,10 +3060,6 @@ instance HasCField Funptr_typedef4_Aux "unwrapFunptr_typedef4_Aux"
     where type CFieldType Funptr_typedef4_Aux
                           "unwrapFunptr_typedef4_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapFunptr_typedef4_Aux" Funptr_typedef4_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef4_Aux{unwrapFunptr_typedef4_Aux = y_1},
-                              getField @"unwrapFunptr_typedef4_Aux" x_0)
 {-| __C declaration:__ @funptr_typedef4@
 
     __defined at:__ @macros\/reparse.h 135:16@
@@ -3075,16 +3075,16 @@ newtype Funptr_typedef4
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Funptr_typedef4_Aux) =>
+         HasField "unwrapFunptr_typedef4" Funptr_typedef4 ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef4{unwrapFunptr_typedef4 = y_1},
+                              getField @"unwrapFunptr_typedef4" x_0)
+instance (~) ty (FunPtr Funptr_typedef4_Aux) =>
          HasField "unwrapFunptr_typedef4" (Ptr Funptr_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef4")
 instance HasCField Funptr_typedef4 "unwrapFunptr_typedef4"
     where type CFieldType Funptr_typedef4
                           "unwrapFunptr_typedef4" = FunPtr Funptr_typedef4_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Funptr_typedef4_Aux) =>
-         HasField "unwrapFunptr_typedef4" Funptr_typedef4 ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef4{unwrapFunptr_typedef4 = y_1},
-                              getField @"unwrapFunptr_typedef4" x_0)
 {-| Auxiliary type used by 'Funptr_typedef5'
 
     __C declaration:__ @funptr_typedef5@
@@ -3123,6 +3123,10 @@ instance ToFunPtr Funptr_typedef5_Aux
 instance FromFunPtr Funptr_typedef5_Aux
     where fromFunPtr = hs_bindgen_0bd1877eaaba0d3e
 instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
+         HasField "unwrapFunptr_typedef5_Aux" Funptr_typedef5_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef5_Aux{unwrapFunptr_typedef5_Aux = y_1},
+                              getField @"unwrapFunptr_typedef5_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
          HasField "unwrapFunptr_typedef5_Aux"
                   (Ptr Funptr_typedef5_Aux)
                   (Ptr ty)
@@ -3131,10 +3135,6 @@ instance HasCField Funptr_typedef5_Aux "unwrapFunptr_typedef5_Aux"
     where type CFieldType Funptr_typedef5_Aux
                           "unwrapFunptr_typedef5_Aux" = CInt -> CDouble -> IO (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
-         HasField "unwrapFunptr_typedef5_Aux" Funptr_typedef5_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef5_Aux{unwrapFunptr_typedef5_Aux = y_1},
-                              getField @"unwrapFunptr_typedef5_Aux" x_0)
 {-| __C declaration:__ @funptr_typedef5@
 
     __defined at:__ @macros\/reparse.h 136:16@
@@ -3150,16 +3150,16 @@ newtype Funptr_typedef5
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Funptr_typedef5_Aux) =>
+         HasField "unwrapFunptr_typedef5" Funptr_typedef5 ty
+    where hasField = \x_0 -> (\y_1 -> Funptr_typedef5{unwrapFunptr_typedef5 = y_1},
+                              getField @"unwrapFunptr_typedef5" x_0)
+instance (~) ty (FunPtr Funptr_typedef5_Aux) =>
          HasField "unwrapFunptr_typedef5" (Ptr Funptr_typedef5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunptr_typedef5")
 instance HasCField Funptr_typedef5 "unwrapFunptr_typedef5"
     where type CFieldType Funptr_typedef5
                           "unwrapFunptr_typedef5" = FunPtr Funptr_typedef5_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Funptr_typedef5_Aux) =>
-         HasField "unwrapFunptr_typedef5" Funptr_typedef5 ty
-    where hasField = \x_0 -> (\y_1 -> Funptr_typedef5{unwrapFunptr_typedef5 = y_1},
-                              getField @"unwrapFunptr_typedef5" x_0)
 {-| __C declaration:__ @comments2@
 
     __defined at:__ @macros\/reparse.h 145:30@
@@ -3184,15 +3184,15 @@ newtype Comments2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty A => HasField "unwrapComments2" Comments2 ty
+    where hasField = \x_0 -> (\y_1 -> Comments2{unwrapComments2 = y_1},
+                              getField @"unwrapComments2" x_0)
 instance (~) ty A =>
          HasField "unwrapComments2" (Ptr Comments2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapComments2")
 instance HasCField Comments2 "unwrapComments2"
     where type CFieldType Comments2 "unwrapComments2" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A => HasField "unwrapComments2" Comments2 ty
-    where hasField = \x_0 -> (\y_1 -> Comments2{unwrapComments2 = y_1},
-                              getField @"unwrapComments2" x_0)
 {-| Struct fields
 
     __C declaration:__ @struct example_struct@
@@ -3235,44 +3235,44 @@ instance WriteRaw Example_struct
                                                       example_struct_field2_3
                                                       example_struct_field3_4 -> writeRaw (Proxy @"example_struct_field1") ptr_0 example_struct_field1_2 >> (writeRaw (Proxy @"example_struct_field2") ptr_0 example_struct_field2_3 >> writeRaw (Proxy @"example_struct_field3") ptr_0 example_struct_field3_4)
 deriving via (EquivStorable Example_struct) instance Storable Example_struct
-instance HasCField Example_struct "example_struct_field1"
-    where type CFieldType Example_struct "example_struct_field1" = A
-          offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "example_struct_field1" (Ptr Example_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_field1")
 instance (~) ty A =>
          HasField "example_struct_field1" Example_struct ty
     where hasField = \x_0 -> (\y_1 -> Example_struct{example_struct_field1 = y_1,
                                                      example_struct_field2 = getField @"example_struct_field2" x_0,
                                                      example_struct_field3 = getField @"example_struct_field3" x_0},
                               getField @"example_struct_field1" x_0)
-instance HasCField Example_struct "example_struct_field2"
-    where type CFieldType Example_struct
-                          "example_struct_field2" = Ptr A
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr A) =>
-         HasField "example_struct_field2" (Ptr Example_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_field2")
+instance (~) ty A =>
+         HasField "example_struct_field1" (Ptr Example_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"example_struct_field1")
+instance HasCField Example_struct "example_struct_field1"
+    where type CFieldType Example_struct "example_struct_field1" = A
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr A) =>
          HasField "example_struct_field2" Example_struct ty
     where hasField = \x_0 -> (\y_1 -> Example_struct{example_struct_field2 = y_1,
                                                      example_struct_field1 = getField @"example_struct_field1" x_0,
                                                      example_struct_field3 = getField @"example_struct_field3" x_0},
                               getField @"example_struct_field2" x_0)
-instance HasCField Example_struct "example_struct_field3"
+instance (~) ty (Ptr A) =>
+         HasField "example_struct_field2" (Ptr Example_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"example_struct_field2")
+instance HasCField Example_struct "example_struct_field2"
     where type CFieldType Example_struct
-                          "example_struct_field3" = Ptr (Ptr A)
-          offset# = \_ -> \_ -> 16
-instance (~) ty (Ptr (Ptr A)) =>
-         HasField "example_struct_field3" (Ptr Example_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_field3")
+                          "example_struct_field2" = Ptr A
+          offset# = \_ -> \_ -> 8
 instance (~) ty (Ptr (Ptr A)) =>
          HasField "example_struct_field3" Example_struct ty
     where hasField = \x_0 -> (\y_1 -> Example_struct{example_struct_field3 = y_1,
                                                      example_struct_field1 = getField @"example_struct_field1" x_0,
                                                      example_struct_field2 = getField @"example_struct_field2" x_0},
                               getField @"example_struct_field3" x_0)
+instance (~) ty (Ptr (Ptr A)) =>
+         HasField "example_struct_field3" (Ptr Example_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"example_struct_field3")
+instance HasCField Example_struct "example_struct_field3"
+    where type CFieldType Example_struct
+                          "example_struct_field3" = Ptr (Ptr A)
+          offset# = \_ -> \_ -> 16
 {-| __C declaration:__ @const_typedef1@
 
     __defined at:__ @macros\/reparse.h 218:25@
@@ -3298,15 +3298,15 @@ newtype Const_typedef1
                       Storable,
                       WriteRaw)
 instance (~) ty A =>
+         HasField "unwrapConst_typedef1" Const_typedef1 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef1{unwrapConst_typedef1 = y_1},
+                              getField @"unwrapConst_typedef1" x_0)
+instance (~) ty A =>
          HasField "unwrapConst_typedef1" (Ptr Const_typedef1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef1")
 instance HasCField Const_typedef1 "unwrapConst_typedef1"
     where type CFieldType Const_typedef1 "unwrapConst_typedef1" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "unwrapConst_typedef1" Const_typedef1 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef1{unwrapConst_typedef1 = y_1},
-                              getField @"unwrapConst_typedef1" x_0)
 {-| __C declaration:__ @const_typedef2@
 
     __defined at:__ @macros\/reparse.h 219:25@
@@ -3332,15 +3332,15 @@ newtype Const_typedef2
                       Storable,
                       WriteRaw)
 instance (~) ty A =>
+         HasField "unwrapConst_typedef2" Const_typedef2 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef2{unwrapConst_typedef2 = y_1},
+                              getField @"unwrapConst_typedef2" x_0)
+instance (~) ty A =>
          HasField "unwrapConst_typedef2" (Ptr Const_typedef2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef2")
 instance HasCField Const_typedef2 "unwrapConst_typedef2"
     where type CFieldType Const_typedef2 "unwrapConst_typedef2" = A
           offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "unwrapConst_typedef2" Const_typedef2 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef2{unwrapConst_typedef2 = y_1},
-                              getField @"unwrapConst_typedef2" x_0)
 {-| __C declaration:__ @const_typedef3@
 
     __defined at:__ @macros\/reparse.h 220:25@
@@ -3356,16 +3356,16 @@ newtype Const_typedef3
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst A) =>
+         HasField "unwrapConst_typedef3" Const_typedef3 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef3{unwrapConst_typedef3 = y_1},
+                              getField @"unwrapConst_typedef3" x_0)
+instance (~) ty (PtrConst A) =>
          HasField "unwrapConst_typedef3" (Ptr Const_typedef3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef3")
 instance HasCField Const_typedef3 "unwrapConst_typedef3"
     where type CFieldType Const_typedef3
                           "unwrapConst_typedef3" = PtrConst A
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef3" Const_typedef3 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef3{unwrapConst_typedef3 = y_1},
-                              getField @"unwrapConst_typedef3" x_0)
 {-| __C declaration:__ @const_typedef4@
 
     __defined at:__ @macros\/reparse.h 221:25@
@@ -3381,16 +3381,16 @@ newtype Const_typedef4
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst A) =>
+         HasField "unwrapConst_typedef4" Const_typedef4 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef4{unwrapConst_typedef4 = y_1},
+                              getField @"unwrapConst_typedef4" x_0)
+instance (~) ty (PtrConst A) =>
          HasField "unwrapConst_typedef4" (Ptr Const_typedef4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef4")
 instance HasCField Const_typedef4 "unwrapConst_typedef4"
     where type CFieldType Const_typedef4
                           "unwrapConst_typedef4" = PtrConst A
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef4" Const_typedef4 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef4{unwrapConst_typedef4 = y_1},
-                              getField @"unwrapConst_typedef4" x_0)
 {-| __C declaration:__ @const_typedef5@
 
     __defined at:__ @macros\/reparse.h 222:25@
@@ -3406,15 +3406,15 @@ newtype Const_typedef5
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr A) =>
+         HasField "unwrapConst_typedef5" Const_typedef5 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef5{unwrapConst_typedef5 = y_1},
+                              getField @"unwrapConst_typedef5" x_0)
+instance (~) ty (Ptr A) =>
          HasField "unwrapConst_typedef5" (Ptr Const_typedef5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef5")
 instance HasCField Const_typedef5 "unwrapConst_typedef5"
     where type CFieldType Const_typedef5 "unwrapConst_typedef5" = Ptr A
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr A) =>
-         HasField "unwrapConst_typedef5" Const_typedef5 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef5{unwrapConst_typedef5 = y_1},
-                              getField @"unwrapConst_typedef5" x_0)
 {-| __C declaration:__ @const_typedef6@
 
     __defined at:__ @macros\/reparse.h 223:25@
@@ -3430,16 +3430,16 @@ newtype Const_typedef6
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst A) =>
+         HasField "unwrapConst_typedef6" Const_typedef6 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef6{unwrapConst_typedef6 = y_1},
+                              getField @"unwrapConst_typedef6" x_0)
+instance (~) ty (PtrConst A) =>
          HasField "unwrapConst_typedef6" (Ptr Const_typedef6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef6")
 instance HasCField Const_typedef6 "unwrapConst_typedef6"
     where type CFieldType Const_typedef6
                           "unwrapConst_typedef6" = PtrConst A
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef6" Const_typedef6 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef6{unwrapConst_typedef6 = y_1},
-                              getField @"unwrapConst_typedef6" x_0)
 {-| __C declaration:__ @const_typedef7@
 
     __defined at:__ @macros\/reparse.h 224:25@
@@ -3455,16 +3455,16 @@ newtype Const_typedef7
                       Storable,
                       WriteRaw)
 instance (~) ty (PtrConst A) =>
+         HasField "unwrapConst_typedef7" Const_typedef7 ty
+    where hasField = \x_0 -> (\y_1 -> Const_typedef7{unwrapConst_typedef7 = y_1},
+                              getField @"unwrapConst_typedef7" x_0)
+instance (~) ty (PtrConst A) =>
          HasField "unwrapConst_typedef7" (Ptr Const_typedef7) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_typedef7")
 instance HasCField Const_typedef7 "unwrapConst_typedef7"
     where type CFieldType Const_typedef7
                           "unwrapConst_typedef7" = PtrConst A
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst A) =>
-         HasField "unwrapConst_typedef7" Const_typedef7 ty
-    where hasField = \x_0 -> (\y_1 -> Const_typedef7{unwrapConst_typedef7 = y_1},
-                              getField @"unwrapConst_typedef7" x_0)
 {-| __C declaration:__ @struct example_struct_with_const@
 
     __defined at:__ @macros\/reparse.h 226:8@
@@ -3537,16 +3537,6 @@ instance WriteRaw Example_struct_with_const
                                                                  example_struct_with_const_const_field6_7
                                                                  example_struct_with_const_const_field7_8 -> writeRaw (Proxy @"example_struct_with_const_const_field1") ptr_0 example_struct_with_const_const_field1_2 >> (writeRaw (Proxy @"example_struct_with_const_const_field2") ptr_0 example_struct_with_const_const_field2_3 >> (writeRaw (Proxy @"example_struct_with_const_const_field3") ptr_0 example_struct_with_const_const_field3_4 >> (writeRaw (Proxy @"example_struct_with_const_const_field4") ptr_0 example_struct_with_const_const_field4_5 >> (writeRaw (Proxy @"example_struct_with_const_const_field5") ptr_0 example_struct_with_const_const_field5_6 >> (writeRaw (Proxy @"example_struct_with_const_const_field6") ptr_0 example_struct_with_const_const_field6_7 >> writeRaw (Proxy @"example_struct_with_const_const_field7") ptr_0 example_struct_with_const_const_field7_8)))))
 deriving via (EquivStorable Example_struct_with_const) instance Storable Example_struct_with_const
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field1"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field1" = A
-          offset# = \_ -> \_ -> 0
-instance (~) ty A =>
-         HasField "example_struct_with_const_const_field1"
-                  (Ptr Example_struct_with_const)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field1")
 instance (~) ty A =>
          HasField "example_struct_with_const_const_field1"
                   Example_struct_with_const
@@ -3559,16 +3549,16 @@ instance (~) ty A =>
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field1" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field2"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field2" = A
-          offset# = \_ -> \_ -> 4
 instance (~) ty A =>
-         HasField "example_struct_with_const_const_field2"
+         HasField "example_struct_with_const_const_field1"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field2")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field1")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field1"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field1" = A
+          offset# = \_ -> \_ -> 0
 instance (~) ty A =>
          HasField "example_struct_with_const_const_field2"
                   Example_struct_with_const
@@ -3581,16 +3571,16 @@ instance (~) ty A =>
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field2" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field3"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field3" = PtrConst A
-          offset# = \_ -> \_ -> 8
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field3"
+instance (~) ty A =>
+         HasField "example_struct_with_const_const_field2"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field3")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field2")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field2"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field2" = A
+          offset# = \_ -> \_ -> 4
 instance (~) ty (PtrConst A) =>
          HasField "example_struct_with_const_const_field3"
                   Example_struct_with_const
@@ -3603,16 +3593,16 @@ instance (~) ty (PtrConst A) =>
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field3" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field4"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field4" = PtrConst A
-          offset# = \_ -> \_ -> 16
 instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field4"
+         HasField "example_struct_with_const_const_field3"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field4")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field3")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field3"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field3" = PtrConst A
+          offset# = \_ -> \_ -> 8
 instance (~) ty (PtrConst A) =>
          HasField "example_struct_with_const_const_field4"
                   Example_struct_with_const
@@ -3625,16 +3615,16 @@ instance (~) ty (PtrConst A) =>
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field4" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field5"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field5" = Ptr A
-          offset# = \_ -> \_ -> 24
-instance (~) ty (Ptr A) =>
-         HasField "example_struct_with_const_const_field5"
+instance (~) ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field4"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field5")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field4")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field4"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field4" = PtrConst A
+          offset# = \_ -> \_ -> 16
 instance (~) ty (Ptr A) =>
          HasField "example_struct_with_const_const_field5"
                   Example_struct_with_const
@@ -3647,16 +3637,16 @@ instance (~) ty (Ptr A) =>
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field5" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field6"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field6" = PtrConst A
-          offset# = \_ -> \_ -> 32
-instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field6"
+instance (~) ty (Ptr A) =>
+         HasField "example_struct_with_const_const_field5"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field6")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field5")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field5"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field5" = Ptr A
+          offset# = \_ -> \_ -> 24
 instance (~) ty (PtrConst A) =>
          HasField "example_struct_with_const_const_field6"
                   Example_struct_with_const
@@ -3669,16 +3659,16 @@ instance (~) ty (PtrConst A) =>
                                                                 example_struct_with_const_const_field5 = getField @"example_struct_with_const_const_field5" x_0,
                                                                 example_struct_with_const_const_field7 = getField @"example_struct_with_const_const_field7" x_0},
                               getField @"example_struct_with_const_const_field6" x_0)
-instance HasCField Example_struct_with_const
-                   "example_struct_with_const_const_field7"
-    where type CFieldType Example_struct_with_const
-                          "example_struct_with_const_const_field7" = PtrConst A
-          offset# = \_ -> \_ -> 40
 instance (~) ty (PtrConst A) =>
-         HasField "example_struct_with_const_const_field7"
+         HasField "example_struct_with_const_const_field6"
                   (Ptr Example_struct_with_const)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"example_struct_with_const_const_field7")
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field6")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field6"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field6" = PtrConst A
+          offset# = \_ -> \_ -> 32
 instance (~) ty (PtrConst A) =>
          HasField "example_struct_with_const_const_field7"
                   Example_struct_with_const
@@ -3691,6 +3681,16 @@ instance (~) ty (PtrConst A) =>
                                                                 example_struct_with_const_const_field5 = getField @"example_struct_with_const_const_field5" x_0,
                                                                 example_struct_with_const_const_field6 = getField @"example_struct_with_const_const_field6" x_0},
                               getField @"example_struct_with_const_const_field7" x_0)
+instance (~) ty (PtrConst A) =>
+         HasField "example_struct_with_const_const_field7"
+                  (Ptr Example_struct_with_const)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"example_struct_with_const_const_field7")
+instance HasCField Example_struct_with_const
+                   "example_struct_with_const_const_field7"
+    where type CFieldType Example_struct_with_const
+                          "example_struct_with_const_const_field7" = PtrConst A
+          offset# = \_ -> \_ -> 40
 {-| Auxiliary type used by 'Const_funptr1'
 
     __C declaration:__ @const_funptr1@
@@ -3729,16 +3729,16 @@ instance ToFunPtr Const_funptr1_Aux
 instance FromFunPtr Const_funptr1_Aux
     where fromFunPtr = hs_bindgen_ac4bd8d789bba94b
 instance (~) ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapConst_funptr1_Aux" Const_funptr1_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr1_Aux{unwrapConst_funptr1_Aux = y_1},
+                              getField @"unwrapConst_funptr1_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO A) =>
          HasField "unwrapConst_funptr1_Aux" (Ptr Const_funptr1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr1_Aux")
 instance HasCField Const_funptr1_Aux "unwrapConst_funptr1_Aux"
     where type CFieldType Const_funptr1_Aux
                           "unwrapConst_funptr1_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapConst_funptr1_Aux" Const_funptr1_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr1_Aux{unwrapConst_funptr1_Aux = y_1},
-                              getField @"unwrapConst_funptr1_Aux" x_0)
 {-| __C declaration:__ @const_funptr1@
 
     __defined at:__ @macros\/reparse.h 236:27@
@@ -3754,16 +3754,16 @@ newtype Const_funptr1
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr1_Aux) =>
+         HasField "unwrapConst_funptr1" Const_funptr1 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr1{unwrapConst_funptr1 = y_1},
+                              getField @"unwrapConst_funptr1" x_0)
+instance (~) ty (FunPtr Const_funptr1_Aux) =>
          HasField "unwrapConst_funptr1" (Ptr Const_funptr1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr1")
 instance HasCField Const_funptr1 "unwrapConst_funptr1"
     where type CFieldType Const_funptr1
                           "unwrapConst_funptr1" = FunPtr Const_funptr1_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr1_Aux) =>
-         HasField "unwrapConst_funptr1" Const_funptr1 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr1{unwrapConst_funptr1 = y_1},
-                              getField @"unwrapConst_funptr1" x_0)
 {-| Auxiliary type used by 'Const_funptr2'
 
     __C declaration:__ @const_funptr2@
@@ -3802,16 +3802,16 @@ instance ToFunPtr Const_funptr2_Aux
 instance FromFunPtr Const_funptr2_Aux
     where fromFunPtr = hs_bindgen_352cebf463125ca9
 instance (~) ty (CInt -> CDouble -> IO A) =>
+         HasField "unwrapConst_funptr2_Aux" Const_funptr2_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr2_Aux{unwrapConst_funptr2_Aux = y_1},
+                              getField @"unwrapConst_funptr2_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO A) =>
          HasField "unwrapConst_funptr2_Aux" (Ptr Const_funptr2_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr2_Aux")
 instance HasCField Const_funptr2_Aux "unwrapConst_funptr2_Aux"
     where type CFieldType Const_funptr2_Aux
                           "unwrapConst_funptr2_Aux" = CInt -> CDouble -> IO A
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO A) =>
-         HasField "unwrapConst_funptr2_Aux" Const_funptr2_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr2_Aux{unwrapConst_funptr2_Aux = y_1},
-                              getField @"unwrapConst_funptr2_Aux" x_0)
 {-| __C declaration:__ @const_funptr2@
 
     __defined at:__ @macros\/reparse.h 237:27@
@@ -3827,16 +3827,16 @@ newtype Const_funptr2
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr2_Aux) =>
+         HasField "unwrapConst_funptr2" Const_funptr2 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr2{unwrapConst_funptr2 = y_1},
+                              getField @"unwrapConst_funptr2" x_0)
+instance (~) ty (FunPtr Const_funptr2_Aux) =>
          HasField "unwrapConst_funptr2" (Ptr Const_funptr2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr2")
 instance HasCField Const_funptr2 "unwrapConst_funptr2"
     where type CFieldType Const_funptr2
                           "unwrapConst_funptr2" = FunPtr Const_funptr2_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr2_Aux) =>
-         HasField "unwrapConst_funptr2" Const_funptr2 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr2{unwrapConst_funptr2 = y_1},
-                              getField @"unwrapConst_funptr2" x_0)
 {-| Auxiliary type used by 'Const_funptr3'
 
     __C declaration:__ @const_funptr3@
@@ -3875,16 +3875,16 @@ instance ToFunPtr Const_funptr3_Aux
 instance FromFunPtr Const_funptr3_Aux
     where fromFunPtr = hs_bindgen_86738dcfd7c9d33c
 instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr3_Aux" Const_funptr3_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr3_Aux{unwrapConst_funptr3_Aux = y_1},
+                              getField @"unwrapConst_funptr3_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
          HasField "unwrapConst_funptr3_Aux" (Ptr Const_funptr3_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr3_Aux")
 instance HasCField Const_funptr3_Aux "unwrapConst_funptr3_Aux"
     where type CFieldType Const_funptr3_Aux
                           "unwrapConst_funptr3_Aux" = CInt -> CDouble -> IO (PtrConst A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr3_Aux" Const_funptr3_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr3_Aux{unwrapConst_funptr3_Aux = y_1},
-                              getField @"unwrapConst_funptr3_Aux" x_0)
 {-| __C declaration:__ @const_funptr3@
 
     __defined at:__ @macros\/reparse.h 238:27@
@@ -3900,16 +3900,16 @@ newtype Const_funptr3
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr3_Aux) =>
+         HasField "unwrapConst_funptr3" Const_funptr3 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr3{unwrapConst_funptr3 = y_1},
+                              getField @"unwrapConst_funptr3" x_0)
+instance (~) ty (FunPtr Const_funptr3_Aux) =>
          HasField "unwrapConst_funptr3" (Ptr Const_funptr3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr3")
 instance HasCField Const_funptr3 "unwrapConst_funptr3"
     where type CFieldType Const_funptr3
                           "unwrapConst_funptr3" = FunPtr Const_funptr3_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr3_Aux) =>
-         HasField "unwrapConst_funptr3" Const_funptr3 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr3{unwrapConst_funptr3 = y_1},
-                              getField @"unwrapConst_funptr3" x_0)
 {-| Auxiliary type used by 'Const_funptr4'
 
     __C declaration:__ @const_funptr4@
@@ -3948,16 +3948,16 @@ instance ToFunPtr Const_funptr4_Aux
 instance FromFunPtr Const_funptr4_Aux
     where fromFunPtr = hs_bindgen_de7846fca3bfd1b6
 instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr4_Aux" Const_funptr4_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr4_Aux{unwrapConst_funptr4_Aux = y_1},
+                              getField @"unwrapConst_funptr4_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
          HasField "unwrapConst_funptr4_Aux" (Ptr Const_funptr4_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr4_Aux")
 instance HasCField Const_funptr4_Aux "unwrapConst_funptr4_Aux"
     where type CFieldType Const_funptr4_Aux
                           "unwrapConst_funptr4_Aux" = CInt -> CDouble -> IO (PtrConst A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr4_Aux" Const_funptr4_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr4_Aux{unwrapConst_funptr4_Aux = y_1},
-                              getField @"unwrapConst_funptr4_Aux" x_0)
 {-| __C declaration:__ @const_funptr4@
 
     __defined at:__ @macros\/reparse.h 239:27@
@@ -3973,16 +3973,16 @@ newtype Const_funptr4
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr4_Aux) =>
+         HasField "unwrapConst_funptr4" Const_funptr4 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr4{unwrapConst_funptr4 = y_1},
+                              getField @"unwrapConst_funptr4" x_0)
+instance (~) ty (FunPtr Const_funptr4_Aux) =>
          HasField "unwrapConst_funptr4" (Ptr Const_funptr4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr4")
 instance HasCField Const_funptr4 "unwrapConst_funptr4"
     where type CFieldType Const_funptr4
                           "unwrapConst_funptr4" = FunPtr Const_funptr4_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr4_Aux) =>
-         HasField "unwrapConst_funptr4" Const_funptr4 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr4{unwrapConst_funptr4 = y_1},
-                              getField @"unwrapConst_funptr4" x_0)
 {-| Auxiliary type used by 'Const_funptr5'
 
     __C declaration:__ @const_funptr5@
@@ -4021,16 +4021,16 @@ instance ToFunPtr Const_funptr5_Aux
 instance FromFunPtr Const_funptr5_Aux
     where fromFunPtr = hs_bindgen_38a21d84bb7115b5
 instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
+         HasField "unwrapConst_funptr5_Aux" Const_funptr5_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr5_Aux{unwrapConst_funptr5_Aux = y_1},
+                              getField @"unwrapConst_funptr5_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
          HasField "unwrapConst_funptr5_Aux" (Ptr Const_funptr5_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr5_Aux")
 instance HasCField Const_funptr5_Aux "unwrapConst_funptr5_Aux"
     where type CFieldType Const_funptr5_Aux
                           "unwrapConst_funptr5_Aux" = CInt -> CDouble -> IO (Ptr A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (Ptr A)) =>
-         HasField "unwrapConst_funptr5_Aux" Const_funptr5_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr5_Aux{unwrapConst_funptr5_Aux = y_1},
-                              getField @"unwrapConst_funptr5_Aux" x_0)
 {-| __C declaration:__ @const_funptr5@
 
     __defined at:__ @macros\/reparse.h 240:27@
@@ -4046,16 +4046,16 @@ newtype Const_funptr5
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr5_Aux) =>
+         HasField "unwrapConst_funptr5" Const_funptr5 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr5{unwrapConst_funptr5 = y_1},
+                              getField @"unwrapConst_funptr5" x_0)
+instance (~) ty (FunPtr Const_funptr5_Aux) =>
          HasField "unwrapConst_funptr5" (Ptr Const_funptr5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr5")
 instance HasCField Const_funptr5 "unwrapConst_funptr5"
     where type CFieldType Const_funptr5
                           "unwrapConst_funptr5" = FunPtr Const_funptr5_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr5_Aux) =>
-         HasField "unwrapConst_funptr5" Const_funptr5 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr5{unwrapConst_funptr5 = y_1},
-                              getField @"unwrapConst_funptr5" x_0)
 {-| Auxiliary type used by 'Const_funptr6'
 
     __C declaration:__ @const_funptr6@
@@ -4094,16 +4094,16 @@ instance ToFunPtr Const_funptr6_Aux
 instance FromFunPtr Const_funptr6_Aux
     where fromFunPtr = hs_bindgen_45251216b04aa8b5
 instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr6_Aux" Const_funptr6_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr6_Aux{unwrapConst_funptr6_Aux = y_1},
+                              getField @"unwrapConst_funptr6_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
          HasField "unwrapConst_funptr6_Aux" (Ptr Const_funptr6_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr6_Aux")
 instance HasCField Const_funptr6_Aux "unwrapConst_funptr6_Aux"
     where type CFieldType Const_funptr6_Aux
                           "unwrapConst_funptr6_Aux" = CInt -> CDouble -> IO (PtrConst A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr6_Aux" Const_funptr6_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr6_Aux{unwrapConst_funptr6_Aux = y_1},
-                              getField @"unwrapConst_funptr6_Aux" x_0)
 {-| __C declaration:__ @const_funptr6@
 
     __defined at:__ @macros\/reparse.h 241:27@
@@ -4119,16 +4119,16 @@ newtype Const_funptr6
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr6_Aux) =>
+         HasField "unwrapConst_funptr6" Const_funptr6 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr6{unwrapConst_funptr6 = y_1},
+                              getField @"unwrapConst_funptr6" x_0)
+instance (~) ty (FunPtr Const_funptr6_Aux) =>
          HasField "unwrapConst_funptr6" (Ptr Const_funptr6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr6")
 instance HasCField Const_funptr6 "unwrapConst_funptr6"
     where type CFieldType Const_funptr6
                           "unwrapConst_funptr6" = FunPtr Const_funptr6_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr6_Aux) =>
-         HasField "unwrapConst_funptr6" Const_funptr6 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr6{unwrapConst_funptr6 = y_1},
-                              getField @"unwrapConst_funptr6" x_0)
 {-| Auxiliary type used by 'Const_funptr7'
 
     __C declaration:__ @const_funptr7@
@@ -4167,16 +4167,16 @@ instance ToFunPtr Const_funptr7_Aux
 instance FromFunPtr Const_funptr7_Aux
     where fromFunPtr = hs_bindgen_42fbcebf75a973ba
 instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
+         HasField "unwrapConst_funptr7_Aux" Const_funptr7_Aux ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr7_Aux{unwrapConst_funptr7_Aux = y_1},
+                              getField @"unwrapConst_funptr7_Aux" x_0)
+instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
          HasField "unwrapConst_funptr7_Aux" (Ptr Const_funptr7_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr7_Aux")
 instance HasCField Const_funptr7_Aux "unwrapConst_funptr7_Aux"
     where type CFieldType Const_funptr7_Aux
                           "unwrapConst_funptr7_Aux" = CInt -> CDouble -> IO (PtrConst A)
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CDouble -> IO (PtrConst A)) =>
-         HasField "unwrapConst_funptr7_Aux" Const_funptr7_Aux ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr7_Aux{unwrapConst_funptr7_Aux = y_1},
-                              getField @"unwrapConst_funptr7_Aux" x_0)
 {-| __C declaration:__ @const_funptr7@
 
     __defined at:__ @macros\/reparse.h 242:27@
@@ -4192,16 +4192,16 @@ newtype Const_funptr7
                       Storable,
                       WriteRaw)
 instance (~) ty (FunPtr Const_funptr7_Aux) =>
+         HasField "unwrapConst_funptr7" Const_funptr7 ty
+    where hasField = \x_0 -> (\y_1 -> Const_funptr7{unwrapConst_funptr7 = y_1},
+                              getField @"unwrapConst_funptr7" x_0)
+instance (~) ty (FunPtr Const_funptr7_Aux) =>
          HasField "unwrapConst_funptr7" (Ptr Const_funptr7) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapConst_funptr7")
 instance HasCField Const_funptr7 "unwrapConst_funptr7"
     where type CFieldType Const_funptr7
                           "unwrapConst_funptr7" = FunPtr Const_funptr7_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr Const_funptr7_Aux) =>
-         HasField "unwrapConst_funptr7" Const_funptr7 ty
-    where hasField = \x_0 -> (\y_1 -> Const_funptr7{unwrapConst_funptr7 = y_1},
-                              getField @"unwrapConst_funptr7" x_0)
 {-| Macro-defined types
 
     __C declaration:__ @macro BOOL@
@@ -4228,14 +4228,14 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CBool => HasField "unwrapBOOL" BOOL ty
+    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
+                              getField @"unwrapBOOL" x_0)
 instance (~) ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "unwrapBOOL" BOOL ty
-    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
-                              getField @"unwrapBOOL" x_0)
 {-| __C declaration:__ @macro INT@
 
     __defined at:__ @macros\/reparse.h 279:9@
@@ -4260,14 +4260,14 @@ newtype INT
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapINT" INT ty
+    where hasField = \x_0 -> (\y_1 -> INT{unwrapINT = y_1},
+                              getField @"unwrapINT" x_0)
 instance (~) ty CInt => HasField "unwrapINT" (Ptr INT) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINT")
 instance HasCField INT "unwrapINT"
     where type CFieldType INT "unwrapINT" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapINT" INT ty
-    where hasField = \x_0 -> (\y_1 -> INT{unwrapINT = y_1},
-                              getField @"unwrapINT" x_0)
 {-| __C declaration:__ @macro INTP@
 
     __defined at:__ @macros\/reparse.h 280:9@
@@ -4282,15 +4282,15 @@ newtype INTP
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr CInt) => HasField "unwrapINTP" INTP ty
+    where hasField = \x_0 -> (\y_1 -> INTP{unwrapINTP = y_1},
+                              getField @"unwrapINTP" x_0)
 instance (~) ty (Ptr CInt) =>
          HasField "unwrapINTP" (Ptr INTP) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINTP")
 instance HasCField INTP "unwrapINTP"
     where type CFieldType INTP "unwrapINTP" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) => HasField "unwrapINTP" INTP ty
-    where hasField = \x_0 -> (\y_1 -> INTP{unwrapINTP = y_1},
-                              getField @"unwrapINTP" x_0)
 {-| __C declaration:__ @macro INTCP@
 
     __defined at:__ @macros\/reparse.h 281:9@
@@ -4305,15 +4305,15 @@ newtype INTCP
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (PtrConst CInt) => HasField "unwrapINTCP" INTCP ty
+    where hasField = \x_0 -> (\y_1 -> INTCP{unwrapINTCP = y_1},
+                              getField @"unwrapINTCP" x_0)
 instance (~) ty (PtrConst CInt) =>
          HasField "unwrapINTCP" (Ptr INTCP) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapINTCP")
 instance HasCField INTCP "unwrapINTCP"
     where type CFieldType INTCP "unwrapINTCP" = PtrConst CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (PtrConst CInt) => HasField "unwrapINTCP" INTCP ty
-    where hasField = \x_0 -> (\y_1 -> INTCP{unwrapINTCP = y_1},
-                              getField @"unwrapINTCP" x_0)
 -- __unique:__ @test_macrosreparse_Example_Safe_args_char1@
 foreign import ccall safe "hs_bindgen_f15610128336b06a" hs_bindgen_f15610128336b06a_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/undef/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/undef/Example.hs
@@ -50,6 +50,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
@@ -60,9 +66,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/macros/undef/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/undef/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/macros/undef/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/undef/th.txt
@@ -44,14 +44,14 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 -- __unique:__ @test_macrosundef_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_2a245181e5fb1e1c" hs_bindgen_2a245181e5fb1e1c_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/Example.hs
@@ -72,19 +72,6 @@ instance Marshal.WriteRaw UU1_fieldY where
 
 deriving via Marshal.EquivStorable UU1_fieldY instance RIP.Storable UU1_fieldY
 
-instance HasCField.HasCField UU1_fieldY "uU1_fieldY_fieldX" where
-
-  type CFieldType UU1_fieldY "uU1_fieldY_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uU1_fieldY_fieldX" (RIP.Ptr UU1_fieldY) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uU1_fieldY_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "uU1_fieldY_fieldX" UU1_fieldY ty where
 
@@ -93,6 +80,19 @@ instance ( ty ~ RIP.CInt
       ( \y1 -> UU1_fieldY {uU1_fieldY_fieldX = y1}
       , RIP.getField @"uU1_fieldY_fieldX" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uU1_fieldY_fieldX" (RIP.Ptr UU1_fieldY) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uU1_fieldY_fieldX")
+
+instance HasCField.HasCField UU1_fieldY "uU1_fieldY_fieldX" where
+
+  type CFieldType UU1_fieldY "uU1_fieldY_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct UU1@
 
@@ -135,18 +135,6 @@ instance Marshal.WriteRaw UU1 where
 
 deriving via Marshal.EquivStorable UU1 instance RIP.Storable UU1
 
-instance HasCField.HasCField UU1 "uU1_fieldY" where
-
-  type CFieldType UU1 "uU1_fieldY" = UU1_fieldY
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UU1_fieldY
-         ) => RIP.HasField "uU1_fieldY" (RIP.Ptr UU1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uU1_fieldY")
-
 instance ( ty ~ UU1_fieldY
          ) => RIP.CompatHasField.HasField "uU1_fieldY" UU1 ty where
 
@@ -154,6 +142,18 @@ instance ( ty ~ UU1_fieldY
     \x0 ->
       (\y1 ->
          UU1 {uU1_fieldY = y1}, RIP.getField @"uU1_fieldY" x0)
+
+instance ( ty ~ UU1_fieldY
+         ) => RIP.HasField "uU1_fieldY" (RIP.Ptr UU1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uU1_fieldY")
+
+instance HasCField.HasCField UU1 "uU1_fieldY" where
+
+  type CFieldType UU1 "uU1_fieldY" = UU1_fieldY
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@UU2_fieldY@
 
@@ -196,19 +196,6 @@ instance Marshal.WriteRaw UU2_fieldY where
 
 deriving via Marshal.EquivStorable UU2_fieldY instance RIP.Storable UU2_fieldY
 
-instance HasCField.HasCField UU2_fieldY "uU2_fieldY_fieldX" where
-
-  type CFieldType UU2_fieldY "uU2_fieldY_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uU2_fieldY_fieldX" (RIP.Ptr UU2_fieldY) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uU2_fieldY_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "uU2_fieldY_fieldX" UU2_fieldY ty where
 
@@ -217,6 +204,19 @@ instance ( ty ~ RIP.CInt
       ( \y1 -> UU2_fieldY {uU2_fieldY_fieldX = y1}
       , RIP.getField @"uU2_fieldY_fieldX" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uU2_fieldY_fieldX" (RIP.Ptr UU2_fieldY) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uU2_fieldY_fieldX")
+
+instance HasCField.HasCField UU2_fieldY "uU2_fieldY_fieldX" where
+
+  type CFieldType UU2_fieldY "uU2_fieldY_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct UU2@
 
@@ -259,18 +259,6 @@ instance Marshal.WriteRaw UU2 where
 
 deriving via Marshal.EquivStorable UU2 instance RIP.Storable UU2
 
-instance HasCField.HasCField UU2 "uU2_fieldY" where
-
-  type CFieldType UU2 "uU2_fieldY" = UU2_fieldY
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UU2_fieldY
-         ) => RIP.HasField "uU2_fieldY" (RIP.Ptr UU2) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uU2_fieldY")
-
 instance ( ty ~ UU2_fieldY
          ) => RIP.CompatHasField.HasField "uU2_fieldY" UU2 ty where
 
@@ -278,6 +266,18 @@ instance ( ty ~ UU2_fieldY
     \x0 ->
       (\y1 ->
          UU2 {uU2_fieldY = y1}, RIP.getField @"uU2_fieldY" x0)
+
+instance ( ty ~ UU2_fieldY
+         ) => RIP.HasField "uU2_fieldY" (RIP.Ptr UU2) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uU2_fieldY")
+
+instance HasCField.HasCField UU2 "uU2_fieldY" where
+
+  type CFieldType UU2 "uU2_fieldY" = UU2_fieldY
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@VV1_fieldA@
 
@@ -320,18 +320,6 @@ instance Marshal.WriteRaw VV1_fieldA where
 
 deriving via Marshal.EquivStorable VV1_fieldA instance RIP.Storable VV1_fieldA
 
-instance HasCField.HasCField VV1_fieldA "vV1_fieldA_a" where
-
-  type CFieldType VV1_fieldA "vV1_fieldA_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV1_fieldA_a" (RIP.Ptr VV1_fieldA) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV1_fieldA_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "vV1_fieldA_a" VV1_fieldA ty where
 
@@ -339,6 +327,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          VV1_fieldA {vV1_fieldA_a = y1}, RIP.getField @"vV1_fieldA_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "vV1_fieldA_a" (RIP.Ptr VV1_fieldA) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV1_fieldA_a")
+
+instance HasCField.HasCField VV1_fieldA "vV1_fieldA_a" where
+
+  type CFieldType VV1_fieldA "vV1_fieldA_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@VV1_fieldB@
 
@@ -381,18 +381,6 @@ instance Marshal.WriteRaw VV1_fieldB where
 
 deriving via Marshal.EquivStorable VV1_fieldB instance RIP.Storable VV1_fieldB
 
-instance HasCField.HasCField VV1_fieldB "vV1_fieldB_b" where
-
-  type CFieldType VV1_fieldB "vV1_fieldB_b" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV1_fieldB_b" (RIP.Ptr VV1_fieldB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV1_fieldB_b")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "vV1_fieldB_b" VV1_fieldB ty where
 
@@ -400,6 +388,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          VV1_fieldB {vV1_fieldB_b = y1}, RIP.getField @"vV1_fieldB_b" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "vV1_fieldB_b" (RIP.Ptr VV1_fieldB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV1_fieldB_b")
+
+instance HasCField.HasCField VV1_fieldB "vV1_fieldB_b" where
+
+  type CFieldType VV1_fieldB "vV1_fieldB_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct VV1@
 
@@ -451,18 +451,6 @@ instance Marshal.WriteRaw VV1 where
 
 deriving via Marshal.EquivStorable VV1 instance RIP.Storable VV1
 
-instance HasCField.HasCField VV1 "vV1_fieldA" where
-
-  type CFieldType VV1 "vV1_fieldA" = VV1_fieldA
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ VV1_fieldA
-         ) => RIP.HasField "vV1_fieldA" (RIP.Ptr VV1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV1_fieldA")
-
 instance ( ty ~ VV1_fieldA
          ) => RIP.CompatHasField.HasField "vV1_fieldA" VV1 ty where
 
@@ -473,17 +461,17 @@ instance ( ty ~ VV1_fieldA
       , RIP.getField @"vV1_fieldA" x0
       )
 
-instance HasCField.HasCField VV1 "vV1_fieldB" where
-
-  type CFieldType VV1 "vV1_fieldB" = VV1_fieldB
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ VV1_fieldB
-         ) => RIP.HasField "vV1_fieldB" (RIP.Ptr VV1) (RIP.Ptr ty) where
+instance ( ty ~ VV1_fieldA
+         ) => RIP.HasField "vV1_fieldA" (RIP.Ptr VV1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"vV1_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"vV1_fieldA")
+
+instance HasCField.HasCField VV1 "vV1_fieldA" where
+
+  type CFieldType VV1 "vV1_fieldA" = VV1_fieldA
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ VV1_fieldB
          ) => RIP.CompatHasField.HasField "vV1_fieldB" VV1 ty where
@@ -494,6 +482,18 @@ instance ( ty ~ VV1_fieldB
           VV1 {vV1_fieldB = y1, vV1_fieldA = RIP.getField @"vV1_fieldA" x0}
       , RIP.getField @"vV1_fieldB" x0
       )
+
+instance ( ty ~ VV1_fieldB
+         ) => RIP.HasField "vV1_fieldB" (RIP.Ptr VV1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV1_fieldB")
+
+instance HasCField.HasCField VV1 "vV1_fieldB" where
+
+  type CFieldType VV1 "vV1_fieldB" = VV1_fieldB
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@VV2_fieldA@
 
@@ -536,18 +536,6 @@ instance Marshal.WriteRaw VV2_fieldA where
 
 deriving via Marshal.EquivStorable VV2_fieldA instance RIP.Storable VV2_fieldA
 
-instance HasCField.HasCField VV2_fieldA "vV2_fieldA_a" where
-
-  type CFieldType VV2_fieldA "vV2_fieldA_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV2_fieldA_a" (RIP.Ptr VV2_fieldA) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV2_fieldA_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "vV2_fieldA_a" VV2_fieldA ty where
 
@@ -555,6 +543,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          VV2_fieldA {vV2_fieldA_a = y1}, RIP.getField @"vV2_fieldA_a" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "vV2_fieldA_a" (RIP.Ptr VV2_fieldA) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV2_fieldA_a")
+
+instance HasCField.HasCField VV2_fieldA "vV2_fieldA_a" where
+
+  type CFieldType VV2_fieldA "vV2_fieldA_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@VV2_fieldB@
 
@@ -597,18 +597,6 @@ instance Marshal.WriteRaw VV2_fieldB where
 
 deriving via Marshal.EquivStorable VV2_fieldB instance RIP.Storable VV2_fieldB
 
-instance HasCField.HasCField VV2_fieldB "vV2_fieldB_b" where
-
-  type CFieldType VV2_fieldB "vV2_fieldB_b" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "vV2_fieldB_b" (RIP.Ptr VV2_fieldB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV2_fieldB_b")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "vV2_fieldB_b" VV2_fieldB ty where
 
@@ -616,6 +604,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          VV2_fieldB {vV2_fieldB_b = y1}, RIP.getField @"vV2_fieldB_b" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "vV2_fieldB_b" (RIP.Ptr VV2_fieldB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV2_fieldB_b")
+
+instance HasCField.HasCField VV2_fieldB "vV2_fieldB_b" where
+
+  type CFieldType VV2_fieldB "vV2_fieldB_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct VV2@
 
@@ -667,18 +667,6 @@ instance Marshal.WriteRaw VV2 where
 
 deriving via Marshal.EquivStorable VV2 instance RIP.Storable VV2
 
-instance HasCField.HasCField VV2 "vV2_fieldA" where
-
-  type CFieldType VV2 "vV2_fieldA" = VV2_fieldA
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ VV2_fieldA
-         ) => RIP.HasField "vV2_fieldA" (RIP.Ptr VV2) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"vV2_fieldA")
-
 instance ( ty ~ VV2_fieldA
          ) => RIP.CompatHasField.HasField "vV2_fieldA" VV2 ty where
 
@@ -689,17 +677,17 @@ instance ( ty ~ VV2_fieldA
       , RIP.getField @"vV2_fieldA" x0
       )
 
-instance HasCField.HasCField VV2 "vV2_fieldB" where
-
-  type CFieldType VV2 "vV2_fieldB" = VV2_fieldB
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ VV2_fieldB
-         ) => RIP.HasField "vV2_fieldB" (RIP.Ptr VV2) (RIP.Ptr ty) where
+instance ( ty ~ VV2_fieldA
+         ) => RIP.HasField "vV2_fieldA" (RIP.Ptr VV2) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"vV2_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"vV2_fieldA")
+
+instance HasCField.HasCField VV2 "vV2_fieldA" where
+
+  type CFieldType VV2 "vV2_fieldA" = VV2_fieldA
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ VV2_fieldB
          ) => RIP.CompatHasField.HasField "vV2_fieldB" VV2 ty where
@@ -710,3 +698,15 @@ instance ( ty ~ VV2_fieldB
           VV2 {vV2_fieldB = y1, vV2_fieldA = RIP.getField @"vV2_fieldA" x0}
       , RIP.getField @"vV2_fieldB" x0
       )
+
+instance ( ty ~ VV2_fieldB
+         ) => RIP.HasField "vV2_fieldB" (RIP.Ptr VV2) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"vV2_fieldB")
+
+instance HasCField.HasCField VV2 "vV2_fieldB" where
+
+  type CFieldType VV2 "vV2_fieldB" = VV2_fieldB
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/bindingspec.yaml
@@ -47,11 +47,12 @@ hstypes:
       fields:
       - uU1_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -64,11 +65,12 @@ hstypes:
       fields:
       - uU1_fieldY_fieldX
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -81,11 +83,12 @@ hstypes:
       fields:
       - uU2_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -98,11 +101,12 @@ hstypes:
       fields:
       - uU2_fieldY_fieldX
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -116,11 +120,12 @@ hstypes:
       - vV1_fieldA
       - vV1_fieldB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -133,11 +138,12 @@ hstypes:
       fields:
       - vV1_fieldA_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -150,11 +156,12 @@ hstypes:
       fields:
       - vV1_fieldB_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -168,11 +175,12 @@ hstypes:
       - vV2_fieldA
       - vV2_fieldB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -185,11 +193,12 @@ hstypes:
       fields:
       - vV2_fieldA_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -202,11 +211,12 @@ hstypes:
       fields:
       - vV2_fieldB_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/wrong_source_location/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw UU1_fieldY
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UU1_fieldY uU1_fieldY_fieldX_2 -> writeRaw (Proxy @"uU1_fieldY_fieldX") ptr_0 uU1_fieldY_fieldX_2
 deriving via (EquivStorable UU1_fieldY) instance Storable UU1_fieldY
-instance HasCField UU1_fieldY "uU1_fieldY_fieldX"
-    where type CFieldType UU1_fieldY "uU1_fieldY_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "uU1_fieldY_fieldX" (Ptr UU1_fieldY) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU1_fieldY_fieldX")
 instance (~) ty CInt => HasField "uU1_fieldY_fieldX" UU1_fieldY ty
     where hasField = \x_0 -> (\y_1 -> UU1_fieldY{uU1_fieldY_fieldX = y_1},
                               getField @"uU1_fieldY_fieldX" x_0)
+instance (~) ty CInt =>
+         HasField "uU1_fieldY_fieldX" (Ptr UU1_fieldY) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU1_fieldY_fieldX")
+instance HasCField UU1_fieldY "uU1_fieldY_fieldX"
+    where type CFieldType UU1_fieldY "uU1_fieldY_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct UU1@
 
     __defined at:__ @macros\/wrong_source_location.h 19:1@
@@ -56,15 +56,15 @@ instance WriteRaw UU1
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UU1 uU1_fieldY_2 -> writeRaw (Proxy @"uU1_fieldY") ptr_0 uU1_fieldY_2
 deriving via (EquivStorable UU1) instance Storable UU1
-instance HasCField UU1 "uU1_fieldY"
-    where type CFieldType UU1 "uU1_fieldY" = UU1_fieldY
-          offset# = \_ -> \_ -> 0
-instance (~) ty UU1_fieldY =>
-         HasField "uU1_fieldY" (Ptr UU1) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU1_fieldY")
 instance (~) ty UU1_fieldY => HasField "uU1_fieldY" UU1 ty
     where hasField = \x_0 -> (\y_1 -> UU1{uU1_fieldY = y_1},
                               getField @"uU1_fieldY" x_0)
+instance (~) ty UU1_fieldY =>
+         HasField "uU1_fieldY" (Ptr UU1) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU1_fieldY")
+instance HasCField UU1 "uU1_fieldY"
+    where type CFieldType UU1 "uU1_fieldY" = UU1_fieldY
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@UU2_fieldY@
 
     __defined at:__ @macros\/wrong_source_location.h 21:1@
@@ -89,15 +89,15 @@ instance WriteRaw UU2_fieldY
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UU2_fieldY uU2_fieldY_fieldX_2 -> writeRaw (Proxy @"uU2_fieldY_fieldX") ptr_0 uU2_fieldY_fieldX_2
 deriving via (EquivStorable UU2_fieldY) instance Storable UU2_fieldY
-instance HasCField UU2_fieldY "uU2_fieldY_fieldX"
-    where type CFieldType UU2_fieldY "uU2_fieldY_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "uU2_fieldY_fieldX" (Ptr UU2_fieldY) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU2_fieldY_fieldX")
 instance (~) ty CInt => HasField "uU2_fieldY_fieldX" UU2_fieldY ty
     where hasField = \x_0 -> (\y_1 -> UU2_fieldY{uU2_fieldY_fieldX = y_1},
                               getField @"uU2_fieldY_fieldX" x_0)
+instance (~) ty CInt =>
+         HasField "uU2_fieldY_fieldX" (Ptr UU2_fieldY) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU2_fieldY_fieldX")
+instance HasCField UU2_fieldY "uU2_fieldY_fieldX"
+    where type CFieldType UU2_fieldY "uU2_fieldY_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct UU2@
 
     __defined at:__ @macros\/wrong_source_location.h 21:1@
@@ -122,15 +122,15 @@ instance WriteRaw UU2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UU2 uU2_fieldY_2 -> writeRaw (Proxy @"uU2_fieldY") ptr_0 uU2_fieldY_2
 deriving via (EquivStorable UU2) instance Storable UU2
-instance HasCField UU2 "uU2_fieldY"
-    where type CFieldType UU2 "uU2_fieldY" = UU2_fieldY
-          offset# = \_ -> \_ -> 0
-instance (~) ty UU2_fieldY =>
-         HasField "uU2_fieldY" (Ptr UU2) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU2_fieldY")
 instance (~) ty UU2_fieldY => HasField "uU2_fieldY" UU2 ty
     where hasField = \x_0 -> (\y_1 -> UU2{uU2_fieldY = y_1},
                               getField @"uU2_fieldY" x_0)
+instance (~) ty UU2_fieldY =>
+         HasField "uU2_fieldY" (Ptr UU2) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU2_fieldY")
+instance HasCField UU2 "uU2_fieldY"
+    where type CFieldType UU2 "uU2_fieldY" = UU2_fieldY
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@VV1_fieldA@
 
     __defined at:__ @macros\/wrong_source_location.h 29:1@
@@ -155,15 +155,15 @@ instance WriteRaw VV1_fieldA
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        VV1_fieldA vV1_fieldA_a_2 -> writeRaw (Proxy @"vV1_fieldA_a") ptr_0 vV1_fieldA_a_2
 deriving via (EquivStorable VV1_fieldA) instance Storable VV1_fieldA
-instance HasCField VV1_fieldA "vV1_fieldA_a"
-    where type CFieldType VV1_fieldA "vV1_fieldA_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV1_fieldA_a" (Ptr VV1_fieldA) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV1_fieldA_a")
 instance (~) ty CInt => HasField "vV1_fieldA_a" VV1_fieldA ty
     where hasField = \x_0 -> (\y_1 -> VV1_fieldA{vV1_fieldA_a = y_1},
                               getField @"vV1_fieldA_a" x_0)
+instance (~) ty CInt =>
+         HasField "vV1_fieldA_a" (Ptr VV1_fieldA) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV1_fieldA_a")
+instance HasCField VV1_fieldA "vV1_fieldA_a"
+    where type CFieldType VV1_fieldA "vV1_fieldA_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@VV1_fieldB@
 
     __defined at:__ @macros\/wrong_source_location.h 29:1@
@@ -188,15 +188,15 @@ instance WriteRaw VV1_fieldB
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        VV1_fieldB vV1_fieldB_b_2 -> writeRaw (Proxy @"vV1_fieldB_b") ptr_0 vV1_fieldB_b_2
 deriving via (EquivStorable VV1_fieldB) instance Storable VV1_fieldB
-instance HasCField VV1_fieldB "vV1_fieldB_b"
-    where type CFieldType VV1_fieldB "vV1_fieldB_b" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV1_fieldB_b" (Ptr VV1_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV1_fieldB_b")
 instance (~) ty CInt => HasField "vV1_fieldB_b" VV1_fieldB ty
     where hasField = \x_0 -> (\y_1 -> VV1_fieldB{vV1_fieldB_b = y_1},
                               getField @"vV1_fieldB_b" x_0)
+instance (~) ty CInt =>
+         HasField "vV1_fieldB_b" (Ptr VV1_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV1_fieldB_b")
+instance HasCField VV1_fieldB "vV1_fieldB_b"
+    where type CFieldType VV1_fieldB "vV1_fieldB_b" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct VV1@
 
     __defined at:__ @macros\/wrong_source_location.h 29:1@
@@ -229,26 +229,26 @@ instance WriteRaw VV1
                                        VV1 vV1_fieldA_2
                                            vV1_fieldB_3 -> writeRaw (Proxy @"vV1_fieldA") ptr_0 vV1_fieldA_2 >> writeRaw (Proxy @"vV1_fieldB") ptr_0 vV1_fieldB_3
 deriving via (EquivStorable VV1) instance Storable VV1
-instance HasCField VV1 "vV1_fieldA"
-    where type CFieldType VV1 "vV1_fieldA" = VV1_fieldA
-          offset# = \_ -> \_ -> 0
-instance (~) ty VV1_fieldA =>
-         HasField "vV1_fieldA" (Ptr VV1) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV1_fieldA")
 instance (~) ty VV1_fieldA => HasField "vV1_fieldA" VV1 ty
     where hasField = \x_0 -> (\y_1 -> VV1{vV1_fieldA = y_1,
                                           vV1_fieldB = getField @"vV1_fieldB" x_0},
                               getField @"vV1_fieldA" x_0)
-instance HasCField VV1 "vV1_fieldB"
-    where type CFieldType VV1 "vV1_fieldB" = VV1_fieldB
-          offset# = \_ -> \_ -> 4
-instance (~) ty VV1_fieldB =>
-         HasField "vV1_fieldB" (Ptr VV1) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV1_fieldB")
+instance (~) ty VV1_fieldA =>
+         HasField "vV1_fieldA" (Ptr VV1) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV1_fieldA")
+instance HasCField VV1 "vV1_fieldA"
+    where type CFieldType VV1 "vV1_fieldA" = VV1_fieldA
+          offset# = \_ -> \_ -> 0
 instance (~) ty VV1_fieldB => HasField "vV1_fieldB" VV1 ty
     where hasField = \x_0 -> (\y_1 -> VV1{vV1_fieldB = y_1,
                                           vV1_fieldA = getField @"vV1_fieldA" x_0},
                               getField @"vV1_fieldB" x_0)
+instance (~) ty VV1_fieldB =>
+         HasField "vV1_fieldB" (Ptr VV1) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV1_fieldB")
+instance HasCField VV1 "vV1_fieldB"
+    where type CFieldType VV1 "vV1_fieldB" = VV1_fieldB
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@VV2_fieldA@
 
     __defined at:__ @macros\/wrong_source_location.h 31:1@
@@ -273,15 +273,15 @@ instance WriteRaw VV2_fieldA
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        VV2_fieldA vV2_fieldA_a_2 -> writeRaw (Proxy @"vV2_fieldA_a") ptr_0 vV2_fieldA_a_2
 deriving via (EquivStorable VV2_fieldA) instance Storable VV2_fieldA
-instance HasCField VV2_fieldA "vV2_fieldA_a"
-    where type CFieldType VV2_fieldA "vV2_fieldA_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV2_fieldA_a" (Ptr VV2_fieldA) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV2_fieldA_a")
 instance (~) ty CInt => HasField "vV2_fieldA_a" VV2_fieldA ty
     where hasField = \x_0 -> (\y_1 -> VV2_fieldA{vV2_fieldA_a = y_1},
                               getField @"vV2_fieldA_a" x_0)
+instance (~) ty CInt =>
+         HasField "vV2_fieldA_a" (Ptr VV2_fieldA) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV2_fieldA_a")
+instance HasCField VV2_fieldA "vV2_fieldA_a"
+    where type CFieldType VV2_fieldA "vV2_fieldA_a" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@VV2_fieldB@
 
     __defined at:__ @macros\/wrong_source_location.h 31:1@
@@ -306,15 +306,15 @@ instance WriteRaw VV2_fieldB
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        VV2_fieldB vV2_fieldB_b_2 -> writeRaw (Proxy @"vV2_fieldB_b") ptr_0 vV2_fieldB_b_2
 deriving via (EquivStorable VV2_fieldB) instance Storable VV2_fieldB
-instance HasCField VV2_fieldB "vV2_fieldB_b"
-    where type CFieldType VV2_fieldB "vV2_fieldB_b" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "vV2_fieldB_b" (Ptr VV2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV2_fieldB_b")
 instance (~) ty CInt => HasField "vV2_fieldB_b" VV2_fieldB ty
     where hasField = \x_0 -> (\y_1 -> VV2_fieldB{vV2_fieldB_b = y_1},
                               getField @"vV2_fieldB_b" x_0)
+instance (~) ty CInt =>
+         HasField "vV2_fieldB_b" (Ptr VV2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV2_fieldB_b")
+instance HasCField VV2_fieldB "vV2_fieldB_b"
+    where type CFieldType VV2_fieldB "vV2_fieldB_b" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct VV2@
 
     __defined at:__ @macros\/wrong_source_location.h 31:1@
@@ -347,23 +347,23 @@ instance WriteRaw VV2
                                        VV2 vV2_fieldA_2
                                            vV2_fieldB_3 -> writeRaw (Proxy @"vV2_fieldA") ptr_0 vV2_fieldA_2 >> writeRaw (Proxy @"vV2_fieldB") ptr_0 vV2_fieldB_3
 deriving via (EquivStorable VV2) instance Storable VV2
-instance HasCField VV2 "vV2_fieldA"
-    where type CFieldType VV2 "vV2_fieldA" = VV2_fieldA
-          offset# = \_ -> \_ -> 0
-instance (~) ty VV2_fieldA =>
-         HasField "vV2_fieldA" (Ptr VV2) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV2_fieldA")
 instance (~) ty VV2_fieldA => HasField "vV2_fieldA" VV2 ty
     where hasField = \x_0 -> (\y_1 -> VV2{vV2_fieldA = y_1,
                                           vV2_fieldB = getField @"vV2_fieldB" x_0},
                               getField @"vV2_fieldA" x_0)
-instance HasCField VV2 "vV2_fieldB"
-    where type CFieldType VV2 "vV2_fieldB" = VV2_fieldB
-          offset# = \_ -> \_ -> 4
-instance (~) ty VV2_fieldB =>
-         HasField "vV2_fieldB" (Ptr VV2) (Ptr ty)
-    where getField = fromPtr (Proxy @"vV2_fieldB")
+instance (~) ty VV2_fieldA =>
+         HasField "vV2_fieldA" (Ptr VV2) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV2_fieldA")
+instance HasCField VV2 "vV2_fieldA"
+    where type CFieldType VV2 "vV2_fieldA" = VV2_fieldA
+          offset# = \_ -> \_ -> 0
 instance (~) ty VV2_fieldB => HasField "vV2_fieldB" VV2 ty
     where hasField = \x_0 -> (\y_1 -> VV2{vV2_fieldB = y_1,
                                           vV2_fieldA = getField @"vV2_fieldA" x_0},
                               getField @"vV2_fieldB" x_0)
+instance (~) ty VV2_fieldB =>
+         HasField "vV2_fieldB" (Ptr VV2) (Ptr ty)
+    where getField = fromPtr (Proxy @"vV2_fieldB")
+instance HasCField VV2 "vV2_fieldB"
+    where type CFieldType VV2 "vV2_fieldB" = VV2_fieldB
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/Example.hs
@@ -52,6 +52,16 @@ newtype OUTER_BEFORE_CIRCULAR_INCLUDE = OUTER_BEFORE_CIRCULAR_INCLUDE
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" OUTER_BEFORE_CIRCULAR_INCLUDE ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          OUTER_BEFORE_CIRCULAR_INCLUDE {unwrapOUTER_BEFORE_CIRCULAR_INCLUDE = y1}
+      , RIP.getField @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_BEFORE_CIRCULAR_INCLUDE) (RIP.Ptr ty) where
 
   getField =
@@ -63,16 +73,6 @@ instance HasCField.HasCField OUTER_BEFORE_CIRCULAR_INCLUDE "unwrapOUTER_BEFORE_C
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" OUTER_BEFORE_CIRCULAR_INCLUDE ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          OUTER_BEFORE_CIRCULAR_INCLUDE {unwrapOUTER_BEFORE_CIRCULAR_INCLUDE = y1}
-      , RIP.getField @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" x0
-      )
 
 {-| __C declaration:__ @OUTER_AFTER_CIRCULAR_INCLUDE@
 
@@ -103,6 +103,16 @@ newtype OUTER_AFTER_CIRCULAR_INCLUDE = OUTER_AFTER_CIRCULAR_INCLUDE
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" OUTER_AFTER_CIRCULAR_INCLUDE ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          OUTER_AFTER_CIRCULAR_INCLUDE {unwrapOUTER_AFTER_CIRCULAR_INCLUDE = y1}
+      , RIP.getField @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" (RIP.Ptr OUTER_AFTER_CIRCULAR_INCLUDE) (RIP.Ptr ty) where
 
   getField =
@@ -114,13 +124,3 @@ instance HasCField.HasCField OUTER_AFTER_CIRCULAR_INCLUDE "unwrapOUTER_AFTER_CIR
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" OUTER_AFTER_CIRCULAR_INCLUDE ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          OUTER_AFTER_CIRCULAR_INCLUDE {unwrapOUTER_AFTER_CIRCULAR_INCLUDE = y1}
-      , RIP.getField @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/circular_includes/th.txt
@@ -26,6 +26,12 @@ newtype OUTER_BEFORE_CIRCULAR_INCLUDE
                       WriteRaw)
 instance (~) ty CInt =>
          HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
+                  OUTER_BEFORE_CIRCULAR_INCLUDE
+                  ty
+    where hasField = \x_0 -> (\y_1 -> OUTER_BEFORE_CIRCULAR_INCLUDE{unwrapOUTER_BEFORE_CIRCULAR_INCLUDE = y_1},
+                              getField @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" x_0)
+instance (~) ty CInt =>
+         HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
                   (Ptr OUTER_BEFORE_CIRCULAR_INCLUDE)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE")
@@ -34,12 +40,6 @@ instance HasCField OUTER_BEFORE_CIRCULAR_INCLUDE
     where type CFieldType OUTER_BEFORE_CIRCULAR_INCLUDE
                           "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapOUTER_BEFORE_CIRCULAR_INCLUDE"
-                  OUTER_BEFORE_CIRCULAR_INCLUDE
-                  ty
-    where hasField = \x_0 -> (\y_1 -> OUTER_BEFORE_CIRCULAR_INCLUDE{unwrapOUTER_BEFORE_CIRCULAR_INCLUDE = y_1},
-                              getField @"unwrapOUTER_BEFORE_CIRCULAR_INCLUDE" x_0)
 {-| __C declaration:__ @OUTER_AFTER_CIRCULAR_INCLUDE@
 
     __defined at:__ @program-analysis\/circular_includes.h 4:13@
@@ -66,6 +66,12 @@ newtype OUTER_AFTER_CIRCULAR_INCLUDE
                       WriteRaw)
 instance (~) ty CInt =>
          HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"
+                  OUTER_AFTER_CIRCULAR_INCLUDE
+                  ty
+    where hasField = \x_0 -> (\y_1 -> OUTER_AFTER_CIRCULAR_INCLUDE{unwrapOUTER_AFTER_CIRCULAR_INCLUDE = y_1},
+                              getField @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE" x_0)
+instance (~) ty CInt =>
+         HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"
                   (Ptr OUTER_AFTER_CIRCULAR_INCLUDE)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE")
@@ -74,9 +80,3 @@ instance HasCField OUTER_AFTER_CIRCULAR_INCLUDE
     where type CFieldType OUTER_AFTER_CIRCULAR_INCLUDE
                           "unwrapOUTER_AFTER_CIRCULAR_INCLUDE" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapOUTER_AFTER_CIRCULAR_INCLUDE"
-                  OUTER_AFTER_CIRCULAR_INCLUDE
-                  ty
-    where hasField = \x_0 -> (\y_1 -> OUTER_AFTER_CIRCULAR_INCLUDE{unwrapOUTER_AFTER_CIRCULAR_INCLUDE = y_1},
-                              getField @"unwrapOUTER_AFTER_CIRCULAR_INCLUDE" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/Example.hs
@@ -51,6 +51,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
@@ -61,12 +67,6 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 {-| __C declaration:__ @macro U@
 
@@ -96,6 +96,12 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
@@ -106,9 +112,3 @@ instance HasCField.HasCField U "unwrapU" where
   type CFieldType U "unwrapU" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_selected/th.txt
@@ -65,14 +65,14 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 {-| __C declaration:__ @macro U@
 
     __defined at:__ @program-analysis\/program-slicing\/macro_selected.h 9:9@
@@ -97,14 +97,14 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
 instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)
 -- __unique:__ @test_programanalysisprogramslici_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_27fdf7030b0bb40d" hs_bindgen_27fdf7030b0bb40d_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/Example.hs
@@ -50,6 +50,12 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
@@ -60,9 +66,3 @@ instance HasCField.HasCField U "unwrapU" where
   type CFieldType U "unwrapU" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/macro_unselected/th.txt
@@ -45,14 +45,14 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
 instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)
 -- __unique:__ @test_programanalysisprogramslici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_ef8f97cf27661c20" hs_bindgen_ef8f97cf27661c20_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/Example.hs
@@ -51,6 +51,12 @@ newtype T = T
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
@@ -61,12 +67,6 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 {-| __C declaration:__ @macro U@
 
@@ -96,6 +96,12 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
@@ -106,9 +112,3 @@ instance HasCField.HasCField U "unwrapU" where
   type CFieldType U "unwrapU" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_selected/th.txt
@@ -65,14 +65,14 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 {-| __C declaration:__ @macro U@
 
     __defined at:__ @program-analysis\/program-slicing\/typedef_selected.h 9:9@
@@ -97,14 +97,14 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
 instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)
 -- __unique:__ @test_programanalysisprogramslici_Example_Safe_foo@
 foreign import ccall safe "hs_bindgen_27fdf7030b0bb40d" hs_bindgen_27fdf7030b0bb40d_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/Example.hs
@@ -50,6 +50,12 @@ newtype U = U
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
@@ -60,9 +66,3 @@ instance HasCField.HasCField U "unwrapU" where
   type CFieldType U "unwrapU" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program-slicing/typedef_unselected/th.txt
@@ -45,14 +45,14 @@ newtype U
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
 instance (~) ty CInt => HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)
 -- __unique:__ @test_programanalysisprogramslici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_ef8f97cf27661c20" hs_bindgen_ef8f97cf27661c20_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/Example.hs
@@ -109,6 +109,16 @@ instance Read FileOperationStatus where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapFileOperationStatus" FileOperationStatus ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          FileOperationStatus {unwrapFileOperationStatus = y1}
+      , RIP.getField @"unwrapFileOperationStatus" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapFileOperationStatus" (RIP.Ptr FileOperationStatus) (RIP.Ptr ty) where
 
   getField =
@@ -120,16 +130,6 @@ instance HasCField.HasCField FileOperationStatus "unwrapFileOperationStatus" whe
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapFileOperationStatus" FileOperationStatus ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          FileOperationStatus {unwrapFileOperationStatus = y1}
-      , RIP.getField @"unwrapFileOperationStatus" x0
-      )
 
 {-| __C declaration:__ @SUCCESS@
 
@@ -237,19 +237,6 @@ instance Marshal.WriteRaw FileOperationRecord where
 
 deriving via Marshal.EquivStorable FileOperationRecord instance RIP.Storable FileOperationRecord
 
-instance HasCField.HasCField FileOperationRecord "fileOperationRecord_status" where
-
-  type CFieldType FileOperationRecord "fileOperationRecord_status" =
-    FileOperationStatus
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ FileOperationStatus
-         ) => RIP.HasField "fileOperationRecord_status" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_status")
-
 instance ( ty ~ FileOperationStatus
          ) => RIP.CompatHasField.HasField "fileOperationRecord_status" FileOperationRecord ty where
 
@@ -262,18 +249,18 @@ instance ( ty ~ FileOperationStatus
       , RIP.getField @"fileOperationRecord_status" x0
       )
 
-instance HasCField.HasCField FileOperationRecord "fileOperationRecord_bytes_processed" where
-
-  type CFieldType FileOperationRecord "fileOperationRecord_bytes_processed" =
-    HsBindgen.Runtime.LibC.CSize
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CSize
-         ) => RIP.HasField "fileOperationRecord_bytes_processed" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
+instance ( ty ~ FileOperationStatus
+         ) => RIP.HasField "fileOperationRecord_status" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_bytes_processed")
+    HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_status")
+
+instance HasCField.HasCField FileOperationRecord "fileOperationRecord_status" where
+
+  type CFieldType FileOperationRecord "fileOperationRecord_status" =
+    FileOperationStatus
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CSize
          ) => RIP.CompatHasField.HasField "fileOperationRecord_bytes_processed" FileOperationRecord ty where
@@ -286,3 +273,16 @@ instance ( ty ~ HsBindgen.Runtime.LibC.CSize
                               }
       , RIP.getField @"fileOperationRecord_bytes_processed" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CSize
+         ) => RIP.HasField "fileOperationRecord_bytes_processed" (RIP.Ptr FileOperationRecord) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"fileOperationRecord_bytes_processed")
+
+instance HasCField.HasCField FileOperationRecord "fileOperationRecord_bytes_processed" where
+
+  type CFieldType FileOperationRecord "fileOperationRecord_bytes_processed" =
+    HsBindgen.Runtime.LibC.CSize
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - fileOperationRecord_status
       - fileOperationRecord_bytes_processed
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -36,12 +37,13 @@ hstypes:
       - unwrapFileOperationStatus
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/th.txt
@@ -75,6 +75,10 @@ instance Read FileOperationStatus
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CInt =>
+         HasField "unwrapFileOperationStatus" FileOperationStatus ty
+    where hasField = \x_0 -> (\y_1 -> FileOperationStatus{unwrapFileOperationStatus = y_1},
+                              getField @"unwrapFileOperationStatus" x_0)
+instance (~) ty CInt =>
          HasField "unwrapFileOperationStatus"
                   (Ptr FileOperationStatus)
                   (Ptr ty)
@@ -83,10 +87,6 @@ instance HasCField FileOperationStatus "unwrapFileOperationStatus"
     where type CFieldType FileOperationStatus
                           "unwrapFileOperationStatus" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapFileOperationStatus" FileOperationStatus ty
-    where hasField = \x_0 -> (\y_1 -> FileOperationStatus{unwrapFileOperationStatus = y_1},
-                              getField @"unwrapFileOperationStatus" x_0)
 {-| __C declaration:__ @SUCCESS@
 
     __defined at:__ @program-analysis\/program_slicing_selection.h 8:3@
@@ -167,30 +167,20 @@ instance WriteRaw FileOperationRecord
                                        FileOperationRecord fileOperationRecord_status_2
                                                            fileOperationRecord_bytes_processed_3 -> writeRaw (Proxy @"fileOperationRecord_status") ptr_0 fileOperationRecord_status_2 >> writeRaw (Proxy @"fileOperationRecord_bytes_processed") ptr_0 fileOperationRecord_bytes_processed_3
 deriving via (EquivStorable FileOperationRecord) instance Storable FileOperationRecord
-instance HasCField FileOperationRecord "fileOperationRecord_status"
-    where type CFieldType FileOperationRecord
-                          "fileOperationRecord_status" = FileOperationStatus
-          offset# = \_ -> \_ -> 0
-instance (~) ty FileOperationStatus =>
-         HasField "fileOperationRecord_status"
-                  (Ptr FileOperationRecord)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"fileOperationRecord_status")
 instance (~) ty FileOperationStatus =>
          HasField "fileOperationRecord_status" FileOperationRecord ty
     where hasField = \x_0 -> (\y_1 -> FileOperationRecord{fileOperationRecord_status = y_1,
                                                           fileOperationRecord_bytes_processed = getField @"fileOperationRecord_bytes_processed" x_0},
                               getField @"fileOperationRecord_status" x_0)
-instance HasCField FileOperationRecord
-                   "fileOperationRecord_bytes_processed"
-    where type CFieldType FileOperationRecord
-                          "fileOperationRecord_bytes_processed" = HsBindgen.Runtime.LibC.CSize
-          offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.CSize =>
-         HasField "fileOperationRecord_bytes_processed"
+instance (~) ty FileOperationStatus =>
+         HasField "fileOperationRecord_status"
                   (Ptr FileOperationRecord)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"fileOperationRecord_bytes_processed")
+    where getField = fromPtr (Proxy @"fileOperationRecord_status")
+instance HasCField FileOperationRecord "fileOperationRecord_status"
+    where type CFieldType FileOperationRecord
+                          "fileOperationRecord_status" = FileOperationStatus
+          offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.CSize =>
          HasField "fileOperationRecord_bytes_processed"
                   FileOperationRecord
@@ -198,6 +188,16 @@ instance (~) ty HsBindgen.Runtime.LibC.CSize =>
     where hasField = \x_0 -> (\y_1 -> FileOperationRecord{fileOperationRecord_bytes_processed = y_1,
                                                           fileOperationRecord_status = getField @"fileOperationRecord_status" x_0},
                               getField @"fileOperationRecord_bytes_processed" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CSize =>
+         HasField "fileOperationRecord_bytes_processed"
+                  (Ptr FileOperationRecord)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"fileOperationRecord_bytes_processed")
+instance HasCField FileOperationRecord
+                   "fileOperationRecord_bytes_processed"
+    where type CFieldType FileOperationRecord
+                          "fileOperationRecord_bytes_processed" = HsBindgen.Runtime.LibC.CSize
+          offset# = \_ -> \_ -> 8
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_read_file_chunk@
 foreign import ccall safe "hs_bindgen_b2a91b3b7edf2ad3" hs_bindgen_b2a91b3b7edf2ad3_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/Example.hs
@@ -53,6 +53,14 @@ newtype Uint32_t = Uint32_t
     )
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapUint32_t" Uint32_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Uint32_t {unwrapUint32_t = y1}, RIP.getField @"unwrapUint32_t" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapUint32_t" (RIP.Ptr Uint32_t) (RIP.Ptr ty) where
 
   getField =
@@ -63,14 +71,6 @@ instance HasCField.HasCField Uint32_t "unwrapUint32_t" where
   type CFieldType Uint32_t "unwrapUint32_t" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapUint32_t" Uint32_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Uint32_t {unwrapUint32_t = y1}, RIP.getField @"unwrapUint32_t" x0)
 
 {-| __C declaration:__ @struct foo@
 
@@ -116,18 +116,6 @@ instance RIP.Storable Foo where
                HasCField.poke (RIP.Proxy @"foo_sixty_four") ptr0 foo_sixty_four2
             >> HasCField.poke (RIP.Proxy @"foo_thirty_two") ptr0 foo_thirty_two3
 
-instance HasCField.HasCField Foo "foo_sixty_four" where
-
-  type CFieldType Foo "foo_sixty_four" = Foreign.Word64
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Foreign.Word64
-         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
-
 instance ( ty ~ Foreign.Word64
          ) => RIP.CompatHasField.HasField "foo_sixty_four" Foo ty where
 
@@ -138,17 +126,17 @@ instance ( ty ~ Foreign.Word64
       , RIP.getField @"foo_sixty_four" x0
       )
 
-instance HasCField.HasCField Foo "foo_thirty_two" where
-
-  type CFieldType Foo "foo_thirty_two" = Uint32_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ Uint32_t
-         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance ( ty ~ Foreign.Word64
+         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")
+    HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
+
+instance HasCField.HasCField Foo "foo_sixty_four" where
+
+  type CFieldType Foo "foo_sixty_four" = Foreign.Word64
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Uint32_t
          ) => RIP.CompatHasField.HasField "foo_thirty_two" Foo ty where
@@ -159,3 +147,15 @@ instance ( ty ~ Uint32_t
           Foo {foo_thirty_two = y1, foo_sixty_four = RIP.getField @"foo_sixty_four" x0}
       , RIP.getField @"foo_thirty_two" x0
       )
+
+instance ( ty ~ Uint32_t
+         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")
+
+instance HasCField.HasCField Foo "foo_thirty_two" where
+
+  type CFieldType Foo "foo_thirty_two" = Uint32_t
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - foo_sixty_four
       - foo_thirty_two
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Show
   - Storable
 - hsname: Uint32_t
@@ -35,7 +36,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -43,6 +43,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_simple/th.txt
@@ -50,15 +50,15 @@ newtype Uint32_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CUInt => HasField "unwrapUint32_t" Uint32_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint32_t{unwrapUint32_t = y_1},
+                              getField @"unwrapUint32_t" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapUint32_t" (Ptr Uint32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint32_t")
 instance HasCField Uint32_t "unwrapUint32_t"
     where type CFieldType Uint32_t "unwrapUint32_t" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapUint32_t" Uint32_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint32_t{unwrapUint32_t = y_1},
-                              getField @"unwrapUint32_t" x_0)
 {-| __C declaration:__ @struct foo@
 
     __defined at:__ @program-analysis\/program_slicing_simple.h 3:8@
@@ -88,26 +88,26 @@ instance Storable Foo
           poke = \ptr_1 -> \s_2 -> case s_2 of
                                    Foo foo_sixty_four_3
                                        foo_thirty_two_4 -> poke (Proxy @"foo_sixty_four") ptr_1 foo_sixty_four_3 >> poke (Proxy @"foo_thirty_two") ptr_1 foo_thirty_two_4
-instance HasCField Foo "foo_sixty_four"
-    where type CFieldType Foo "foo_sixty_four" = Foreign.Word64
-          offset# = \_ -> \_ -> 0
-instance (~) ty Foreign.Word64 =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_sixty_four")
 instance (~) ty Foreign.Word64 => HasField "foo_sixty_four" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_sixty_four = y_1,
                                           foo_thirty_two = getField @"foo_thirty_two" x_0},
                               getField @"foo_sixty_four" x_0)
-instance HasCField Foo "foo_thirty_two"
-    where type CFieldType Foo "foo_thirty_two" = Uint32_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty Uint32_t =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_thirty_two")
+instance (~) ty Foreign.Word64 =>
+         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_sixty_four")
+instance HasCField Foo "foo_sixty_four"
+    where type CFieldType Foo "foo_sixty_four" = Foreign.Word64
+          offset# = \_ -> \_ -> 0
 instance (~) ty Uint32_t => HasField "foo_thirty_two" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_thirty_two = y_1,
                                           foo_sixty_four = getField @"foo_sixty_four" x_0},
                               getField @"foo_thirty_two" x_0)
+instance (~) ty Uint32_t =>
+         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_thirty_two")
+instance HasCField Foo "foo_thirty_two"
+    where type CFieldType Foo "foo_thirty_two" = Uint32_t
+          offset# = \_ -> \_ -> 8
 -- __unique:__ @test_programanalysisprogram_slici_Example_Safe_bar@
 foreign import ccall safe "hs_bindgen_48dbbf4b09b5b3c1" hs_bindgen_48dbbf4b09b5b3c1_base ::
     Word64

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/Example.hs
@@ -50,6 +50,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -60,9 +66,3 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/bindingspec.yaml
@@ -17,7 +17,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -25,6 +24,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_bad/th.txt
@@ -24,11 +24,11 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/Example.hs
@@ -64,18 +64,6 @@ instance Marshal.WriteRaw OkBefore where
 
 deriving via Marshal.EquivStorable OkBefore instance RIP.Storable OkBefore
 
-instance HasCField.HasCField OkBefore "okBefore_x" where
-
-  type CFieldType OkBefore "okBefore_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okBefore_x" OkBefore ty where
 
@@ -83,6 +71,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkBefore {okBefore_x = y1}, RIP.getField @"okBefore_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
+
+instance HasCField.HasCField OkBefore "okBefore_x" where
+
+  type CFieldType OkBefore "okBefore_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct OkAfter@
 
@@ -125,17 +125,6 @@ instance Marshal.WriteRaw OkAfter where
 
 deriving via Marshal.EquivStorable OkAfter instance RIP.Storable OkAfter
 
-instance HasCField.HasCField OkAfter "okAfter_x" where
-
-  type CFieldType OkAfter "okAfter_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okAfter_x" OkAfter ty where
 
@@ -143,3 +132,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkAfter {okAfter_x = y1}, RIP.getField @"okAfter_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
+
+instance HasCField.HasCField OkAfter "okAfter_x" where
+
+  type CFieldType OkAfter "okAfter_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - okAfter_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - okBefore_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.1.deselect_failed/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw OkBefore
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkBefore okBefore_x_2 -> writeRaw (Proxy @"okBefore_x") ptr_0 okBefore_x_2
 deriving via (EquivStorable OkBefore) instance Storable OkBefore
-instance HasCField OkBefore "okBefore_x"
-    where type CFieldType OkBefore "okBefore_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
-    where getField = fromPtr (Proxy @"okBefore_x")
 instance (~) ty CInt => HasField "okBefore_x" OkBefore ty
     where hasField = \x_0 -> (\y_1 -> OkBefore{okBefore_x = y_1},
                               getField @"okBefore_x" x_0)
+instance (~) ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+    where getField = fromPtr (Proxy @"okBefore_x")
+instance HasCField OkBefore "okBefore_x"
+    where type CFieldType OkBefore "okBefore_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct OkAfter@
 
     __defined at:__ @program-analysis\/selection_fail.h 26:8@
@@ -56,11 +56,11 @@ instance WriteRaw OkAfter
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkAfter okAfter_x_2 -> writeRaw (Proxy @"okAfter_x") ptr_0 okAfter_x_2
 deriving via (EquivStorable OkAfter) instance Storable OkAfter
-instance HasCField OkAfter "okAfter_x"
-    where type CFieldType OkAfter "okAfter_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
-    where getField = fromPtr (Proxy @"okAfter_x")
 instance (~) ty CInt => HasField "okAfter_x" OkAfter ty
     where hasField = \x_0 -> (\y_1 -> OkAfter{okAfter_x = y_1},
                               getField @"okAfter_x" x_0)
+instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+    where getField = fromPtr (Proxy @"okAfter_x")
+instance HasCField OkAfter "okAfter_x"
+    where type CFieldType OkAfter "okAfter_x" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/Example.hs
@@ -64,18 +64,6 @@ instance Marshal.WriteRaw OkBefore where
 
 deriving via Marshal.EquivStorable OkBefore instance RIP.Storable OkBefore
 
-instance HasCField.HasCField OkBefore "okBefore_x" where
-
-  type CFieldType OkBefore "okBefore_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okBefore_x" OkBefore ty where
 
@@ -83,6 +71,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkBefore {okBefore_x = y1}, RIP.getField @"okBefore_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
+
+instance HasCField.HasCField OkBefore "okBefore_x" where
+
+  type CFieldType OkBefore "okBefore_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct OkAfter@
 
@@ -125,17 +125,6 @@ instance Marshal.WriteRaw OkAfter where
 
 deriving via Marshal.EquivStorable OkAfter instance RIP.Storable OkAfter
 
-instance HasCField.HasCField OkAfter "okAfter_x" where
-
-  type CFieldType OkAfter "okAfter_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okAfter_x" OkAfter ty where
 
@@ -143,3 +132,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkAfter {okAfter_x = y1}, RIP.getField @"okAfter_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
+
+instance HasCField.HasCField OkAfter "okAfter_x" where
+
+  type CFieldType OkAfter "okAfter_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - okAfter_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - okBefore_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.2.program_slicing/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw OkBefore
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkBefore okBefore_x_2 -> writeRaw (Proxy @"okBefore_x") ptr_0 okBefore_x_2
 deriving via (EquivStorable OkBefore) instance Storable OkBefore
-instance HasCField OkBefore "okBefore_x"
-    where type CFieldType OkBefore "okBefore_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
-    where getField = fromPtr (Proxy @"okBefore_x")
 instance (~) ty CInt => HasField "okBefore_x" OkBefore ty
     where hasField = \x_0 -> (\y_1 -> OkBefore{okBefore_x = y_1},
                               getField @"okBefore_x" x_0)
+instance (~) ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+    where getField = fromPtr (Proxy @"okBefore_x")
+instance HasCField OkBefore "okBefore_x"
+    where type CFieldType OkBefore "okBefore_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct OkAfter@
 
     __defined at:__ @program-analysis\/selection_fail.h 26:8@
@@ -56,11 +56,11 @@ instance WriteRaw OkAfter
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkAfter okAfter_x_2 -> writeRaw (Proxy @"okAfter_x") ptr_0 okAfter_x_2
 deriving via (EquivStorable OkAfter) instance Storable OkAfter
-instance HasCField OkAfter "okAfter_x"
-    where type CFieldType OkAfter "okAfter_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
-    where getField = fromPtr (Proxy @"okAfter_x")
 instance (~) ty CInt => HasField "okAfter_x" OkAfter ty
     where hasField = \x_0 -> (\y_1 -> OkAfter{okAfter_x = y_1},
                               getField @"okAfter_x" x_0)
+instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+    where getField = fromPtr (Proxy @"okAfter_x")
+instance HasCField OkAfter "okAfter_x"
+    where type CFieldType OkAfter "okAfter_x" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/Example.hs
@@ -63,18 +63,6 @@ instance Marshal.WriteRaw OkBefore where
 
 deriving via Marshal.EquivStorable OkBefore instance RIP.Storable OkBefore
 
-instance HasCField.HasCField OkBefore "okBefore_x" where
-
-  type CFieldType OkBefore "okBefore_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okBefore_x" OkBefore ty where
 
@@ -82,3 +70,15 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkBefore {okBefore_x = y1}, RIP.getField @"okBefore_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
+
+instance HasCField.HasCField OkBefore "okBefore_x" where
+
+  type CFieldType OkBefore "okBefore_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - okBefore_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail.3.select_ok/th.txt
@@ -23,12 +23,12 @@ instance WriteRaw OkBefore
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkBefore okBefore_x_2 -> writeRaw (Proxy @"okBefore_x") ptr_0 okBefore_x_2
 deriving via (EquivStorable OkBefore) instance Storable OkBefore
-instance HasCField OkBefore "okBefore_x"
-    where type CFieldType OkBefore "okBefore_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
-    where getField = fromPtr (Proxy @"okBefore_x")
 instance (~) ty CInt => HasField "okBefore_x" OkBefore ty
     where hasField = \x_0 -> (\y_1 -> OkBefore{okBefore_x = y_1},
                               getField @"okBefore_x" x_0)
+instance (~) ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+    where getField = fromPtr (Proxy @"okBefore_x")
+instance HasCField OkBefore "okBefore_x"
+    where type CFieldType OkBefore "okBefore_x" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/Example.hs
@@ -64,18 +64,6 @@ instance Marshal.WriteRaw OkBefore where
 
 deriving via Marshal.EquivStorable OkBefore instance RIP.Storable OkBefore
 
-instance HasCField.HasCField OkBefore "okBefore_x" where
-
-  type CFieldType OkBefore "okBefore_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okBefore_x" OkBefore ty where
 
@@ -83,6 +71,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkBefore {okBefore_x = y1}, RIP.getField @"okBefore_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okBefore_x" (RIP.Ptr OkBefore) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"okBefore_x")
+
+instance HasCField.HasCField OkBefore "okBefore_x" where
+
+  type CFieldType OkBefore "okBefore_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct OkAfter@
 
@@ -125,17 +125,6 @@ instance Marshal.WriteRaw OkAfter where
 
 deriving via Marshal.EquivStorable OkAfter instance RIP.Storable OkAfter
 
-instance HasCField.HasCField OkAfter "okAfter_x" where
-
-  type CFieldType OkAfter "okAfter_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "okAfter_x" OkAfter ty where
 
@@ -143,3 +132,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          OkAfter {okAfter_x = y1}, RIP.getField @"okAfter_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "okAfter_x" (RIP.Ptr OkAfter) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"okAfter_x")
+
+instance HasCField.HasCField OkAfter "okAfter_x" where
+
+  type CFieldType OkAfter "okAfter_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - okAfter_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - okBefore_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_fail/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw OkBefore
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkBefore okBefore_x_2 -> writeRaw (Proxy @"okBefore_x") ptr_0 okBefore_x_2
 deriving via (EquivStorable OkBefore) instance Storable OkBefore
-instance HasCField OkBefore "okBefore_x"
-    where type CFieldType OkBefore "okBefore_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
-    where getField = fromPtr (Proxy @"okBefore_x")
 instance (~) ty CInt => HasField "okBefore_x" OkBefore ty
     where hasField = \x_0 -> (\y_1 -> OkBefore{okBefore_x = y_1},
                               getField @"okBefore_x" x_0)
+instance (~) ty CInt =>
+         HasField "okBefore_x" (Ptr OkBefore) (Ptr ty)
+    where getField = fromPtr (Proxy @"okBefore_x")
+instance HasCField OkBefore "okBefore_x"
+    where type CFieldType OkBefore "okBefore_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct OkAfter@
 
     __defined at:__ @program-analysis\/selection_fail.h 26:8@
@@ -56,11 +56,11 @@ instance WriteRaw OkAfter
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        OkAfter okAfter_x_2 -> writeRaw (Proxy @"okAfter_x") ptr_0 okAfter_x_2
 deriving via (EquivStorable OkAfter) instance Storable OkAfter
-instance HasCField OkAfter "okAfter_x"
-    where type CFieldType OkAfter "okAfter_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
-    where getField = fromPtr (Proxy @"okAfter_x")
 instance (~) ty CInt => HasField "okAfter_x" OkAfter ty
     where hasField = \x_0 -> (\y_1 -> OkAfter{okAfter_x = y_1},
                               getField @"okAfter_x" x_0)
+instance (~) ty CInt => HasField "okAfter_x" (Ptr OkAfter) (Ptr ty)
+    where getField = fromPtr (Proxy @"okAfter_x")
+instance HasCField OkAfter "okAfter_x"
+    where type CFieldType OkAfter "okAfter_x" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/Example.hs
@@ -63,17 +63,6 @@ instance Marshal.WriteRaw NewName where
 
 deriving via Marshal.EquivStorable NewName instance RIP.Storable NewName
 
-instance HasCField.HasCField NewName "newName_x" where
-
-  type CFieldType NewName "newName_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "newName_x" (RIP.Ptr NewName) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"newName_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "newName_x" NewName ty where
 
@@ -81,3 +70,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          NewName {newName_x = y1}, RIP.getField @"newName_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "newName_x" (RIP.Ptr NewName) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"newName_x")
+
+instance HasCField.HasCField NewName "newName_x" where
+
+  type CFieldType NewName "newName_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - newName_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_matches_c_names.1.positive_case/th.txt
@@ -38,14 +38,14 @@ instance WriteRaw NewName
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        NewName newName_x_2 -> writeRaw (Proxy @"newName_x") ptr_0 newName_x_2
 deriving via (EquivStorable NewName) instance Storable NewName
-instance HasCField NewName "newName_x"
-    where type CFieldType NewName "newName_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "newName_x" (Ptr NewName) (Ptr ty)
-    where getField = fromPtr (Proxy @"newName_x")
 instance (~) ty CInt => HasField "newName_x" NewName ty
     where hasField = \x_0 -> (\y_1 -> NewName{newName_x = y_1},
                               getField @"newName_x" x_0)
+instance (~) ty CInt => HasField "newName_x" (Ptr NewName) (Ptr ty)
+    where getField = fromPtr (Proxy @"newName_x")
+instance HasCField NewName "newName_x"
+    where type CFieldType NewName "newName_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_programanalysisselection_mat_Example_Safe_FunctionWithAssignedHaskellNameByNameMangler@
 foreign import ccall safe "hs_bindgen_c9b1dc5577fd8ced" hs_bindgen_c9b1dc5577fd8ced_base ::
     IO Int32

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/Example.hs
@@ -63,19 +63,6 @@ instance Marshal.WriteRaw UnrelatedDeclaration where
 
 deriving via Marshal.EquivStorable UnrelatedDeclaration instance RIP.Storable UnrelatedDeclaration
 
-instance HasCField.HasCField UnrelatedDeclaration "unrelatedDeclaration_m" where
-
-  type CFieldType UnrelatedDeclaration "unrelatedDeclaration_m" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unrelatedDeclaration_m" (RIP.Ptr UnrelatedDeclaration) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"unrelatedDeclaration_m")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "unrelatedDeclaration_m" UnrelatedDeclaration ty where
 
@@ -85,3 +72,16 @@ instance ( ty ~ RIP.CInt
           UnrelatedDeclaration {unrelatedDeclaration_m = y1}
       , RIP.getField @"unrelatedDeclaration_m" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unrelatedDeclaration_m" (RIP.Ptr UnrelatedDeclaration) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"unrelatedDeclaration_m")
+
+instance HasCField.HasCField UnrelatedDeclaration "unrelatedDeclaration_m" where
+
+  type CFieldType UnrelatedDeclaration "unrelatedDeclaration_m" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - unrelatedDeclaration_m
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_a/th.txt
@@ -24,16 +24,16 @@ instance WriteRaw UnrelatedDeclaration
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UnrelatedDeclaration unrelatedDeclaration_m_2 -> writeRaw (Proxy @"unrelatedDeclaration_m") ptr_0 unrelatedDeclaration_m_2
 deriving via (EquivStorable UnrelatedDeclaration) instance Storable UnrelatedDeclaration
-instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
-    where type CFieldType UnrelatedDeclaration
-                          "unrelatedDeclaration_m" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "unrelatedDeclaration_m" UnrelatedDeclaration ty
+    where hasField = \x_0 -> (\y_1 -> UnrelatedDeclaration{unrelatedDeclaration_m = y_1},
+                              getField @"unrelatedDeclaration_m" x_0)
 instance (~) ty CInt =>
          HasField "unrelatedDeclaration_m"
                   (Ptr UnrelatedDeclaration)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unrelatedDeclaration_m")
-instance (~) ty CInt =>
-         HasField "unrelatedDeclaration_m" UnrelatedDeclaration ty
-    where hasField = \x_0 -> (\y_1 -> UnrelatedDeclaration{unrelatedDeclaration_m = y_1},
-                              getField @"unrelatedDeclaration_m" x_0)
+instance HasCField UnrelatedDeclaration "unrelatedDeclaration_m"
+    where type CFieldType UnrelatedDeclaration
+                          "unrelatedDeclaration_m" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/Example.hs
@@ -65,17 +65,6 @@ instance Marshal.WriteRaw Omitted where
 
 deriving via Marshal.EquivStorable Omitted instance RIP.Storable Omitted
 
-instance HasCField.HasCField Omitted "omitted_n" where
-
-  type CFieldType Omitted "omitted_n" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "omitted_n" (RIP.Ptr Omitted) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"omitted_n")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "omitted_n" Omitted ty where
 
@@ -83,6 +72,17 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Omitted {omitted_n = y1}, RIP.getField @"omitted_n" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "omitted_n" (RIP.Ptr Omitted) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"omitted_n")
+
+instance HasCField.HasCField Omitted "omitted_n" where
+
+  type CFieldType Omitted "omitted_n" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct DirectlyDependsOnOmitted@
 
@@ -125,19 +125,6 @@ instance Marshal.WriteRaw DirectlyDependsOnOmitted where
 
 deriving via Marshal.EquivStorable DirectlyDependsOnOmitted instance RIP.Storable DirectlyDependsOnOmitted
 
-instance HasCField.HasCField DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" where
-
-  type CFieldType DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" =
-    Omitted
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Omitted
-         ) => RIP.HasField "directlyDependsOnOmitted_o" (RIP.Ptr DirectlyDependsOnOmitted) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"directlyDependsOnOmitted_o")
-
 instance ( ty ~ Omitted
          ) => RIP.CompatHasField.HasField "directlyDependsOnOmitted_o" DirectlyDependsOnOmitted ty where
 
@@ -147,6 +134,19 @@ instance ( ty ~ Omitted
           DirectlyDependsOnOmitted {directlyDependsOnOmitted_o = y1}
       , RIP.getField @"directlyDependsOnOmitted_o" x0
       )
+
+instance ( ty ~ Omitted
+         ) => RIP.HasField "directlyDependsOnOmitted_o" (RIP.Ptr DirectlyDependsOnOmitted) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"directlyDependsOnOmitted_o")
+
+instance HasCField.HasCField DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" where
+
+  type CFieldType DirectlyDependsOnOmitted "directlyDependsOnOmitted_o" =
+    Omitted
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct IndirectlyDependsOnOmitted@
 
@@ -189,19 +189,6 @@ instance Marshal.WriteRaw IndirectlyDependsOnOmitted where
 
 deriving via Marshal.EquivStorable IndirectlyDependsOnOmitted instance RIP.Storable IndirectlyDependsOnOmitted
 
-instance HasCField.HasCField IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" where
-
-  type CFieldType IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" =
-    DirectlyDependsOnOmitted
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ DirectlyDependsOnOmitted
-         ) => RIP.HasField "indirectlyDependsOnOmitted_d" (RIP.Ptr IndirectlyDependsOnOmitted) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"indirectlyDependsOnOmitted_d")
-
 instance ( ty ~ DirectlyDependsOnOmitted
          ) => RIP.CompatHasField.HasField "indirectlyDependsOnOmitted_d" IndirectlyDependsOnOmitted ty where
 
@@ -211,3 +198,16 @@ instance ( ty ~ DirectlyDependsOnOmitted
           IndirectlyDependsOnOmitted {indirectlyDependsOnOmitted_d = y1}
       , RIP.getField @"indirectlyDependsOnOmitted_d" x0
       )
+
+instance ( ty ~ DirectlyDependsOnOmitted
+         ) => RIP.HasField "indirectlyDependsOnOmitted_d" (RIP.Ptr IndirectlyDependsOnOmitted) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"indirectlyDependsOnOmitted_d")
+
+instance HasCField.HasCField IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" where
+
+  type CFieldType IndirectlyDependsOnOmitted "indirectlyDependsOnOmitted_d" =
+    DirectlyDependsOnOmitted
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - directlyDependsOnOmitted_o
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       fields:
       - indirectlyDependsOnOmitted_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,11 +56,12 @@ hstypes:
       fields:
       - omitted_n
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/selection_omit_external_b/th.txt
@@ -24,14 +24,14 @@ instance WriteRaw Omitted
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Omitted omitted_n_2 -> writeRaw (Proxy @"omitted_n") ptr_0 omitted_n_2
 deriving via (EquivStorable Omitted) instance Storable Omitted
-instance HasCField Omitted "omitted_n"
-    where type CFieldType Omitted "omitted_n" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "omitted_n" (Ptr Omitted) (Ptr ty)
-    where getField = fromPtr (Proxy @"omitted_n")
 instance (~) ty CInt => HasField "omitted_n" Omitted ty
     where hasField = \x_0 -> (\y_1 -> Omitted{omitted_n = y_1},
                               getField @"omitted_n" x_0)
+instance (~) ty CInt => HasField "omitted_n" (Ptr Omitted) (Ptr ty)
+    where getField = fromPtr (Proxy @"omitted_n")
+instance HasCField Omitted "omitted_n"
+    where type CFieldType Omitted "omitted_n" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct DirectlyDependsOnOmitted@
 
     __defined at:__ @program-analysis\/selection_omit_external_b.h 4:8@
@@ -56,20 +56,20 @@ instance WriteRaw DirectlyDependsOnOmitted
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        DirectlyDependsOnOmitted directlyDependsOnOmitted_o_2 -> writeRaw (Proxy @"directlyDependsOnOmitted_o") ptr_0 directlyDependsOnOmitted_o_2
 deriving via (EquivStorable DirectlyDependsOnOmitted) instance Storable DirectlyDependsOnOmitted
-instance HasCField DirectlyDependsOnOmitted
-                   "directlyDependsOnOmitted_o"
-    where type CFieldType DirectlyDependsOnOmitted
-                          "directlyDependsOnOmitted_o" = Omitted
-          offset# = \_ -> \_ -> 0
+instance (~) ty Omitted =>
+         HasField "directlyDependsOnOmitted_o" DirectlyDependsOnOmitted ty
+    where hasField = \x_0 -> (\y_1 -> DirectlyDependsOnOmitted{directlyDependsOnOmitted_o = y_1},
+                              getField @"directlyDependsOnOmitted_o" x_0)
 instance (~) ty Omitted =>
          HasField "directlyDependsOnOmitted_o"
                   (Ptr DirectlyDependsOnOmitted)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"directlyDependsOnOmitted_o")
-instance (~) ty Omitted =>
-         HasField "directlyDependsOnOmitted_o" DirectlyDependsOnOmitted ty
-    where hasField = \x_0 -> (\y_1 -> DirectlyDependsOnOmitted{directlyDependsOnOmitted_o = y_1},
-                              getField @"directlyDependsOnOmitted_o" x_0)
+instance HasCField DirectlyDependsOnOmitted
+                   "directlyDependsOnOmitted_o"
+    where type CFieldType DirectlyDependsOnOmitted
+                          "directlyDependsOnOmitted_o" = Omitted
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct IndirectlyDependsOnOmitted@
 
     __defined at:__ @program-analysis\/selection_omit_external_b.h 8:8@
@@ -94,19 +94,19 @@ instance WriteRaw IndirectlyDependsOnOmitted
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        IndirectlyDependsOnOmitted indirectlyDependsOnOmitted_d_2 -> writeRaw (Proxy @"indirectlyDependsOnOmitted_d") ptr_0 indirectlyDependsOnOmitted_d_2
 deriving via (EquivStorable IndirectlyDependsOnOmitted) instance Storable IndirectlyDependsOnOmitted
-instance HasCField IndirectlyDependsOnOmitted
-                   "indirectlyDependsOnOmitted_d"
-    where type CFieldType IndirectlyDependsOnOmitted
-                          "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
-          offset# = \_ -> \_ -> 0
-instance (~) ty DirectlyDependsOnOmitted =>
-         HasField "indirectlyDependsOnOmitted_d"
-                  (Ptr IndirectlyDependsOnOmitted)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"indirectlyDependsOnOmitted_d")
 instance (~) ty DirectlyDependsOnOmitted =>
          HasField "indirectlyDependsOnOmitted_d"
                   IndirectlyDependsOnOmitted
                   ty
     where hasField = \x_0 -> (\y_1 -> IndirectlyDependsOnOmitted{indirectlyDependsOnOmitted_d = y_1},
                               getField @"indirectlyDependsOnOmitted_d" x_0)
+instance (~) ty DirectlyDependsOnOmitted =>
+         HasField "indirectlyDependsOnOmitted_d"
+                  (Ptr IndirectlyDependsOnOmitted)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"indirectlyDependsOnOmitted_d")
+instance HasCField IndirectlyDependsOnOmitted
+                   "indirectlyDependsOnOmitted_d"
+    where type CFieldType IndirectlyDependsOnOmitted
+                          "indirectlyDependsOnOmitted_d" = DirectlyDependsOnOmitted
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/Example.hs
@@ -168,6 +168,14 @@ newtype Struct5_t = Struct5_t
     )
 
 instance ( ty ~ RIP.Ptr Struct5
+         ) => RIP.CompatHasField.HasField "unwrapStruct5_t" Struct5_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct5_t {unwrapStruct5_t = y1}, RIP.getField @"unwrapStruct5_t" x0)
+
+instance ( ty ~ RIP.Ptr Struct5
          ) => RIP.HasField "unwrapStruct5_t" (RIP.Ptr Struct5_t) (RIP.Ptr ty) where
 
   getField =
@@ -179,14 +187,6 @@ instance HasCField.HasCField Struct5_t "unwrapStruct5_t" where
     RIP.Ptr Struct5
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Struct5
-         ) => RIP.CompatHasField.HasField "unwrapStruct5_t" Struct5_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct5_t {unwrapStruct5_t = y1}, RIP.getField @"unwrapStruct5_t" x0)
 
 {-| __C declaration:__ @struct struct6@
 
@@ -237,6 +237,14 @@ newtype Struct6 = Struct6
     )
 
 instance ( ty ~ RIP.Ptr Struct6_Aux
+         ) => RIP.CompatHasField.HasField "unwrapStruct6" Struct6 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct6 {unwrapStruct6 = y1}, RIP.getField @"unwrapStruct6" x0)
+
+instance ( ty ~ RIP.Ptr Struct6_Aux
          ) => RIP.HasField "unwrapStruct6" (RIP.Ptr Struct6) (RIP.Ptr ty) where
 
   getField =
@@ -248,14 +256,6 @@ instance HasCField.HasCField Struct6 "unwrapStruct6" where
     RIP.Ptr Struct6_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Struct6_Aux
-         ) => RIP.CompatHasField.HasField "unwrapStruct6" Struct6 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct6 {unwrapStruct6 = y1}, RIP.getField @"unwrapStruct6" x0)
 
 {-| __C declaration:__ @struct struct7@
 
@@ -305,6 +305,14 @@ newtype Struct7a = Struct7a
     )
 
 instance ( ty ~ Struct7
+         ) => RIP.CompatHasField.HasField "unwrapStruct7a" Struct7a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct7a {unwrapStruct7a = y1}, RIP.getField @"unwrapStruct7a" x0)
+
+instance ( ty ~ Struct7
          ) => RIP.HasField "unwrapStruct7a" (RIP.Ptr Struct7a) (RIP.Ptr ty) where
 
   getField =
@@ -315,14 +323,6 @@ instance HasCField.HasCField Struct7a "unwrapStruct7a" where
   type CFieldType Struct7a "unwrapStruct7a" = Struct7
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct7
-         ) => RIP.CompatHasField.HasField "unwrapStruct7a" Struct7a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct7a {unwrapStruct7a = y1}, RIP.getField @"unwrapStruct7a" x0)
 
 {-| __C declaration:__ @struct7b@
 
@@ -342,6 +342,14 @@ newtype Struct7b = Struct7b
     )
 
 instance ( ty ~ Struct7
+         ) => RIP.CompatHasField.HasField "unwrapStruct7b" Struct7b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct7b {unwrapStruct7b = y1}, RIP.getField @"unwrapStruct7b" x0)
+
+instance ( ty ~ Struct7
          ) => RIP.HasField "unwrapStruct7b" (RIP.Ptr Struct7b) (RIP.Ptr ty) where
 
   getField =
@@ -352,14 +360,6 @@ instance HasCField.HasCField Struct7b "unwrapStruct7b" where
   type CFieldType Struct7b "unwrapStruct7b" = Struct7
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct7
-         ) => RIP.CompatHasField.HasField "unwrapStruct7b" Struct7b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct7b {unwrapStruct7b = y1}, RIP.getField @"unwrapStruct7b" x0)
 
 {-| __C declaration:__ @struct struct8@
 
@@ -409,6 +409,14 @@ newtype Struct8b = Struct8b
     )
 
 instance ( ty ~ Struct8
+         ) => RIP.CompatHasField.HasField "unwrapStruct8b" Struct8b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct8b {unwrapStruct8b = y1}, RIP.getField @"unwrapStruct8b" x0)
+
+instance ( ty ~ Struct8
          ) => RIP.HasField "unwrapStruct8b" (RIP.Ptr Struct8b) (RIP.Ptr ty) where
 
   getField =
@@ -419,14 +427,6 @@ instance HasCField.HasCField Struct8b "unwrapStruct8b" where
   type CFieldType Struct8b "unwrapStruct8b" = Struct8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct8
-         ) => RIP.CompatHasField.HasField "unwrapStruct8b" Struct8b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct8b {unwrapStruct8b = y1}, RIP.getField @"unwrapStruct8b" x0)
 
 {-| __C declaration:__ @struct struct9@
 
@@ -476,6 +476,14 @@ newtype Struct9_t = Struct9_t
     )
 
 instance ( ty ~ Struct9
+         ) => RIP.CompatHasField.HasField "unwrapStruct9_t" Struct9_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Struct9_t {unwrapStruct9_t = y1}, RIP.getField @"unwrapStruct9_t" x0)
+
+instance ( ty ~ Struct9
          ) => RIP.HasField "unwrapStruct9_t" (RIP.Ptr Struct9_t) (RIP.Ptr ty) where
 
   getField =
@@ -486,14 +494,6 @@ instance HasCField.HasCField Struct9_t "unwrapStruct9_t" where
   type CFieldType Struct9_t "unwrapStruct9_t" = Struct9
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct9
-         ) => RIP.CompatHasField.HasField "unwrapStruct9_t" Struct9_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Struct9_t {unwrapStruct9_t = y1}, RIP.getField @"unwrapStruct9_t" x0)
 
 {-| __C declaration:__ @struct struct10@
 
@@ -543,6 +543,15 @@ newtype Struct10_t_t = Struct10_t_t
     )
 
 instance ( ty ~ Struct10_t
+         ) => RIP.CompatHasField.HasField "unwrapStruct10_t_t" Struct10_t_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Struct10_t_t {unwrapStruct10_t_t = y1}
+      , RIP.getField @"unwrapStruct10_t_t" x0
+      )
+
+instance ( ty ~ Struct10_t
          ) => RIP.HasField "unwrapStruct10_t_t" (RIP.Ptr Struct10_t_t) (RIP.Ptr ty) where
 
   getField =
@@ -554,15 +563,6 @@ instance HasCField.HasCField Struct10_t_t "unwrapStruct10_t_t" where
     Struct10_t
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct10_t
-         ) => RIP.CompatHasField.HasField "unwrapStruct10_t_t" Struct10_t_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Struct10_t_t {unwrapStruct10_t_t = y1}
-      , RIP.getField @"unwrapStruct10_t_t" x0
-      )
 
 {-| __C declaration:__ @struct struct11@
 
@@ -614,18 +614,6 @@ instance Marshal.WriteRaw Struct11_t where
 
 deriving via Marshal.EquivStorable Struct11_t instance RIP.Storable Struct11_t
 
-instance HasCField.HasCField Struct11_t "struct11_t_x" where
-
-  type CFieldType Struct11_t "struct11_t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct11_t_x" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"struct11_t_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct11_t_x" Struct11_t ty where
 
@@ -636,18 +624,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"struct11_t_x" x0
       )
 
-instance HasCField.HasCField Struct11_t "struct11_t_self" where
-
-  type CFieldType Struct11_t "struct11_t_self" =
-    RIP.Ptr Struct11_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Struct11_t
-         ) => RIP.HasField "struct11_t_self" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct11_t_x" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"struct11_t_self")
+    HasCField.fromPtr (RIP.Proxy @"struct11_t_x")
+
+instance HasCField.HasCField Struct11_t "struct11_t_x" where
+
+  type CFieldType Struct11_t "struct11_t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Struct11_t
          ) => RIP.CompatHasField.HasField "struct11_t_self" Struct11_t ty where
@@ -658,6 +645,19 @@ instance ( ty ~ RIP.Ptr Struct11_t
           Struct11_t {struct11_t_self = y1, struct11_t_x = RIP.getField @"struct11_t_x" x0}
       , RIP.getField @"struct11_t_self" x0
       )
+
+instance ( ty ~ RIP.Ptr Struct11_t
+         ) => RIP.HasField "struct11_t_self" (RIP.Ptr Struct11_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"struct11_t_self")
+
+instance HasCField.HasCField Struct11_t "struct11_t_self" where
+
+  type CFieldType Struct11_t "struct11_t_self" =
+    RIP.Ptr Struct11_t
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct struct12@
 
@@ -709,18 +709,6 @@ instance Marshal.WriteRaw Struct12_t where
 
 deriving via Marshal.EquivStorable Struct12_t instance RIP.Storable Struct12_t
 
-instance HasCField.HasCField Struct12_t "struct12_t_x" where
-
-  type CFieldType Struct12_t "struct12_t_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct12_t_x" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"struct12_t_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct12_t_x" Struct12_t ty where
 
@@ -731,18 +719,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"struct12_t_x" x0
       )
 
-instance HasCField.HasCField Struct12_t "struct12_t_self" where
-
-  type CFieldType Struct12_t "struct12_t_self" =
-    RIP.Ptr Struct12_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Struct12_t
-         ) => RIP.HasField "struct12_t_self" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct12_t_x" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"struct12_t_self")
+    HasCField.fromPtr (RIP.Proxy @"struct12_t_x")
+
+instance HasCField.HasCField Struct12_t "struct12_t_x" where
+
+  type CFieldType Struct12_t "struct12_t_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Struct12_t
          ) => RIP.CompatHasField.HasField "struct12_t_self" Struct12_t ty where
@@ -753,6 +740,19 @@ instance ( ty ~ RIP.Ptr Struct12_t
           Struct12_t {struct12_t_self = y1, struct12_t_x = RIP.getField @"struct12_t_x" x0}
       , RIP.getField @"struct12_t_self" x0
       )
+
+instance ( ty ~ RIP.Ptr Struct12_t
+         ) => RIP.HasField "struct12_t_self" (RIP.Ptr Struct12_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"struct12_t_self")
+
+instance HasCField.HasCField Struct12_t "struct12_t_self" where
+
+  type CFieldType Struct12_t "struct12_t_self" =
+    RIP.Ptr Struct12_t
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct use_sites@
 
@@ -966,19 +966,6 @@ instance Marshal.WriteRaw Use_sites where
 
 deriving via Marshal.EquivStorable Use_sites instance RIP.Storable Use_sites
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct1_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct1_t" =
-    Struct1_t
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct1_t
-         ) => RIP.HasField "use_sites_useTypedef_struct1_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct1_t")
-
 instance ( ty ~ Struct1_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct1_t" Use_sites ty where
 
@@ -1007,18 +994,18 @@ instance ( ty ~ Struct1_t
       , RIP.getField @"use_sites_useTypedef_struct1_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct2_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct2_t" =
-    Struct2_t
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Struct2_t
-         ) => RIP.HasField "use_sites_useTypedef_struct2_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct1_t
+         ) => RIP.HasField "use_sites_useTypedef_struct1_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct2_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct1_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct1_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct1_t" =
+    Struct1_t
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Struct2_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct2_t" Use_sites ty where
@@ -1048,18 +1035,18 @@ instance ( ty ~ Struct2_t
       , RIP.getField @"use_sites_useTypedef_struct2_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct3_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct3_t" =
-    RIP.Ptr Struct3_t
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Struct3_t
-         ) => RIP.HasField "use_sites_useTypedef_struct3_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct2_t
+         ) => RIP.HasField "use_sites_useTypedef_struct2_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct3_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct2_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct2_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct2_t" =
+    Struct2_t
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Struct3_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct3_t" Use_sites ty where
@@ -1089,18 +1076,18 @@ instance ( ty ~ RIP.Ptr Struct3_t
       , RIP.getField @"use_sites_useTypedef_struct3_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct4_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct4_t" =
-    RIP.Ptr Struct4_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Struct4_t
-         ) => RIP.HasField "use_sites_useTypedef_struct4_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr Struct3_t
+         ) => RIP.HasField "use_sites_useTypedef_struct3_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct4_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct3_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct3_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct3_t" =
+    RIP.Ptr Struct3_t
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Struct4_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct4_t" Use_sites ty where
@@ -1130,18 +1117,18 @@ instance ( ty ~ RIP.Ptr Struct4_t
       , RIP.getField @"use_sites_useTypedef_struct4_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useStruct_struct5" where
-
-  type CFieldType Use_sites "use_sites_useStruct_struct5" =
-    Struct5
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ Struct5
-         ) => RIP.HasField "use_sites_useStruct_struct5" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Ptr Struct4_t
+         ) => RIP.HasField "use_sites_useTypedef_struct4_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct5")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct4_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct4_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct4_t" =
+    RIP.Ptr Struct4_t
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ Struct5
          ) => RIP.CompatHasField.HasField "use_sites_useStruct_struct5" Use_sites ty where
@@ -1171,18 +1158,18 @@ instance ( ty ~ Struct5
       , RIP.getField @"use_sites_useStruct_struct5" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct5_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct5_t" =
-    Struct5_t
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ Struct5_t
-         ) => RIP.HasField "use_sites_useTypedef_struct5_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct5
+         ) => RIP.HasField "use_sites_useStruct_struct5" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct5_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct5")
+
+instance HasCField.HasCField Use_sites "use_sites_useStruct_struct5" where
+
+  type CFieldType Use_sites "use_sites_useStruct_struct5" =
+    Struct5
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ Struct5_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct5_t" Use_sites ty where
@@ -1212,18 +1199,18 @@ instance ( ty ~ Struct5_t
       , RIP.getField @"use_sites_useTypedef_struct5_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6" where
-
-  type CFieldType Use_sites "use_sites_useStruct_struct6" =
-    Struct6_Aux
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ Struct6_Aux
-         ) => RIP.HasField "use_sites_useStruct_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct5_t
+         ) => RIP.HasField "use_sites_useTypedef_struct5_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct5_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct5_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct5_t" =
+    Struct5_t
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ Struct6_Aux
          ) => RIP.CompatHasField.HasField "use_sites_useStruct_struct6" Use_sites ty where
@@ -1253,18 +1240,18 @@ instance ( ty ~ Struct6_Aux
       , RIP.getField @"use_sites_useStruct_struct6" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct6" =
-    Struct6
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ Struct6
-         ) => RIP.HasField "use_sites_useTypedef_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct6_Aux
+         ) => RIP.HasField "use_sites_useStruct_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useStruct_struct6")
+
+instance HasCField.HasCField Use_sites "use_sites_useStruct_struct6" where
+
+  type CFieldType Use_sites "use_sites_useStruct_struct6" =
+    Struct6_Aux
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ Struct6
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct6" Use_sites ty where
@@ -1294,18 +1281,18 @@ instance ( ty ~ Struct6
       , RIP.getField @"use_sites_useTypedef_struct6" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7a" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct7a" =
-    Struct7a
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct7a
-         ) => RIP.HasField "use_sites_useTypedef_struct7a" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct6
+         ) => RIP.HasField "use_sites_useTypedef_struct6" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7a")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct6")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct6" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct6" =
+    Struct6
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ Struct7a
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct7a" Use_sites ty where
@@ -1335,18 +1322,18 @@ instance ( ty ~ Struct7a
       , RIP.getField @"use_sites_useTypedef_struct7a" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7b" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct7b" =
-    Struct7b
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct7b
-         ) => RIP.HasField "use_sites_useTypedef_struct7b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct7a
+         ) => RIP.HasField "use_sites_useTypedef_struct7a" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7b")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7a")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7a" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct7a" =
+    Struct7a
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct7b
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct7b" Use_sites ty where
@@ -1376,18 +1363,18 @@ instance ( ty ~ Struct7b
       , RIP.getField @"use_sites_useTypedef_struct7b" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct8" =
-    Struct8
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct8
-         ) => RIP.HasField "use_sites_useTypedef_struct8" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct7b
+         ) => RIP.HasField "use_sites_useTypedef_struct7b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct7b")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct7b" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct7b" =
+    Struct7b
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct8
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct8" Use_sites ty where
@@ -1417,18 +1404,18 @@ instance ( ty ~ Struct8
       , RIP.getField @"use_sites_useTypedef_struct8" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8b" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct8b" =
-    Struct8b
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct8b
-         ) => RIP.HasField "use_sites_useTypedef_struct8b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct8
+         ) => RIP.HasField "use_sites_useTypedef_struct8" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8b")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct8" =
+    Struct8
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct8b
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct8b" Use_sites ty where
@@ -1458,18 +1445,18 @@ instance ( ty ~ Struct8b
       , RIP.getField @"use_sites_useTypedef_struct8b" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct9" =
-    Struct9
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct9
-         ) => RIP.HasField "use_sites_useTypedef_struct9" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct8b
+         ) => RIP.HasField "use_sites_useTypedef_struct8b" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct8b")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct8b" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct8b" =
+    Struct8b
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct9
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct9" Use_sites ty where
@@ -1499,18 +1486,18 @@ instance ( ty ~ Struct9
       , RIP.getField @"use_sites_useTypedef_struct9" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct9_t" =
-    Struct9_t
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct9_t
-         ) => RIP.HasField "use_sites_useTypedef_struct9_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct9
+         ) => RIP.HasField "use_sites_useTypedef_struct9" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct9" =
+    Struct9
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct9_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct9_t" Use_sites ty where
@@ -1540,18 +1527,18 @@ instance ( ty ~ Struct9_t
       , RIP.getField @"use_sites_useTypedef_struct9_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct10_t" =
-    Struct10_t
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct10_t
-         ) => RIP.HasField "use_sites_useTypedef_struct10_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct9_t
+         ) => RIP.HasField "use_sites_useTypedef_struct9_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct9_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct9_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct9_t" =
+    Struct9_t
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct10_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct10_t" Use_sites ty where
@@ -1581,18 +1568,18 @@ instance ( ty ~ Struct10_t
       , RIP.getField @"use_sites_useTypedef_struct10_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct10_t_t" =
-    Struct10_t_t
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct10_t_t
-         ) => RIP.HasField "use_sites_useTypedef_struct10_t_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct10_t
+         ) => RIP.HasField "use_sites_useTypedef_struct10_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct10_t" =
+    Struct10_t
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct10_t_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct10_t_t" Use_sites ty where
@@ -1622,18 +1609,18 @@ instance ( ty ~ Struct10_t_t
       , RIP.getField @"use_sites_useTypedef_struct10_t_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct11_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct11_t" =
-    Struct11_t
-
-  offset# = \_ -> \_ -> 32
-
-instance ( ty ~ Struct11_t
-         ) => RIP.HasField "use_sites_useTypedef_struct11_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct10_t_t
+         ) => RIP.HasField "use_sites_useTypedef_struct10_t_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct11_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct10_t_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct10_t_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct10_t_t" =
+    Struct10_t_t
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct11_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct11_t" Use_sites ty where
@@ -1663,18 +1650,18 @@ instance ( ty ~ Struct11_t
       , RIP.getField @"use_sites_useTypedef_struct11_t" x0
       )
 
-instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct12_t" where
-
-  type CFieldType Use_sites "use_sites_useTypedef_struct12_t" =
-    Struct12_t
-
-  offset# = \_ -> \_ -> 48
-
-instance ( ty ~ Struct12_t
-         ) => RIP.HasField "use_sites_useTypedef_struct12_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+instance ( ty ~ Struct11_t
+         ) => RIP.HasField "use_sites_useTypedef_struct11_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct12_t")
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct11_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct11_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct11_t" =
+    Struct11_t
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ Struct12_t
          ) => RIP.CompatHasField.HasField "use_sites_useTypedef_struct12_t" Use_sites ty where
@@ -1703,3 +1690,16 @@ instance ( ty ~ Struct12_t
                     }
       , RIP.getField @"use_sites_useTypedef_struct12_t" x0
       )
+
+instance ( ty ~ Struct12_t
+         ) => RIP.HasField "use_sites_useTypedef_struct12_t" (RIP.Ptr Use_sites) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"use_sites_useTypedef_struct12_t")
+
+instance HasCField.HasCField Use_sites "use_sites_useTypedef_struct12_t" where
+
+  type CFieldType Use_sites "use_sites_useTypedef_struct12_t" =
+    Struct12_t
+
+  offset# = \_ -> \_ -> 48

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/bindingspec.yaml
@@ -111,11 +111,12 @@ hstypes:
       fields:
       - unwrapStruct10_t_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -129,11 +130,12 @@ hstypes:
       - struct11_t_x
       - struct11_t_self
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -147,11 +149,12 @@ hstypes:
       - struct12_t_x
       - struct12_t_self
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -207,12 +210,13 @@ hstypes:
       fields:
       - unwrapStruct5_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -226,12 +230,13 @@ hstypes:
       fields:
       - unwrapStruct6
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -271,11 +276,12 @@ hstypes:
       fields:
       - unwrapStruct7a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -288,11 +294,12 @@ hstypes:
       fields:
       - unwrapStruct7b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -318,11 +325,12 @@ hstypes:
       fields:
       - unwrapStruct8b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -348,11 +356,12 @@ hstypes:
       fields:
       - unwrapStruct9_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -382,11 +391,12 @@ hstypes:
       - use_sites_useTypedef_struct11_t
       - use_sites_useTypedef_struct12_t
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/typedef_analysis/th.txt
@@ -76,15 +76,15 @@ newtype Struct5_t
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Struct5) =>
+         HasField "unwrapStruct5_t" Struct5_t ty
+    where hasField = \x_0 -> (\y_1 -> Struct5_t{unwrapStruct5_t = y_1},
+                              getField @"unwrapStruct5_t" x_0)
+instance (~) ty (Ptr Struct5) =>
          HasField "unwrapStruct5_t" (Ptr Struct5_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct5_t")
 instance HasCField Struct5_t "unwrapStruct5_t"
     where type CFieldType Struct5_t "unwrapStruct5_t" = Ptr Struct5
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Struct5) =>
-         HasField "unwrapStruct5_t" Struct5_t ty
-    where hasField = \x_0 -> (\y_1 -> Struct5_t{unwrapStruct5_t = y_1},
-                              getField @"unwrapStruct5_t" x_0)
 {-| __C declaration:__ @struct struct6@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 25:16@
@@ -118,15 +118,15 @@ newtype Struct6
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr Struct6_Aux) =>
+         HasField "unwrapStruct6" Struct6 ty
+    where hasField = \x_0 -> (\y_1 -> Struct6{unwrapStruct6 = y_1},
+                              getField @"unwrapStruct6" x_0)
+instance (~) ty (Ptr Struct6_Aux) =>
          HasField "unwrapStruct6" (Ptr Struct6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct6")
 instance HasCField Struct6 "unwrapStruct6"
     where type CFieldType Struct6 "unwrapStruct6" = Ptr Struct6_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Struct6_Aux) =>
-         HasField "unwrapStruct6" Struct6 ty
-    where hasField = \x_0 -> (\y_1 -> Struct6{unwrapStruct6 = y_1},
-                              getField @"unwrapStruct6" x_0)
 {-| __C declaration:__ @struct struct7@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 28:8@
@@ -153,15 +153,15 @@ newtype Struct7a
     = Struct7a {unwrapStruct7a :: Struct7}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Struct7 => HasField "unwrapStruct7a" Struct7a ty
+    where hasField = \x_0 -> (\y_1 -> Struct7a{unwrapStruct7a = y_1},
+                              getField @"unwrapStruct7a" x_0)
 instance (~) ty Struct7 =>
          HasField "unwrapStruct7a" (Ptr Struct7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct7a")
 instance HasCField Struct7a "unwrapStruct7a"
     where type CFieldType Struct7a "unwrapStruct7a" = Struct7
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct7 => HasField "unwrapStruct7a" Struct7a ty
-    where hasField = \x_0 -> (\y_1 -> Struct7a{unwrapStruct7a = y_1},
-                              getField @"unwrapStruct7a" x_0)
 {-| __C declaration:__ @struct7b@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 30:24@
@@ -172,15 +172,15 @@ newtype Struct7b
     = Struct7b {unwrapStruct7b :: Struct7}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Struct7 => HasField "unwrapStruct7b" Struct7b ty
+    where hasField = \x_0 -> (\y_1 -> Struct7b{unwrapStruct7b = y_1},
+                              getField @"unwrapStruct7b" x_0)
 instance (~) ty Struct7 =>
          HasField "unwrapStruct7b" (Ptr Struct7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct7b")
 instance HasCField Struct7b "unwrapStruct7b"
     where type CFieldType Struct7b "unwrapStruct7b" = Struct7
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct7 => HasField "unwrapStruct7b" Struct7b ty
-    where hasField = \x_0 -> (\y_1 -> Struct7b{unwrapStruct7b = y_1},
-                              getField @"unwrapStruct7b" x_0)
 {-| __C declaration:__ @struct struct8@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 33:8@
@@ -207,15 +207,15 @@ newtype Struct8b
     = Struct8b {unwrapStruct8b :: Struct8}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Struct8 => HasField "unwrapStruct8b" Struct8b ty
+    where hasField = \x_0 -> (\y_1 -> Struct8b{unwrapStruct8b = y_1},
+                              getField @"unwrapStruct8b" x_0)
 instance (~) ty Struct8 =>
          HasField "unwrapStruct8b" (Ptr Struct8b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct8b")
 instance HasCField Struct8b "unwrapStruct8b"
     where type CFieldType Struct8b "unwrapStruct8b" = Struct8
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct8 => HasField "unwrapStruct8b" Struct8b ty
-    where hasField = \x_0 -> (\y_1 -> Struct8b{unwrapStruct8b = y_1},
-                              getField @"unwrapStruct8b" x_0)
 {-| __C declaration:__ @struct struct9@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 38:8@
@@ -242,15 +242,15 @@ newtype Struct9_t
     = Struct9_t {unwrapStruct9_t :: Struct9}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty Struct9 => HasField "unwrapStruct9_t" Struct9_t ty
+    where hasField = \x_0 -> (\y_1 -> Struct9_t{unwrapStruct9_t = y_1},
+                              getField @"unwrapStruct9_t" x_0)
 instance (~) ty Struct9 =>
          HasField "unwrapStruct9_t" (Ptr Struct9_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct9_t")
 instance HasCField Struct9_t "unwrapStruct9_t"
     where type CFieldType Struct9_t "unwrapStruct9_t" = Struct9
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct9 => HasField "unwrapStruct9_t" Struct9_t ty
-    where hasField = \x_0 -> (\y_1 -> Struct9_t{unwrapStruct9_t = y_1},
-                              getField @"unwrapStruct9_t" x_0)
 {-| __C declaration:__ @struct struct10@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 46:8@
@@ -278,16 +278,16 @@ newtype Struct10_t_t
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty Struct10_t =>
+         HasField "unwrapStruct10_t_t" Struct10_t_t ty
+    where hasField = \x_0 -> (\y_1 -> Struct10_t_t{unwrapStruct10_t_t = y_1},
+                              getField @"unwrapStruct10_t_t" x_0)
+instance (~) ty Struct10_t =>
          HasField "unwrapStruct10_t_t" (Ptr Struct10_t_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapStruct10_t_t")
 instance HasCField Struct10_t_t "unwrapStruct10_t_t"
     where type CFieldType Struct10_t_t
                           "unwrapStruct10_t_t" = Struct10_t
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct10_t =>
-         HasField "unwrapStruct10_t_t" Struct10_t_t ty
-    where hasField = \x_0 -> (\y_1 -> Struct10_t_t{unwrapStruct10_t_t = y_1},
-                              getField @"unwrapStruct10_t_t" x_0)
 {-| __C declaration:__ @struct struct11@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 51:8@
@@ -320,27 +320,27 @@ instance WriteRaw Struct11_t
                                        Struct11_t struct11_t_x_2
                                                   struct11_t_self_3 -> writeRaw (Proxy @"struct11_t_x") ptr_0 struct11_t_x_2 >> writeRaw (Proxy @"struct11_t_self") ptr_0 struct11_t_self_3
 deriving via (EquivStorable Struct11_t) instance Storable Struct11_t
-instance HasCField Struct11_t "struct11_t_x"
-    where type CFieldType Struct11_t "struct11_t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "struct11_t_x" (Ptr Struct11_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct11_t_x")
 instance (~) ty CInt => HasField "struct11_t_x" Struct11_t ty
     where hasField = \x_0 -> (\y_1 -> Struct11_t{struct11_t_x = y_1,
                                                  struct11_t_self = getField @"struct11_t_self" x_0},
                               getField @"struct11_t_x" x_0)
-instance HasCField Struct11_t "struct11_t_self"
-    where type CFieldType Struct11_t "struct11_t_self" = Ptr Struct11_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct11_t) =>
-         HasField "struct11_t_self" (Ptr Struct11_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct11_t_self")
+instance (~) ty CInt =>
+         HasField "struct11_t_x" (Ptr Struct11_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct11_t_x")
+instance HasCField Struct11_t "struct11_t_x"
+    where type CFieldType Struct11_t "struct11_t_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Struct11_t) =>
          HasField "struct11_t_self" Struct11_t ty
     where hasField = \x_0 -> (\y_1 -> Struct11_t{struct11_t_self = y_1,
                                                  struct11_t_x = getField @"struct11_t_x" x_0},
                               getField @"struct11_t_self" x_0)
+instance (~) ty (Ptr Struct11_t) =>
+         HasField "struct11_t_self" (Ptr Struct11_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct11_t_self")
+instance HasCField Struct11_t "struct11_t_self"
+    where type CFieldType Struct11_t "struct11_t_self" = Ptr Struct11_t
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct struct12@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 60:8@
@@ -373,27 +373,27 @@ instance WriteRaw Struct12_t
                                        Struct12_t struct12_t_x_2
                                                   struct12_t_self_3 -> writeRaw (Proxy @"struct12_t_x") ptr_0 struct12_t_x_2 >> writeRaw (Proxy @"struct12_t_self") ptr_0 struct12_t_self_3
 deriving via (EquivStorable Struct12_t) instance Storable Struct12_t
-instance HasCField Struct12_t "struct12_t_x"
-    where type CFieldType Struct12_t "struct12_t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "struct12_t_x" (Ptr Struct12_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct12_t_x")
 instance (~) ty CInt => HasField "struct12_t_x" Struct12_t ty
     where hasField = \x_0 -> (\y_1 -> Struct12_t{struct12_t_x = y_1,
                                                  struct12_t_self = getField @"struct12_t_self" x_0},
                               getField @"struct12_t_x" x_0)
-instance HasCField Struct12_t "struct12_t_self"
-    where type CFieldType Struct12_t "struct12_t_self" = Ptr Struct12_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct12_t) =>
-         HasField "struct12_t_self" (Ptr Struct12_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct12_t_self")
+instance (~) ty CInt =>
+         HasField "struct12_t_x" (Ptr Struct12_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct12_t_x")
+instance HasCField Struct12_t "struct12_t_x"
+    where type CFieldType Struct12_t "struct12_t_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Struct12_t) =>
          HasField "struct12_t_self" Struct12_t ty
     where hasField = \x_0 -> (\y_1 -> Struct12_t{struct12_t_self = y_1,
                                                  struct12_t_x = getField @"struct12_t_x" x_0},
                               getField @"struct12_t_self" x_0)
+instance (~) ty (Ptr Struct12_t) =>
+         HasField "struct12_t_self" (Ptr Struct12_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct12_t_self")
+instance HasCField Struct12_t "struct12_t_self"
+    where type CFieldType Struct12_t "struct12_t_self" = Ptr Struct12_t
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct use_sites@
 
     __defined at:__ @program-analysis\/typedef_analysis.h 66:8@
@@ -554,13 +554,6 @@ instance WriteRaw Use_sites
                                                  use_sites_useTypedef_struct11_t_18
                                                  use_sites_useTypedef_struct12_t_19 -> writeRaw (Proxy @"use_sites_useTypedef_struct1_t") ptr_0 use_sites_useTypedef_struct1_t_2 >> (writeRaw (Proxy @"use_sites_useTypedef_struct2_t") ptr_0 use_sites_useTypedef_struct2_t_3 >> (writeRaw (Proxy @"use_sites_useTypedef_struct3_t") ptr_0 use_sites_useTypedef_struct3_t_4 >> (writeRaw (Proxy @"use_sites_useTypedef_struct4_t") ptr_0 use_sites_useTypedef_struct4_t_5 >> (writeRaw (Proxy @"use_sites_useStruct_struct5") ptr_0 use_sites_useStruct_struct5_6 >> (writeRaw (Proxy @"use_sites_useTypedef_struct5_t") ptr_0 use_sites_useTypedef_struct5_t_7 >> (writeRaw (Proxy @"use_sites_useStruct_struct6") ptr_0 use_sites_useStruct_struct6_8 >> (writeRaw (Proxy @"use_sites_useTypedef_struct6") ptr_0 use_sites_useTypedef_struct6_9 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7a") ptr_0 use_sites_useTypedef_struct7a_10 >> (writeRaw (Proxy @"use_sites_useTypedef_struct7b") ptr_0 use_sites_useTypedef_struct7b_11 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8") ptr_0 use_sites_useTypedef_struct8_12 >> (writeRaw (Proxy @"use_sites_useTypedef_struct8b") ptr_0 use_sites_useTypedef_struct8b_13 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9") ptr_0 use_sites_useTypedef_struct9_14 >> (writeRaw (Proxy @"use_sites_useTypedef_struct9_t") ptr_0 use_sites_useTypedef_struct9_t_15 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t") ptr_0 use_sites_useTypedef_struct10_t_16 >> (writeRaw (Proxy @"use_sites_useTypedef_struct10_t_t") ptr_0 use_sites_useTypedef_struct10_t_t_17 >> (writeRaw (Proxy @"use_sites_useTypedef_struct11_t") ptr_0 use_sites_useTypedef_struct11_t_18 >> writeRaw (Proxy @"use_sites_useTypedef_struct12_t") ptr_0 use_sites_useTypedef_struct12_t_19))))))))))))))))
 deriving via (EquivStorable Use_sites) instance Storable Use_sites
-instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
-    where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct1_t" = Struct1_t
-          offset# = \_ -> \_ -> 0
-instance (~) ty Struct1_t =>
-         HasField "use_sites_useTypedef_struct1_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct1_t")
 instance (~) ty Struct1_t =>
          HasField "use_sites_useTypedef_struct1_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct1_t = y_1,
@@ -582,13 +575,13 @@ instance (~) ty Struct1_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct1_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct2_t"
+instance (~) ty Struct1_t =>
+         HasField "use_sites_useTypedef_struct1_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct1_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct1_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct2_t" = Struct2_t
+                          "use_sites_useTypedef_struct1_t" = Struct1_t
           offset# = \_ -> \_ -> 0
-instance (~) ty Struct2_t =>
-         HasField "use_sites_useTypedef_struct2_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct2_t")
 instance (~) ty Struct2_t =>
          HasField "use_sites_useTypedef_struct2_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct2_t = y_1,
@@ -610,13 +603,13 @@ instance (~) ty Struct2_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct2_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct3_t"
+instance (~) ty Struct2_t =>
+         HasField "use_sites_useTypedef_struct2_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct2_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct2_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct3_t" = Ptr Struct3_t
+                          "use_sites_useTypedef_struct2_t" = Struct2_t
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Struct3_t) =>
-         HasField "use_sites_useTypedef_struct3_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct3_t")
 instance (~) ty (Ptr Struct3_t) =>
          HasField "use_sites_useTypedef_struct3_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct3_t = y_1,
@@ -638,13 +631,13 @@ instance (~) ty (Ptr Struct3_t) =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct3_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct4_t"
+instance (~) ty (Ptr Struct3_t) =>
+         HasField "use_sites_useTypedef_struct3_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct3_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct3_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct4_t" = Ptr Struct4_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Struct4_t) =>
-         HasField "use_sites_useTypedef_struct4_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct4_t")
+                          "use_sites_useTypedef_struct3_t" = Ptr Struct3_t
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Struct4_t) =>
          HasField "use_sites_useTypedef_struct4_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct4_t = y_1,
@@ -666,13 +659,13 @@ instance (~) ty (Ptr Struct4_t) =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct4_t" x_0)
-instance HasCField Use_sites "use_sites_useStruct_struct5"
+instance (~) ty (Ptr Struct4_t) =>
+         HasField "use_sites_useTypedef_struct4_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct4_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct4_t"
     where type CFieldType Use_sites
-                          "use_sites_useStruct_struct5" = Struct5
-          offset# = \_ -> \_ -> 16
-instance (~) ty Struct5 =>
-         HasField "use_sites_useStruct_struct5" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useStruct_struct5")
+                          "use_sites_useTypedef_struct4_t" = Ptr Struct4_t
+          offset# = \_ -> \_ -> 8
 instance (~) ty Struct5 =>
          HasField "use_sites_useStruct_struct5" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useStruct_struct5 = y_1,
@@ -694,13 +687,13 @@ instance (~) ty Struct5 =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useStruct_struct5" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
+instance (~) ty Struct5 =>
+         HasField "use_sites_useStruct_struct5" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useStruct_struct5")
+instance HasCField Use_sites "use_sites_useStruct_struct5"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct5_t" = Struct5_t
+                          "use_sites_useStruct_struct5" = Struct5
           offset# = \_ -> \_ -> 16
-instance (~) ty Struct5_t =>
-         HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
 instance (~) ty Struct5_t =>
          HasField "use_sites_useTypedef_struct5_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct5_t = y_1,
@@ -722,13 +715,13 @@ instance (~) ty Struct5_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct5_t" x_0)
-instance HasCField Use_sites "use_sites_useStruct_struct6"
+instance (~) ty Struct5_t =>
+         HasField "use_sites_useTypedef_struct5_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct5_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct5_t"
     where type CFieldType Use_sites
-                          "use_sites_useStruct_struct6" = Struct6_Aux
-          offset# = \_ -> \_ -> 24
-instance (~) ty Struct6_Aux =>
-         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
+                          "use_sites_useTypedef_struct5_t" = Struct5_t
+          offset# = \_ -> \_ -> 16
 instance (~) ty Struct6_Aux =>
          HasField "use_sites_useStruct_struct6" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useStruct_struct6 = y_1,
@@ -750,13 +743,13 @@ instance (~) ty Struct6_Aux =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useStruct_struct6" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct6"
+instance (~) ty Struct6_Aux =>
+         HasField "use_sites_useStruct_struct6" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useStruct_struct6")
+instance HasCField Use_sites "use_sites_useStruct_struct6"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct6" = Struct6
+                          "use_sites_useStruct_struct6" = Struct6_Aux
           offset# = \_ -> \_ -> 24
-instance (~) ty Struct6 =>
-         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
 instance (~) ty Struct6 =>
          HasField "use_sites_useTypedef_struct6" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct6 = y_1,
@@ -778,13 +771,13 @@ instance (~) ty Struct6 =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct6" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct7a"
+instance (~) ty Struct6 =>
+         HasField "use_sites_useTypedef_struct6" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct6")
+instance HasCField Use_sites "use_sites_useTypedef_struct6"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct7a" = Struct7a
-          offset# = \_ -> \_ -> 32
-instance (~) ty Struct7a =>
-         HasField "use_sites_useTypedef_struct7a" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7a")
+                          "use_sites_useTypedef_struct6" = Struct6
+          offset# = \_ -> \_ -> 24
 instance (~) ty Struct7a =>
          HasField "use_sites_useTypedef_struct7a" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct7a = y_1,
@@ -806,13 +799,13 @@ instance (~) ty Struct7a =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct7a" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct7b"
+instance (~) ty Struct7a =>
+         HasField "use_sites_useTypedef_struct7a" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7a")
+instance HasCField Use_sites "use_sites_useTypedef_struct7a"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct7b" = Struct7b
+                          "use_sites_useTypedef_struct7a" = Struct7a
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct7b =>
-         HasField "use_sites_useTypedef_struct7b" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7b")
 instance (~) ty Struct7b =>
          HasField "use_sites_useTypedef_struct7b" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct7b = y_1,
@@ -834,13 +827,13 @@ instance (~) ty Struct7b =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct7b" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct8"
+instance (~) ty Struct7b =>
+         HasField "use_sites_useTypedef_struct7b" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct7b")
+instance HasCField Use_sites "use_sites_useTypedef_struct7b"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct8" = Struct8
+                          "use_sites_useTypedef_struct7b" = Struct7b
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct8 =>
-         HasField "use_sites_useTypedef_struct8" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8")
 instance (~) ty Struct8 =>
          HasField "use_sites_useTypedef_struct8" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct8 = y_1,
@@ -862,13 +855,13 @@ instance (~) ty Struct8 =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct8" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct8b"
+instance (~) ty Struct8 =>
+         HasField "use_sites_useTypedef_struct8" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8")
+instance HasCField Use_sites "use_sites_useTypedef_struct8"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct8b" = Struct8b
+                          "use_sites_useTypedef_struct8" = Struct8
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct8b =>
-         HasField "use_sites_useTypedef_struct8b" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8b")
 instance (~) ty Struct8b =>
          HasField "use_sites_useTypedef_struct8b" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct8b = y_1,
@@ -890,13 +883,13 @@ instance (~) ty Struct8b =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct8b" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct9"
+instance (~) ty Struct8b =>
+         HasField "use_sites_useTypedef_struct8b" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct8b")
+instance HasCField Use_sites "use_sites_useTypedef_struct8b"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct9" = Struct9
+                          "use_sites_useTypedef_struct8b" = Struct8b
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct9 =>
-         HasField "use_sites_useTypedef_struct9" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9")
 instance (~) ty Struct9 =>
          HasField "use_sites_useTypedef_struct9" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct9 = y_1,
@@ -918,13 +911,13 @@ instance (~) ty Struct9 =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct9" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct9_t"
+instance (~) ty Struct9 =>
+         HasField "use_sites_useTypedef_struct9" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9")
+instance HasCField Use_sites "use_sites_useTypedef_struct9"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct9_t" = Struct9_t
+                          "use_sites_useTypedef_struct9" = Struct9
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct9_t =>
-         HasField "use_sites_useTypedef_struct9_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9_t")
 instance (~) ty Struct9_t =>
          HasField "use_sites_useTypedef_struct9_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct9_t = y_1,
@@ -946,13 +939,13 @@ instance (~) ty Struct9_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct9_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct10_t"
+instance (~) ty Struct9_t =>
+         HasField "use_sites_useTypedef_struct9_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct9_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct9_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct10_t" = Struct10_t
+                          "use_sites_useTypedef_struct9_t" = Struct9_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct10_t =>
-         HasField "use_sites_useTypedef_struct10_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t")
 instance (~) ty Struct10_t =>
          HasField "use_sites_useTypedef_struct10_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct10_t = y_1,
@@ -974,15 +967,13 @@ instance (~) ty Struct10_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct10_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct10_t_t"
+instance (~) ty Struct10_t =>
+         HasField "use_sites_useTypedef_struct10_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct10_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct10_t_t" = Struct10_t_t
+                          "use_sites_useTypedef_struct10_t" = Struct10_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct10_t_t =>
-         HasField "use_sites_useTypedef_struct10_t_t"
-                  (Ptr Use_sites)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t_t")
 instance (~) ty Struct10_t_t =>
          HasField "use_sites_useTypedef_struct10_t_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct10_t_t = y_1,
@@ -1004,13 +995,15 @@ instance (~) ty Struct10_t_t =>
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct10_t_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct11_t"
+instance (~) ty Struct10_t_t =>
+         HasField "use_sites_useTypedef_struct10_t_t"
+                  (Ptr Use_sites)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct10_t_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct10_t_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct11_t" = Struct11_t
+                          "use_sites_useTypedef_struct10_t_t" = Struct10_t_t
           offset# = \_ -> \_ -> 32
-instance (~) ty Struct11_t =>
-         HasField "use_sites_useTypedef_struct11_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct11_t")
 instance (~) ty Struct11_t =>
          HasField "use_sites_useTypedef_struct11_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct11_t = y_1,
@@ -1032,13 +1025,13 @@ instance (~) ty Struct11_t =>
                                                 use_sites_useTypedef_struct10_t_t = getField @"use_sites_useTypedef_struct10_t_t" x_0,
                                                 use_sites_useTypedef_struct12_t = getField @"use_sites_useTypedef_struct12_t" x_0},
                               getField @"use_sites_useTypedef_struct11_t" x_0)
-instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
+instance (~) ty Struct11_t =>
+         HasField "use_sites_useTypedef_struct11_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct11_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct11_t"
     where type CFieldType Use_sites
-                          "use_sites_useTypedef_struct12_t" = Struct12_t
-          offset# = \_ -> \_ -> 48
-instance (~) ty Struct12_t =>
-         HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
-    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")
+                          "use_sites_useTypedef_struct11_t" = Struct11_t
+          offset# = \_ -> \_ -> 32
 instance (~) ty Struct12_t =>
          HasField "use_sites_useTypedef_struct12_t" Use_sites ty
     where hasField = \x_0 -> (\y_1 -> Use_sites{use_sites_useTypedef_struct12_t = y_1,
@@ -1060,3 +1053,10 @@ instance (~) ty Struct12_t =>
                                                 use_sites_useTypedef_struct10_t_t = getField @"use_sites_useTypedef_struct10_t_t" x_0,
                                                 use_sites_useTypedef_struct11_t = getField @"use_sites_useTypedef_struct11_t" x_0},
                               getField @"use_sites_useTypedef_struct12_t" x_0)
+instance (~) ty Struct12_t =>
+         HasField "use_sites_useTypedef_struct12_t" (Ptr Use_sites) (Ptr ty)
+    where getField = fromPtr (Proxy @"use_sites_useTypedef_struct12_t")
+instance HasCField Use_sites "use_sites_useTypedef_struct12_t"
+    where type CFieldType Use_sites
+                          "use_sites_useTypedef_struct12_t" = Struct12_t
+          offset# = \_ -> \_ -> 48

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/Example.hs
@@ -65,18 +65,6 @@ instance Marshal.WriteRaw S_y_anon'x where
 
 deriving via Marshal.EquivStorable S_y_anon'x instance RIP.Storable S_y_anon'x
 
-instance HasCField.HasCField S_y_anon'x "s_y_anon'x_x" where
-
-  type CFieldType S_y_anon'x "s_y_anon'x_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s_y_anon'x_x" (RIP.Ptr S_y_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s_y_anon'x_x" S_y_anon'x ty where
 
@@ -84,6 +72,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          S_y_anon'x {s_y_anon'x_x = y1}, RIP.getField @"s_y_anon'x_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s_y_anon'x_x" (RIP.Ptr S_y_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x_x")
+
+instance HasCField.HasCField S_y_anon'x "s_y_anon'x_x" where
+
+  type CFieldType S_y_anon'x "s_y_anon'x_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@S_y@
 
@@ -126,18 +126,6 @@ instance Marshal.WriteRaw S_y where
 
 deriving via Marshal.EquivStorable S_y instance RIP.Storable S_y
 
-instance HasCField.HasCField S_y "s_y_anon'x" where
-
-  type CFieldType S_y "s_y_anon'x" = S_y_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S_y_anon'x
-         ) => RIP.HasField "s_y_anon'x" (RIP.Ptr S_y) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x")
-
 instance ( ty ~ S_y_anon'x
          ) => RIP.CompatHasField.HasField "s_y_anon'x" S_y ty where
 
@@ -145,6 +133,18 @@ instance ( ty ~ S_y_anon'x
     \x0 ->
       (\y1 ->
          S_y {s_y_anon'x = y1}, RIP.getField @"s_y_anon'x" x0)
+
+instance ( ty ~ S_y_anon'x
+         ) => RIP.HasField "s_y_anon'x" (RIP.Ptr S_y) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x")
+
+instance HasCField.HasCField S_y "s_y_anon'x" where
+
+  type CFieldType S_y "s_y_anon'x" = S_y_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S@
 
@@ -187,17 +187,17 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_y" where
+instance (ty ~ S_y) => RIP.CompatHasField.HasField "s_y" S ty where
 
-  type CFieldType S "s_y" = S_y
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S {s_y = y1}, RIP.getField @"s_y" x0)
 
 instance (ty ~ S_y) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"s_y")
 
-instance (ty ~ S_y) => RIP.CompatHasField.HasField "s_y" S ty where
+instance HasCField.HasCField S "s_y" where
 
-  hasField =
-    \x0 -> (\y1 -> S {s_y = y1}, RIP.getField @"s_y" x0)
+  type CFieldType S "s_y" = S_y
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/bindingspec.yaml
@@ -20,11 +20,12 @@ hstypes:
       fields:
       - s_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       fields:
       - s_y_anon'x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,11 +56,12 @@ hstypes:
       fields:
       - s_y_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/anon_in_nonanon/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw S_y_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S_y_anon'x s_y_anon'x_x_2 -> writeRaw (Proxy @"s_y_anon'x_x") ptr_0 s_y_anon'x_x_2
 deriving via (EquivStorable S_y_anon'x) instance Storable S_y_anon'x
-instance HasCField S_y_anon'x "s_y_anon'x_x"
-    where type CFieldType S_y_anon'x "s_y_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s_y_anon'x_x" (Ptr S_y_anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y_anon'x_x")
 instance (~) ty CInt => HasField "s_y_anon'x_x" S_y_anon'x ty
     where hasField = \x_0 -> (\y_1 -> S_y_anon'x{s_y_anon'x_x = y_1},
                               getField @"s_y_anon'x_x" x_0)
+instance (~) ty CInt =>
+         HasField "s_y_anon'x_x" (Ptr S_y_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y_anon'x_x")
+instance HasCField S_y_anon'x "s_y_anon'x_x"
+    where type CFieldType S_y_anon'x "s_y_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/anon_in_nonanon.h 14:3@
@@ -56,15 +56,15 @@ instance WriteRaw S_y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S_y s_y_anon'x_2 -> writeRaw (Proxy @"s_y_anon'x") ptr_0 s_y_anon'x_2
 deriving via (EquivStorable S_y) instance Storable S_y
-instance HasCField S_y "s_y_anon'x"
-    where type CFieldType S_y "s_y_anon'x" = S_y_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty S_y_anon'x =>
-         HasField "s_y_anon'x" (Ptr S_y) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y_anon'x")
 instance (~) ty S_y_anon'x => HasField "s_y_anon'x" S_y ty
     where hasField = \x_0 -> (\y_1 -> S_y{s_y_anon'x = y_1},
                               getField @"s_y_anon'x" x_0)
+instance (~) ty S_y_anon'x =>
+         HasField "s_y_anon'x" (Ptr S_y) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y_anon'x")
+instance HasCField S_y "s_y_anon'x"
+    where type CFieldType S_y "s_y_anon'x" = S_y_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
     __defined at:__ @types\/anonymous\/edge-cases\/anon_in_nonanon.h 13:8@
@@ -89,11 +89,11 @@ instance WriteRaw S
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S s_y_2 -> writeRaw (Proxy @"s_y") ptr_0 s_y_2
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_y"
-    where type CFieldType S "s_y" = S_y
-          offset# = \_ -> \_ -> 0
-instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y")
 instance (~) ty S_y => HasField "s_y" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_y = y_1},
                               getField @"s_y" x_0)
+instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y")
+instance HasCField S "s_y"
+    where type CFieldType S "s_y" = S_y
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/Example.hs
@@ -69,6 +69,20 @@ instance Marshal.WriteRaw S1_anon'y where
 
 deriving via Marshal.EquivStorable S1_anon'y instance RIP.Storable S1_anon'y
 
+instance ( ty ~ RIP.CChar
+         ) => RIP.CompatHasField.HasField "s1_anon'y_y" S1_anon'y ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         S1_anon'y {s1_anon'y_y = y1}, RIP.getField @"s1_anon'y_y" x0)
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s1_anon'y_y" (RIP.Ptr S1_anon'y) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"s1_anon'y_y")
+
 instance HasCBitfield.HasCBitfield S1_anon'y "s1_anon'y_y" where
 
   type CBitfieldType S1_anon'y "s1_anon'y_y" =
@@ -77,20 +91,6 @@ instance HasCBitfield.HasCBitfield S1_anon'y "s1_anon'y_y" where
   bitfieldOffset# = \_ -> \_ -> 0
 
   bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s1_anon'y_y" (RIP.Ptr S1_anon'y) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"s1_anon'y_y")
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.CompatHasField.HasField "s1_anon'y_y" S1_anon'y ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         S1_anon'y {s1_anon'y_y = y1}, RIP.getField @"s1_anon'y_y" x0)
 
 {-| __C declaration:__ @struct S1@
 
@@ -142,17 +142,6 @@ instance Marshal.WriteRaw S1 where
 
 deriving via Marshal.EquivStorable S1 instance RIP.Storable S1
 
-instance HasCField.HasCField S1 "s1_anon'y" where
-
-  type CFieldType S1 "s1_anon'y" = S1_anon'y
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S1_anon'y
-         ) => RIP.HasField "s1_anon'y" (RIP.Ptr S1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_anon'y")
-
 instance (ty ~ S1_anon'y) => RIP.CompatHasField.HasField "s1_anon'y" S1 ty where
 
   hasField =
@@ -162,15 +151,16 @@ instance (ty ~ S1_anon'y) => RIP.CompatHasField.HasField "s1_anon'y" S1 ty where
       , RIP.getField @"s1_anon'y" x0
       )
 
-instance HasCField.HasCField S1 "s1_x" where
+instance ( ty ~ S1_anon'y
+         ) => RIP.HasField "s1_anon'y" (RIP.Ptr S1) (RIP.Ptr ty) where
 
-  type CFieldType S1 "s1_x" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_anon'y")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S1 "s1_anon'y" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_x" (RIP.Ptr S1) (RIP.Ptr ty) where
+  type CFieldType S1 "s1_anon'y" = S1_anon'y
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_x")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_x" S1 ty where
 
@@ -180,6 +170,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_x" S1 ty where
           S1 {s1_x = y1, s1_anon'y = RIP.getField @"s1_anon'y" x0}
       , RIP.getField @"s1_x" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s1_x" (RIP.Ptr S1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_x")
+
+instance HasCField.HasCField S1 "s1_x" where
+
+  type CFieldType S1 "s1_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@S2_anon\'anon\'y_anon\'y@
 
@@ -222,21 +222,6 @@ instance Marshal.WriteRaw S2_anon'anon'y_anon'y where
 
 deriving via Marshal.EquivStorable S2_anon'anon'y_anon'y instance RIP.Storable S2_anon'anon'y_anon'y
 
-instance HasCBitfield.HasCBitfield S2_anon'anon'y_anon'y "s2_anon'anon'y_anon'y_y" where
-
-  type CBitfieldType S2_anon'anon'y_anon'y "s2_anon'anon'y_anon'y_y" =
-    RIP.CChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_anon'anon'y_anon'y_y" (RIP.Ptr S2_anon'anon'y_anon'y) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"s2_anon'anon'y_anon'y_y")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "s2_anon'anon'y_anon'y_y" S2_anon'anon'y_anon'y ty where
 
@@ -246,6 +231,21 @@ instance ( ty ~ RIP.CChar
           S2_anon'anon'y_anon'y {s2_anon'anon'y_anon'y_y = y1}
       , RIP.getField @"s2_anon'anon'y_anon'y_y" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s2_anon'anon'y_anon'y_y" (RIP.Ptr S2_anon'anon'y_anon'y) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"s2_anon'anon'y_anon'y_y")
+
+instance HasCBitfield.HasCBitfield S2_anon'anon'y_anon'y "s2_anon'anon'y_anon'y_y" where
+
+  type CBitfieldType S2_anon'anon'y_anon'y "s2_anon'anon'y_anon'y_y" =
+    RIP.CChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
 
 {-| __C declaration:__ @struct \@S2_anon\'anon\'y@
 
@@ -297,19 +297,6 @@ instance Marshal.WriteRaw S2_anon'anon'y where
 
 deriving via Marshal.EquivStorable S2_anon'anon'y instance RIP.Storable S2_anon'anon'y
 
-instance HasCField.HasCField S2_anon'anon'y "s2_anon'anon'y_anon'y" where
-
-  type CFieldType S2_anon'anon'y "s2_anon'anon'y_anon'y" =
-    S2_anon'anon'y_anon'y
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S2_anon'anon'y_anon'y
-         ) => RIP.HasField "s2_anon'anon'y_anon'y" (RIP.Ptr S2_anon'anon'y) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y_anon'y")
-
 instance ( ty ~ S2_anon'anon'y_anon'y
          ) => RIP.CompatHasField.HasField "s2_anon'anon'y_anon'y" S2_anon'anon'y ty where
 
@@ -322,18 +309,18 @@ instance ( ty ~ S2_anon'anon'y_anon'y
       , RIP.getField @"s2_anon'anon'y_anon'y" x0
       )
 
-instance HasCField.HasCField S2_anon'anon'y "s2_anon'anon'y_x" where
-
-  type CFieldType S2_anon'anon'y "s2_anon'anon'y_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_anon'anon'y_x" (RIP.Ptr S2_anon'anon'y) (RIP.Ptr ty) where
+instance ( ty ~ S2_anon'anon'y_anon'y
+         ) => RIP.HasField "s2_anon'anon'y_anon'y" (RIP.Ptr S2_anon'anon'y) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y_x")
+    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y_anon'y")
+
+instance HasCField.HasCField S2_anon'anon'y "s2_anon'anon'y_anon'y" where
+
+  type CFieldType S2_anon'anon'y "s2_anon'anon'y_anon'y" =
+    S2_anon'anon'y_anon'y
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s2_anon'anon'y_x" S2_anon'anon'y ty where
@@ -346,6 +333,19 @@ instance ( ty ~ RIP.CInt
                          }
       , RIP.getField @"s2_anon'anon'y_x" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s2_anon'anon'y_x" (RIP.Ptr S2_anon'anon'y) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y_x")
+
+instance HasCField.HasCField S2_anon'anon'y "s2_anon'anon'y_x" where
+
+  type CFieldType S2_anon'anon'y "s2_anon'anon'y_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S2@
 
@@ -388,18 +388,6 @@ instance Marshal.WriteRaw S2 where
 
 deriving via Marshal.EquivStorable S2 instance RIP.Storable S2
 
-instance HasCField.HasCField S2 "s2_anon'anon'y" where
-
-  type CFieldType S2 "s2_anon'anon'y" = S2_anon'anon'y
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S2_anon'anon'y
-         ) => RIP.HasField "s2_anon'anon'y" (RIP.Ptr S2) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y")
-
 instance ( ty ~ S2_anon'anon'y
          ) => RIP.CompatHasField.HasField "s2_anon'anon'y" S2 ty where
 
@@ -407,3 +395,15 @@ instance ( ty ~ S2_anon'anon'y
     \x0 ->
       (\y1 ->
          S2 {s2_anon'anon'y = y1}, RIP.getField @"s2_anon'anon'y" x0)
+
+instance ( ty ~ S2_anon'anon'y
+         ) => RIP.HasField "s2_anon'anon'y" (RIP.Ptr S2) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s2_anon'anon'y")
+
+instance HasCField.HasCField S2 "s2_anon'anon'y" where
+
+  type CFieldType S2 "s2_anon'anon'y" = S2_anon'anon'y
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/bindingspec.yaml
@@ -27,11 +27,12 @@ hstypes:
       - s1_anon'y
       - s1_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -44,11 +45,12 @@ hstypes:
       fields:
       - s1_anon'y_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -61,11 +63,12 @@ hstypes:
       fields:
       - s2_anon'anon'y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -79,11 +82,12 @@ hstypes:
       - s2_anon'anon'y_anon'y
       - s2_anon'anon'y_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -96,11 +100,12 @@ hstypes:
       fields:
       - s2_anon'anon'y_anon'y_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/bitfield/th.txt
@@ -23,16 +23,16 @@ instance WriteRaw S1_anon'y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S1_anon'y s1_anon'y_y_2 -> poke (Proxy @"s1_anon'y_y") ptr_0 s1_anon'y_y_2
 deriving via (EquivStorable S1_anon'y) instance Storable S1_anon'y
+instance (~) ty CChar => HasField "s1_anon'y_y" S1_anon'y ty
+    where hasField = \x_0 -> (\y_1 -> S1_anon'y{s1_anon'y_y = y_1},
+                              getField @"s1_anon'y_y" x_0)
+instance (~) ty CChar =>
+         HasField "s1_anon'y_y" (Ptr S1_anon'y) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"s1_anon'y_y")
 instance HasCBitfield S1_anon'y "s1_anon'y_y"
     where type CBitfieldType S1_anon'y "s1_anon'y_y" = CChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CChar =>
-         HasField "s1_anon'y_y" (Ptr S1_anon'y) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"s1_anon'y_y")
-instance (~) ty CChar => HasField "s1_anon'y_y" S1_anon'y ty
-    where hasField = \x_0 -> (\y_1 -> S1_anon'y{s1_anon'y_y = y_1},
-                              getField @"s1_anon'y_y" x_0)
 {-| __C declaration:__ @struct S1@
 
     __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 12:8@
@@ -65,24 +65,24 @@ instance WriteRaw S1
                                        S1 s1_anon'y_2
                                           s1_x_3 -> writeRaw (Proxy @"s1_anon'y") ptr_0 s1_anon'y_2 >> writeRaw (Proxy @"s1_x") ptr_0 s1_x_3
 deriving via (EquivStorable S1) instance Storable S1
-instance HasCField S1 "s1_anon'y"
-    where type CFieldType S1 "s1_anon'y" = S1_anon'y
-          offset# = \_ -> \_ -> 0
-instance (~) ty S1_anon'y => HasField "s1_anon'y" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_anon'y")
 instance (~) ty S1_anon'y => HasField "s1_anon'y" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_anon'y = y_1,
                                          s1_x = getField @"s1_x" x_0},
                               getField @"s1_anon'y" x_0)
-instance HasCField S1 "s1_x"
-    where type CFieldType S1 "s1_x" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s1_x" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_x")
+instance (~) ty S1_anon'y => HasField "s1_anon'y" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_anon'y")
+instance HasCField S1 "s1_anon'y"
+    where type CFieldType S1 "s1_anon'y" = S1_anon'y
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s1_x" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_x = y_1,
                                          s1_anon'y = getField @"s1_anon'y" x_0},
                               getField @"s1_x" x_0)
+instance (~) ty CInt => HasField "s1_x" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_x")
+instance HasCField S1 "s1_x"
+    where type CFieldType S1 "s1_x" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@S2_anon\'anon\'y_anon\'y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 21:5@
@@ -107,21 +107,21 @@ instance WriteRaw S2_anon'anon'y_anon'y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S2_anon'anon'y_anon'y s2_anon'anon'y_anon'y_y_2 -> poke (Proxy @"s2_anon'anon'y_anon'y_y") ptr_0 s2_anon'anon'y_anon'y_y_2
 deriving via (EquivStorable S2_anon'anon'y_anon'y) instance Storable S2_anon'anon'y_anon'y
+instance (~) ty CChar =>
+         HasField "s2_anon'anon'y_anon'y_y" S2_anon'anon'y_anon'y ty
+    where hasField = \x_0 -> (\y_1 -> S2_anon'anon'y_anon'y{s2_anon'anon'y_anon'y_y = y_1},
+                              getField @"s2_anon'anon'y_anon'y_y" x_0)
+instance (~) ty CChar =>
+         HasField "s2_anon'anon'y_anon'y_y"
+                  (Ptr S2_anon'anon'y_anon'y)
+                  (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"s2_anon'anon'y_anon'y_y")
 instance HasCBitfield S2_anon'anon'y_anon'y
                       "s2_anon'anon'y_anon'y_y"
     where type CBitfieldType S2_anon'anon'y_anon'y
                              "s2_anon'anon'y_anon'y_y" = CChar
           bitfieldOffset# = \_ -> \_ -> 0
           bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CChar =>
-         HasField "s2_anon'anon'y_anon'y_y"
-                  (Ptr S2_anon'anon'y_anon'y)
-                  (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"s2_anon'anon'y_anon'y_y")
-instance (~) ty CChar =>
-         HasField "s2_anon'anon'y_anon'y_y" S2_anon'anon'y_anon'y ty
-    where hasField = \x_0 -> (\y_1 -> S2_anon'anon'y_anon'y{s2_anon'anon'y_anon'y_y = y_1},
-                              getField @"s2_anon'anon'y_anon'y_y" x_0)
 {-| __C declaration:__ @struct \@S2_anon\'anon\'y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 20:3@
@@ -154,29 +154,29 @@ instance WriteRaw S2_anon'anon'y
                                        S2_anon'anon'y s2_anon'anon'y_anon'y_2
                                                       s2_anon'anon'y_x_3 -> writeRaw (Proxy @"s2_anon'anon'y_anon'y") ptr_0 s2_anon'anon'y_anon'y_2 >> writeRaw (Proxy @"s2_anon'anon'y_x") ptr_0 s2_anon'anon'y_x_3
 deriving via (EquivStorable S2_anon'anon'y) instance Storable S2_anon'anon'y
-instance HasCField S2_anon'anon'y "s2_anon'anon'y_anon'y"
-    where type CFieldType S2_anon'anon'y
-                          "s2_anon'anon'y_anon'y" = S2_anon'anon'y_anon'y
-          offset# = \_ -> \_ -> 0
-instance (~) ty S2_anon'anon'y_anon'y =>
-         HasField "s2_anon'anon'y_anon'y" (Ptr S2_anon'anon'y) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_anon'anon'y_anon'y")
 instance (~) ty S2_anon'anon'y_anon'y =>
          HasField "s2_anon'anon'y_anon'y" S2_anon'anon'y ty
     where hasField = \x_0 -> (\y_1 -> S2_anon'anon'y{s2_anon'anon'y_anon'y = y_1,
                                                      s2_anon'anon'y_x = getField @"s2_anon'anon'y_x" x_0},
                               getField @"s2_anon'anon'y_anon'y" x_0)
-instance HasCField S2_anon'anon'y "s2_anon'anon'y_x"
-    where type CFieldType S2_anon'anon'y "s2_anon'anon'y_x" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "s2_anon'anon'y_x" (Ptr S2_anon'anon'y) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_anon'anon'y_x")
+instance (~) ty S2_anon'anon'y_anon'y =>
+         HasField "s2_anon'anon'y_anon'y" (Ptr S2_anon'anon'y) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_anon'anon'y_anon'y")
+instance HasCField S2_anon'anon'y "s2_anon'anon'y_anon'y"
+    where type CFieldType S2_anon'anon'y
+                          "s2_anon'anon'y_anon'y" = S2_anon'anon'y_anon'y
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "s2_anon'anon'y_x" S2_anon'anon'y ty
     where hasField = \x_0 -> (\y_1 -> S2_anon'anon'y{s2_anon'anon'y_x = y_1,
                                                      s2_anon'anon'y_anon'y = getField @"s2_anon'anon'y_anon'y" x_0},
                               getField @"s2_anon'anon'y_x" x_0)
+instance (~) ty CInt =>
+         HasField "s2_anon'anon'y_x" (Ptr S2_anon'anon'y) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_anon'anon'y_x")
+instance HasCField S2_anon'anon'y "s2_anon'anon'y_x"
+    where type CFieldType S2_anon'anon'y "s2_anon'anon'y_x" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @types\/anonymous\/edge-cases\/bitfield.h 19:8@
@@ -201,12 +201,12 @@ instance WriteRaw S2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S2 s2_anon'anon'y_2 -> writeRaw (Proxy @"s2_anon'anon'y") ptr_0 s2_anon'anon'y_2
 deriving via (EquivStorable S2) instance Storable S2
-instance HasCField S2 "s2_anon'anon'y"
-    where type CFieldType S2 "s2_anon'anon'y" = S2_anon'anon'y
-          offset# = \_ -> \_ -> 0
-instance (~) ty S2_anon'anon'y =>
-         HasField "s2_anon'anon'y" (Ptr S2) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_anon'anon'y")
 instance (~) ty S2_anon'anon'y => HasField "s2_anon'anon'y" S2 ty
     where hasField = \x_0 -> (\y_1 -> S2{s2_anon'anon'y = y_1},
                               getField @"s2_anon'anon'y" x_0)
+instance (~) ty S2_anon'anon'y =>
+         HasField "s2_anon'anon'y" (Ptr S2) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_anon'anon'y")
+instance HasCField S2 "s2_anon'anon'y"
+    where type CFieldType S2 "s2_anon'anon'y" = S2_anon'anon'y
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/Example.hs
@@ -65,18 +65,6 @@ instance Marshal.WriteRaw S_y_anon'x where
 
 deriving via Marshal.EquivStorable S_y_anon'x instance RIP.Storable S_y_anon'x
 
-instance HasCField.HasCField S_y_anon'x "s_y_anon'x_x" where
-
-  type CFieldType S_y_anon'x "s_y_anon'x_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s_y_anon'x_x" (RIP.Ptr S_y_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s_y_anon'x_x" S_y_anon'x ty where
 
@@ -84,6 +72,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          S_y_anon'x {s_y_anon'x_x = y1}, RIP.getField @"s_y_anon'x_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s_y_anon'x_x" (RIP.Ptr S_y_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x_x")
+
+instance HasCField.HasCField S_y_anon'x "s_y_anon'x_x" where
+
+  type CFieldType S_y_anon'x "s_y_anon'x_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@S_y@
 
@@ -126,18 +126,6 @@ instance Marshal.WriteRaw S_y where
 
 deriving via Marshal.EquivStorable S_y instance RIP.Storable S_y
 
-instance HasCField.HasCField S_y "s_y_anon'x" where
-
-  type CFieldType S_y "s_y_anon'x" = S_y_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S_y_anon'x
-         ) => RIP.HasField "s_y_anon'x" (RIP.Ptr S_y) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x")
-
 instance ( ty ~ S_y_anon'x
          ) => RIP.CompatHasField.HasField "s_y_anon'x" S_y ty where
 
@@ -145,6 +133,18 @@ instance ( ty ~ S_y_anon'x
     \x0 ->
       (\y1 ->
          S_y {s_y_anon'x = y1}, RIP.getField @"s_y_anon'x" x0)
+
+instance ( ty ~ S_y_anon'x
+         ) => RIP.HasField "s_y_anon'x" (RIP.Ptr S_y) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s_y_anon'x")
+
+instance HasCField.HasCField S_y "s_y_anon'x" where
+
+  type CFieldType S_y "s_y_anon'x" = S_y_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S@
 
@@ -196,16 +196,6 @@ instance Marshal.WriteRaw S where
 
 deriving via Marshal.EquivStorable S instance RIP.Storable S
 
-instance HasCField.HasCField S "s_x" where
-
-  type CFieldType S "s_x" = RIP.CULLong
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CULLong) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
-
 instance (ty ~ RIP.CULLong) => RIP.CompatHasField.HasField "s_x" S ty where
 
   hasField =
@@ -213,15 +203,15 @@ instance (ty ~ RIP.CULLong) => RIP.CompatHasField.HasField "s_x" S ty where
       (\y1 ->
          S {s_x = y1, s_y = RIP.getField @"s_y" x0}, RIP.getField @"s_x" x0)
 
-instance HasCField.HasCField S "s_y" where
+instance (ty ~ RIP.CULLong) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
 
-  type CFieldType S "s_y" = S_y
+  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S "s_x" where
 
-instance (ty ~ S_y) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
+  type CFieldType S "s_x" = RIP.CULLong
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s_y")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ S_y) => RIP.CompatHasField.HasField "s_y" S ty where
 
@@ -229,3 +219,13 @@ instance (ty ~ S_y) => RIP.CompatHasField.HasField "s_y" S ty where
     \x0 ->
       (\y1 ->
          S {s_y = y1, s_x = RIP.getField @"s_x" x0}, RIP.getField @"s_y" x0)
+
+instance (ty ~ S_y) => RIP.HasField "s_y" (RIP.Ptr S) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s_y")
+
+instance HasCField.HasCField S "s_y" where
+
+  type CFieldType S "s_y" = S_y
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/bindingspec.yaml
@@ -21,11 +21,12 @@ hstypes:
       - s_x
       - s_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -38,11 +39,12 @@ hstypes:
       fields:
       - s_y_anon'x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -55,11 +57,12 @@ hstypes:
       fields:
       - s_y_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/duplicate_field_names/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw S_y_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S_y_anon'x s_y_anon'x_x_2 -> writeRaw (Proxy @"s_y_anon'x_x") ptr_0 s_y_anon'x_x_2
 deriving via (EquivStorable S_y_anon'x) instance Storable S_y_anon'x
-instance HasCField S_y_anon'x "s_y_anon'x_x"
-    where type CFieldType S_y_anon'x "s_y_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s_y_anon'x_x" (Ptr S_y_anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y_anon'x_x")
 instance (~) ty CInt => HasField "s_y_anon'x_x" S_y_anon'x ty
     where hasField = \x_0 -> (\y_1 -> S_y_anon'x{s_y_anon'x_x = y_1},
                               getField @"s_y_anon'x_x" x_0)
+instance (~) ty CInt =>
+         HasField "s_y_anon'x_x" (Ptr S_y_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y_anon'x_x")
+instance HasCField S_y_anon'x "s_y_anon'x_x"
+    where type CFieldType S_y_anon'x "s_y_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/duplicate_field_names.h 15:3@
@@ -56,15 +56,15 @@ instance WriteRaw S_y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S_y s_y_anon'x_2 -> writeRaw (Proxy @"s_y_anon'x") ptr_0 s_y_anon'x_2
 deriving via (EquivStorable S_y) instance Storable S_y
-instance HasCField S_y "s_y_anon'x"
-    where type CFieldType S_y "s_y_anon'x" = S_y_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty S_y_anon'x =>
-         HasField "s_y_anon'x" (Ptr S_y) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y_anon'x")
 instance (~) ty S_y_anon'x => HasField "s_y_anon'x" S_y ty
     where hasField = \x_0 -> (\y_1 -> S_y{s_y_anon'x = y_1},
                               getField @"s_y_anon'x" x_0)
+instance (~) ty S_y_anon'x =>
+         HasField "s_y_anon'x" (Ptr S_y) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y_anon'x")
+instance HasCField S_y "s_y_anon'x"
+    where type CFieldType S_y "s_y_anon'x" = S_y_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
     __defined at:__ @types\/anonymous\/edge-cases\/duplicate_field_names.h 13:8@
@@ -97,21 +97,21 @@ instance WriteRaw S
                                        S s_x_2
                                          s_y_3 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2 >> writeRaw (Proxy @"s_y") ptr_0 s_y_3
 deriving via (EquivStorable S) instance Storable S
-instance HasCField S "s_x"
-    where type CFieldType S "s_x" = CULLong
-          offset# = \_ -> \_ -> 0
-instance (~) ty CULLong => HasField "s_x" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_x")
 instance (~) ty CULLong => HasField "s_x" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_x = y_1,
                                         s_y = getField @"s_y" x_0},
                               getField @"s_x" x_0)
-instance HasCField S "s_y"
-    where type CFieldType S "s_y" = S_y
-          offset# = \_ -> \_ -> 8
-instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
-    where getField = fromPtr (Proxy @"s_y")
+instance (~) ty CULLong => HasField "s_x" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_x")
+instance HasCField S "s_x"
+    where type CFieldType S "s_x" = CULLong
+          offset# = \_ -> \_ -> 0
 instance (~) ty S_y => HasField "s_y" S ty
     where hasField = \x_0 -> (\y_1 -> S{s_y = y_1,
                                         s_x = getField @"s_x" x_0},
                               getField @"s_y" x_0)
+instance (~) ty S_y => HasField "s_y" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_y")
+instance HasCField S "s_y"
+    where type CFieldType S "s_y" = S_y
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/Example.hs
@@ -110,19 +110,6 @@ instance Marshal.WriteRaw SSS_anon'anon'x_anon'x where
 
 deriving via Marshal.EquivStorable SSS_anon'anon'x_anon'x instance RIP.Storable SSS_anon'anon'x_anon'x
 
-instance HasCField.HasCField SSS_anon'anon'x_anon'x "sSS_anon'anon'x_anon'x_x" where
-
-  type CFieldType SSS_anon'anon'x_anon'x "sSS_anon'anon'x_anon'x_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sSS_anon'anon'x_anon'x_x" (RIP.Ptr SSS_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "sSS_anon'anon'x_anon'x_x" SSS_anon'anon'x_anon'x ty where
 
@@ -132,6 +119,19 @@ instance ( ty ~ RIP.CInt
           SSS_anon'anon'x_anon'x {sSS_anon'anon'x_anon'x_x = y1}
       , RIP.getField @"sSS_anon'anon'x_anon'x_x" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "sSS_anon'anon'x_anon'x_x" (RIP.Ptr SSS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x_anon'x_x")
+
+instance HasCField.HasCField SSS_anon'anon'x_anon'x "sSS_anon'anon'x_anon'x_x" where
+
+  type CFieldType SSS_anon'anon'x_anon'x "sSS_anon'anon'x_anon'x_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@SSS_anon\'anon\'x@
 
@@ -174,19 +174,6 @@ instance Marshal.WriteRaw SSS_anon'anon'x where
 
 deriving via Marshal.EquivStorable SSS_anon'anon'x instance RIP.Storable SSS_anon'anon'x
 
-instance HasCField.HasCField SSS_anon'anon'x "sSS_anon'anon'x_anon'x" where
-
-  type CFieldType SSS_anon'anon'x "sSS_anon'anon'x_anon'x" =
-    SSS_anon'anon'x_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SSS_anon'anon'x_anon'x
-         ) => RIP.HasField "sSS_anon'anon'x_anon'x" (RIP.Ptr SSS_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x_anon'x")
-
 instance ( ty ~ SSS_anon'anon'x_anon'x
          ) => RIP.CompatHasField.HasField "sSS_anon'anon'x_anon'x" SSS_anon'anon'x ty where
 
@@ -196,6 +183,19 @@ instance ( ty ~ SSS_anon'anon'x_anon'x
           SSS_anon'anon'x {sSS_anon'anon'x_anon'x = y1}
       , RIP.getField @"sSS_anon'anon'x_anon'x" x0
       )
+
+instance ( ty ~ SSS_anon'anon'x_anon'x
+         ) => RIP.HasField "sSS_anon'anon'x_anon'x" (RIP.Ptr SSS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x_anon'x")
+
+instance HasCField.HasCField SSS_anon'anon'x "sSS_anon'anon'x_anon'x" where
+
+  type CFieldType SSS_anon'anon'x "sSS_anon'anon'x_anon'x" =
+    SSS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct SSS@
 
@@ -238,19 +238,6 @@ instance Marshal.WriteRaw SSS where
 
 deriving via Marshal.EquivStorable SSS instance RIP.Storable SSS
 
-instance HasCField.HasCField SSS "sSS_anon'anon'x" where
-
-  type CFieldType SSS "sSS_anon'anon'x" =
-    SSS_anon'anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SSS_anon'anon'x
-         ) => RIP.HasField "sSS_anon'anon'x" (RIP.Ptr SSS) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x")
-
 instance ( ty ~ SSS_anon'anon'x
          ) => RIP.CompatHasField.HasField "sSS_anon'anon'x" SSS ty where
 
@@ -258,6 +245,19 @@ instance ( ty ~ SSS_anon'anon'x
     \x0 ->
       (\y1 ->
          SSS {sSS_anon'anon'x = y1}, RIP.getField @"sSS_anon'anon'x" x0)
+
+instance ( ty ~ SSS_anon'anon'x
+         ) => RIP.HasField "sSS_anon'anon'x" (RIP.Ptr SSS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSS_anon'anon'x")
+
+instance HasCField.HasCField SSS "sSS_anon'anon'x" where
+
+  type CFieldType SSS "sSS_anon'anon'x" =
+    SSS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@USS_anon\'anon\'x_anon\'x@
 
@@ -300,19 +300,6 @@ instance Marshal.WriteRaw USS_anon'anon'x_anon'x where
 
 deriving via Marshal.EquivStorable USS_anon'anon'x_anon'x instance RIP.Storable USS_anon'anon'x_anon'x
 
-instance HasCField.HasCField USS_anon'anon'x_anon'x "uSS_anon'anon'x_anon'x_x" where
-
-  type CFieldType USS_anon'anon'x_anon'x "uSS_anon'anon'x_anon'x_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uSS_anon'anon'x_anon'x_x" (RIP.Ptr USS_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "uSS_anon'anon'x_anon'x_x" USS_anon'anon'x_anon'x ty where
 
@@ -322,6 +309,19 @@ instance ( ty ~ RIP.CInt
           USS_anon'anon'x_anon'x {uSS_anon'anon'x_anon'x_x = y1}
       , RIP.getField @"uSS_anon'anon'x_anon'x_x" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uSS_anon'anon'x_anon'x_x" (RIP.Ptr USS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x_anon'x_x")
+
+instance HasCField.HasCField USS_anon'anon'x_anon'x "uSS_anon'anon'x_anon'x_x" where
+
+  type CFieldType USS_anon'anon'x_anon'x "uSS_anon'anon'x_anon'x_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@USS_anon\'anon\'x@
 
@@ -364,19 +364,6 @@ instance Marshal.WriteRaw USS_anon'anon'x where
 
 deriving via Marshal.EquivStorable USS_anon'anon'x instance RIP.Storable USS_anon'anon'x
 
-instance HasCField.HasCField USS_anon'anon'x "uSS_anon'anon'x_anon'x" where
-
-  type CFieldType USS_anon'anon'x "uSS_anon'anon'x_anon'x" =
-    USS_anon'anon'x_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ USS_anon'anon'x_anon'x
-         ) => RIP.HasField "uSS_anon'anon'x_anon'x" (RIP.Ptr USS_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x_anon'x")
-
 instance ( ty ~ USS_anon'anon'x_anon'x
          ) => RIP.CompatHasField.HasField "uSS_anon'anon'x_anon'x" USS_anon'anon'x ty where
 
@@ -386,6 +373,19 @@ instance ( ty ~ USS_anon'anon'x_anon'x
           USS_anon'anon'x {uSS_anon'anon'x_anon'x = y1}
       , RIP.getField @"uSS_anon'anon'x_anon'x" x0
       )
+
+instance ( ty ~ USS_anon'anon'x_anon'x
+         ) => RIP.HasField "uSS_anon'anon'x_anon'x" (RIP.Ptr USS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x_anon'x")
+
+instance HasCField.HasCField USS_anon'anon'x "uSS_anon'anon'x_anon'x" where
+
+  type CFieldType USS_anon'anon'x "uSS_anon'anon'x_anon'x" =
+    USS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union USS@
 
@@ -431,18 +431,18 @@ set_uSS_anon'anon'x ::
   -> USS
 set_uSS_anon'anon'x = RIP.setUnionPayload
 
+instance ( ty ~ USS_anon'anon'x
+         ) => RIP.HasField "uSS_anon'anon'x" (RIP.Ptr USS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x")
+
 instance HasCField.HasCField USS "uSS_anon'anon'x" where
 
   type CFieldType USS "uSS_anon'anon'x" =
     USS_anon'anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ USS_anon'anon'x
-         ) => RIP.HasField "uSS_anon'anon'x" (RIP.Ptr USS) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSS_anon'anon'x")
 
 {-| __C declaration:__ @struct \@SUS_anon\'anon\'x_anon\'x@
 
@@ -485,19 +485,6 @@ instance Marshal.WriteRaw SUS_anon'anon'x_anon'x where
 
 deriving via Marshal.EquivStorable SUS_anon'anon'x_anon'x instance RIP.Storable SUS_anon'anon'x_anon'x
 
-instance HasCField.HasCField SUS_anon'anon'x_anon'x "sUS_anon'anon'x_anon'x_x" where
-
-  type CFieldType SUS_anon'anon'x_anon'x "sUS_anon'anon'x_anon'x_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sUS_anon'anon'x_anon'x_x" (RIP.Ptr SUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "sUS_anon'anon'x_anon'x_x" SUS_anon'anon'x_anon'x ty where
 
@@ -507,6 +494,19 @@ instance ( ty ~ RIP.CInt
           SUS_anon'anon'x_anon'x {sUS_anon'anon'x_anon'x_x = y1}
       , RIP.getField @"sUS_anon'anon'x_anon'x_x" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "sUS_anon'anon'x_anon'x_x" (RIP.Ptr SUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x_anon'x_x")
+
+instance HasCField.HasCField SUS_anon'anon'x_anon'x "sUS_anon'anon'x_anon'x_x" where
+
+  type CFieldType SUS_anon'anon'x_anon'x "sUS_anon'anon'x_anon'x_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@SUS_anon\'anon\'x@
 
@@ -552,18 +552,18 @@ set_sUS_anon'anon'x_anon'x ::
   -> SUS_anon'anon'x
 set_sUS_anon'anon'x_anon'x = RIP.setUnionPayload
 
+instance ( ty ~ SUS_anon'anon'x_anon'x
+         ) => RIP.HasField "sUS_anon'anon'x_anon'x" (RIP.Ptr SUS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x_anon'x")
+
 instance HasCField.HasCField SUS_anon'anon'x "sUS_anon'anon'x_anon'x" where
 
   type CFieldType SUS_anon'anon'x "sUS_anon'anon'x_anon'x" =
     SUS_anon'anon'x_anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SUS_anon'anon'x_anon'x
-         ) => RIP.HasField "sUS_anon'anon'x_anon'x" (RIP.Ptr SUS_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x_anon'x")
 
 {-| __C declaration:__ @struct SUS@
 
@@ -606,19 +606,6 @@ instance Marshal.WriteRaw SUS where
 
 deriving via Marshal.EquivStorable SUS instance RIP.Storable SUS
 
-instance HasCField.HasCField SUS "sUS_anon'anon'x" where
-
-  type CFieldType SUS "sUS_anon'anon'x" =
-    SUS_anon'anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SUS_anon'anon'x
-         ) => RIP.HasField "sUS_anon'anon'x" (RIP.Ptr SUS) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x")
-
 instance ( ty ~ SUS_anon'anon'x
          ) => RIP.CompatHasField.HasField "sUS_anon'anon'x" SUS ty where
 
@@ -626,6 +613,19 @@ instance ( ty ~ SUS_anon'anon'x
     \x0 ->
       (\y1 ->
          SUS {sUS_anon'anon'x = y1}, RIP.getField @"sUS_anon'anon'x" x0)
+
+instance ( ty ~ SUS_anon'anon'x
+         ) => RIP.HasField "sUS_anon'anon'x" (RIP.Ptr SUS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUS_anon'anon'x")
+
+instance HasCField.HasCField SUS "sUS_anon'anon'x" where
+
+  type CFieldType SUS "sUS_anon'anon'x" =
+    SUS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@UUS_anon\'anon\'x_anon\'x@
 
@@ -668,19 +668,6 @@ instance Marshal.WriteRaw UUS_anon'anon'x_anon'x where
 
 deriving via Marshal.EquivStorable UUS_anon'anon'x_anon'x instance RIP.Storable UUS_anon'anon'x_anon'x
 
-instance HasCField.HasCField UUS_anon'anon'x_anon'x "uUS_anon'anon'x_anon'x_x" where
-
-  type CFieldType UUS_anon'anon'x_anon'x "uUS_anon'anon'x_anon'x_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uUS_anon'anon'x_anon'x_x" (RIP.Ptr UUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x_anon'x_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "uUS_anon'anon'x_anon'x_x" UUS_anon'anon'x_anon'x ty where
 
@@ -690,6 +677,19 @@ instance ( ty ~ RIP.CInt
           UUS_anon'anon'x_anon'x {uUS_anon'anon'x_anon'x_x = y1}
       , RIP.getField @"uUS_anon'anon'x_anon'x_x" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uUS_anon'anon'x_anon'x_x" (RIP.Ptr UUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x_anon'x_x")
+
+instance HasCField.HasCField UUS_anon'anon'x_anon'x "uUS_anon'anon'x_anon'x_x" where
+
+  type CFieldType UUS_anon'anon'x_anon'x "uUS_anon'anon'x_anon'x_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@UUS_anon\'anon\'x@
 
@@ -735,18 +735,18 @@ set_uUS_anon'anon'x_anon'x ::
   -> UUS_anon'anon'x
 set_uUS_anon'anon'x_anon'x = RIP.setUnionPayload
 
+instance ( ty ~ UUS_anon'anon'x_anon'x
+         ) => RIP.HasField "uUS_anon'anon'x_anon'x" (RIP.Ptr UUS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x_anon'x")
+
 instance HasCField.HasCField UUS_anon'anon'x "uUS_anon'anon'x_anon'x" where
 
   type CFieldType UUS_anon'anon'x "uUS_anon'anon'x_anon'x" =
     UUS_anon'anon'x_anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UUS_anon'anon'x_anon'x
-         ) => RIP.HasField "uUS_anon'anon'x_anon'x" (RIP.Ptr UUS_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x_anon'x")
 
 {-| __C declaration:__ @union UUS@
 
@@ -792,18 +792,18 @@ set_uUS_anon'anon'x ::
   -> UUS
 set_uUS_anon'anon'x = RIP.setUnionPayload
 
+instance ( ty ~ UUS_anon'anon'x
+         ) => RIP.HasField "uUS_anon'anon'x" (RIP.Ptr UUS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x")
+
 instance HasCField.HasCField UUS "uUS_anon'anon'x" where
 
   type CFieldType UUS "uUS_anon'anon'x" =
     UUS_anon'anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UUS_anon'anon'x
-         ) => RIP.HasField "uUS_anon'anon'x" (RIP.Ptr UUS) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUS_anon'anon'x")
 
 {-| __C declaration:__ @union \@SSU_anon\'anon\'x_anon\'x@
 
@@ -849,18 +849,18 @@ set_sSU_anon'anon'x_anon'x_x ::
   -> SSU_anon'anon'x_anon'x
 set_sSU_anon'anon'x_anon'x_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "sSU_anon'anon'x_anon'x_x" (RIP.Ptr SSU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x_anon'x_x")
+
 instance HasCField.HasCField SSU_anon'anon'x_anon'x "sSU_anon'anon'x_anon'x_x" where
 
   type CFieldType SSU_anon'anon'x_anon'x "sSU_anon'anon'x_anon'x_x" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sSU_anon'anon'x_anon'x_x" (RIP.Ptr SSU_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x_anon'x_x")
 
 {-| __C declaration:__ @struct \@SSU_anon\'anon\'x@
 
@@ -903,19 +903,6 @@ instance Marshal.WriteRaw SSU_anon'anon'x where
 
 deriving via Marshal.EquivStorable SSU_anon'anon'x instance RIP.Storable SSU_anon'anon'x
 
-instance HasCField.HasCField SSU_anon'anon'x "sSU_anon'anon'x_anon'x" where
-
-  type CFieldType SSU_anon'anon'x "sSU_anon'anon'x_anon'x" =
-    SSU_anon'anon'x_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SSU_anon'anon'x_anon'x
-         ) => RIP.HasField "sSU_anon'anon'x_anon'x" (RIP.Ptr SSU_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x_anon'x")
-
 instance ( ty ~ SSU_anon'anon'x_anon'x
          ) => RIP.CompatHasField.HasField "sSU_anon'anon'x_anon'x" SSU_anon'anon'x ty where
 
@@ -925,6 +912,19 @@ instance ( ty ~ SSU_anon'anon'x_anon'x
           SSU_anon'anon'x {sSU_anon'anon'x_anon'x = y1}
       , RIP.getField @"sSU_anon'anon'x_anon'x" x0
       )
+
+instance ( ty ~ SSU_anon'anon'x_anon'x
+         ) => RIP.HasField "sSU_anon'anon'x_anon'x" (RIP.Ptr SSU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x_anon'x")
+
+instance HasCField.HasCField SSU_anon'anon'x "sSU_anon'anon'x_anon'x" where
+
+  type CFieldType SSU_anon'anon'x "sSU_anon'anon'x_anon'x" =
+    SSU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct SSU@
 
@@ -967,19 +967,6 @@ instance Marshal.WriteRaw SSU where
 
 deriving via Marshal.EquivStorable SSU instance RIP.Storable SSU
 
-instance HasCField.HasCField SSU "sSU_anon'anon'x" where
-
-  type CFieldType SSU "sSU_anon'anon'x" =
-    SSU_anon'anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SSU_anon'anon'x
-         ) => RIP.HasField "sSU_anon'anon'x" (RIP.Ptr SSU) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x")
-
 instance ( ty ~ SSU_anon'anon'x
          ) => RIP.CompatHasField.HasField "sSU_anon'anon'x" SSU ty where
 
@@ -987,6 +974,19 @@ instance ( ty ~ SSU_anon'anon'x
     \x0 ->
       (\y1 ->
          SSU {sSU_anon'anon'x = y1}, RIP.getField @"sSU_anon'anon'x" x0)
+
+instance ( ty ~ SSU_anon'anon'x
+         ) => RIP.HasField "sSU_anon'anon'x" (RIP.Ptr SSU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sSU_anon'anon'x")
+
+instance HasCField.HasCField SSU "sSU_anon'anon'x" where
+
+  type CFieldType SSU "sSU_anon'anon'x" =
+    SSU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@USU_anon\'anon\'x_anon\'x@
 
@@ -1032,18 +1032,18 @@ set_uSU_anon'anon'x_anon'x_x ::
   -> USU_anon'anon'x_anon'x
 set_uSU_anon'anon'x_anon'x_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uSU_anon'anon'x_anon'x_x" (RIP.Ptr USU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x_anon'x_x")
+
 instance HasCField.HasCField USU_anon'anon'x_anon'x "uSU_anon'anon'x_anon'x_x" where
 
   type CFieldType USU_anon'anon'x_anon'x "uSU_anon'anon'x_anon'x_x" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uSU_anon'anon'x_anon'x_x" (RIP.Ptr USU_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x_anon'x_x")
 
 {-| __C declaration:__ @struct \@USU_anon\'anon\'x@
 
@@ -1086,19 +1086,6 @@ instance Marshal.WriteRaw USU_anon'anon'x where
 
 deriving via Marshal.EquivStorable USU_anon'anon'x instance RIP.Storable USU_anon'anon'x
 
-instance HasCField.HasCField USU_anon'anon'x "uSU_anon'anon'x_anon'x" where
-
-  type CFieldType USU_anon'anon'x "uSU_anon'anon'x_anon'x" =
-    USU_anon'anon'x_anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ USU_anon'anon'x_anon'x
-         ) => RIP.HasField "uSU_anon'anon'x_anon'x" (RIP.Ptr USU_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x_anon'x")
-
 instance ( ty ~ USU_anon'anon'x_anon'x
          ) => RIP.CompatHasField.HasField "uSU_anon'anon'x_anon'x" USU_anon'anon'x ty where
 
@@ -1108,6 +1095,19 @@ instance ( ty ~ USU_anon'anon'x_anon'x
           USU_anon'anon'x {uSU_anon'anon'x_anon'x = y1}
       , RIP.getField @"uSU_anon'anon'x_anon'x" x0
       )
+
+instance ( ty ~ USU_anon'anon'x_anon'x
+         ) => RIP.HasField "uSU_anon'anon'x_anon'x" (RIP.Ptr USU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x_anon'x")
+
+instance HasCField.HasCField USU_anon'anon'x "uSU_anon'anon'x_anon'x" where
+
+  type CFieldType USU_anon'anon'x "uSU_anon'anon'x_anon'x" =
+    USU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union USU@
 
@@ -1153,18 +1153,18 @@ set_uSU_anon'anon'x ::
   -> USU
 set_uSU_anon'anon'x = RIP.setUnionPayload
 
+instance ( ty ~ USU_anon'anon'x
+         ) => RIP.HasField "uSU_anon'anon'x" (RIP.Ptr USU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x")
+
 instance HasCField.HasCField USU "uSU_anon'anon'x" where
 
   type CFieldType USU "uSU_anon'anon'x" =
     USU_anon'anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ USU_anon'anon'x
-         ) => RIP.HasField "uSU_anon'anon'x" (RIP.Ptr USU) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uSU_anon'anon'x")
 
 {-| __C declaration:__ @union \@SUU_anon\'anon\'x_anon\'x@
 
@@ -1210,18 +1210,18 @@ set_sUU_anon'anon'x_anon'x_x ::
   -> SUU_anon'anon'x_anon'x
 set_sUU_anon'anon'x_anon'x_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "sUU_anon'anon'x_anon'x_x" (RIP.Ptr SUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x_anon'x_x")
+
 instance HasCField.HasCField SUU_anon'anon'x_anon'x "sUU_anon'anon'x_anon'x_x" where
 
   type CFieldType SUU_anon'anon'x_anon'x "sUU_anon'anon'x_anon'x_x" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sUU_anon'anon'x_anon'x_x" (RIP.Ptr SUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x_anon'x_x")
 
 {-| __C declaration:__ @union \@SUU_anon\'anon\'x@
 
@@ -1267,18 +1267,18 @@ set_sUU_anon'anon'x_anon'x ::
   -> SUU_anon'anon'x
 set_sUU_anon'anon'x_anon'x = RIP.setUnionPayload
 
+instance ( ty ~ SUU_anon'anon'x_anon'x
+         ) => RIP.HasField "sUU_anon'anon'x_anon'x" (RIP.Ptr SUU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x_anon'x")
+
 instance HasCField.HasCField SUU_anon'anon'x "sUU_anon'anon'x_anon'x" where
 
   type CFieldType SUU_anon'anon'x "sUU_anon'anon'x_anon'x" =
     SUU_anon'anon'x_anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SUU_anon'anon'x_anon'x
-         ) => RIP.HasField "sUU_anon'anon'x_anon'x" (RIP.Ptr SUU_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x_anon'x")
 
 {-| __C declaration:__ @struct SUU@
 
@@ -1321,19 +1321,6 @@ instance Marshal.WriteRaw SUU where
 
 deriving via Marshal.EquivStorable SUU instance RIP.Storable SUU
 
-instance HasCField.HasCField SUU "sUU_anon'anon'x" where
-
-  type CFieldType SUU "sUU_anon'anon'x" =
-    SUU_anon'anon'x
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ SUU_anon'anon'x
-         ) => RIP.HasField "sUU_anon'anon'x" (RIP.Ptr SUU) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x")
-
 instance ( ty ~ SUU_anon'anon'x
          ) => RIP.CompatHasField.HasField "sUU_anon'anon'x" SUU ty where
 
@@ -1341,6 +1328,19 @@ instance ( ty ~ SUU_anon'anon'x
     \x0 ->
       (\y1 ->
          SUU {sUU_anon'anon'x = y1}, RIP.getField @"sUU_anon'anon'x" x0)
+
+instance ( ty ~ SUU_anon'anon'x
+         ) => RIP.HasField "sUU_anon'anon'x" (RIP.Ptr SUU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sUU_anon'anon'x")
+
+instance HasCField.HasCField SUU "sUU_anon'anon'x" where
+
+  type CFieldType SUU "sUU_anon'anon'x" =
+    SUU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@UUU_anon\'anon\'x_anon\'x@
 
@@ -1386,18 +1386,18 @@ set_uUU_anon'anon'x_anon'x_x ::
   -> UUU_anon'anon'x_anon'x
 set_uUU_anon'anon'x_anon'x_x = RIP.setUnionPayload
 
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uUU_anon'anon'x_anon'x_x" (RIP.Ptr UUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x_anon'x_x")
+
 instance HasCField.HasCField UUU_anon'anon'x_anon'x "uUU_anon'anon'x_anon'x_x" where
 
   type CFieldType UUU_anon'anon'x_anon'x "uUU_anon'anon'x_anon'x_x" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uUU_anon'anon'x_anon'x_x" (RIP.Ptr UUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x_anon'x_x")
 
 {-| __C declaration:__ @union \@UUU_anon\'anon\'x@
 
@@ -1443,18 +1443,18 @@ set_uUU_anon'anon'x_anon'x ::
   -> UUU_anon'anon'x
 set_uUU_anon'anon'x_anon'x = RIP.setUnionPayload
 
+instance ( ty ~ UUU_anon'anon'x_anon'x
+         ) => RIP.HasField "uUU_anon'anon'x_anon'x" (RIP.Ptr UUU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x_anon'x")
+
 instance HasCField.HasCField UUU_anon'anon'x "uUU_anon'anon'x_anon'x" where
 
   type CFieldType UUU_anon'anon'x "uUU_anon'anon'x_anon'x" =
     UUU_anon'anon'x_anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UUU_anon'anon'x_anon'x
-         ) => RIP.HasField "uUU_anon'anon'x_anon'x" (RIP.Ptr UUU_anon'anon'x) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x_anon'x")
 
 {-| __C declaration:__ @union UUU@
 
@@ -1500,15 +1500,15 @@ set_uUU_anon'anon'x ::
   -> UUU
 set_uUU_anon'anon'x = RIP.setUnionPayload
 
+instance ( ty ~ UUU_anon'anon'x
+         ) => RIP.HasField "uUU_anon'anon'x" (RIP.Ptr UUU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x")
+
 instance HasCField.HasCField UUU "uUU_anon'anon'x" where
 
   type CFieldType UUU "uUU_anon'anon'x" =
     UUU_anon'anon'x
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ UUU_anon'anon'x
-         ) => RIP.HasField "uUU_anon'anon'x" (RIP.Ptr UUU) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uUU_anon'anon'x")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/bindingspec.yaml
@@ -83,11 +83,12 @@ hstypes:
       fields:
       - sSS_anon'anon'x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -100,11 +101,12 @@ hstypes:
       fields:
       - sSS_anon'anon'x_anon'x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -117,11 +119,12 @@ hstypes:
       fields:
       - sSS_anon'anon'x_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -134,10 +137,11 @@ hstypes:
       fields:
       - sSU_anon'anon'x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -149,10 +153,11 @@ hstypes:
       fields:
       - sSU_anon'anon'x_anon'x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -166,7 +171,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -178,10 +183,11 @@ hstypes:
       fields:
       - sUS_anon'anon'x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -195,7 +201,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -207,11 +213,12 @@ hstypes:
       fields:
       - sUS_anon'anon'x_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -224,10 +231,11 @@ hstypes:
       fields:
       - sUU_anon'anon'x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -241,7 +249,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -255,7 +263,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -269,7 +277,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -281,11 +289,12 @@ hstypes:
       fields:
       - uSS_anon'anon'x_anon'x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -298,11 +307,12 @@ hstypes:
       fields:
       - uSS_anon'anon'x_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -317,7 +327,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -329,10 +339,11 @@ hstypes:
       fields:
       - uSU_anon'anon'x_anon'x
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -346,7 +357,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -360,7 +371,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -374,7 +385,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -386,11 +397,12 @@ hstypes:
       fields:
       - uUS_anon'anon'x_anon'x_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -405,7 +417,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -419,7 +431,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -433,7 +445,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting/th.txt
@@ -23,20 +23,20 @@ instance WriteRaw SSS_anon'anon'x_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SSS_anon'anon'x_anon'x sSS_anon'anon'x_anon'x_x_2 -> writeRaw (Proxy @"sSS_anon'anon'x_anon'x_x") ptr_0 sSS_anon'anon'x_anon'x_x_2
 deriving via (EquivStorable SSS_anon'anon'x_anon'x) instance Storable SSS_anon'anon'x_anon'x
-instance HasCField SSS_anon'anon'x_anon'x
-                   "sSS_anon'anon'x_anon'x_x"
-    where type CFieldType SSS_anon'anon'x_anon'x
-                          "sSS_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "sSS_anon'anon'x_anon'x_x" SSS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SSS_anon'anon'x_anon'x{sSS_anon'anon'x_anon'x_x = y_1},
+                              getField @"sSS_anon'anon'x_anon'x_x" x_0)
 instance (~) ty CInt =>
          HasField "sSS_anon'anon'x_anon'x_x"
                   (Ptr SSS_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"sSS_anon'anon'x_anon'x_x")
-instance (~) ty CInt =>
-         HasField "sSS_anon'anon'x_anon'x_x" SSS_anon'anon'x_anon'x ty
-    where hasField = \x_0 -> (\y_1 -> SSS_anon'anon'x_anon'x{sSS_anon'anon'x_anon'x_x = y_1},
-                              getField @"sSS_anon'anon'x_anon'x_x" x_0)
+instance HasCField SSS_anon'anon'x_anon'x
+                   "sSS_anon'anon'x_anon'x_x"
+    where type CFieldType SSS_anon'anon'x_anon'x
+                          "sSS_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@SSS_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 16:3@
@@ -61,17 +61,17 @@ instance WriteRaw SSS_anon'anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SSS_anon'anon'x sSS_anon'anon'x_anon'x_2 -> writeRaw (Proxy @"sSS_anon'anon'x_anon'x") ptr_0 sSS_anon'anon'x_anon'x_2
 deriving via (EquivStorable SSS_anon'anon'x) instance Storable SSS_anon'anon'x
-instance HasCField SSS_anon'anon'x "sSS_anon'anon'x_anon'x"
-    where type CFieldType SSS_anon'anon'x
-                          "sSS_anon'anon'x_anon'x" = SSS_anon'anon'x_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SSS_anon'anon'x_anon'x =>
-         HasField "sSS_anon'anon'x_anon'x" (Ptr SSS_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"sSS_anon'anon'x_anon'x")
 instance (~) ty SSS_anon'anon'x_anon'x =>
          HasField "sSS_anon'anon'x_anon'x" SSS_anon'anon'x ty
     where hasField = \x_0 -> (\y_1 -> SSS_anon'anon'x{sSS_anon'anon'x_anon'x = y_1},
                               getField @"sSS_anon'anon'x_anon'x" x_0)
+instance (~) ty SSS_anon'anon'x_anon'x =>
+         HasField "sSS_anon'anon'x_anon'x" (Ptr SSS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"sSS_anon'anon'x_anon'x")
+instance HasCField SSS_anon'anon'x "sSS_anon'anon'x_anon'x"
+    where type CFieldType SSS_anon'anon'x
+                          "sSS_anon'anon'x_anon'x" = SSS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct SSS@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 15:8@
@@ -96,16 +96,16 @@ instance WriteRaw SSS
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SSS sSS_anon'anon'x_2 -> writeRaw (Proxy @"sSS_anon'anon'x") ptr_0 sSS_anon'anon'x_2
 deriving via (EquivStorable SSS) instance Storable SSS
-instance HasCField SSS "sSS_anon'anon'x"
-    where type CFieldType SSS "sSS_anon'anon'x" = SSS_anon'anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SSS_anon'anon'x =>
-         HasField "sSS_anon'anon'x" (Ptr SSS) (Ptr ty)
-    where getField = fromPtr (Proxy @"sSS_anon'anon'x")
 instance (~) ty SSS_anon'anon'x =>
          HasField "sSS_anon'anon'x" SSS ty
     where hasField = \x_0 -> (\y_1 -> SSS{sSS_anon'anon'x = y_1},
                               getField @"sSS_anon'anon'x" x_0)
+instance (~) ty SSS_anon'anon'x =>
+         HasField "sSS_anon'anon'x" (Ptr SSS) (Ptr ty)
+    where getField = fromPtr (Proxy @"sSS_anon'anon'x")
+instance HasCField SSS "sSS_anon'anon'x"
+    where type CFieldType SSS "sSS_anon'anon'x" = SSS_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@USS_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 25:5@
@@ -130,20 +130,20 @@ instance WriteRaw USS_anon'anon'x_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        USS_anon'anon'x_anon'x uSS_anon'anon'x_anon'x_x_2 -> writeRaw (Proxy @"uSS_anon'anon'x_anon'x_x") ptr_0 uSS_anon'anon'x_anon'x_x_2
 deriving via (EquivStorable USS_anon'anon'x_anon'x) instance Storable USS_anon'anon'x_anon'x
-instance HasCField USS_anon'anon'x_anon'x
-                   "uSS_anon'anon'x_anon'x_x"
-    where type CFieldType USS_anon'anon'x_anon'x
-                          "uSS_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "uSS_anon'anon'x_anon'x_x" USS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> USS_anon'anon'x_anon'x{uSS_anon'anon'x_anon'x_x = y_1},
+                              getField @"uSS_anon'anon'x_anon'x_x" x_0)
 instance (~) ty CInt =>
          HasField "uSS_anon'anon'x_anon'x_x"
                   (Ptr USS_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"uSS_anon'anon'x_anon'x_x")
-instance (~) ty CInt =>
-         HasField "uSS_anon'anon'x_anon'x_x" USS_anon'anon'x_anon'x ty
-    where hasField = \x_0 -> (\y_1 -> USS_anon'anon'x_anon'x{uSS_anon'anon'x_anon'x_x = y_1},
-                              getField @"uSS_anon'anon'x_anon'x_x" x_0)
+instance HasCField USS_anon'anon'x_anon'x
+                   "uSS_anon'anon'x_anon'x_x"
+    where type CFieldType USS_anon'anon'x_anon'x
+                          "uSS_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@USS_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 24:3@
@@ -168,17 +168,17 @@ instance WriteRaw USS_anon'anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        USS_anon'anon'x uSS_anon'anon'x_anon'x_2 -> writeRaw (Proxy @"uSS_anon'anon'x_anon'x") ptr_0 uSS_anon'anon'x_anon'x_2
 deriving via (EquivStorable USS_anon'anon'x) instance Storable USS_anon'anon'x
-instance HasCField USS_anon'anon'x "uSS_anon'anon'x_anon'x"
-    where type CFieldType USS_anon'anon'x
-                          "uSS_anon'anon'x_anon'x" = USS_anon'anon'x_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty USS_anon'anon'x_anon'x =>
-         HasField "uSS_anon'anon'x_anon'x" (Ptr USS_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"uSS_anon'anon'x_anon'x")
 instance (~) ty USS_anon'anon'x_anon'x =>
          HasField "uSS_anon'anon'x_anon'x" USS_anon'anon'x ty
     where hasField = \x_0 -> (\y_1 -> USS_anon'anon'x{uSS_anon'anon'x_anon'x = y_1},
                               getField @"uSS_anon'anon'x_anon'x" x_0)
+instance (~) ty USS_anon'anon'x_anon'x =>
+         HasField "uSS_anon'anon'x_anon'x" (Ptr USS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"uSS_anon'anon'x_anon'x")
+instance HasCField USS_anon'anon'x "uSS_anon'anon'x_anon'x"
+    where type CFieldType USS_anon'anon'x
+                          "uSS_anon'anon'x_anon'x" = USS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union USS@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 23:7@
@@ -224,12 +224,12 @@ set_uSS_anon'anon'x :: USS_anon'anon'x -> USS
 
 -}
 set_uSS_anon'anon'x = setUnionPayload
-instance HasCField USS "uSS_anon'anon'x"
-    where type CFieldType USS "uSS_anon'anon'x" = USS_anon'anon'x
-          offset# = \_ -> \_ -> 0
 instance (~) ty USS_anon'anon'x =>
          HasField "uSS_anon'anon'x" (Ptr USS) (Ptr ty)
     where getField = fromPtr (Proxy @"uSS_anon'anon'x")
+instance HasCField USS "uSS_anon'anon'x"
+    where type CFieldType USS "uSS_anon'anon'x" = USS_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@SUS_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 33:5@
@@ -254,20 +254,20 @@ instance WriteRaw SUS_anon'anon'x_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SUS_anon'anon'x_anon'x sUS_anon'anon'x_anon'x_x_2 -> writeRaw (Proxy @"sUS_anon'anon'x_anon'x_x") ptr_0 sUS_anon'anon'x_anon'x_x_2
 deriving via (EquivStorable SUS_anon'anon'x_anon'x) instance Storable SUS_anon'anon'x_anon'x
-instance HasCField SUS_anon'anon'x_anon'x
-                   "sUS_anon'anon'x_anon'x_x"
-    where type CFieldType SUS_anon'anon'x_anon'x
-                          "sUS_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "sUS_anon'anon'x_anon'x_x" SUS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SUS_anon'anon'x_anon'x{sUS_anon'anon'x_anon'x_x = y_1},
+                              getField @"sUS_anon'anon'x_anon'x_x" x_0)
 instance (~) ty CInt =>
          HasField "sUS_anon'anon'x_anon'x_x"
                   (Ptr SUS_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"sUS_anon'anon'x_anon'x_x")
-instance (~) ty CInt =>
-         HasField "sUS_anon'anon'x_anon'x_x" SUS_anon'anon'x_anon'x ty
-    where hasField = \x_0 -> (\y_1 -> SUS_anon'anon'x_anon'x{sUS_anon'anon'x_anon'x_x = y_1},
-                              getField @"sUS_anon'anon'x_anon'x_x" x_0)
+instance HasCField SUS_anon'anon'x_anon'x
+                   "sUS_anon'anon'x_anon'x_x"
+    where type CFieldType SUS_anon'anon'x_anon'x
+                          "sUS_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@SUS_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 32:3@
@@ -318,13 +318,13 @@ set_sUS_anon'anon'x_anon'x :: SUS_anon'anon'x_anon'x ->
 
 -}
 set_sUS_anon'anon'x_anon'x = setUnionPayload
+instance (~) ty SUS_anon'anon'x_anon'x =>
+         HasField "sUS_anon'anon'x_anon'x" (Ptr SUS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"sUS_anon'anon'x_anon'x")
 instance HasCField SUS_anon'anon'x "sUS_anon'anon'x_anon'x"
     where type CFieldType SUS_anon'anon'x
                           "sUS_anon'anon'x_anon'x" = SUS_anon'anon'x_anon'x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUS_anon'anon'x_anon'x =>
-         HasField "sUS_anon'anon'x_anon'x" (Ptr SUS_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"sUS_anon'anon'x_anon'x")
 {-| __C declaration:__ @struct SUS@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 31:8@
@@ -349,16 +349,16 @@ instance WriteRaw SUS
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SUS sUS_anon'anon'x_2 -> writeRaw (Proxy @"sUS_anon'anon'x") ptr_0 sUS_anon'anon'x_2
 deriving via (EquivStorable SUS) instance Storable SUS
-instance HasCField SUS "sUS_anon'anon'x"
-    where type CFieldType SUS "sUS_anon'anon'x" = SUS_anon'anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SUS_anon'anon'x =>
-         HasField "sUS_anon'anon'x" (Ptr SUS) (Ptr ty)
-    where getField = fromPtr (Proxy @"sUS_anon'anon'x")
 instance (~) ty SUS_anon'anon'x =>
          HasField "sUS_anon'anon'x" SUS ty
     where hasField = \x_0 -> (\y_1 -> SUS{sUS_anon'anon'x = y_1},
                               getField @"sUS_anon'anon'x" x_0)
+instance (~) ty SUS_anon'anon'x =>
+         HasField "sUS_anon'anon'x" (Ptr SUS) (Ptr ty)
+    where getField = fromPtr (Proxy @"sUS_anon'anon'x")
+instance HasCField SUS "sUS_anon'anon'x"
+    where type CFieldType SUS "sUS_anon'anon'x" = SUS_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@UUS_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 41:5@
@@ -383,20 +383,20 @@ instance WriteRaw UUS_anon'anon'x_anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        UUS_anon'anon'x_anon'x uUS_anon'anon'x_anon'x_x_2 -> writeRaw (Proxy @"uUS_anon'anon'x_anon'x_x") ptr_0 uUS_anon'anon'x_anon'x_x_2
 deriving via (EquivStorable UUS_anon'anon'x_anon'x) instance Storable UUS_anon'anon'x_anon'x
-instance HasCField UUS_anon'anon'x_anon'x
-                   "uUS_anon'anon'x_anon'x_x"
-    where type CFieldType UUS_anon'anon'x_anon'x
-                          "uUS_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
+instance (~) ty CInt =>
+         HasField "uUS_anon'anon'x_anon'x_x" UUS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> UUS_anon'anon'x_anon'x{uUS_anon'anon'x_anon'x_x = y_1},
+                              getField @"uUS_anon'anon'x_anon'x_x" x_0)
 instance (~) ty CInt =>
          HasField "uUS_anon'anon'x_anon'x_x"
                   (Ptr UUS_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"uUS_anon'anon'x_anon'x_x")
-instance (~) ty CInt =>
-         HasField "uUS_anon'anon'x_anon'x_x" UUS_anon'anon'x_anon'x ty
-    where hasField = \x_0 -> (\y_1 -> UUS_anon'anon'x_anon'x{uUS_anon'anon'x_anon'x_x = y_1},
-                              getField @"uUS_anon'anon'x_anon'x_x" x_0)
+instance HasCField UUS_anon'anon'x_anon'x
+                   "uUS_anon'anon'x_anon'x_x"
+    where type CFieldType UUS_anon'anon'x_anon'x
+                          "uUS_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@UUS_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 40:3@
@@ -447,13 +447,13 @@ set_uUS_anon'anon'x_anon'x :: UUS_anon'anon'x_anon'x ->
 
 -}
 set_uUS_anon'anon'x_anon'x = setUnionPayload
+instance (~) ty UUS_anon'anon'x_anon'x =>
+         HasField "uUS_anon'anon'x_anon'x" (Ptr UUS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"uUS_anon'anon'x_anon'x")
 instance HasCField UUS_anon'anon'x "uUS_anon'anon'x_anon'x"
     where type CFieldType UUS_anon'anon'x
                           "uUS_anon'anon'x_anon'x" = UUS_anon'anon'x_anon'x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUS_anon'anon'x_anon'x =>
-         HasField "uUS_anon'anon'x_anon'x" (Ptr UUS_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"uUS_anon'anon'x_anon'x")
 {-| __C declaration:__ @union UUS@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 39:7@
@@ -499,12 +499,12 @@ set_uUS_anon'anon'x :: UUS_anon'anon'x -> UUS
 
 -}
 set_uUS_anon'anon'x = setUnionPayload
-instance HasCField UUS "uUS_anon'anon'x"
-    where type CFieldType UUS "uUS_anon'anon'x" = UUS_anon'anon'x
-          offset# = \_ -> \_ -> 0
 instance (~) ty UUS_anon'anon'x =>
          HasField "uUS_anon'anon'x" (Ptr UUS) (Ptr ty)
     where getField = fromPtr (Proxy @"uUS_anon'anon'x")
+instance HasCField UUS "uUS_anon'anon'x"
+    where type CFieldType UUS "uUS_anon'anon'x" = UUS_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@SSU_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 49:5@
@@ -555,16 +555,16 @@ set_sSU_anon'anon'x_anon'x_x :: CInt -> SSU_anon'anon'x_anon'x
 
 -}
 set_sSU_anon'anon'x_anon'x_x = setUnionPayload
-instance HasCField SSU_anon'anon'x_anon'x
-                   "sSU_anon'anon'x_anon'x_x"
-    where type CFieldType SSU_anon'anon'x_anon'x
-                          "sSU_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "sSU_anon'anon'x_anon'x_x"
                   (Ptr SSU_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"sSU_anon'anon'x_anon'x_x")
+instance HasCField SSU_anon'anon'x_anon'x
+                   "sSU_anon'anon'x_anon'x_x"
+    where type CFieldType SSU_anon'anon'x_anon'x
+                          "sSU_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@SSU_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 48:3@
@@ -589,17 +589,17 @@ instance WriteRaw SSU_anon'anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SSU_anon'anon'x sSU_anon'anon'x_anon'x_2 -> writeRaw (Proxy @"sSU_anon'anon'x_anon'x") ptr_0 sSU_anon'anon'x_anon'x_2
 deriving via (EquivStorable SSU_anon'anon'x) instance Storable SSU_anon'anon'x
-instance HasCField SSU_anon'anon'x "sSU_anon'anon'x_anon'x"
-    where type CFieldType SSU_anon'anon'x
-                          "sSU_anon'anon'x_anon'x" = SSU_anon'anon'x_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SSU_anon'anon'x_anon'x =>
-         HasField "sSU_anon'anon'x_anon'x" (Ptr SSU_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"sSU_anon'anon'x_anon'x")
 instance (~) ty SSU_anon'anon'x_anon'x =>
          HasField "sSU_anon'anon'x_anon'x" SSU_anon'anon'x ty
     where hasField = \x_0 -> (\y_1 -> SSU_anon'anon'x{sSU_anon'anon'x_anon'x = y_1},
                               getField @"sSU_anon'anon'x_anon'x" x_0)
+instance (~) ty SSU_anon'anon'x_anon'x =>
+         HasField "sSU_anon'anon'x_anon'x" (Ptr SSU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"sSU_anon'anon'x_anon'x")
+instance HasCField SSU_anon'anon'x "sSU_anon'anon'x_anon'x"
+    where type CFieldType SSU_anon'anon'x
+                          "sSU_anon'anon'x_anon'x" = SSU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct SSU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 47:8@
@@ -624,16 +624,16 @@ instance WriteRaw SSU
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SSU sSU_anon'anon'x_2 -> writeRaw (Proxy @"sSU_anon'anon'x") ptr_0 sSU_anon'anon'x_2
 deriving via (EquivStorable SSU) instance Storable SSU
-instance HasCField SSU "sSU_anon'anon'x"
-    where type CFieldType SSU "sSU_anon'anon'x" = SSU_anon'anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SSU_anon'anon'x =>
-         HasField "sSU_anon'anon'x" (Ptr SSU) (Ptr ty)
-    where getField = fromPtr (Proxy @"sSU_anon'anon'x")
 instance (~) ty SSU_anon'anon'x =>
          HasField "sSU_anon'anon'x" SSU ty
     where hasField = \x_0 -> (\y_1 -> SSU{sSU_anon'anon'x = y_1},
                               getField @"sSU_anon'anon'x" x_0)
+instance (~) ty SSU_anon'anon'x =>
+         HasField "sSU_anon'anon'x" (Ptr SSU) (Ptr ty)
+    where getField = fromPtr (Proxy @"sSU_anon'anon'x")
+instance HasCField SSU "sSU_anon'anon'x"
+    where type CFieldType SSU "sSU_anon'anon'x" = SSU_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@USU_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 57:5@
@@ -684,16 +684,16 @@ set_uSU_anon'anon'x_anon'x_x :: CInt -> USU_anon'anon'x_anon'x
 
 -}
 set_uSU_anon'anon'x_anon'x_x = setUnionPayload
-instance HasCField USU_anon'anon'x_anon'x
-                   "uSU_anon'anon'x_anon'x_x"
-    where type CFieldType USU_anon'anon'x_anon'x
-                          "uSU_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "uSU_anon'anon'x_anon'x_x"
                   (Ptr USU_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"uSU_anon'anon'x_anon'x_x")
+instance HasCField USU_anon'anon'x_anon'x
+                   "uSU_anon'anon'x_anon'x_x"
+    where type CFieldType USU_anon'anon'x_anon'x
+                          "uSU_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@USU_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 56:3@
@@ -718,17 +718,17 @@ instance WriteRaw USU_anon'anon'x
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        USU_anon'anon'x uSU_anon'anon'x_anon'x_2 -> writeRaw (Proxy @"uSU_anon'anon'x_anon'x") ptr_0 uSU_anon'anon'x_anon'x_2
 deriving via (EquivStorable USU_anon'anon'x) instance Storable USU_anon'anon'x
-instance HasCField USU_anon'anon'x "uSU_anon'anon'x_anon'x"
-    where type CFieldType USU_anon'anon'x
-                          "uSU_anon'anon'x_anon'x" = USU_anon'anon'x_anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty USU_anon'anon'x_anon'x =>
-         HasField "uSU_anon'anon'x_anon'x" (Ptr USU_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"uSU_anon'anon'x_anon'x")
 instance (~) ty USU_anon'anon'x_anon'x =>
          HasField "uSU_anon'anon'x_anon'x" USU_anon'anon'x ty
     where hasField = \x_0 -> (\y_1 -> USU_anon'anon'x{uSU_anon'anon'x_anon'x = y_1},
                               getField @"uSU_anon'anon'x_anon'x" x_0)
+instance (~) ty USU_anon'anon'x_anon'x =>
+         HasField "uSU_anon'anon'x_anon'x" (Ptr USU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"uSU_anon'anon'x_anon'x")
+instance HasCField USU_anon'anon'x "uSU_anon'anon'x_anon'x"
+    where type CFieldType USU_anon'anon'x
+                          "uSU_anon'anon'x_anon'x" = USU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union USU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 55:7@
@@ -774,12 +774,12 @@ set_uSU_anon'anon'x :: USU_anon'anon'x -> USU
 
 -}
 set_uSU_anon'anon'x = setUnionPayload
-instance HasCField USU "uSU_anon'anon'x"
-    where type CFieldType USU "uSU_anon'anon'x" = USU_anon'anon'x
-          offset# = \_ -> \_ -> 0
 instance (~) ty USU_anon'anon'x =>
          HasField "uSU_anon'anon'x" (Ptr USU) (Ptr ty)
     where getField = fromPtr (Proxy @"uSU_anon'anon'x")
+instance HasCField USU "uSU_anon'anon'x"
+    where type CFieldType USU "uSU_anon'anon'x" = USU_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@SUU_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 65:5@
@@ -830,16 +830,16 @@ set_sUU_anon'anon'x_anon'x_x :: CInt -> SUU_anon'anon'x_anon'x
 
 -}
 set_sUU_anon'anon'x_anon'x_x = setUnionPayload
-instance HasCField SUU_anon'anon'x_anon'x
-                   "sUU_anon'anon'x_anon'x_x"
-    where type CFieldType SUU_anon'anon'x_anon'x
-                          "sUU_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "sUU_anon'anon'x_anon'x_x"
                   (Ptr SUU_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"sUU_anon'anon'x_anon'x_x")
+instance HasCField SUU_anon'anon'x_anon'x
+                   "sUU_anon'anon'x_anon'x_x"
+    where type CFieldType SUU_anon'anon'x_anon'x
+                          "sUU_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@SUU_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 64:3@
@@ -890,13 +890,13 @@ set_sUU_anon'anon'x_anon'x :: SUU_anon'anon'x_anon'x ->
 
 -}
 set_sUU_anon'anon'x_anon'x = setUnionPayload
+instance (~) ty SUU_anon'anon'x_anon'x =>
+         HasField "sUU_anon'anon'x_anon'x" (Ptr SUU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"sUU_anon'anon'x_anon'x")
 instance HasCField SUU_anon'anon'x "sUU_anon'anon'x_anon'x"
     where type CFieldType SUU_anon'anon'x
                           "sUU_anon'anon'x_anon'x" = SUU_anon'anon'x_anon'x
           offset# = \_ -> \_ -> 0
-instance (~) ty SUU_anon'anon'x_anon'x =>
-         HasField "sUU_anon'anon'x_anon'x" (Ptr SUU_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"sUU_anon'anon'x_anon'x")
 {-| __C declaration:__ @struct SUU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 63:8@
@@ -921,16 +921,16 @@ instance WriteRaw SUU
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SUU sUU_anon'anon'x_2 -> writeRaw (Proxy @"sUU_anon'anon'x") ptr_0 sUU_anon'anon'x_2
 deriving via (EquivStorable SUU) instance Storable SUU
-instance HasCField SUU "sUU_anon'anon'x"
-    where type CFieldType SUU "sUU_anon'anon'x" = SUU_anon'anon'x
-          offset# = \_ -> \_ -> 0
-instance (~) ty SUU_anon'anon'x =>
-         HasField "sUU_anon'anon'x" (Ptr SUU) (Ptr ty)
-    where getField = fromPtr (Proxy @"sUU_anon'anon'x")
 instance (~) ty SUU_anon'anon'x =>
          HasField "sUU_anon'anon'x" SUU ty
     where hasField = \x_0 -> (\y_1 -> SUU{sUU_anon'anon'x = y_1},
                               getField @"sUU_anon'anon'x" x_0)
+instance (~) ty SUU_anon'anon'x =>
+         HasField "sUU_anon'anon'x" (Ptr SUU) (Ptr ty)
+    where getField = fromPtr (Proxy @"sUU_anon'anon'x")
+instance HasCField SUU "sUU_anon'anon'x"
+    where type CFieldType SUU "sUU_anon'anon'x" = SUU_anon'anon'x
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@UUU_anon\'anon\'x_anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 73:5@
@@ -981,16 +981,16 @@ set_uUU_anon'anon'x_anon'x_x :: CInt -> UUU_anon'anon'x_anon'x
 
 -}
 set_uUU_anon'anon'x_anon'x_x = setUnionPayload
-instance HasCField UUU_anon'anon'x_anon'x
-                   "uUU_anon'anon'x_anon'x_x"
-    where type CFieldType UUU_anon'anon'x_anon'x
-                          "uUU_anon'anon'x_anon'x_x" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "uUU_anon'anon'x_anon'x_x"
                   (Ptr UUU_anon'anon'x_anon'x)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"uUU_anon'anon'x_anon'x_x")
+instance HasCField UUU_anon'anon'x_anon'x
+                   "uUU_anon'anon'x_anon'x_x"
+    where type CFieldType UUU_anon'anon'x_anon'x
+                          "uUU_anon'anon'x_anon'x_x" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@UUU_anon\'anon\'x@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 72:3@
@@ -1041,13 +1041,13 @@ set_uUU_anon'anon'x_anon'x :: UUU_anon'anon'x_anon'x ->
 
 -}
 set_uUU_anon'anon'x_anon'x = setUnionPayload
+instance (~) ty UUU_anon'anon'x_anon'x =>
+         HasField "uUU_anon'anon'x_anon'x" (Ptr UUU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"uUU_anon'anon'x_anon'x")
 instance HasCField UUU_anon'anon'x "uUU_anon'anon'x_anon'x"
     where type CFieldType UUU_anon'anon'x
                           "uUU_anon'anon'x_anon'x" = UUU_anon'anon'x_anon'x
           offset# = \_ -> \_ -> 0
-instance (~) ty UUU_anon'anon'x_anon'x =>
-         HasField "uUU_anon'anon'x_anon'x" (Ptr UUU_anon'anon'x) (Ptr ty)
-    where getField = fromPtr (Proxy @"uUU_anon'anon'x_anon'x")
 {-| __C declaration:__ @union UUU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 71:7@
@@ -1093,9 +1093,9 @@ set_uUU_anon'anon'x :: UUU_anon'anon'x -> UUU
 
 -}
 set_uUU_anon'anon'x = setUnionPayload
-instance HasCField UUU "uUU_anon'anon'x"
-    where type CFieldType UUU "uUU_anon'anon'x" = UUU_anon'anon'x
-          offset# = \_ -> \_ -> 0
 instance (~) ty UUU_anon'anon'x =>
          HasField "uUU_anon'anon'x" (Ptr UUU) (Ptr ty)
     where getField = fromPtr (Proxy @"uUU_anon'anon'x")
+instance HasCField UUU "uUU_anon'anon'x"
+    where type CFieldType UUU "uUU_anon'anon'x" = UUU_anon'anon'x
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/Example.hs
@@ -86,18 +86,6 @@ instance Marshal.WriteRaw SS_anon'y where
 
 deriving via Marshal.EquivStorable SS_anon'y instance RIP.Storable SS_anon'y
 
-instance HasCField.HasCField SS_anon'y "sS_anon'y_y" where
-
-  type CFieldType SS_anon'y "sS_anon'y_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "sS_anon'y_y" (RIP.Ptr SS_anon'y) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"sS_anon'y_y")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "sS_anon'y_y" SS_anon'y ty where
 
@@ -105,6 +93,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          SS_anon'y {sS_anon'y_y = y1}, RIP.getField @"sS_anon'y_y" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "sS_anon'y_y" (RIP.Ptr SS_anon'y) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"sS_anon'y_y")
+
+instance HasCField.HasCField SS_anon'y "sS_anon'y_y" where
+
+  type CFieldType SS_anon'y "sS_anon'y_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct SS@
 
@@ -165,16 +165,6 @@ instance Marshal.WriteRaw SS where
 
 deriving via Marshal.EquivStorable SS instance RIP.Storable SS
 
-instance HasCField.HasCField SS "sS_x" where
-
-  type CFieldType SS "sS_x" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "sS_x" (RIP.Ptr SS) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"sS_x")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "sS_x" SS ty where
 
   hasField =
@@ -187,16 +177,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "sS_x" SS ty where
       , RIP.getField @"sS_x" x0
       )
 
-instance HasCField.HasCField SS "sS_anon'y" where
+instance (ty ~ RIP.CChar) => RIP.HasField "sS_x" (RIP.Ptr SS) (RIP.Ptr ty) where
 
-  type CFieldType SS "sS_anon'y" = SS_anon'y
+  getField = HasCField.fromPtr (RIP.Proxy @"sS_x")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField SS "sS_x" where
 
-instance ( ty ~ SS_anon'y
-         ) => RIP.HasField "sS_anon'y" (RIP.Ptr SS) (RIP.Ptr ty) where
+  type CFieldType SS "sS_x" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"sS_anon'y")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ SS_anon'y) => RIP.CompatHasField.HasField "sS_anon'y" SS ty where
 
@@ -207,15 +196,16 @@ instance (ty ~ SS_anon'y) => RIP.CompatHasField.HasField "sS_anon'y" SS ty where
       , RIP.getField @"sS_anon'y" x0
       )
 
-instance HasCField.HasCField SS "sS_z" where
+instance ( ty ~ SS_anon'y
+         ) => RIP.HasField "sS_anon'y" (RIP.Ptr SS) (RIP.Ptr ty) where
 
-  type CFieldType SS "sS_z" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"sS_anon'y")
 
-  offset# = \_ -> \_ -> 12
+instance HasCField.HasCField SS "sS_anon'y" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "sS_z" (RIP.Ptr SS) (RIP.Ptr ty) where
+  type CFieldType SS "sS_anon'y" = SS_anon'y
 
-  getField = HasCField.fromPtr (RIP.Proxy @"sS_z")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "sS_z" SS ty where
 
@@ -228,6 +218,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "sS_z" SS ty where
              }
       , RIP.getField @"sS_z" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "sS_z" (RIP.Ptr SS) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"sS_z")
+
+instance HasCField.HasCField SS "sS_z" where
+
+  type CFieldType SS "sS_z" = RIP.CInt
+
+  offset# = \_ -> \_ -> 12
 
 {-| __C declaration:__ @union \@SU_anon\'y@
 
@@ -273,17 +273,17 @@ set_sU_anon'y_y ::
   -> SU_anon'y
 set_sU_anon'y_y = RIP.setUnionPayload
 
-instance HasCField.HasCField SU_anon'y "sU_anon'y_y" where
-
-  type CFieldType SU_anon'y "sU_anon'y_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "sU_anon'y_y" (RIP.Ptr SU_anon'y) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"sU_anon'y_y")
+
+instance HasCField.HasCField SU_anon'y "sU_anon'y_y" where
+
+  type CFieldType SU_anon'y "sU_anon'y_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct SU@
 
@@ -344,16 +344,6 @@ instance Marshal.WriteRaw SU where
 
 deriving via Marshal.EquivStorable SU instance RIP.Storable SU
 
-instance HasCField.HasCField SU "sU_x" where
-
-  type CFieldType SU "sU_x" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "sU_x" (RIP.Ptr SU) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"sU_x")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "sU_x" SU ty where
 
   hasField =
@@ -366,16 +356,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "sU_x" SU ty where
       , RIP.getField @"sU_x" x0
       )
 
-instance HasCField.HasCField SU "sU_anon'y" where
+instance (ty ~ RIP.CChar) => RIP.HasField "sU_x" (RIP.Ptr SU) (RIP.Ptr ty) where
 
-  type CFieldType SU "sU_anon'y" = SU_anon'y
+  getField = HasCField.fromPtr (RIP.Proxy @"sU_x")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField SU "sU_x" where
 
-instance ( ty ~ SU_anon'y
-         ) => RIP.HasField "sU_anon'y" (RIP.Ptr SU) (RIP.Ptr ty) where
+  type CFieldType SU "sU_x" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"sU_anon'y")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ SU_anon'y) => RIP.CompatHasField.HasField "sU_anon'y" SU ty where
 
@@ -386,15 +375,16 @@ instance (ty ~ SU_anon'y) => RIP.CompatHasField.HasField "sU_anon'y" SU ty where
       , RIP.getField @"sU_anon'y" x0
       )
 
-instance HasCField.HasCField SU "sU_z" where
+instance ( ty ~ SU_anon'y
+         ) => RIP.HasField "sU_anon'y" (RIP.Ptr SU) (RIP.Ptr ty) where
 
-  type CFieldType SU "sU_z" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"sU_anon'y")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField SU "sU_anon'y" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "sU_z" (RIP.Ptr SU) (RIP.Ptr ty) where
+  type CFieldType SU "sU_anon'y" = SU_anon'y
 
-  getField = HasCField.fromPtr (RIP.Proxy @"sU_z")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "sU_z" SU ty where
 
@@ -407,6 +397,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "sU_z" SU ty where
              }
       , RIP.getField @"sU_z" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "sU_z" (RIP.Ptr SU) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"sU_z")
+
+instance HasCField.HasCField SU "sU_z" where
+
+  type CFieldType SU "sU_z" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@US_anon\'y@
 
@@ -449,18 +449,6 @@ instance Marshal.WriteRaw US_anon'y where
 
 deriving via Marshal.EquivStorable US_anon'y instance RIP.Storable US_anon'y
 
-instance HasCField.HasCField US_anon'y "uS_anon'y_y" where
-
-  type CFieldType US_anon'y "uS_anon'y_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "uS_anon'y_y" (RIP.Ptr US_anon'y) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"uS_anon'y_y")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "uS_anon'y_y" US_anon'y ty where
 
@@ -468,6 +456,18 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          US_anon'y {uS_anon'y_y = y1}, RIP.getField @"uS_anon'y_y" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "uS_anon'y_y" (RIP.Ptr US_anon'y) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"uS_anon'y_y")
+
+instance HasCField.HasCField US_anon'y "uS_anon'y_y" where
+
+  type CFieldType US_anon'y "uS_anon'y_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union US@
 
@@ -563,19 +563,13 @@ set_uS_z ::
   -> US
 set_uS_z = RIP.setUnionPayload
 
-instance HasCField.HasCField US "uS_x" where
-
-  type CFieldType US "uS_x" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance (ty ~ RIP.CChar) => RIP.HasField "uS_x" (RIP.Ptr US) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_x")
 
-instance HasCField.HasCField US "uS_anon'y" where
+instance HasCField.HasCField US "uS_x" where
 
-  type CFieldType US "uS_anon'y" = US_anon'y
+  type CFieldType US "uS_x" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -584,15 +578,21 @@ instance ( ty ~ US_anon'y
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_anon'y")
 
-instance HasCField.HasCField US "uS_z" where
+instance HasCField.HasCField US "uS_anon'y" where
 
-  type CFieldType US "uS_z" = RIP.CInt
+  type CFieldType US "uS_anon'y" = US_anon'y
 
   offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.HasField "uS_z" (RIP.Ptr US) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uS_z")
+
+instance HasCField.HasCField US "uS_z" where
+
+  type CFieldType US "uS_z" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@UU_anon\'y@
 
@@ -638,17 +638,17 @@ set_uU_anon'y_y ::
   -> UU_anon'y
 set_uU_anon'y_y = RIP.setUnionPayload
 
-instance HasCField.HasCField UU_anon'y "uU_anon'y_y" where
-
-  type CFieldType UU_anon'y "uU_anon'y_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "uU_anon'y_y" (RIP.Ptr UU_anon'y) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"uU_anon'y_y")
+
+instance HasCField.HasCField UU_anon'y "uU_anon'y_y" where
+
+  type CFieldType UU_anon'y "uU_anon'y_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union UU@
 
@@ -744,19 +744,13 @@ set_uU_z ::
   -> UU
 set_uU_z = RIP.setUnionPayload
 
-instance HasCField.HasCField UU "uU_x" where
-
-  type CFieldType UU "uU_x" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance (ty ~ RIP.CChar) => RIP.HasField "uU_x" (RIP.Ptr UU) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_x")
 
-instance HasCField.HasCField UU "uU_anon'y" where
+instance HasCField.HasCField UU "uU_x" where
 
-  type CFieldType UU "uU_anon'y" = UU_anon'y
+  type CFieldType UU "uU_x" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -765,12 +759,18 @@ instance ( ty ~ UU_anon'y
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_anon'y")
 
-instance HasCField.HasCField UU "uU_z" where
+instance HasCField.HasCField UU "uU_anon'y" where
 
-  type CFieldType UU "uU_z" = RIP.CInt
+  type CFieldType UU "uU_anon'y" = UU_anon'y
 
   offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.HasField "uU_z" (RIP.Ptr UU) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"uU_z")
+
+instance HasCField.HasCField UU "uU_z" where
+
+  type CFieldType UU "uU_z" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/bindingspec.yaml
@@ -37,11 +37,12 @@ hstypes:
       - sS_anon'y
       - sS_z
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -54,11 +55,12 @@ hstypes:
       fields:
       - sS_anon'y_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,10 +75,11 @@ hstypes:
       - sU_anon'y
       - sU_z
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -90,7 +93,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -104,7 +107,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -116,11 +119,12 @@ hstypes:
       fields:
       - uS_anon'y_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -135,7 +139,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -149,7 +153,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/padding/th.txt
@@ -23,15 +23,15 @@ instance WriteRaw SS_anon'y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        SS_anon'y sS_anon'y_y_2 -> writeRaw (Proxy @"sS_anon'y_y") ptr_0 sS_anon'y_y_2
 deriving via (EquivStorable SS_anon'y) instance Storable SS_anon'y
-instance HasCField SS_anon'y "sS_anon'y_y"
-    where type CFieldType SS_anon'y "sS_anon'y_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "sS_anon'y_y" (Ptr SS_anon'y) (Ptr ty)
-    where getField = fromPtr (Proxy @"sS_anon'y_y")
 instance (~) ty CInt => HasField "sS_anon'y_y" SS_anon'y ty
     where hasField = \x_0 -> (\y_1 -> SS_anon'y{sS_anon'y_y = y_1},
                               getField @"sS_anon'y_y" x_0)
+instance (~) ty CInt =>
+         HasField "sS_anon'y_y" (Ptr SS_anon'y) (Ptr ty)
+    where getField = fromPtr (Proxy @"sS_anon'y_y")
+instance HasCField SS_anon'y "sS_anon'y_y"
+    where type CFieldType SS_anon'y "sS_anon'y_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct SS@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 13:8@
@@ -72,36 +72,36 @@ instance WriteRaw SS
                                           sS_anon'y_3
                                           sS_z_4 -> writeRaw (Proxy @"sS_x") ptr_0 sS_x_2 >> (writeRaw (Proxy @"sS_anon'y") ptr_0 sS_anon'y_3 >> writeRaw (Proxy @"sS_z") ptr_0 sS_z_4)
 deriving via (EquivStorable SS) instance Storable SS
-instance HasCField SS "sS_x"
-    where type CFieldType SS "sS_x" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "sS_x" (Ptr SS) (Ptr ty)
-    where getField = fromPtr (Proxy @"sS_x")
 instance (~) ty CChar => HasField "sS_x" SS ty
     where hasField = \x_0 -> (\y_1 -> SS{sS_x = y_1,
                                          sS_anon'y = getField @"sS_anon'y" x_0,
                                          sS_z = getField @"sS_z" x_0},
                               getField @"sS_x" x_0)
-instance HasCField SS "sS_anon'y"
-    where type CFieldType SS "sS_anon'y" = SS_anon'y
-          offset# = \_ -> \_ -> 4
-instance (~) ty SS_anon'y => HasField "sS_anon'y" (Ptr SS) (Ptr ty)
-    where getField = fromPtr (Proxy @"sS_anon'y")
+instance (~) ty CChar => HasField "sS_x" (Ptr SS) (Ptr ty)
+    where getField = fromPtr (Proxy @"sS_x")
+instance HasCField SS "sS_x"
+    where type CFieldType SS "sS_x" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty SS_anon'y => HasField "sS_anon'y" SS ty
     where hasField = \x_0 -> (\y_1 -> SS{sS_anon'y = y_1,
                                          sS_x = getField @"sS_x" x_0,
                                          sS_z = getField @"sS_z" x_0},
                               getField @"sS_anon'y" x_0)
-instance HasCField SS "sS_z"
-    where type CFieldType SS "sS_z" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt => HasField "sS_z" (Ptr SS) (Ptr ty)
-    where getField = fromPtr (Proxy @"sS_z")
+instance (~) ty SS_anon'y => HasField "sS_anon'y" (Ptr SS) (Ptr ty)
+    where getField = fromPtr (Proxy @"sS_anon'y")
+instance HasCField SS "sS_anon'y"
+    where type CFieldType SS "sS_anon'y" = SS_anon'y
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "sS_z" SS ty
     where hasField = \x_0 -> (\y_1 -> SS{sS_z = y_1,
                                          sS_x = getField @"sS_x" x_0,
                                          sS_anon'y = getField @"sS_anon'y" x_0},
                               getField @"sS_z" x_0)
+instance (~) ty CInt => HasField "sS_z" (Ptr SS) (Ptr ty)
+    where getField = fromPtr (Proxy @"sS_z")
+instance HasCField SS "sS_z"
+    where type CFieldType SS "sS_z" = CInt
+          offset# = \_ -> \_ -> 12
 {-| __C declaration:__ @union \@SU_anon\'y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 24:3@
@@ -149,12 +149,12 @@ set_sU_anon'y_y :: CInt -> SU_anon'y
 
 -}
 set_sU_anon'y_y = setUnionPayload
-instance HasCField SU_anon'y "sU_anon'y_y"
-    where type CFieldType SU_anon'y "sU_anon'y_y" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "sU_anon'y_y" (Ptr SU_anon'y) (Ptr ty)
     where getField = fromPtr (Proxy @"sU_anon'y_y")
+instance HasCField SU_anon'y "sU_anon'y_y"
+    where type CFieldType SU_anon'y "sU_anon'y_y" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct SU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 22:8@
@@ -195,36 +195,36 @@ instance WriteRaw SU
                                           sU_anon'y_3
                                           sU_z_4 -> writeRaw (Proxy @"sU_x") ptr_0 sU_x_2 >> (writeRaw (Proxy @"sU_anon'y") ptr_0 sU_anon'y_3 >> writeRaw (Proxy @"sU_z") ptr_0 sU_z_4)
 deriving via (EquivStorable SU) instance Storable SU
-instance HasCField SU "sU_x"
-    where type CFieldType SU "sU_x" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "sU_x" (Ptr SU) (Ptr ty)
-    where getField = fromPtr (Proxy @"sU_x")
 instance (~) ty CChar => HasField "sU_x" SU ty
     where hasField = \x_0 -> (\y_1 -> SU{sU_x = y_1,
                                          sU_anon'y = getField @"sU_anon'y" x_0,
                                          sU_z = getField @"sU_z" x_0},
                               getField @"sU_x" x_0)
-instance HasCField SU "sU_anon'y"
-    where type CFieldType SU "sU_anon'y" = SU_anon'y
-          offset# = \_ -> \_ -> 4
-instance (~) ty SU_anon'y => HasField "sU_anon'y" (Ptr SU) (Ptr ty)
-    where getField = fromPtr (Proxy @"sU_anon'y")
+instance (~) ty CChar => HasField "sU_x" (Ptr SU) (Ptr ty)
+    where getField = fromPtr (Proxy @"sU_x")
+instance HasCField SU "sU_x"
+    where type CFieldType SU "sU_x" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty SU_anon'y => HasField "sU_anon'y" SU ty
     where hasField = \x_0 -> (\y_1 -> SU{sU_anon'y = y_1,
                                          sU_x = getField @"sU_x" x_0,
                                          sU_z = getField @"sU_z" x_0},
                               getField @"sU_anon'y" x_0)
-instance HasCField SU "sU_z"
-    where type CFieldType SU "sU_z" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "sU_z" (Ptr SU) (Ptr ty)
-    where getField = fromPtr (Proxy @"sU_z")
+instance (~) ty SU_anon'y => HasField "sU_anon'y" (Ptr SU) (Ptr ty)
+    where getField = fromPtr (Proxy @"sU_anon'y")
+instance HasCField SU "sU_anon'y"
+    where type CFieldType SU "sU_anon'y" = SU_anon'y
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "sU_z" SU ty
     where hasField = \x_0 -> (\y_1 -> SU{sU_z = y_1,
                                          sU_x = getField @"sU_x" x_0,
                                          sU_anon'y = getField @"sU_anon'y" x_0},
                               getField @"sU_z" x_0)
+instance (~) ty CInt => HasField "sU_z" (Ptr SU) (Ptr ty)
+    where getField = fromPtr (Proxy @"sU_z")
+instance HasCField SU "sU_z"
+    where type CFieldType SU "sU_z" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@US_anon\'y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 33:3@
@@ -249,15 +249,15 @@ instance WriteRaw US_anon'y
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        US_anon'y uS_anon'y_y_2 -> writeRaw (Proxy @"uS_anon'y_y") ptr_0 uS_anon'y_y_2
 deriving via (EquivStorable US_anon'y) instance Storable US_anon'y
-instance HasCField US_anon'y "uS_anon'y_y"
-    where type CFieldType US_anon'y "uS_anon'y_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "uS_anon'y_y" (Ptr US_anon'y) (Ptr ty)
-    where getField = fromPtr (Proxy @"uS_anon'y_y")
 instance (~) ty CInt => HasField "uS_anon'y_y" US_anon'y ty
     where hasField = \x_0 -> (\y_1 -> US_anon'y{uS_anon'y_y = y_1},
                               getField @"uS_anon'y_y" x_0)
+instance (~) ty CInt =>
+         HasField "uS_anon'y_y" (Ptr US_anon'y) (Ptr ty)
+    where getField = fromPtr (Proxy @"uS_anon'y_y")
+instance HasCField US_anon'y "uS_anon'y_y"
+    where type CFieldType US_anon'y "uS_anon'y_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union US@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 31:7@
@@ -371,21 +371,21 @@ set_uS_z :: CInt -> US
 
 -}
 set_uS_z = setUnionPayload
+instance (~) ty CChar => HasField "uS_x" (Ptr US) (Ptr ty)
+    where getField = fromPtr (Proxy @"uS_x")
 instance HasCField US "uS_x"
     where type CFieldType US "uS_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "uS_x" (Ptr US) (Ptr ty)
-    where getField = fromPtr (Proxy @"uS_x")
+instance (~) ty US_anon'y => HasField "uS_anon'y" (Ptr US) (Ptr ty)
+    where getField = fromPtr (Proxy @"uS_anon'y")
 instance HasCField US "uS_anon'y"
     where type CFieldType US "uS_anon'y" = US_anon'y
           offset# = \_ -> \_ -> 0
-instance (~) ty US_anon'y => HasField "uS_anon'y" (Ptr US) (Ptr ty)
-    where getField = fromPtr (Proxy @"uS_anon'y")
+instance (~) ty CInt => HasField "uS_z" (Ptr US) (Ptr ty)
+    where getField = fromPtr (Proxy @"uS_z")
 instance HasCField US "uS_z"
     where type CFieldType US "uS_z" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uS_z" (Ptr US) (Ptr ty)
-    where getField = fromPtr (Proxy @"uS_z")
 {-| __C declaration:__ @union \@UU_anon\'y@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 42:3@
@@ -433,12 +433,12 @@ set_uU_anon'y_y :: CInt -> UU_anon'y
 
 -}
 set_uU_anon'y_y = setUnionPayload
-instance HasCField UU_anon'y "uU_anon'y_y"
-    where type CFieldType UU_anon'y "uU_anon'y_y" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "uU_anon'y_y" (Ptr UU_anon'y) (Ptr ty)
     where getField = fromPtr (Proxy @"uU_anon'y_y")
+instance HasCField UU_anon'y "uU_anon'y_y"
+    where type CFieldType UU_anon'y "uU_anon'y_y" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union UU@
 
     __defined at:__ @types\/anonymous\/edge-cases\/padding.h 40:7@
@@ -552,18 +552,18 @@ set_uU_z :: CInt -> UU
 
 -}
 set_uU_z = setUnionPayload
+instance (~) ty CChar => HasField "uU_x" (Ptr UU) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU_x")
 instance HasCField UU "uU_x"
     where type CFieldType UU "uU_x" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "uU_x" (Ptr UU) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU_x")
+instance (~) ty UU_anon'y => HasField "uU_anon'y" (Ptr UU) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU_anon'y")
 instance HasCField UU "uU_anon'y"
     where type CFieldType UU "uU_anon'y" = UU_anon'y
           offset# = \_ -> \_ -> 0
-instance (~) ty UU_anon'y => HasField "uU_anon'y" (Ptr UU) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU_anon'y")
+instance (~) ty CInt => HasField "uU_z" (Ptr UU) (Ptr ty)
+    where getField = fromPtr (Proxy @"uU_z")
 instance HasCField UU "uU_z"
     where type CFieldType UU "uU_z" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "uU_z" (Ptr UU) (Ptr ty)
-    where getField = fromPtr (Proxy @"uU_z")

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/Example.hs
@@ -81,19 +81,6 @@ instance Marshal.WriteRaw Has_implicit_fields_anon'x2_1 where
 
 deriving via Marshal.EquivStorable Has_implicit_fields_anon'x2_1 instance RIP.Storable Has_implicit_fields_anon'x2_1
 
-instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" where
-
-  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_1" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x2_1_x2_1" Has_implicit_fields_anon'x2_1 ty where
 
@@ -106,18 +93,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_anon'x2_1_x2_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" where
-
-  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_2" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
+         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_1" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_1")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" where
+
+  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x2_1_x2_2" Has_implicit_fields_anon'x2_1 ty where
@@ -130,6 +117,19 @@ instance ( ty ~ RIP.CInt
                                         }
       , RIP.getField @"has_implicit_fields_anon'x2_1_x2_2" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_2" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" where
+
+  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@has_implicit_fields_anon\'x4_1@
 
@@ -183,19 +183,6 @@ instance Marshal.WriteRaw Has_implicit_fields_anon'x4_1 where
 
 deriving via Marshal.EquivStorable Has_implicit_fields_anon'x4_1 instance RIP.Storable Has_implicit_fields_anon'x4_1
 
-instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" where
-
-  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_1" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x4_1_x4_1" Has_implicit_fields_anon'x4_1 ty where
 
@@ -208,18 +195,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_anon'x4_1_x4_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" where
-
-  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_2" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
+         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_1" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_1")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" where
+
+  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x4_1_x4_2" Has_implicit_fields_anon'x4_1 ty where
@@ -232,6 +219,19 @@ instance ( ty ~ RIP.CInt
                                         }
       , RIP.getField @"has_implicit_fields_anon'x4_1_x4_2" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_2" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" where
+
+  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union \@has_implicit_fields_anon\'x5_1@
 
@@ -306,22 +306,15 @@ set_has_implicit_fields_anon'x5_1_x5_2 ::
 set_has_implicit_fields_anon'x5_1_x5_2 =
   RIP.setUnionPayload
 
-instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" where
-
-  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "has_implicit_fields_anon'x5_1_x5_1" (RIP.Ptr Has_implicit_fields_anon'x5_1) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1_x5_1")
 
-instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" where
+instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" where
 
-  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" =
+  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -331,6 +324,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1_x5_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" where
+
+  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct has_implicit_fields@
 
@@ -424,19 +424,6 @@ instance Marshal.WriteRaw Has_implicit_fields where
 
 deriving via Marshal.EquivStorable Has_implicit_fields instance RIP.Storable Has_implicit_fields
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_x1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_x1" Has_implicit_fields ty where
 
@@ -453,18 +440,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_x1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x2_1" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x2_1" =
-    Has_implicit_fields_anon'x2_1
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Has_implicit_fields_anon'x2_1
-         ) => RIP.HasField "has_implicit_fields_anon'x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x1")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_x1" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Has_implicit_fields_anon'x2_1
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x2_1" Has_implicit_fields ty where
@@ -482,18 +469,18 @@ instance ( ty ~ Has_implicit_fields_anon'x2_1
       , RIP.getField @"has_implicit_fields_anon'x2_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_x3" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance ( ty ~ Has_implicit_fields_anon'x2_1
+         ) => RIP.HasField "has_implicit_fields_anon'x2_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x3")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x2_1" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x2_1" =
+    Has_implicit_fields_anon'x2_1
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_x3" Has_implicit_fields ty where
@@ -511,18 +498,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_x3" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x4_1" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x4_1" =
-    Has_implicit_fields_anon'x4_1
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ Has_implicit_fields_anon'x4_1
-         ) => RIP.HasField "has_implicit_fields_anon'x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_x3" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x3")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_x3" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 12
 
 instance ( ty ~ Has_implicit_fields_anon'x4_1
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x4_1" Has_implicit_fields ty where
@@ -540,18 +527,18 @@ instance ( ty ~ Has_implicit_fields_anon'x4_1
       , RIP.getField @"has_implicit_fields_anon'x4_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x5_1" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x5_1" =
-    Has_implicit_fields_anon'x5_1
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ Has_implicit_fields_anon'x5_1
-         ) => RIP.HasField "has_implicit_fields_anon'x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance ( ty ~ Has_implicit_fields_anon'x4_1
+         ) => RIP.HasField "has_implicit_fields_anon'x4_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x4_1" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x4_1" =
+    Has_implicit_fields_anon'x4_1
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ Has_implicit_fields_anon'x5_1
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x5_1" Has_implicit_fields ty where
@@ -569,18 +556,18 @@ instance ( ty ~ Has_implicit_fields_anon'x5_1
       , RIP.getField @"has_implicit_fields_anon'x5_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_x5" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 28
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+instance ( ty ~ Has_implicit_fields_anon'x5_1
+         ) => RIP.HasField "has_implicit_fields_anon'x5_1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x5_1" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x5_1" =
+    Has_implicit_fields_anon'x5_1
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_x5" Has_implicit_fields ty where
@@ -597,3 +584,16 @@ instance ( ty ~ RIP.CInt
                               }
       , RIP.getField @"has_implicit_fields_x5" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_x5" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_x5" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 28

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/bindingspec.yaml
@@ -28,10 +28,11 @@ hstypes:
       - has_implicit_fields_anon'x5_1
       - has_implicit_fields_x5
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -44,11 +45,12 @@ hstypes:
       - has_implicit_fields_anon'x2_1_x2_1
       - has_implicit_fields_anon'x2_1_x2_2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -62,11 +64,12 @@ hstypes:
       - has_implicit_fields_anon'x4_1_x4_1
       - has_implicit_fields_anon'x4_1_x4_2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -81,7 +84,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct/th.txt
@@ -31,16 +31,6 @@ instance WriteRaw Has_implicit_fields_anon'x2_1
                                        Has_implicit_fields_anon'x2_1 has_implicit_fields_anon'x2_1_x2_1_2
                                                                      has_implicit_fields_anon'x2_1_x2_2_3 -> writeRaw (Proxy @"has_implicit_fields_anon'x2_1_x2_1") ptr_0 has_implicit_fields_anon'x2_1_x2_1_2 >> writeRaw (Proxy @"has_implicit_fields_anon'x2_1_x2_2") ptr_0 has_implicit_fields_anon'x2_1_x2_2_3
 deriving via (EquivStorable Has_implicit_fields_anon'x2_1) instance Storable Has_implicit_fields_anon'x2_1
-instance HasCField Has_implicit_fields_anon'x2_1
-                   "has_implicit_fields_anon'x2_1_x2_1"
-    where type CFieldType Has_implicit_fields_anon'x2_1
-                          "has_implicit_fields_anon'x2_1_x2_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x2_1_x2_1"
-                  (Ptr Has_implicit_fields_anon'x2_1)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_1")
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x2_1_x2_1"
                   Has_implicit_fields_anon'x2_1
@@ -48,16 +38,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x2_1{has_implicit_fields_anon'x2_1_x2_1 = y_1,
                                                                     has_implicit_fields_anon'x2_1_x2_2 = getField @"has_implicit_fields_anon'x2_1_x2_2" x_0},
                               getField @"has_implicit_fields_anon'x2_1_x2_1" x_0)
-instance HasCField Has_implicit_fields_anon'x2_1
-                   "has_implicit_fields_anon'x2_1_x2_2"
-    where type CFieldType Has_implicit_fields_anon'x2_1
-                          "has_implicit_fields_anon'x2_1_x2_2" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x2_1_x2_2"
+         HasField "has_implicit_fields_anon'x2_1_x2_1"
                   (Ptr Has_implicit_fields_anon'x2_1)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_1")
+instance HasCField Has_implicit_fields_anon'x2_1
+                   "has_implicit_fields_anon'x2_1_x2_1"
+    where type CFieldType Has_implicit_fields_anon'x2_1
+                          "has_implicit_fields_anon'x2_1_x2_1" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x2_1_x2_2"
                   Has_implicit_fields_anon'x2_1
@@ -65,6 +55,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x2_1{has_implicit_fields_anon'x2_1_x2_2 = y_1,
                                                                     has_implicit_fields_anon'x2_1_x2_1 = getField @"has_implicit_fields_anon'x2_1_x2_1" x_0},
                               getField @"has_implicit_fields_anon'x2_1_x2_2" x_0)
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_anon'x2_1_x2_2"
+                  (Ptr Has_implicit_fields_anon'x2_1)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+instance HasCField Has_implicit_fields_anon'x2_1
+                   "has_implicit_fields_anon'x2_1_x2_2"
+    where type CFieldType Has_implicit_fields_anon'x2_1
+                          "has_implicit_fields_anon'x2_1_x2_2" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@has_implicit_fields_anon\'x4_1@
 
     __defined at:__ @types\/anonymous\/struct.h 12:3@
@@ -97,16 +97,6 @@ instance WriteRaw Has_implicit_fields_anon'x4_1
                                        Has_implicit_fields_anon'x4_1 has_implicit_fields_anon'x4_1_x4_1_2
                                                                      has_implicit_fields_anon'x4_1_x4_2_3 -> writeRaw (Proxy @"has_implicit_fields_anon'x4_1_x4_1") ptr_0 has_implicit_fields_anon'x4_1_x4_1_2 >> writeRaw (Proxy @"has_implicit_fields_anon'x4_1_x4_2") ptr_0 has_implicit_fields_anon'x4_1_x4_2_3
 deriving via (EquivStorable Has_implicit_fields_anon'x4_1) instance Storable Has_implicit_fields_anon'x4_1
-instance HasCField Has_implicit_fields_anon'x4_1
-                   "has_implicit_fields_anon'x4_1_x4_1"
-    where type CFieldType Has_implicit_fields_anon'x4_1
-                          "has_implicit_fields_anon'x4_1_x4_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x4_1_x4_1"
-                  (Ptr Has_implicit_fields_anon'x4_1)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_1")
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x4_1_x4_1"
                   Has_implicit_fields_anon'x4_1
@@ -114,16 +104,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x4_1{has_implicit_fields_anon'x4_1_x4_1 = y_1,
                                                                     has_implicit_fields_anon'x4_1_x4_2 = getField @"has_implicit_fields_anon'x4_1_x4_2" x_0},
                               getField @"has_implicit_fields_anon'x4_1_x4_1" x_0)
-instance HasCField Has_implicit_fields_anon'x4_1
-                   "has_implicit_fields_anon'x4_1_x4_2"
-    where type CFieldType Has_implicit_fields_anon'x4_1
-                          "has_implicit_fields_anon'x4_1_x4_2" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x4_1_x4_2"
+         HasField "has_implicit_fields_anon'x4_1_x4_1"
                   (Ptr Has_implicit_fields_anon'x4_1)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_1")
+instance HasCField Has_implicit_fields_anon'x4_1
+                   "has_implicit_fields_anon'x4_1_x4_1"
+    where type CFieldType Has_implicit_fields_anon'x4_1
+                          "has_implicit_fields_anon'x4_1_x4_1" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x4_1_x4_2"
                   Has_implicit_fields_anon'x4_1
@@ -131,6 +121,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x4_1{has_implicit_fields_anon'x4_1_x4_2 = y_1,
                                                                     has_implicit_fields_anon'x4_1_x4_1 = getField @"has_implicit_fields_anon'x4_1_x4_1" x_0},
                               getField @"has_implicit_fields_anon'x4_1_x4_2" x_0)
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_anon'x4_1_x4_2"
+                  (Ptr Has_implicit_fields_anon'x4_1)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+instance HasCField Has_implicit_fields_anon'x4_1
+                   "has_implicit_fields_anon'x4_1_x4_2"
+    where type CFieldType Has_implicit_fields_anon'x4_1
+                          "has_implicit_fields_anon'x4_1_x4_2" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union \@has_implicit_fields_anon\'x5_1@
 
     __defined at:__ @types\/anonymous\/struct.h 16:3@
@@ -219,26 +219,26 @@ set_has_implicit_fields_anon'x5_1_x5_2 :: CInt ->
 
 -}
 set_has_implicit_fields_anon'x5_1_x5_2 = setUnionPayload
-instance HasCField Has_implicit_fields_anon'x5_1
-                   "has_implicit_fields_anon'x5_1_x5_1"
-    where type CFieldType Has_implicit_fields_anon'x5_1
-                          "has_implicit_fields_anon'x5_1_x5_1" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x5_1_x5_1"
                   (Ptr Has_implicit_fields_anon'x5_1)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1_x5_1")
 instance HasCField Has_implicit_fields_anon'x5_1
-                   "has_implicit_fields_anon'x5_1_x5_2"
+                   "has_implicit_fields_anon'x5_1_x5_1"
     where type CFieldType Has_implicit_fields_anon'x5_1
-                          "has_implicit_fields_anon'x5_1_x5_2" = CInt
+                          "has_implicit_fields_anon'x5_1_x5_1" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x5_1_x5_2"
                   (Ptr Has_implicit_fields_anon'x5_1)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1_x5_2")
+instance HasCField Has_implicit_fields_anon'x5_1
+                   "has_implicit_fields_anon'x5_1_x5_2"
+    where type CFieldType Has_implicit_fields_anon'x5_1
+                          "has_implicit_fields_anon'x5_1_x5_2" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct has_implicit_fields@
 
     __defined at:__ @types\/anonymous\/struct.h 5:8@
@@ -303,15 +303,6 @@ instance WriteRaw Has_implicit_fields
                                                            has_implicit_fields_anon'x5_1_6
                                                            has_implicit_fields_x5_7 -> writeRaw (Proxy @"has_implicit_fields_x1") ptr_0 has_implicit_fields_x1_2 >> (writeRaw (Proxy @"has_implicit_fields_anon'x2_1") ptr_0 has_implicit_fields_anon'x2_1_3 >> (writeRaw (Proxy @"has_implicit_fields_x3") ptr_0 has_implicit_fields_x3_4 >> (writeRaw (Proxy @"has_implicit_fields_anon'x4_1") ptr_0 has_implicit_fields_anon'x4_1_5 >> (writeRaw (Proxy @"has_implicit_fields_anon'x5_1") ptr_0 has_implicit_fields_anon'x5_1_6 >> writeRaw (Proxy @"has_implicit_fields_x5") ptr_0 has_implicit_fields_x5_7))))
 deriving via (EquivStorable Has_implicit_fields) instance Storable Has_implicit_fields
-instance HasCField Has_implicit_fields "has_implicit_fields_x1"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x1"
-                  (Ptr Has_implicit_fields)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_x1")
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x1" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_x1 = y_1,
@@ -321,16 +312,15 @@ instance (~) ty CInt =>
                                                           has_implicit_fields_anon'x5_1 = getField @"has_implicit_fields_anon'x5_1" x_0,
                                                           has_implicit_fields_x5 = getField @"has_implicit_fields_x5" x_0},
                               getField @"has_implicit_fields_x1" x_0)
-instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x2_1"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x2_1" = Has_implicit_fields_anon'x2_1
-          offset# = \_ -> \_ -> 4
-instance (~) ty Has_implicit_fields_anon'x2_1 =>
-         HasField "has_implicit_fields_anon'x2_1"
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_x1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1")
+    where getField = fromPtr (Proxy @"has_implicit_fields_x1")
+instance HasCField Has_implicit_fields "has_implicit_fields_x1"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_x1" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty Has_implicit_fields_anon'x2_1 =>
          HasField "has_implicit_fields_anon'x2_1" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_anon'x2_1 = y_1,
@@ -340,15 +330,16 @@ instance (~) ty Has_implicit_fields_anon'x2_1 =>
                                                           has_implicit_fields_anon'x5_1 = getField @"has_implicit_fields_anon'x5_1" x_0,
                                                           has_implicit_fields_x5 = getField @"has_implicit_fields_x5" x_0},
                               getField @"has_implicit_fields_anon'x2_1" x_0)
-instance HasCField Has_implicit_fields "has_implicit_fields_x3"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x3" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x3"
+instance (~) ty Has_implicit_fields_anon'x2_1 =>
+         HasField "has_implicit_fields_anon'x2_1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_x3")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1")
+instance HasCField Has_implicit_fields
+                   "has_implicit_fields_anon'x2_1"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_anon'x2_1" = Has_implicit_fields_anon'x2_1
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x3" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_x3 = y_1,
@@ -358,16 +349,15 @@ instance (~) ty CInt =>
                                                           has_implicit_fields_anon'x5_1 = getField @"has_implicit_fields_anon'x5_1" x_0,
                                                           has_implicit_fields_x5 = getField @"has_implicit_fields_x5" x_0},
                               getField @"has_implicit_fields_x3" x_0)
-instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x4_1"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x4_1" = Has_implicit_fields_anon'x4_1
-          offset# = \_ -> \_ -> 16
-instance (~) ty Has_implicit_fields_anon'x4_1 =>
-         HasField "has_implicit_fields_anon'x4_1"
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_x3"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1")
+    where getField = fromPtr (Proxy @"has_implicit_fields_x3")
+instance HasCField Has_implicit_fields "has_implicit_fields_x3"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_x3" = CInt
+          offset# = \_ -> \_ -> 12
 instance (~) ty Has_implicit_fields_anon'x4_1 =>
          HasField "has_implicit_fields_anon'x4_1" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_anon'x4_1 = y_1,
@@ -377,16 +367,16 @@ instance (~) ty Has_implicit_fields_anon'x4_1 =>
                                                           has_implicit_fields_anon'x5_1 = getField @"has_implicit_fields_anon'x5_1" x_0,
                                                           has_implicit_fields_x5 = getField @"has_implicit_fields_x5" x_0},
                               getField @"has_implicit_fields_anon'x4_1" x_0)
-instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x5_1"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x5_1" = Has_implicit_fields_anon'x5_1
-          offset# = \_ -> \_ -> 24
-instance (~) ty Has_implicit_fields_anon'x5_1 =>
-         HasField "has_implicit_fields_anon'x5_1"
+instance (~) ty Has_implicit_fields_anon'x4_1 =>
+         HasField "has_implicit_fields_anon'x4_1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1")
+instance HasCField Has_implicit_fields
+                   "has_implicit_fields_anon'x4_1"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_anon'x4_1" = Has_implicit_fields_anon'x4_1
+          offset# = \_ -> \_ -> 16
 instance (~) ty Has_implicit_fields_anon'x5_1 =>
          HasField "has_implicit_fields_anon'x5_1" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_anon'x5_1 = y_1,
@@ -396,15 +386,16 @@ instance (~) ty Has_implicit_fields_anon'x5_1 =>
                                                           has_implicit_fields_anon'x4_1 = getField @"has_implicit_fields_anon'x4_1" x_0,
                                                           has_implicit_fields_x5 = getField @"has_implicit_fields_x5" x_0},
                               getField @"has_implicit_fields_anon'x5_1" x_0)
-instance HasCField Has_implicit_fields "has_implicit_fields_x5"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x5" = CInt
-          offset# = \_ -> \_ -> 28
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_x5"
+instance (~) ty Has_implicit_fields_anon'x5_1 =>
+         HasField "has_implicit_fields_anon'x5_1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_x5")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1")
+instance HasCField Has_implicit_fields
+                   "has_implicit_fields_anon'x5_1"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_anon'x5_1" = Has_implicit_fields_anon'x5_1
+          offset# = \_ -> \_ -> 24
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x5" Has_implicit_fields ty
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields{has_implicit_fields_x5 = y_1,
@@ -414,3 +405,12 @@ instance (~) ty CInt =>
                                                           has_implicit_fields_anon'x4_1 = getField @"has_implicit_fields_anon'x4_1" x_0,
                                                           has_implicit_fields_anon'x5_1 = getField @"has_implicit_fields_anon'x5_1" x_0},
                               getField @"has_implicit_fields_x5" x_0)
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_x5"
+                  (Ptr Has_implicit_fields)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"has_implicit_fields_x5")
+instance HasCField Has_implicit_fields "has_implicit_fields_x5"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_x5" = CInt
+          offset# = \_ -> \_ -> 28

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/Example.hs
@@ -77,19 +77,6 @@ instance Marshal.WriteRaw Outer1_anon'fieldX where
 
 deriving via Marshal.EquivStorable Outer1_anon'fieldX instance RIP.Storable Outer1_anon'fieldX
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX_fieldX" Outer1_anon'fieldX ty where
 
@@ -102,18 +89,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"outer1_anon'fieldX_fieldX" x0
       )
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_anon'fieldX_fieldY" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
+         ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX_fieldY" Outer1_anon'fieldX ty where
@@ -126,6 +113,19 @@ instance ( ty ~ RIP.CInt
                              }
       , RIP.getField @"outer1_anon'fieldX_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer1_anon'fieldX_fieldY" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct outer1@
 
@@ -186,18 +186,6 @@ instance Marshal.WriteRaw Outer1 where
 
 deriving via Marshal.EquivStorable Outer1 instance RIP.Storable Outer1
 
-instance HasCField.HasCField Outer1 "outer1_fieldA" where
-
-  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer1_fieldA" Outer1 ty where
 
@@ -211,18 +199,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer1_fieldA" x0
       )
 
-instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
-
-  type CFieldType Outer1 "outer1_anon'fieldX" =
-    Outer1_anon'fieldX
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Outer1_anon'fieldX
-         ) => RIP.HasField "outer1_anon'fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
+    HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
+
+instance HasCField.HasCField Outer1 "outer1_fieldA" where
+
+  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Outer1_anon'fieldX
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX" Outer1 ty where
@@ -237,17 +224,18 @@ instance ( ty ~ Outer1_anon'fieldX
       , RIP.getField @"outer1_anon'fieldX" x0
       )
 
-instance HasCField.HasCField Outer1 "outer1_fieldC" where
-
-  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance ( ty ~ Outer1_anon'fieldX
+         ) => RIP.HasField "outer1_anon'fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
+
+instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
+
+  type CFieldType Outer1 "outer1_anon'fieldX" =
+    Outer1_anon'fieldX
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_fieldC" Outer1 ty where
@@ -261,6 +249,18 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer1_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+
+instance HasCField.HasCField Outer1 "outer1_fieldC" where
+
+  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 12
 
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
@@ -312,19 +312,6 @@ instance Marshal.WriteRaw Outer2_fieldB where
 
 deriving via Marshal.EquivStorable Outer2_fieldB instance RIP.Storable Outer2_fieldB
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldB_fieldX" Outer2_fieldB ty where
 
@@ -337,18 +324,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"outer2_fieldB_fieldX" x0
       )
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldB_fieldY" Outer2_fieldB ty where
@@ -361,6 +348,19 @@ instance ( ty ~ RIP.CInt
                         }
       , RIP.getField @"outer2_fieldB_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct outer2@
 
@@ -421,18 +421,6 @@ instance Marshal.WriteRaw Outer2 where
 
 deriving via Marshal.EquivStorable Outer2 instance RIP.Storable Outer2
 
-instance HasCField.HasCField Outer2 "outer2_fieldA" where
-
-  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer2_fieldA" Outer2 ty where
 
@@ -446,18 +434,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer2_fieldA" x0
       )
 
-instance HasCField.HasCField Outer2 "outer2_fieldB" where
-
-  type CFieldType Outer2 "outer2_fieldB" =
-    Outer2_fieldB
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
+
+instance HasCField.HasCField Outer2 "outer2_fieldA" where
+
+  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Outer2_fieldB
          ) => RIP.CompatHasField.HasField "outer2_fieldB" Outer2 ty where
@@ -472,17 +459,18 @@ instance ( ty ~ Outer2_fieldB
       , RIP.getField @"outer2_fieldB" x0
       )
 
-instance HasCField.HasCField Outer2 "outer2_fieldC" where
-
-  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance ( ty ~ Outer2_fieldB
+         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
+
+instance HasCField.HasCField Outer2 "outer2_fieldB" where
+
+  type CFieldType Outer2 "outer2_fieldB" =
+    Outer2_fieldB
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldC" Outer2 ty where
@@ -496,6 +484,18 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer2_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+
+instance HasCField.HasCField Outer2 "outer2_fieldC" where
+
+  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 12
 
 {-| __C declaration:__ @struct inner3@
 
@@ -547,18 +547,6 @@ instance Marshal.WriteRaw Inner3 where
 
 deriving via Marshal.EquivStorable Inner3 instance RIP.Storable Inner3
 
-instance HasCField.HasCField Inner3 "inner3_fieldX" where
-
-  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inner3_fieldX" Inner3 ty where
 
@@ -569,17 +557,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"inner3_fieldX" x0
       )
 
-instance HasCField.HasCField Inner3 "inner3_fieldY" where
-
-  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
+
+instance HasCField.HasCField Inner3 "inner3_fieldX" where
+
+  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inner3_fieldY" Inner3 ty where
@@ -590,6 +578,18 @@ instance ( ty ~ RIP.CInt
           Inner3 {inner3_fieldY = y1, inner3_fieldX = RIP.getField @"inner3_fieldX" x0}
       , RIP.getField @"inner3_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+
+instance HasCField.HasCField Inner3 "inner3_fieldY" where
+
+  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct outer3@
 
@@ -650,18 +650,6 @@ instance Marshal.WriteRaw Outer3 where
 
 deriving via Marshal.EquivStorable Outer3 instance RIP.Storable Outer3
 
-instance HasCField.HasCField Outer3 "outer3_fieldA" where
-
-  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer3_fieldA" Outer3 ty where
 
@@ -675,17 +663,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer3_fieldA" x0
       )
 
-instance HasCField.HasCField Outer3 "outer3_fieldB" where
-
-  type CFieldType Outer3 "outer3_fieldB" = Inner3
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
+
+instance HasCField.HasCField Outer3 "outer3_fieldA" where
+
+  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Inner3
          ) => RIP.CompatHasField.HasField "outer3_fieldB" Outer3 ty where
@@ -700,17 +688,17 @@ instance ( ty ~ Inner3
       , RIP.getField @"outer3_fieldB" x0
       )
 
-instance HasCField.HasCField Outer3 "outer3_fieldC" where
-
-  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance ( ty ~ Inner3
+         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
+
+instance HasCField.HasCField Outer3 "outer3_fieldB" where
+
+  type CFieldType Outer3 "outer3_fieldB" = Inner3
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer3_fieldC" Outer3 ty where
@@ -724,3 +712,15 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer3_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+
+instance HasCField.HasCField Outer3 "outer3_fieldC" where
+
+  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 12

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/bindingspec.yaml
@@ -30,11 +30,12 @@ hstypes:
       - inner3_fieldX
       - inner3_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -49,11 +50,12 @@ hstypes:
       - outer1_anon'fieldX
       - outer1_fieldC
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -67,11 +69,12 @@ hstypes:
       - outer1_anon'fieldX_fieldX
       - outer1_anon'fieldX_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -86,11 +89,12 @@ hstypes:
       - outer2_fieldB
       - outer2_fieldC
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -104,11 +108,12 @@ hstypes:
       - outer2_fieldB_fieldX
       - outer2_fieldB_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -123,11 +128,12 @@ hstypes:
       - outer3_fieldB
       - outer3_fieldC
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_struct/th.txt
@@ -31,34 +31,34 @@ instance WriteRaw Outer1_anon'fieldX
                                        Outer1_anon'fieldX outer1_anon'fieldX_fieldX_2
                                                           outer1_anon'fieldX_fieldY_3 -> writeRaw (Proxy @"outer1_anon'fieldX_fieldX") ptr_0 outer1_anon'fieldX_fieldX_2 >> writeRaw (Proxy @"outer1_anon'fieldX_fieldY") ptr_0 outer1_anon'fieldX_fieldY_3
 deriving via (EquivStorable Outer1_anon'fieldX) instance Storable Outer1_anon'fieldX
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_anon'fieldX_fieldX"
-                  (Ptr Outer1_anon'fieldX)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldX" Outer1_anon'fieldX ty
     where hasField = \x_0 -> (\y_1 -> Outer1_anon'fieldX{outer1_anon'fieldX_fieldX = y_1,
                                                          outer1_anon'fieldX_fieldY = getField @"outer1_anon'fieldX_fieldY" x_0},
                               getField @"outer1_anon'fieldX_fieldX" x_0)
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "outer1_anon'fieldX_fieldY"
+         HasField "outer1_anon'fieldX_fieldX"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldY" Outer1_anon'fieldX ty
     where hasField = \x_0 -> (\y_1 -> Outer1_anon'fieldX{outer1_anon'fieldX_fieldY = y_1,
                                                          outer1_anon'fieldX_fieldX = getField @"outer1_anon'fieldX_fieldX" x_0},
                               getField @"outer1_anon'fieldX_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "outer1_anon'fieldX_fieldY"
+                  (Ptr Outer1_anon'fieldX)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct outer1@
 
     __defined at:__ @types\/anonymous\/struct_in_struct.h 6:8@
@@ -99,41 +99,41 @@ instance WriteRaw Outer1
                                               outer1_anon'fieldX_3
                                               outer1_fieldC_4 -> writeRaw (Proxy @"outer1_fieldA") ptr_0 outer1_fieldA_2 >> (writeRaw (Proxy @"outer1_anon'fieldX") ptr_0 outer1_anon'fieldX_3 >> writeRaw (Proxy @"outer1_fieldC") ptr_0 outer1_fieldC_4)
 deriving via (EquivStorable Outer1) instance Storable Outer1
-instance HasCField Outer1 "outer1_fieldA"
-    where type CFieldType Outer1 "outer1_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_fieldA")
 instance (~) ty CChar => HasField "outer1_fieldA" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_fieldA = y_1,
                                              outer1_anon'fieldX = getField @"outer1_anon'fieldX" x_0,
                                              outer1_fieldC = getField @"outer1_fieldC" x_0},
                               getField @"outer1_fieldA" x_0)
-instance HasCField Outer1 "outer1_anon'fieldX"
-    where type CFieldType Outer1
-                          "outer1_anon'fieldX" = Outer1_anon'fieldX
-          offset# = \_ -> \_ -> 4
-instance (~) ty Outer1_anon'fieldX =>
-         HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX")
+instance (~) ty CChar =>
+         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_fieldA")
+instance HasCField Outer1 "outer1_fieldA"
+    where type CFieldType Outer1 "outer1_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Outer1_anon'fieldX =>
          HasField "outer1_anon'fieldX" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_anon'fieldX = y_1,
                                              outer1_fieldA = getField @"outer1_fieldA" x_0,
                                              outer1_fieldC = getField @"outer1_fieldC" x_0},
                               getField @"outer1_anon'fieldX" x_0)
-instance HasCField Outer1 "outer1_fieldC"
-    where type CFieldType Outer1 "outer1_fieldC" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_fieldC")
+instance (~) ty Outer1_anon'fieldX =>
+         HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX")
+instance HasCField Outer1 "outer1_anon'fieldX"
+    where type CFieldType Outer1
+                          "outer1_anon'fieldX" = Outer1_anon'fieldX
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer1_fieldC" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_fieldC = y_1,
                                              outer1_fieldA = getField @"outer1_fieldA" x_0,
                                              outer1_anon'fieldX = getField @"outer1_anon'fieldX" x_0},
                               getField @"outer1_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_fieldC")
+instance HasCField Outer1 "outer1_fieldC"
+    where type CFieldType Outer1 "outer1_fieldC" = CInt
+          offset# = \_ -> \_ -> 12
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
     __defined at:__ @types\/anonymous\/struct_in_struct.h 17:3@
@@ -166,28 +166,28 @@ instance WriteRaw Outer2_fieldB
                                        Outer2_fieldB outer2_fieldB_fieldX_2
                                                      outer2_fieldB_fieldY_3 -> writeRaw (Proxy @"outer2_fieldB_fieldX") ptr_0 outer2_fieldB_fieldX_2 >> writeRaw (Proxy @"outer2_fieldB_fieldY") ptr_0 outer2_fieldB_fieldY_3
 deriving via (EquivStorable Outer2_fieldB) instance Storable Outer2_fieldB
-instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
-    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance (~) ty CInt =>
          HasField "outer2_fieldB_fieldX" Outer2_fieldB ty
     where hasField = \x_0 -> (\y_1 -> Outer2_fieldB{outer2_fieldB_fieldX = y_1,
                                                     outer2_fieldB_fieldY = getField @"outer2_fieldB_fieldY" x_0},
                               getField @"outer2_fieldB_fieldX" x_0)
-instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
-    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
+         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
+instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
+    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer2_fieldB_fieldY" Outer2_fieldB ty
     where hasField = \x_0 -> (\y_1 -> Outer2_fieldB{outer2_fieldB_fieldY = y_1,
                                                     outer2_fieldB_fieldX = getField @"outer2_fieldB_fieldX" x_0},
                               getField @"outer2_fieldB_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
+instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
+    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct outer2@
 
     __defined at:__ @types\/anonymous\/struct_in_struct.h 15:8@
@@ -228,39 +228,39 @@ instance WriteRaw Outer2
                                               outer2_fieldB_3
                                               outer2_fieldC_4 -> writeRaw (Proxy @"outer2_fieldA") ptr_0 outer2_fieldA_2 >> (writeRaw (Proxy @"outer2_fieldB") ptr_0 outer2_fieldB_3 >> writeRaw (Proxy @"outer2_fieldC") ptr_0 outer2_fieldC_4)
 deriving via (EquivStorable Outer2) instance Storable Outer2
-instance HasCField Outer2 "outer2_fieldA"
-    where type CFieldType Outer2 "outer2_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldA")
 instance (~) ty CChar => HasField "outer2_fieldA" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldA = y_1,
                                              outer2_fieldB = getField @"outer2_fieldB" x_0,
                                              outer2_fieldC = getField @"outer2_fieldC" x_0},
                               getField @"outer2_fieldA" x_0)
-instance HasCField Outer2 "outer2_fieldB"
-    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
-          offset# = \_ -> \_ -> 4
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB")
+instance (~) ty CChar =>
+         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldA")
+instance HasCField Outer2 "outer2_fieldA"
+    where type CFieldType Outer2 "outer2_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Outer2_fieldB => HasField "outer2_fieldB" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldB = y_1,
                                              outer2_fieldA = getField @"outer2_fieldA" x_0,
                                              outer2_fieldC = getField @"outer2_fieldC" x_0},
                               getField @"outer2_fieldB" x_0)
-instance HasCField Outer2 "outer2_fieldC"
-    where type CFieldType Outer2 "outer2_fieldC" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldC")
+instance (~) ty Outer2_fieldB =>
+         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB")
+instance HasCField Outer2 "outer2_fieldB"
+    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer2_fieldC" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldC = y_1,
                                              outer2_fieldA = getField @"outer2_fieldA" x_0,
                                              outer2_fieldB = getField @"outer2_fieldB" x_0},
                               getField @"outer2_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldC")
+instance HasCField Outer2 "outer2_fieldC"
+    where type CFieldType Outer2 "outer2_fieldC" = CInt
+          offset# = \_ -> \_ -> 12
 {-| __C declaration:__ @struct inner3@
 
     __defined at:__ @types\/anonymous\/struct_in_struct.h 26:10@
@@ -293,26 +293,26 @@ instance WriteRaw Inner3
                                        Inner3 inner3_fieldX_2
                                               inner3_fieldY_3 -> writeRaw (Proxy @"inner3_fieldX") ptr_0 inner3_fieldX_2 >> writeRaw (Proxy @"inner3_fieldY") ptr_0 inner3_fieldY_3
 deriving via (EquivStorable Inner3) instance Storable Inner3
-instance HasCField Inner3 "inner3_fieldX"
-    where type CFieldType Inner3 "inner3_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldX")
 instance (~) ty CInt => HasField "inner3_fieldX" Inner3 ty
     where hasField = \x_0 -> (\y_1 -> Inner3{inner3_fieldX = y_1,
                                              inner3_fieldY = getField @"inner3_fieldY" x_0},
                               getField @"inner3_fieldX" x_0)
-instance HasCField Inner3 "inner3_fieldY"
-    where type CFieldType Inner3 "inner3_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldY")
+         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldX")
+instance HasCField Inner3 "inner3_fieldX"
+    where type CFieldType Inner3 "inner3_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "inner3_fieldY" Inner3 ty
     where hasField = \x_0 -> (\y_1 -> Inner3{inner3_fieldY = y_1,
                                              inner3_fieldX = getField @"inner3_fieldX" x_0},
                               getField @"inner3_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldY")
+instance HasCField Inner3 "inner3_fieldY"
+    where type CFieldType Inner3 "inner3_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct outer3@
 
     __defined at:__ @types\/anonymous\/struct_in_struct.h 24:8@
@@ -353,36 +353,36 @@ instance WriteRaw Outer3
                                               outer3_fieldB_3
                                               outer3_fieldC_4 -> writeRaw (Proxy @"outer3_fieldA") ptr_0 outer3_fieldA_2 >> (writeRaw (Proxy @"outer3_fieldB") ptr_0 outer3_fieldB_3 >> writeRaw (Proxy @"outer3_fieldC") ptr_0 outer3_fieldC_4)
 deriving via (EquivStorable Outer3) instance Storable Outer3
-instance HasCField Outer3 "outer3_fieldA"
-    where type CFieldType Outer3 "outer3_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldA")
 instance (~) ty CChar => HasField "outer3_fieldA" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldA = y_1,
                                              outer3_fieldB = getField @"outer3_fieldB" x_0,
                                              outer3_fieldC = getField @"outer3_fieldC" x_0},
                               getField @"outer3_fieldA" x_0)
-instance HasCField Outer3 "outer3_fieldB"
-    where type CFieldType Outer3 "outer3_fieldB" = Inner3
-          offset# = \_ -> \_ -> 4
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldB")
+instance (~) ty CChar =>
+         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldA")
+instance HasCField Outer3 "outer3_fieldA"
+    where type CFieldType Outer3 "outer3_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Inner3 => HasField "outer3_fieldB" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldB = y_1,
                                              outer3_fieldA = getField @"outer3_fieldA" x_0,
                                              outer3_fieldC = getField @"outer3_fieldC" x_0},
                               getField @"outer3_fieldB" x_0)
-instance HasCField Outer3 "outer3_fieldC"
-    where type CFieldType Outer3 "outer3_fieldC" = CInt
-          offset# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldC")
+instance (~) ty Inner3 =>
+         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldB")
+instance HasCField Outer3 "outer3_fieldB"
+    where type CFieldType Outer3 "outer3_fieldB" = Inner3
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer3_fieldC" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldC = y_1,
                                              outer3_fieldA = getField @"outer3_fieldA" x_0,
                                              outer3_fieldB = getField @"outer3_fieldB" x_0},
                               getField @"outer3_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldC")
+instance HasCField Outer3 "outer3_fieldC"
+    where type CFieldType Outer3 "outer3_fieldC" = CInt
+          offset# = \_ -> \_ -> 12

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/Example.hs
@@ -95,19 +95,6 @@ instance Marshal.WriteRaw Outer1_anon'fieldX where
 
 deriving via Marshal.EquivStorable Outer1_anon'fieldX instance RIP.Storable Outer1_anon'fieldX
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX_fieldX" Outer1_anon'fieldX ty where
 
@@ -120,18 +107,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"outer1_anon'fieldX_fieldX" x0
       )
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_anon'fieldX_fieldY" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
+         ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX_fieldY" Outer1_anon'fieldX ty where
@@ -144,6 +131,19 @@ instance ( ty ~ RIP.CInt
                              }
       , RIP.getField @"outer1_anon'fieldX_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer1_anon'fieldX_fieldY" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union outer1@
 
@@ -239,22 +239,15 @@ set_outer1_fieldC ::
   -> Outer1
 set_outer1_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer1 "outer1_fieldA" where
-
-  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
 
-instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
+instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
-  type CFieldType Outer1 "outer1_anon'fieldX" =
-    Outer1_anon'fieldX
+  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -264,9 +257,10 @@ instance ( ty ~ Outer1_anon'fieldX
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
 
-instance HasCField.HasCField Outer1 "outer1_fieldC" where
+instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
 
-  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+  type CFieldType Outer1 "outer1_anon'fieldX" =
+    Outer1_anon'fieldX
 
   offset# = \_ -> \_ -> 0
 
@@ -275,6 +269,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+
+instance HasCField.HasCField Outer1 "outer1_fieldC" where
+
+  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
@@ -326,19 +326,6 @@ instance Marshal.WriteRaw Outer2_fieldB where
 
 deriving via Marshal.EquivStorable Outer2_fieldB instance RIP.Storable Outer2_fieldB
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldB_fieldX" Outer2_fieldB ty where
 
@@ -351,18 +338,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"outer2_fieldB_fieldX" x0
       )
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+         ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldB_fieldY" Outer2_fieldB ty where
@@ -375,6 +362,19 @@ instance ( ty ~ RIP.CInt
                         }
       , RIP.getField @"outer2_fieldB_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer2_fieldB_fieldY" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union outer2@
 
@@ -470,22 +470,15 @@ set_outer2_fieldC ::
   -> Outer2
 set_outer2_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer2 "outer2_fieldA" where
-
-  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
 
-instance HasCField.HasCField Outer2 "outer2_fieldB" where
+instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
-  type CFieldType Outer2 "outer2_fieldB" =
-    Outer2_fieldB
+  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -495,9 +488,10 @@ instance ( ty ~ Outer2_fieldB
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
 
-instance HasCField.HasCField Outer2 "outer2_fieldC" where
+instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
-  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+  type CFieldType Outer2 "outer2_fieldB" =
+    Outer2_fieldB
 
   offset# = \_ -> \_ -> 0
 
@@ -506,6 +500,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+
+instance HasCField.HasCField Outer2 "outer2_fieldC" where
+
+  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct inner3@
 
@@ -557,18 +557,6 @@ instance Marshal.WriteRaw Inner3 where
 
 deriving via Marshal.EquivStorable Inner3 instance RIP.Storable Inner3
 
-instance HasCField.HasCField Inner3 "inner3_fieldX" where
-
-  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inner3_fieldX" Inner3 ty where
 
@@ -579,17 +567,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"inner3_fieldX" x0
       )
 
-instance HasCField.HasCField Inner3 "inner3_fieldY" where
-
-  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+         ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+    HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
+
+instance HasCField.HasCField Inner3 "inner3_fieldX" where
+
+  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "inner3_fieldY" Inner3 ty where
@@ -600,6 +588,18 @@ instance ( ty ~ RIP.CInt
           Inner3 {inner3_fieldY = y1, inner3_fieldX = RIP.getField @"inner3_fieldX" x0}
       , RIP.getField @"inner3_fieldY" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "inner3_fieldY" (RIP.Ptr Inner3) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+
+instance HasCField.HasCField Inner3 "inner3_fieldY" where
+
+  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union outer3@
 
@@ -695,21 +695,15 @@ set_outer3_fieldC ::
   -> Outer3
 set_outer3_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer3 "outer3_fieldA" where
-
-  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
 
-instance HasCField.HasCField Outer3 "outer3_fieldB" where
+instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
-  type CFieldType Outer3 "outer3_fieldB" = Inner3
+  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -719,9 +713,9 @@ instance ( ty ~ Inner3
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
 
-instance HasCField.HasCField Outer3 "outer3_fieldC" where
+instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
-  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+  type CFieldType Outer3 "outer3_fieldB" = Inner3
 
   offset# = \_ -> \_ -> 0
 
@@ -730,3 +724,9 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+
+instance HasCField.HasCField Outer3 "outer3_fieldC" where
+
+  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/bindingspec.yaml
@@ -30,11 +30,12 @@ hstypes:
       - inner3_fieldX
       - inner3_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -49,7 +50,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -62,11 +63,12 @@ hstypes:
       - outer1_anon'fieldX_fieldX
       - outer1_anon'fieldX_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -81,7 +83,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -94,11 +96,12 @@ hstypes:
       - outer2_fieldB_fieldX
       - outer2_fieldB_fieldY
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -113,7 +116,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/struct_in_union/th.txt
@@ -31,34 +31,34 @@ instance WriteRaw Outer1_anon'fieldX
                                        Outer1_anon'fieldX outer1_anon'fieldX_fieldX_2
                                                           outer1_anon'fieldX_fieldY_3 -> writeRaw (Proxy @"outer1_anon'fieldX_fieldX") ptr_0 outer1_anon'fieldX_fieldX_2 >> writeRaw (Proxy @"outer1_anon'fieldX_fieldY") ptr_0 outer1_anon'fieldX_fieldY_3
 deriving via (EquivStorable Outer1_anon'fieldX) instance Storable Outer1_anon'fieldX
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer1_anon'fieldX_fieldX"
-                  (Ptr Outer1_anon'fieldX)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldX" Outer1_anon'fieldX ty
     where hasField = \x_0 -> (\y_1 -> Outer1_anon'fieldX{outer1_anon'fieldX_fieldX = y_1,
                                                          outer1_anon'fieldX_fieldY = getField @"outer1_anon'fieldX_fieldY" x_0},
                               getField @"outer1_anon'fieldX_fieldX" x_0)
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "outer1_anon'fieldX_fieldY"
+         HasField "outer1_anon'fieldX_fieldX"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldY" Outer1_anon'fieldX ty
     where hasField = \x_0 -> (\y_1 -> Outer1_anon'fieldX{outer1_anon'fieldX_fieldY = y_1,
                                                          outer1_anon'fieldX_fieldX = getField @"outer1_anon'fieldX_fieldX" x_0},
                               getField @"outer1_anon'fieldX_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "outer1_anon'fieldX_fieldY"
+                  (Ptr Outer1_anon'fieldX)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union outer1@
 
     __defined at:__ @types\/anonymous\/struct_in_union.h 6:7@
@@ -174,25 +174,25 @@ set_outer1_fieldC :: CInt -> Outer1
 
 -}
 set_outer1_fieldC = setUnionPayload
-instance HasCField Outer1 "outer1_fieldA"
-    where type CFieldType Outer1 "outer1_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_fieldA")
-instance HasCField Outer1 "outer1_anon'fieldX"
-    where type CFieldType Outer1
-                          "outer1_anon'fieldX" = Outer1_anon'fieldX
+instance HasCField Outer1 "outer1_fieldA"
+    where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Outer1_anon'fieldX =>
          HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX")
-instance HasCField Outer1 "outer1_fieldC"
-    where type CFieldType Outer1 "outer1_fieldC" = CInt
+instance HasCField Outer1 "outer1_anon'fieldX"
+    where type CFieldType Outer1
+                          "outer1_anon'fieldX" = Outer1_anon'fieldX
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_fieldC")
+instance HasCField Outer1 "outer1_fieldC"
+    where type CFieldType Outer1 "outer1_fieldC" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@outer2_fieldB@
 
     __defined at:__ @types\/anonymous\/struct_in_union.h 17:3@
@@ -225,28 +225,28 @@ instance WriteRaw Outer2_fieldB
                                        Outer2_fieldB outer2_fieldB_fieldX_2
                                                      outer2_fieldB_fieldY_3 -> writeRaw (Proxy @"outer2_fieldB_fieldX") ptr_0 outer2_fieldB_fieldX_2 >> writeRaw (Proxy @"outer2_fieldB_fieldY") ptr_0 outer2_fieldB_fieldY_3
 deriving via (EquivStorable Outer2_fieldB) instance Storable Outer2_fieldB
-instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
-    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance (~) ty CInt =>
          HasField "outer2_fieldB_fieldX" Outer2_fieldB ty
     where hasField = \x_0 -> (\y_1 -> Outer2_fieldB{outer2_fieldB_fieldX = y_1,
                                                     outer2_fieldB_fieldY = getField @"outer2_fieldB_fieldY" x_0},
                               getField @"outer2_fieldB_fieldX" x_0)
-instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
-    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
+         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
+instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
+    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer2_fieldB_fieldY" Outer2_fieldB ty
     where hasField = \x_0 -> (\y_1 -> Outer2_fieldB{outer2_fieldB_fieldY = y_1,
                                                     outer2_fieldB_fieldX = getField @"outer2_fieldB_fieldX" x_0},
                               getField @"outer2_fieldB_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
+instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
+    where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union outer2@
 
     __defined at:__ @types\/anonymous\/struct_in_union.h 15:7@
@@ -362,24 +362,24 @@ set_outer2_fieldC :: CInt -> Outer2
 
 -}
 set_outer2_fieldC = setUnionPayload
-instance HasCField Outer2 "outer2_fieldA"
-    where type CFieldType Outer2 "outer2_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldA")
-instance HasCField Outer2 "outer2_fieldB"
-    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
+instance HasCField Outer2 "outer2_fieldA"
+    where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Outer2_fieldB =>
          HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldB")
-instance HasCField Outer2 "outer2_fieldC"
-    where type CFieldType Outer2 "outer2_fieldC" = CInt
+instance HasCField Outer2 "outer2_fieldB"
+    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldC")
+instance HasCField Outer2 "outer2_fieldC"
+    where type CFieldType Outer2 "outer2_fieldC" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct inner3@
 
     __defined at:__ @types\/anonymous\/struct_in_union.h 26:10@
@@ -412,26 +412,26 @@ instance WriteRaw Inner3
                                        Inner3 inner3_fieldX_2
                                               inner3_fieldY_3 -> writeRaw (Proxy @"inner3_fieldX") ptr_0 inner3_fieldX_2 >> writeRaw (Proxy @"inner3_fieldY") ptr_0 inner3_fieldY_3
 deriving via (EquivStorable Inner3) instance Storable Inner3
-instance HasCField Inner3 "inner3_fieldX"
-    where type CFieldType Inner3 "inner3_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldX")
 instance (~) ty CInt => HasField "inner3_fieldX" Inner3 ty
     where hasField = \x_0 -> (\y_1 -> Inner3{inner3_fieldX = y_1,
                                              inner3_fieldY = getField @"inner3_fieldY" x_0},
                               getField @"inner3_fieldX" x_0)
-instance HasCField Inner3 "inner3_fieldY"
-    where type CFieldType Inner3 "inner3_fieldY" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldY")
+         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldX")
+instance HasCField Inner3 "inner3_fieldX"
+    where type CFieldType Inner3 "inner3_fieldX" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "inner3_fieldY" Inner3 ty
     where hasField = \x_0 -> (\y_1 -> Inner3{inner3_fieldY = y_1,
                                              inner3_fieldX = getField @"inner3_fieldX" x_0},
                               getField @"inner3_fieldY" x_0)
+instance (~) ty CInt =>
+         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldY")
+instance HasCField Inner3 "inner3_fieldY"
+    where type CFieldType Inner3 "inner3_fieldY" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union outer3@
 
     __defined at:__ @types\/anonymous\/struct_in_union.h 24:7@
@@ -547,21 +547,21 @@ set_outer3_fieldC :: CInt -> Outer3
 
 -}
 set_outer3_fieldC = setUnionPayload
-instance HasCField Outer3 "outer3_fieldA"
-    where type CFieldType Outer3 "outer3_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldA")
-instance HasCField Outer3 "outer3_fieldB"
-    where type CFieldType Outer3 "outer3_fieldB" = Inner3
+instance HasCField Outer3 "outer3_fieldA"
+    where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Inner3 =>
          HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldB")
-instance HasCField Outer3 "outer3_fieldC"
-    where type CFieldType Outer3 "outer3_fieldC" = CInt
+instance HasCField Outer3 "outer3_fieldB"
+    where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldC")
+instance HasCField Outer3 "outer3_fieldC"
+    where type CFieldType Outer3 "outer3_fieldC" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/Example.hs
@@ -93,19 +93,6 @@ instance Marshal.WriteRaw Has_implicit_fields_anon'x2_1 where
 
 deriving via Marshal.EquivStorable Has_implicit_fields_anon'x2_1 instance RIP.Storable Has_implicit_fields_anon'x2_1
 
-instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" where
-
-  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_1" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x2_1_x2_1" Has_implicit_fields_anon'x2_1 ty where
 
@@ -118,18 +105,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_anon'x2_1_x2_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" where
-
-  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_2" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
+         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_1" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_1")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" where
+
+  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_1" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x2_1_x2_2" Has_implicit_fields_anon'x2_1 ty where
@@ -142,6 +129,19 @@ instance ( ty ~ RIP.CInt
                                         }
       , RIP.getField @"has_implicit_fields_anon'x2_1_x2_2" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_anon'x2_1_x2_2" (RIP.Ptr Has_implicit_fields_anon'x2_1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" where
+
+  type CFieldType Has_implicit_fields_anon'x2_1 "has_implicit_fields_anon'x2_1_x2_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@has_implicit_fields_anon\'x4_1@
 
@@ -195,19 +195,6 @@ instance Marshal.WriteRaw Has_implicit_fields_anon'x4_1 where
 
 deriving via Marshal.EquivStorable Has_implicit_fields_anon'x4_1 instance RIP.Storable Has_implicit_fields_anon'x4_1
 
-instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" where
-
-  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_1" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x4_1_x4_1" Has_implicit_fields_anon'x4_1 ty where
 
@@ -220,18 +207,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"has_implicit_fields_anon'x4_1_x4_1" x0
       )
 
-instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" where
-
-  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_2" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
+         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_1" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_1")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" where
+
+  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_1" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "has_implicit_fields_anon'x4_1_x4_2" Has_implicit_fields_anon'x4_1 ty where
@@ -244,6 +231,19 @@ instance ( ty ~ RIP.CInt
                                         }
       , RIP.getField @"has_implicit_fields_anon'x4_1_x4_2" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "has_implicit_fields_anon'x4_1_x4_2" (RIP.Ptr Has_implicit_fields_anon'x4_1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" where
+
+  type CFieldType Has_implicit_fields_anon'x4_1 "has_implicit_fields_anon'x4_1_x4_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union \@has_implicit_fields_anon\'x5_1@
 
@@ -318,22 +318,15 @@ set_has_implicit_fields_anon'x5_1_x5_2 ::
 set_has_implicit_fields_anon'x5_1_x5_2 =
   RIP.setUnionPayload
 
-instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" where
-
-  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "has_implicit_fields_anon'x5_1_x5_1" (RIP.Ptr Has_implicit_fields_anon'x5_1) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1_x5_1")
 
-instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" where
+instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" where
 
-  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" =
+  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_1" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -343,6 +336,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1_x5_2")
+
+instance HasCField.HasCField Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" where
+
+  type CFieldType Has_implicit_fields_anon'x5_1 "has_implicit_fields_anon'x5_1_x5_2" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union has_implicit_fields@
 
@@ -519,23 +519,16 @@ set_has_implicit_fields_x5 ::
   -> Has_implicit_fields
 set_has_implicit_fields_x5 = RIP.setUnionPayload
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
-
-  type CFieldType Has_implicit_fields "has_implicit_fields_x1" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "has_implicit_fields_x1" (RIP.Ptr Has_implicit_fields) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x1")
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x2_1" where
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x1" where
 
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x2_1" =
-    Has_implicit_fields_anon'x2_1
+  type CFieldType Has_implicit_fields "has_implicit_fields_x1" =
+    RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -545,10 +538,10 @@ instance ( ty ~ Has_implicit_fields_anon'x2_1
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x2_1")
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x2_1" where
 
-  type CFieldType Has_implicit_fields "has_implicit_fields_x3" =
-    RIP.CInt
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x2_1" =
+    Has_implicit_fields_anon'x2_1
 
   offset# = \_ -> \_ -> 0
 
@@ -558,10 +551,10 @@ instance ( ty ~ RIP.CInt
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x3")
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x4_1" where
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x3" where
 
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x4_1" =
-    Has_implicit_fields_anon'x4_1
+  type CFieldType Has_implicit_fields "has_implicit_fields_x3" =
+    RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -571,10 +564,10 @@ instance ( ty ~ Has_implicit_fields_anon'x4_1
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x4_1")
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x5_1" where
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x4_1" where
 
-  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x5_1" =
-    Has_implicit_fields_anon'x5_1
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x4_1" =
+    Has_implicit_fields_anon'x4_1
 
   offset# = \_ -> \_ -> 0
 
@@ -584,10 +577,10 @@ instance ( ty ~ Has_implicit_fields_anon'x5_1
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_anon'x5_1")
 
-instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_anon'x5_1" where
 
-  type CFieldType Has_implicit_fields "has_implicit_fields_x5" =
-    RIP.CInt
+  type CFieldType Has_implicit_fields "has_implicit_fields_anon'x5_1" =
+    Has_implicit_fields_anon'x5_1
 
   offset# = \_ -> \_ -> 0
 
@@ -596,3 +589,10 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"has_implicit_fields_x5")
+
+instance HasCField.HasCField Has_implicit_fields "has_implicit_fields_x5" where
+
+  type CFieldType Has_implicit_fields "has_implicit_fields_x5" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/bindingspec.yaml
@@ -25,7 +25,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -38,11 +38,12 @@ hstypes:
       - has_implicit_fields_anon'x2_1_x2_1
       - has_implicit_fields_anon'x2_1_x2_2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -56,11 +57,12 @@ hstypes:
       - has_implicit_fields_anon'x4_1_x4_1
       - has_implicit_fields_anon'x4_1_x4_2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -75,7 +77,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union/th.txt
@@ -31,16 +31,6 @@ instance WriteRaw Has_implicit_fields_anon'x2_1
                                        Has_implicit_fields_anon'x2_1 has_implicit_fields_anon'x2_1_x2_1_2
                                                                      has_implicit_fields_anon'x2_1_x2_2_3 -> writeRaw (Proxy @"has_implicit_fields_anon'x2_1_x2_1") ptr_0 has_implicit_fields_anon'x2_1_x2_1_2 >> writeRaw (Proxy @"has_implicit_fields_anon'x2_1_x2_2") ptr_0 has_implicit_fields_anon'x2_1_x2_2_3
 deriving via (EquivStorable Has_implicit_fields_anon'x2_1) instance Storable Has_implicit_fields_anon'x2_1
-instance HasCField Has_implicit_fields_anon'x2_1
-                   "has_implicit_fields_anon'x2_1_x2_1"
-    where type CFieldType Has_implicit_fields_anon'x2_1
-                          "has_implicit_fields_anon'x2_1_x2_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x2_1_x2_1"
-                  (Ptr Has_implicit_fields_anon'x2_1)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_1")
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x2_1_x2_1"
                   Has_implicit_fields_anon'x2_1
@@ -48,16 +38,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x2_1{has_implicit_fields_anon'x2_1_x2_1 = y_1,
                                                                     has_implicit_fields_anon'x2_1_x2_2 = getField @"has_implicit_fields_anon'x2_1_x2_2" x_0},
                               getField @"has_implicit_fields_anon'x2_1_x2_1" x_0)
-instance HasCField Has_implicit_fields_anon'x2_1
-                   "has_implicit_fields_anon'x2_1_x2_2"
-    where type CFieldType Has_implicit_fields_anon'x2_1
-                          "has_implicit_fields_anon'x2_1_x2_2" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x2_1_x2_2"
+         HasField "has_implicit_fields_anon'x2_1_x2_1"
                   (Ptr Has_implicit_fields_anon'x2_1)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_1")
+instance HasCField Has_implicit_fields_anon'x2_1
+                   "has_implicit_fields_anon'x2_1_x2_1"
+    where type CFieldType Has_implicit_fields_anon'x2_1
+                          "has_implicit_fields_anon'x2_1_x2_1" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x2_1_x2_2"
                   Has_implicit_fields_anon'x2_1
@@ -65,6 +55,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x2_1{has_implicit_fields_anon'x2_1_x2_2 = y_1,
                                                                     has_implicit_fields_anon'x2_1_x2_1 = getField @"has_implicit_fields_anon'x2_1_x2_1" x_0},
                               getField @"has_implicit_fields_anon'x2_1_x2_2" x_0)
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_anon'x2_1_x2_2"
+                  (Ptr Has_implicit_fields_anon'x2_1)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1_x2_2")
+instance HasCField Has_implicit_fields_anon'x2_1
+                   "has_implicit_fields_anon'x2_1_x2_2"
+    where type CFieldType Has_implicit_fields_anon'x2_1
+                          "has_implicit_fields_anon'x2_1_x2_2" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@has_implicit_fields_anon\'x4_1@
 
     __defined at:__ @types\/anonymous\/union.h 10:3@
@@ -97,16 +97,6 @@ instance WriteRaw Has_implicit_fields_anon'x4_1
                                        Has_implicit_fields_anon'x4_1 has_implicit_fields_anon'x4_1_x4_1_2
                                                                      has_implicit_fields_anon'x4_1_x4_2_3 -> writeRaw (Proxy @"has_implicit_fields_anon'x4_1_x4_1") ptr_0 has_implicit_fields_anon'x4_1_x4_1_2 >> writeRaw (Proxy @"has_implicit_fields_anon'x4_1_x4_2") ptr_0 has_implicit_fields_anon'x4_1_x4_2_3
 deriving via (EquivStorable Has_implicit_fields_anon'x4_1) instance Storable Has_implicit_fields_anon'x4_1
-instance HasCField Has_implicit_fields_anon'x4_1
-                   "has_implicit_fields_anon'x4_1_x4_1"
-    where type CFieldType Has_implicit_fields_anon'x4_1
-                          "has_implicit_fields_anon'x4_1_x4_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x4_1_x4_1"
-                  (Ptr Has_implicit_fields_anon'x4_1)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_1")
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x4_1_x4_1"
                   Has_implicit_fields_anon'x4_1
@@ -114,16 +104,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x4_1{has_implicit_fields_anon'x4_1_x4_1 = y_1,
                                                                     has_implicit_fields_anon'x4_1_x4_2 = getField @"has_implicit_fields_anon'x4_1_x4_2" x_0},
                               getField @"has_implicit_fields_anon'x4_1_x4_1" x_0)
-instance HasCField Has_implicit_fields_anon'x4_1
-                   "has_implicit_fields_anon'x4_1_x4_2"
-    where type CFieldType Has_implicit_fields_anon'x4_1
-                          "has_implicit_fields_anon'x4_1_x4_2" = CInt
-          offset# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "has_implicit_fields_anon'x4_1_x4_2"
+         HasField "has_implicit_fields_anon'x4_1_x4_1"
                   (Ptr Has_implicit_fields_anon'x4_1)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_1")
+instance HasCField Has_implicit_fields_anon'x4_1
+                   "has_implicit_fields_anon'x4_1_x4_1"
+    where type CFieldType Has_implicit_fields_anon'x4_1
+                          "has_implicit_fields_anon'x4_1_x4_1" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x4_1_x4_2"
                   Has_implicit_fields_anon'x4_1
@@ -131,6 +121,16 @@ instance (~) ty CInt =>
     where hasField = \x_0 -> (\y_1 -> Has_implicit_fields_anon'x4_1{has_implicit_fields_anon'x4_1_x4_2 = y_1,
                                                                     has_implicit_fields_anon'x4_1_x4_1 = getField @"has_implicit_fields_anon'x4_1_x4_1" x_0},
                               getField @"has_implicit_fields_anon'x4_1_x4_2" x_0)
+instance (~) ty CInt =>
+         HasField "has_implicit_fields_anon'x4_1_x4_2"
+                  (Ptr Has_implicit_fields_anon'x4_1)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1_x4_2")
+instance HasCField Has_implicit_fields_anon'x4_1
+                   "has_implicit_fields_anon'x4_1_x4_2"
+    where type CFieldType Has_implicit_fields_anon'x4_1
+                          "has_implicit_fields_anon'x4_1_x4_2" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union \@has_implicit_fields_anon\'x5_1@
 
     __defined at:__ @types\/anonymous\/union.h 14:3@
@@ -219,26 +219,26 @@ set_has_implicit_fields_anon'x5_1_x5_2 :: CInt ->
 
 -}
 set_has_implicit_fields_anon'x5_1_x5_2 = setUnionPayload
-instance HasCField Has_implicit_fields_anon'x5_1
-                   "has_implicit_fields_anon'x5_1_x5_1"
-    where type CFieldType Has_implicit_fields_anon'x5_1
-                          "has_implicit_fields_anon'x5_1_x5_1" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x5_1_x5_1"
                   (Ptr Has_implicit_fields_anon'x5_1)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1_x5_1")
 instance HasCField Has_implicit_fields_anon'x5_1
-                   "has_implicit_fields_anon'x5_1_x5_2"
+                   "has_implicit_fields_anon'x5_1_x5_1"
     where type CFieldType Has_implicit_fields_anon'x5_1
-                          "has_implicit_fields_anon'x5_1_x5_2" = CInt
+                          "has_implicit_fields_anon'x5_1_x5_1" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_anon'x5_1_x5_2"
                   (Ptr Has_implicit_fields_anon'x5_1)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1_x5_2")
+instance HasCField Has_implicit_fields_anon'x5_1
+                   "has_implicit_fields_anon'x5_1_x5_2"
+    where type CFieldType Has_implicit_fields_anon'x5_1
+                          "has_implicit_fields_anon'x5_1_x5_2" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union has_implicit_fields@
 
     __defined at:__ @types\/anonymous\/union.h 3:7@
@@ -465,38 +465,33 @@ set_has_implicit_fields_x5 :: CInt -> Has_implicit_fields
 
 -}
 set_has_implicit_fields_x5 = setUnionPayload
-instance HasCField Has_implicit_fields "has_implicit_fields_x1"
-    where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x1" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_x1")
-instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x2_1"
+instance HasCField Has_implicit_fields "has_implicit_fields_x1"
     where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x2_1" = Has_implicit_fields_anon'x2_1
+                          "has_implicit_fields_x1" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty Has_implicit_fields_anon'x2_1 =>
          HasField "has_implicit_fields_anon'x2_1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x2_1")
-instance HasCField Has_implicit_fields "has_implicit_fields_x3"
+instance HasCField Has_implicit_fields
+                   "has_implicit_fields_anon'x2_1"
     where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x3" = CInt
+                          "has_implicit_fields_anon'x2_1" = Has_implicit_fields_anon'x2_1
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x3"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_x3")
-instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x4_1"
+instance HasCField Has_implicit_fields "has_implicit_fields_x3"
     where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x4_1" = Has_implicit_fields_anon'x4_1
+                          "has_implicit_fields_x3" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty Has_implicit_fields_anon'x4_1 =>
          HasField "has_implicit_fields_anon'x4_1"
@@ -504,21 +499,26 @@ instance (~) ty Has_implicit_fields_anon'x4_1 =>
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x4_1")
 instance HasCField Has_implicit_fields
-                   "has_implicit_fields_anon'x5_1"
+                   "has_implicit_fields_anon'x4_1"
     where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_anon'x5_1" = Has_implicit_fields_anon'x5_1
+                          "has_implicit_fields_anon'x4_1" = Has_implicit_fields_anon'x4_1
           offset# = \_ -> \_ -> 0
 instance (~) ty Has_implicit_fields_anon'x5_1 =>
          HasField "has_implicit_fields_anon'x5_1"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_anon'x5_1")
-instance HasCField Has_implicit_fields "has_implicit_fields_x5"
+instance HasCField Has_implicit_fields
+                   "has_implicit_fields_anon'x5_1"
     where type CFieldType Has_implicit_fields
-                          "has_implicit_fields_x5" = CInt
+                          "has_implicit_fields_anon'x5_1" = Has_implicit_fields_anon'x5_1
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "has_implicit_fields_x5"
                   (Ptr Has_implicit_fields)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"has_implicit_fields_x5")
+instance HasCField Has_implicit_fields "has_implicit_fields_x5"
+    where type CFieldType Has_implicit_fields
+                          "has_implicit_fields_x5" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/Example.hs
@@ -108,22 +108,15 @@ set_outer1_anon'fieldX_fieldY ::
   -> Outer1_anon'fieldX
 set_outer1_anon'fieldX_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
 
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -133,6 +126,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct outer1@
 
@@ -193,18 +193,6 @@ instance Marshal.WriteRaw Outer1 where
 
 deriving via Marshal.EquivStorable Outer1 instance RIP.Storable Outer1
 
-instance HasCField.HasCField Outer1 "outer1_fieldA" where
-
-  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer1_fieldA" Outer1 ty where
 
@@ -218,18 +206,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer1_fieldA" x0
       )
 
-instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
-
-  type CFieldType Outer1 "outer1_anon'fieldX" =
-    Outer1_anon'fieldX
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Outer1_anon'fieldX
-         ) => RIP.HasField "outer1_anon'fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
+    HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
+
+instance HasCField.HasCField Outer1 "outer1_fieldA" where
+
+  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Outer1_anon'fieldX
          ) => RIP.CompatHasField.HasField "outer1_anon'fieldX" Outer1 ty where
@@ -244,17 +231,18 @@ instance ( ty ~ Outer1_anon'fieldX
       , RIP.getField @"outer1_anon'fieldX" x0
       )
 
-instance HasCField.HasCField Outer1 "outer1_fieldC" where
-
-  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+instance ( ty ~ Outer1_anon'fieldX
+         ) => RIP.HasField "outer1_anon'fieldX" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
+
+instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
+
+  type CFieldType Outer1 "outer1_anon'fieldX" =
+    Outer1_anon'fieldX
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer1_fieldC" Outer1 ty where
@@ -268,6 +256,18 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer1_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer1_fieldC" (RIP.Ptr Outer1) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+
+instance HasCField.HasCField Outer1 "outer1_fieldC" where
+
+  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @union \@outer2_fieldB@
 
@@ -338,22 +338,15 @@ set_outer2_fieldB_fieldY ::
   -> Outer2_fieldB
 set_outer2_fieldB_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -363,6 +356,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct outer2@
 
@@ -423,18 +423,6 @@ instance Marshal.WriteRaw Outer2 where
 
 deriving via Marshal.EquivStorable Outer2 instance RIP.Storable Outer2
 
-instance HasCField.HasCField Outer2 "outer2_fieldA" where
-
-  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer2_fieldA" Outer2 ty where
 
@@ -448,18 +436,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer2_fieldA" x0
       )
 
-instance HasCField.HasCField Outer2 "outer2_fieldB" where
-
-  type CFieldType Outer2 "outer2_fieldB" =
-    Outer2_fieldB
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Outer2_fieldB
-         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
+
+instance HasCField.HasCField Outer2 "outer2_fieldA" where
+
+  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Outer2_fieldB
          ) => RIP.CompatHasField.HasField "outer2_fieldB" Outer2 ty where
@@ -474,17 +461,18 @@ instance ( ty ~ Outer2_fieldB
       , RIP.getField @"outer2_fieldB" x0
       )
 
-instance HasCField.HasCField Outer2 "outer2_fieldC" where
-
-  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+instance ( ty ~ Outer2_fieldB
+         ) => RIP.HasField "outer2_fieldB" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
+
+instance HasCField.HasCField Outer2 "outer2_fieldB" where
+
+  type CFieldType Outer2 "outer2_fieldB" =
+    Outer2_fieldB
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer2_fieldC" Outer2 ty where
@@ -498,6 +486,18 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer2_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer2_fieldC" (RIP.Ptr Outer2) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+
+instance HasCField.HasCField Outer2 "outer2_fieldC" where
+
+  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @union inner3@
 
@@ -568,21 +568,15 @@ set_inner3_fieldY ::
   -> Inner3
 set_inner3_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Inner3 "inner3_fieldX" where
-
-  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
 
-instance HasCField.HasCField Inner3 "inner3_fieldY" where
+instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
-  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -591,6 +585,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+
+instance HasCField.HasCField Inner3 "inner3_fieldY" where
+
+  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct outer3@
 
@@ -651,18 +651,6 @@ instance Marshal.WriteRaw Outer3 where
 
 deriving via Marshal.EquivStorable Outer3 instance RIP.Storable Outer3
 
-instance HasCField.HasCField Outer3 "outer3_fieldA" where
-
-  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "outer3_fieldA" Outer3 ty where
 
@@ -676,17 +664,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"outer3_fieldA" x0
       )
 
-instance HasCField.HasCField Outer3 "outer3_fieldB" where
-
-  type CFieldType Outer3 "outer3_fieldB" = Inner3
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ Inner3
-         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
+
+instance HasCField.HasCField Outer3 "outer3_fieldA" where
+
+  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ Inner3
          ) => RIP.CompatHasField.HasField "outer3_fieldB" Outer3 ty where
@@ -701,17 +689,17 @@ instance ( ty ~ Inner3
       , RIP.getField @"outer3_fieldB" x0
       )
 
-instance HasCField.HasCField Outer3 "outer3_fieldC" where
-
-  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+instance ( ty ~ Inner3
+         ) => RIP.HasField "outer3_fieldB" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
+
+instance HasCField.HasCField Outer3 "outer3_fieldB" where
+
+  type CFieldType Outer3 "outer3_fieldB" = Inner3
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "outer3_fieldC" Outer3 ty where
@@ -725,3 +713,15 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"outer3_fieldC" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "outer3_fieldC" (RIP.Ptr Outer3) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+
+instance HasCField.HasCField Outer3 "outer3_fieldC" where
+
+  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/bindingspec.yaml
@@ -31,7 +31,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -45,10 +45,11 @@ hstypes:
       - outer1_anon'fieldX
       - outer1_fieldC
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -62,7 +63,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -76,10 +77,11 @@ hstypes:
       - outer2_fieldB
       - outer2_fieldC
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -93,7 +95,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -107,10 +109,11 @@ hstypes:
       - outer3_fieldB
       - outer3_fieldC
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_struct/th.txt
@@ -83,24 +83,24 @@ set_outer1_anon'fieldX_fieldY :: CInt -> Outer1_anon'fieldX
 
 -}
 set_outer1_anon'fieldX_fieldY = setUnionPayload
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldX"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
     where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldY" = CInt
+                          "outer1_anon'fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldY"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldY" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct outer1@
 
     __defined at:__ @types\/anonymous\/union_in_struct.h 6:8@
@@ -141,41 +141,41 @@ instance WriteRaw Outer1
                                               outer1_anon'fieldX_3
                                               outer1_fieldC_4 -> writeRaw (Proxy @"outer1_fieldA") ptr_0 outer1_fieldA_2 >> (writeRaw (Proxy @"outer1_anon'fieldX") ptr_0 outer1_anon'fieldX_3 >> writeRaw (Proxy @"outer1_fieldC") ptr_0 outer1_fieldC_4)
 deriving via (EquivStorable Outer1) instance Storable Outer1
-instance HasCField Outer1 "outer1_fieldA"
-    where type CFieldType Outer1 "outer1_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_fieldA")
 instance (~) ty CChar => HasField "outer1_fieldA" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_fieldA = y_1,
                                              outer1_anon'fieldX = getField @"outer1_anon'fieldX" x_0,
                                              outer1_fieldC = getField @"outer1_fieldC" x_0},
                               getField @"outer1_fieldA" x_0)
-instance HasCField Outer1 "outer1_anon'fieldX"
-    where type CFieldType Outer1
-                          "outer1_anon'fieldX" = Outer1_anon'fieldX
-          offset# = \_ -> \_ -> 4
-instance (~) ty Outer1_anon'fieldX =>
-         HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_anon'fieldX")
+instance (~) ty CChar =>
+         HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_fieldA")
+instance HasCField Outer1 "outer1_fieldA"
+    where type CFieldType Outer1 "outer1_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Outer1_anon'fieldX =>
          HasField "outer1_anon'fieldX" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_anon'fieldX = y_1,
                                              outer1_fieldA = getField @"outer1_fieldA" x_0,
                                              outer1_fieldC = getField @"outer1_fieldC" x_0},
                               getField @"outer1_anon'fieldX" x_0)
-instance HasCField Outer1 "outer1_fieldC"
-    where type CFieldType Outer1 "outer1_fieldC" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer1_fieldC")
+instance (~) ty Outer1_anon'fieldX =>
+         HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_anon'fieldX")
+instance HasCField Outer1 "outer1_anon'fieldX"
+    where type CFieldType Outer1
+                          "outer1_anon'fieldX" = Outer1_anon'fieldX
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer1_fieldC" Outer1 ty
     where hasField = \x_0 -> (\y_1 -> Outer1{outer1_fieldC = y_1,
                                              outer1_fieldA = getField @"outer1_fieldA" x_0,
                                              outer1_anon'fieldX = getField @"outer1_anon'fieldX" x_0},
                               getField @"outer1_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer1_fieldC")
+instance HasCField Outer1 "outer1_fieldC"
+    where type CFieldType Outer1 "outer1_fieldC" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @union \@outer2_fieldB@
 
     __defined at:__ @types\/anonymous\/union_in_struct.h 17:3@
@@ -257,18 +257,18 @@ set_outer2_fieldB_fieldY :: CInt -> Outer2_fieldB
 
 -}
 set_outer2_fieldB_fieldY = setUnionPayload
+instance (~) ty CInt =>
+         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
+         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @struct outer2@
 
     __defined at:__ @types\/anonymous\/union_in_struct.h 15:8@
@@ -309,39 +309,39 @@ instance WriteRaw Outer2
                                               outer2_fieldB_3
                                               outer2_fieldC_4 -> writeRaw (Proxy @"outer2_fieldA") ptr_0 outer2_fieldA_2 >> (writeRaw (Proxy @"outer2_fieldB") ptr_0 outer2_fieldB_3 >> writeRaw (Proxy @"outer2_fieldC") ptr_0 outer2_fieldC_4)
 deriving via (EquivStorable Outer2) instance Storable Outer2
-instance HasCField Outer2 "outer2_fieldA"
-    where type CFieldType Outer2 "outer2_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldA")
 instance (~) ty CChar => HasField "outer2_fieldA" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldA = y_1,
                                              outer2_fieldB = getField @"outer2_fieldB" x_0,
                                              outer2_fieldC = getField @"outer2_fieldC" x_0},
                               getField @"outer2_fieldA" x_0)
-instance HasCField Outer2 "outer2_fieldB"
-    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
-          offset# = \_ -> \_ -> 4
-instance (~) ty Outer2_fieldB =>
-         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB")
+instance (~) ty CChar =>
+         HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldA")
+instance HasCField Outer2 "outer2_fieldA"
+    where type CFieldType Outer2 "outer2_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Outer2_fieldB => HasField "outer2_fieldB" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldB = y_1,
                                              outer2_fieldA = getField @"outer2_fieldA" x_0,
                                              outer2_fieldC = getField @"outer2_fieldC" x_0},
                               getField @"outer2_fieldB" x_0)
-instance HasCField Outer2 "outer2_fieldC"
-    where type CFieldType Outer2 "outer2_fieldC" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldC")
+instance (~) ty Outer2_fieldB =>
+         HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB")
+instance HasCField Outer2 "outer2_fieldB"
+    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer2_fieldC" Outer2 ty
     where hasField = \x_0 -> (\y_1 -> Outer2{outer2_fieldC = y_1,
                                              outer2_fieldA = getField @"outer2_fieldA" x_0,
                                              outer2_fieldB = getField @"outer2_fieldB" x_0},
                               getField @"outer2_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldC")
+instance HasCField Outer2 "outer2_fieldC"
+    where type CFieldType Outer2 "outer2_fieldC" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @union inner3@
 
     __defined at:__ @types\/anonymous\/union_in_struct.h 26:9@
@@ -423,18 +423,18 @@ set_inner3_fieldY :: CInt -> Inner3
 
 -}
 set_inner3_fieldY = setUnionPayload
+instance (~) ty CInt =>
+         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldX")
+         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldY")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @struct outer3@
 
     __defined at:__ @types\/anonymous\/union_in_struct.h 24:8@
@@ -475,36 +475,36 @@ instance WriteRaw Outer3
                                               outer3_fieldB_3
                                               outer3_fieldC_4 -> writeRaw (Proxy @"outer3_fieldA") ptr_0 outer3_fieldA_2 >> (writeRaw (Proxy @"outer3_fieldB") ptr_0 outer3_fieldB_3 >> writeRaw (Proxy @"outer3_fieldC") ptr_0 outer3_fieldC_4)
 deriving via (EquivStorable Outer3) instance Storable Outer3
-instance HasCField Outer3 "outer3_fieldA"
-    where type CFieldType Outer3 "outer3_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldA")
 instance (~) ty CChar => HasField "outer3_fieldA" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldA = y_1,
                                              outer3_fieldB = getField @"outer3_fieldB" x_0,
                                              outer3_fieldC = getField @"outer3_fieldC" x_0},
                               getField @"outer3_fieldA" x_0)
-instance HasCField Outer3 "outer3_fieldB"
-    where type CFieldType Outer3 "outer3_fieldB" = Inner3
-          offset# = \_ -> \_ -> 4
-instance (~) ty Inner3 =>
-         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldB")
+instance (~) ty CChar =>
+         HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldA")
+instance HasCField Outer3 "outer3_fieldA"
+    where type CFieldType Outer3 "outer3_fieldA" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty Inner3 => HasField "outer3_fieldB" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldB = y_1,
                                              outer3_fieldA = getField @"outer3_fieldA" x_0,
                                              outer3_fieldC = getField @"outer3_fieldC" x_0},
                               getField @"outer3_fieldB" x_0)
-instance HasCField Outer3 "outer3_fieldC"
-    where type CFieldType Outer3 "outer3_fieldC" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt =>
-         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer3_fieldC")
+instance (~) ty Inner3 =>
+         HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldB")
+instance HasCField Outer3 "outer3_fieldB"
+    where type CFieldType Outer3 "outer3_fieldB" = Inner3
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "outer3_fieldC" Outer3 ty
     where hasField = \x_0 -> (\y_1 -> Outer3{outer3_fieldC = y_1,
                                              outer3_fieldA = getField @"outer3_fieldA" x_0,
                                              outer3_fieldB = getField @"outer3_fieldB" x_0},
                               getField @"outer3_fieldC" x_0)
+instance (~) ty CInt =>
+         HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer3_fieldC")
+instance HasCField Outer3 "outer3_fieldC"
+    where type CFieldType Outer3 "outer3_fieldC" = CInt
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/Example.hs
@@ -125,22 +125,15 @@ set_outer1_anon'fieldX_fieldY ::
   -> Outer1_anon'fieldX
 set_outer1_anon'fieldX_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
-
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "outer1_anon'fieldX_fieldX" (RIP.Ptr Outer1_anon'fieldX) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldX")
 
-instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" where
 
-  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldX" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -150,6 +143,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX_fieldY")
+
+instance HasCField.HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" where
+
+  type CFieldType Outer1_anon'fieldX "outer1_anon'fieldX_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union outer1@
 
@@ -245,22 +245,15 @@ set_outer1_fieldC ::
   -> Outer1
 set_outer1_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer1 "outer1_fieldA" where
-
-  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer1_fieldA" (RIP.Ptr Outer1) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldA")
 
-instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
+instance HasCField.HasCField Outer1 "outer1_fieldA" where
 
-  type CFieldType Outer1 "outer1_anon'fieldX" =
-    Outer1_anon'fieldX
+  type CFieldType Outer1 "outer1_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -270,9 +263,10 @@ instance ( ty ~ Outer1_anon'fieldX
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_anon'fieldX")
 
-instance HasCField.HasCField Outer1 "outer1_fieldC" where
+instance HasCField.HasCField Outer1 "outer1_anon'fieldX" where
 
-  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+  type CFieldType Outer1 "outer1_anon'fieldX" =
+    Outer1_anon'fieldX
 
   offset# = \_ -> \_ -> 0
 
@@ -281,6 +275,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer1_fieldC")
+
+instance HasCField.HasCField Outer1 "outer1_fieldC" where
+
+  type CFieldType Outer1 "outer1_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@outer2_fieldB@
 
@@ -351,22 +351,15 @@ set_outer2_fieldB_fieldY ::
   -> Outer2_fieldB
 set_outer2_fieldB_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
-
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "outer2_fieldB_fieldX" (RIP.Ptr Outer2_fieldB) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldX")
 
-instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldX" where
 
-  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" =
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
@@ -376,6 +369,13 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB_fieldY")
+
+instance HasCField.HasCField Outer2_fieldB "outer2_fieldB_fieldY" where
+
+  type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union outer2@
 
@@ -471,22 +471,15 @@ set_outer2_fieldC ::
   -> Outer2
 set_outer2_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer2 "outer2_fieldA" where
-
-  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer2_fieldA" (RIP.Ptr Outer2) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldA")
 
-instance HasCField.HasCField Outer2 "outer2_fieldB" where
+instance HasCField.HasCField Outer2 "outer2_fieldA" where
 
-  type CFieldType Outer2 "outer2_fieldB" =
-    Outer2_fieldB
+  type CFieldType Outer2 "outer2_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -496,9 +489,10 @@ instance ( ty ~ Outer2_fieldB
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldB")
 
-instance HasCField.HasCField Outer2 "outer2_fieldC" where
+instance HasCField.HasCField Outer2 "outer2_fieldB" where
 
-  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+  type CFieldType Outer2 "outer2_fieldB" =
+    Outer2_fieldB
 
   offset# = \_ -> \_ -> 0
 
@@ -507,6 +501,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer2_fieldC")
+
+instance HasCField.HasCField Outer2 "outer2_fieldC" where
+
+  type CFieldType Outer2 "outer2_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union inner3@
 
@@ -577,21 +577,15 @@ set_inner3_fieldY ::
   -> Inner3
 set_inner3_fieldY = RIP.setUnionPayload
 
-instance HasCField.HasCField Inner3 "inner3_fieldX" where
-
-  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "inner3_fieldX" (RIP.Ptr Inner3) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldX")
 
-instance HasCField.HasCField Inner3 "inner3_fieldY" where
+instance HasCField.HasCField Inner3 "inner3_fieldX" where
 
-  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+  type CFieldType Inner3 "inner3_fieldX" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -600,6 +594,12 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"inner3_fieldY")
+
+instance HasCField.HasCField Inner3 "inner3_fieldY" where
+
+  type CFieldType Inner3 "inner3_fieldY" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union outer3@
 
@@ -695,21 +695,15 @@ set_outer3_fieldC ::
   -> Outer3
 set_outer3_fieldC = RIP.setUnionPayload
 
-instance HasCField.HasCField Outer3 "outer3_fieldA" where
-
-  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "outer3_fieldA" (RIP.Ptr Outer3) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldA")
 
-instance HasCField.HasCField Outer3 "outer3_fieldB" where
+instance HasCField.HasCField Outer3 "outer3_fieldA" where
 
-  type CFieldType Outer3 "outer3_fieldB" = Inner3
+  type CFieldType Outer3 "outer3_fieldA" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
 
@@ -719,9 +713,9 @@ instance ( ty ~ Inner3
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldB")
 
-instance HasCField.HasCField Outer3 "outer3_fieldC" where
+instance HasCField.HasCField Outer3 "outer3_fieldB" where
 
-  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+  type CFieldType Outer3 "outer3_fieldB" = Inner3
 
   offset# = \_ -> \_ -> 0
 
@@ -730,3 +724,9 @@ instance ( ty ~ RIP.CInt
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"outer3_fieldC")
+
+instance HasCField.HasCField Outer3 "outer3_fieldC" where
+
+  type CFieldType Outer3 "outer3_fieldC" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/bindingspec.yaml
@@ -31,7 +31,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -45,7 +45,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -59,7 +59,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -73,7 +73,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -87,7 +87,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -101,7 +101,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/union_in_union/th.txt
@@ -83,24 +83,24 @@ set_outer1_anon'fieldX_fieldY :: CInt -> Outer1_anon'fieldX
 
 -}
 set_outer1_anon'fieldX_fieldY = setUnionPayload
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
-    where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldX" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldX"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldX")
-instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldX"
     where type CFieldType Outer1_anon'fieldX
-                          "outer1_anon'fieldX_fieldY" = CInt
+                          "outer1_anon'fieldX_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_anon'fieldX_fieldY"
                   (Ptr Outer1_anon'fieldX)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX_fieldY")
+instance HasCField Outer1_anon'fieldX "outer1_anon'fieldX_fieldY"
+    where type CFieldType Outer1_anon'fieldX
+                          "outer1_anon'fieldX_fieldY" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union outer1@
 
     __defined at:__ @types\/anonymous\/union_in_union.h 6:7@
@@ -216,25 +216,25 @@ set_outer1_fieldC :: CInt -> Outer1
 
 -}
 set_outer1_fieldC = setUnionPayload
-instance HasCField Outer1 "outer1_fieldA"
-    where type CFieldType Outer1 "outer1_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer1_fieldA" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_fieldA")
-instance HasCField Outer1 "outer1_anon'fieldX"
-    where type CFieldType Outer1
-                          "outer1_anon'fieldX" = Outer1_anon'fieldX
+instance HasCField Outer1 "outer1_fieldA"
+    where type CFieldType Outer1 "outer1_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Outer1_anon'fieldX =>
          HasField "outer1_anon'fieldX" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_anon'fieldX")
-instance HasCField Outer1 "outer1_fieldC"
-    where type CFieldType Outer1 "outer1_fieldC" = CInt
+instance HasCField Outer1 "outer1_anon'fieldX"
+    where type CFieldType Outer1
+                          "outer1_anon'fieldX" = Outer1_anon'fieldX
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer1_fieldC" (Ptr Outer1) (Ptr ty)
     where getField = fromPtr (Proxy @"outer1_fieldC")
+instance HasCField Outer1 "outer1_fieldC"
+    where type CFieldType Outer1 "outer1_fieldC" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@outer2_fieldB@
 
     __defined at:__ @types\/anonymous\/union_in_union.h 17:3@
@@ -316,18 +316,18 @@ set_outer2_fieldB_fieldY :: CInt -> Outer2_fieldB
 
 -}
 set_outer2_fieldB_fieldY = setUnionPayload
+instance (~) ty CInt =>
+         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldX"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldX" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldX")
+         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
+    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 instance HasCField Outer2_fieldB "outer2_fieldB_fieldY"
     where type CFieldType Outer2_fieldB "outer2_fieldB_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "outer2_fieldB_fieldY" (Ptr Outer2_fieldB) (Ptr ty)
-    where getField = fromPtr (Proxy @"outer2_fieldB_fieldY")
 {-| __C declaration:__ @union outer2@
 
     __defined at:__ @types\/anonymous\/union_in_union.h 15:7@
@@ -443,24 +443,24 @@ set_outer2_fieldC :: CInt -> Outer2
 
 -}
 set_outer2_fieldC = setUnionPayload
-instance HasCField Outer2 "outer2_fieldA"
-    where type CFieldType Outer2 "outer2_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer2_fieldA" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldA")
-instance HasCField Outer2 "outer2_fieldB"
-    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
+instance HasCField Outer2 "outer2_fieldA"
+    where type CFieldType Outer2 "outer2_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Outer2_fieldB =>
          HasField "outer2_fieldB" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldB")
-instance HasCField Outer2 "outer2_fieldC"
-    where type CFieldType Outer2 "outer2_fieldC" = CInt
+instance HasCField Outer2 "outer2_fieldB"
+    where type CFieldType Outer2 "outer2_fieldB" = Outer2_fieldB
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer2_fieldC" (Ptr Outer2) (Ptr ty)
     where getField = fromPtr (Proxy @"outer2_fieldC")
+instance HasCField Outer2 "outer2_fieldC"
+    where type CFieldType Outer2 "outer2_fieldC" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union inner3@
 
     __defined at:__ @types\/anonymous\/union_in_union.h 26:9@
@@ -542,18 +542,18 @@ set_inner3_fieldY :: CInt -> Inner3
 
 -}
 set_inner3_fieldY = setUnionPayload
+instance (~) ty CInt =>
+         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldX")
 instance HasCField Inner3 "inner3_fieldX"
     where type CFieldType Inner3 "inner3_fieldX" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
-         HasField "inner3_fieldX" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldX")
+         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
+    where getField = fromPtr (Proxy @"inner3_fieldY")
 instance HasCField Inner3 "inner3_fieldY"
     where type CFieldType Inner3 "inner3_fieldY" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "inner3_fieldY" (Ptr Inner3) (Ptr ty)
-    where getField = fromPtr (Proxy @"inner3_fieldY")
 {-| __C declaration:__ @union outer3@
 
     __defined at:__ @types\/anonymous\/union_in_union.h 24:7@
@@ -669,21 +669,21 @@ set_outer3_fieldC :: CInt -> Outer3
 
 -}
 set_outer3_fieldC = setUnionPayload
-instance HasCField Outer3 "outer3_fieldA"
-    where type CFieldType Outer3 "outer3_fieldA" = CChar
-          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "outer3_fieldA" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldA")
-instance HasCField Outer3 "outer3_fieldB"
-    where type CFieldType Outer3 "outer3_fieldB" = Inner3
+instance HasCField Outer3 "outer3_fieldA"
+    where type CFieldType Outer3 "outer3_fieldA" = CChar
           offset# = \_ -> \_ -> 0
 instance (~) ty Inner3 =>
          HasField "outer3_fieldB" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldB")
-instance HasCField Outer3 "outer3_fieldC"
-    where type CFieldType Outer3 "outer3_fieldC" = CInt
+instance HasCField Outer3 "outer3_fieldB"
+    where type CFieldType Outer3 "outer3_fieldB" = Inner3
           offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "outer3_fieldC" (Ptr Outer3) (Ptr ty)
     where getField = fromPtr (Proxy @"outer3_fieldC")
+instance HasCField Outer3 "outer3_fieldC"
+    where type CFieldType Outer3 "outer3_fieldC" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/Example.hs
@@ -84,19 +84,6 @@ instance Marshal.WriteRaw Complex_object_t where
 
 deriving via Marshal.EquivStorable Complex_object_t instance RIP.Storable Complex_object_t
 
-instance HasCField.HasCField Complex_object_t "complex_object_t_velocity" where
-
-  type CFieldType Complex_object_t "complex_object_t_velocity" =
-    RIP.Complex RIP.CFloat
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Complex RIP.CFloat
-         ) => RIP.HasField "complex_object_t_velocity" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"complex_object_t_velocity")
-
 instance ( ty ~ RIP.Complex RIP.CFloat
          ) => RIP.CompatHasField.HasField "complex_object_t_velocity" Complex_object_t ty where
 
@@ -110,18 +97,18 @@ instance ( ty ~ RIP.Complex RIP.CFloat
       , RIP.getField @"complex_object_t_velocity" x0
       )
 
-instance HasCField.HasCField Complex_object_t "complex_object_t_position" where
-
-  type CFieldType Complex_object_t "complex_object_t_position" =
-    RIP.Complex RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Complex RIP.CDouble
-         ) => RIP.HasField "complex_object_t_position" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Complex RIP.CFloat
+         ) => RIP.HasField "complex_object_t_velocity" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"complex_object_t_position")
+    HasCField.fromPtr (RIP.Proxy @"complex_object_t_velocity")
+
+instance HasCField.HasCField Complex_object_t "complex_object_t_velocity" where
+
+  type CFieldType Complex_object_t "complex_object_t_velocity" =
+    RIP.Complex RIP.CFloat
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Complex RIP.CDouble
          ) => RIP.CompatHasField.HasField "complex_object_t_position" Complex_object_t ty where
@@ -136,18 +123,18 @@ instance ( ty ~ RIP.Complex RIP.CDouble
       , RIP.getField @"complex_object_t_position" x0
       )
 
-instance HasCField.HasCField Complex_object_t "complex_object_t_id" where
-
-  type CFieldType Complex_object_t "complex_object_t_id" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 24
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "complex_object_t_id" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.Complex RIP.CDouble
+         ) => RIP.HasField "complex_object_t_position" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"complex_object_t_id")
+    HasCField.fromPtr (RIP.Proxy @"complex_object_t_position")
+
+instance HasCField.HasCField Complex_object_t "complex_object_t_position" where
+
+  type CFieldType Complex_object_t "complex_object_t_position" =
+    RIP.Complex RIP.CDouble
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "complex_object_t_id" Complex_object_t ty where
@@ -161,3 +148,16 @@ instance ( ty ~ RIP.CInt
                            }
       , RIP.getField @"complex_object_t_id" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "complex_object_t_id" (RIP.Ptr Complex_object_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"complex_object_t_id")
+
+instance HasCField.HasCField Complex_object_t "complex_object_t_id" where
+
+  type CFieldType Complex_object_t "complex_object_t_id" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 24

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/bindingspec.yaml
@@ -19,11 +19,12 @@ hstypes:
       - complex_object_t_position
       - complex_object_t_id
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/hsb_complex_test/th.txt
@@ -175,48 +175,48 @@ instance WriteRaw Complex_object_t
                                                         complex_object_t_position_3
                                                         complex_object_t_id_4 -> writeRaw (Proxy @"complex_object_t_velocity") ptr_0 complex_object_t_velocity_2 >> (writeRaw (Proxy @"complex_object_t_position") ptr_0 complex_object_t_position_3 >> writeRaw (Proxy @"complex_object_t_id") ptr_0 complex_object_t_id_4)
 deriving via (EquivStorable Complex_object_t) instance Storable Complex_object_t
-instance HasCField Complex_object_t "complex_object_t_velocity"
-    where type CFieldType Complex_object_t
-                          "complex_object_t_velocity" = Complex CFloat
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Complex CFloat) =>
-         HasField "complex_object_t_velocity"
-                  (Ptr Complex_object_t)
-                  (Ptr ty)
-    where getField = fromPtr (Proxy @"complex_object_t_velocity")
 instance (~) ty (Complex CFloat) =>
          HasField "complex_object_t_velocity" Complex_object_t ty
     where hasField = \x_0 -> (\y_1 -> Complex_object_t{complex_object_t_velocity = y_1,
                                                        complex_object_t_position = getField @"complex_object_t_position" x_0,
                                                        complex_object_t_id = getField @"complex_object_t_id" x_0},
                               getField @"complex_object_t_velocity" x_0)
-instance HasCField Complex_object_t "complex_object_t_position"
-    where type CFieldType Complex_object_t
-                          "complex_object_t_position" = Complex CDouble
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Complex CDouble) =>
-         HasField "complex_object_t_position"
+instance (~) ty (Complex CFloat) =>
+         HasField "complex_object_t_velocity"
                   (Ptr Complex_object_t)
                   (Ptr ty)
-    where getField = fromPtr (Proxy @"complex_object_t_position")
+    where getField = fromPtr (Proxy @"complex_object_t_velocity")
+instance HasCField Complex_object_t "complex_object_t_velocity"
+    where type CFieldType Complex_object_t
+                          "complex_object_t_velocity" = Complex CFloat
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Complex CDouble) =>
          HasField "complex_object_t_position" Complex_object_t ty
     where hasField = \x_0 -> (\y_1 -> Complex_object_t{complex_object_t_position = y_1,
                                                        complex_object_t_velocity = getField @"complex_object_t_velocity" x_0,
                                                        complex_object_t_id = getField @"complex_object_t_id" x_0},
                               getField @"complex_object_t_position" x_0)
-instance HasCField Complex_object_t "complex_object_t_id"
-    where type CFieldType Complex_object_t "complex_object_t_id" = CInt
-          offset# = \_ -> \_ -> 24
-instance (~) ty CInt =>
-         HasField "complex_object_t_id" (Ptr Complex_object_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"complex_object_t_id")
+instance (~) ty (Complex CDouble) =>
+         HasField "complex_object_t_position"
+                  (Ptr Complex_object_t)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"complex_object_t_position")
+instance HasCField Complex_object_t "complex_object_t_position"
+    where type CFieldType Complex_object_t
+                          "complex_object_t_position" = Complex CDouble
+          offset# = \_ -> \_ -> 8
 instance (~) ty CInt =>
          HasField "complex_object_t_id" Complex_object_t ty
     where hasField = \x_0 -> (\y_1 -> Complex_object_t{complex_object_t_id = y_1,
                                                        complex_object_t_velocity = getField @"complex_object_t_velocity" x_0,
                                                        complex_object_t_position = getField @"complex_object_t_position" x_0},
                               getField @"complex_object_t_id" x_0)
+instance (~) ty CInt =>
+         HasField "complex_object_t_id" (Ptr Complex_object_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"complex_object_t_id")
+instance HasCField Complex_object_t "complex_object_t_id"
+    where type CFieldType Complex_object_t "complex_object_t_id" = CInt
+          offset# = \_ -> \_ -> 24
 -- __unique:__ @test_typescomplexhsb_complex_test_Example_Safe_multiply_complex_f@
 foreign import ccall safe "hs_bindgen_687af703c95fba0e" hs_bindgen_687af703c95fba0e_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/Example.hs
@@ -72,17 +72,6 @@ instance Marshal.WriteRaw Vector where
 
 deriving via Marshal.EquivStorable Vector instance RIP.Storable Vector
 
-instance HasCField.HasCField Vector "vector_x" where
-
-  type CFieldType Vector "vector_x" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "vector_x" (RIP.Ptr Vector) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"vector_x")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "vector_x" Vector ty where
 
@@ -93,16 +82,16 @@ instance ( ty ~ RIP.CDouble
       , RIP.getField @"vector_x" x0
       )
 
-instance HasCField.HasCField Vector "vector_y" where
-
-  type CFieldType Vector "vector_y" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "vector_y" (RIP.Ptr Vector) (RIP.Ptr ty) where
+         ) => RIP.HasField "vector_x" (RIP.Ptr Vector) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"vector_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"vector_x")
+
+instance HasCField.HasCField Vector "vector_x" where
+
+  type CFieldType Vector "vector_x" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "vector_y" Vector ty where
@@ -113,3 +102,14 @@ instance ( ty ~ RIP.CDouble
           Vector {vector_y = y1, vector_x = RIP.getField @"vector_x" x0}
       , RIP.getField @"vector_y" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "vector_y" (RIP.Ptr Vector) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"vector_y")
+
+instance HasCField.HasCField Vector "vector_y" where
+
+  type CFieldType Vector "vector_y" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - vector_x
       - vector_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/complex/vector_test/th.txt
@@ -55,26 +55,26 @@ instance WriteRaw Vector
                                        Vector vector_x_2
                                               vector_y_3 -> writeRaw (Proxy @"vector_x") ptr_0 vector_x_2 >> writeRaw (Proxy @"vector_y") ptr_0 vector_y_3
 deriving via (EquivStorable Vector) instance Storable Vector
-instance HasCField Vector "vector_x"
-    where type CFieldType Vector "vector_x" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "vector_x" (Ptr Vector) (Ptr ty)
-    where getField = fromPtr (Proxy @"vector_x")
 instance (~) ty CDouble => HasField "vector_x" Vector ty
     where hasField = \x_0 -> (\y_1 -> Vector{vector_x = y_1,
                                              vector_y = getField @"vector_y" x_0},
                               getField @"vector_x" x_0)
-instance HasCField Vector "vector_y"
-    where type CFieldType Vector "vector_y" = CDouble
-          offset# = \_ -> \_ -> 8
 instance (~) ty CDouble =>
-         HasField "vector_y" (Ptr Vector) (Ptr ty)
-    where getField = fromPtr (Proxy @"vector_y")
+         HasField "vector_x" (Ptr Vector) (Ptr ty)
+    where getField = fromPtr (Proxy @"vector_x")
+instance HasCField Vector "vector_x"
+    where type CFieldType Vector "vector_x" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty CDouble => HasField "vector_y" Vector ty
     where hasField = \x_0 -> (\y_1 -> Vector{vector_y = y_1,
                                              vector_x = getField @"vector_x" x_0},
                               getField @"vector_y" x_0)
+instance (~) ty CDouble =>
+         HasField "vector_y" (Ptr Vector) (Ptr ty)
+    where getField = fromPtr (Proxy @"vector_y")
+instance HasCField Vector "vector_y"
+    where type CFieldType Vector "vector_y" = CDouble
+          offset# = \_ -> \_ -> 8
 -- __unique:__ @test_typescomplexvector_test_Example_Safe_new_vector@
 foreign import ccall safe "hs_bindgen_cd5f566bc96dcba0" hs_bindgen_cd5f566bc96dcba0_base ::
     Double

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/Example.hs
@@ -109,6 +109,14 @@ instance Read Foo_enum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapFoo_enum" Foo_enum ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo_enum {unwrapFoo_enum = y1}, RIP.getField @"unwrapFoo_enum" x0)
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapFoo_enum" (RIP.Ptr Foo_enum) (RIP.Ptr ty) where
 
   getField =
@@ -120,14 +128,6 @@ instance HasCField.HasCField Foo_enum "unwrapFoo_enum" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapFoo_enum" Foo_enum ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Foo_enum {unwrapFoo_enum = y1}, RIP.getField @"unwrapFoo_enum" x0)
 
 {-| __C declaration:__ @A@
 

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
@@ -18,12 +18,13 @@ hstypes:
       - unwrapFoo_enum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/th.txt
@@ -43,16 +43,16 @@ instance Read Foo_enum
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapFoo_enum" Foo_enum ty
+    where hasField = \x_0 -> (\y_1 -> Foo_enum{unwrapFoo_enum = y_1},
+                              getField @"unwrapFoo_enum" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapFoo_enum" (Ptr Foo_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFoo_enum")
 instance HasCField Foo_enum "unwrapFoo_enum"
     where type CFieldType Foo_enum
                           "unwrapFoo_enum" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapFoo_enum" Foo_enum ty
-    where hasField = \x_0 -> (\y_1 -> Foo_enum{unwrapFoo_enum = y_1},
-                              getField @"unwrapFoo_enum" x_0)
 {-| __C declaration:__ @A@
 
     __defined at:__ @types\/enums\/enum_cpp_syntax.h 4:27@

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/Example.hs
@@ -104,6 +104,15 @@ instance Read Uint8_enum where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapUint8_enum" Uint8_enum ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint8_enum {unwrapUint8_enum = y1}
+      , RIP.getField @"unwrapUint8_enum" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapUint8_enum" (RIP.Ptr Uint8_enum) (RIP.Ptr ty) where
 
   getField =
@@ -115,15 +124,6 @@ instance HasCField.HasCField Uint8_enum "unwrapUint8_enum" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapUint8_enum" Uint8_enum ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint8_enum {unwrapUint8_enum = y1}
-      , RIP.getField @"unwrapUint8_enum" x0
-      )
 
 {-| __C declaration:__ @U8_ZERO@
 

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/bindingspec.yaml
@@ -18,12 +18,13 @@ hstypes:
       - unwrapUint8_enum
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/th.txt
@@ -40,16 +40,16 @@ instance Read Uint8_enum
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapUint8_enum" Uint8_enum ty
+    where hasField = \x_0 -> (\y_1 -> Uint8_enum{unwrapUint8_enum = y_1},
+                              getField @"unwrapUint8_enum" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapUint8_enum" (Ptr Uint8_enum) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint8_enum")
 instance HasCField Uint8_enum "unwrapUint8_enum"
     where type CFieldType Uint8_enum
                           "unwrapUint8_enum" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint8_enum" Uint8_enum ty
-    where hasField = \x_0 -> (\y_1 -> Uint8_enum{unwrapUint8_enum = y_1},
-                              getField @"unwrapUint8_enum" x_0)
 {-| __C declaration:__ @U8_ZERO@
 
     __defined at:__ @types\/enums\/enum_unsigned_values.h 5:3@

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/Example.hs
@@ -134,6 +134,14 @@ instance Read First where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapFirst" First ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         First {unwrapFirst = y1}, RIP.getField @"unwrapFirst" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapFirst" (RIP.Ptr First) (RIP.Ptr ty) where
 
   getField =
@@ -144,14 +152,6 @@ instance HasCField.HasCField First "unwrapFirst" where
   type CFieldType First "unwrapFirst" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapFirst" First ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         First {unwrapFirst = y1}, RIP.getField @"unwrapFirst" x0)
 
 {-| __C declaration:__ @FIRST1@
 
@@ -253,6 +253,14 @@ instance Read Second where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapSecond" Second ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Second {unwrapSecond = y1}, RIP.getField @"unwrapSecond" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapSecond" (RIP.Ptr Second) (RIP.Ptr ty) where
 
   getField =
@@ -263,14 +271,6 @@ instance HasCField.HasCField Second "unwrapSecond" where
   type CFieldType Second "unwrapSecond" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapSecond" Second ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Second {unwrapSecond = y1}, RIP.getField @"unwrapSecond" x0)
 
 {-| __C declaration:__ @SECOND_A@
 
@@ -377,6 +377,14 @@ instance Read Same where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapSame" Same ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Same {unwrapSame = y1}, RIP.getField @"unwrapSame" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapSame" (RIP.Ptr Same) (RIP.Ptr ty) where
 
   getField =
@@ -387,14 +395,6 @@ instance HasCField.HasCField Same "unwrapSame" where
   type CFieldType Same "unwrapSame" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapSame" Same ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Same {unwrapSame = y1}, RIP.getField @"unwrapSame" x0)
 
 {-| __C declaration:__ @SAME_A@
 
@@ -486,6 +486,14 @@ instance Read Nonseq where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapNonseq" Nonseq ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Nonseq {unwrapNonseq = y1}, RIP.getField @"unwrapNonseq" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapNonseq" (RIP.Ptr Nonseq) (RIP.Ptr ty) where
 
   getField =
@@ -496,14 +504,6 @@ instance HasCField.HasCField Nonseq "unwrapNonseq" where
   type CFieldType Nonseq "unwrapNonseq" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapNonseq" Nonseq ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Nonseq {unwrapNonseq = y1}, RIP.getField @"unwrapNonseq" x0)
 
 {-| __C declaration:__ @NONSEQ_A@
 
@@ -614,6 +614,14 @@ instance Read Packed where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUChar
+         ) => RIP.CompatHasField.HasField "unwrapPacked" Packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Packed {unwrapPacked = y1}, RIP.getField @"unwrapPacked" x0)
+
+instance ( ty ~ RIP.CUChar
          ) => RIP.HasField "unwrapPacked" (RIP.Ptr Packed) (RIP.Ptr ty) where
 
   getField =
@@ -624,14 +632,6 @@ instance HasCField.HasCField Packed "unwrapPacked" where
   type CFieldType Packed "unwrapPacked" = RIP.CUChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.CompatHasField.HasField "unwrapPacked" Packed ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Packed {unwrapPacked = y1}, RIP.getField @"unwrapPacked" x0)
 
 {-| __C declaration:__ @PACKED_A@
 
@@ -739,6 +739,14 @@ instance Read EnumA where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapEnumA" EnumA ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         EnumA {unwrapEnumA = y1}, RIP.getField @"unwrapEnumA" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr ty) where
 
   getField =
@@ -749,14 +757,6 @@ instance HasCField.HasCField EnumA "unwrapEnumA" where
   type CFieldType EnumA "unwrapEnumA" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapEnumA" EnumA ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         EnumA {unwrapEnumA = y1}, RIP.getField @"unwrapEnumA" x0)
 
 {-| __C declaration:__ @A_FOO@
 
@@ -855,6 +855,14 @@ instance Read EnumB where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapEnumB" EnumB ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         EnumB {unwrapEnumB = y1}, RIP.getField @"unwrapEnumB" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapEnumB" (RIP.Ptr EnumB) (RIP.Ptr ty) where
 
   getField =
@@ -865,14 +873,6 @@ instance HasCField.HasCField EnumB "unwrapEnumB" where
   type CFieldType EnumB "unwrapEnumB" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapEnumB" EnumB ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         EnumB {unwrapEnumB = y1}, RIP.getField @"unwrapEnumB" x0)
 
 {-| __C declaration:__ @B_FOO@
 
@@ -971,6 +971,14 @@ instance Read EnumC where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapEnumC" EnumC ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         EnumC {unwrapEnumC = y1}, RIP.getField @"unwrapEnumC" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapEnumC" (RIP.Ptr EnumC) (RIP.Ptr ty) where
 
   getField =
@@ -981,14 +989,6 @@ instance HasCField.HasCField EnumC "unwrapEnumC" where
   type CFieldType EnumC "unwrapEnumC" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapEnumC" EnumC ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         EnumC {unwrapEnumC = y1}, RIP.getField @"unwrapEnumC" x0)
 
 {-| __C declaration:__ @C_FOO@
 
@@ -1087,6 +1087,14 @@ instance Read EnumD_t where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapEnumD_t" EnumD_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         EnumD_t {unwrapEnumD_t = y1}, RIP.getField @"unwrapEnumD_t" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapEnumD_t" (RIP.Ptr EnumD_t) (RIP.Ptr ty) where
 
   getField =
@@ -1097,14 +1105,6 @@ instance HasCField.HasCField EnumD_t "unwrapEnumD_t" where
   type CFieldType EnumD_t "unwrapEnumD_t" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapEnumD_t" EnumD_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         EnumD_t {unwrapEnumD_t = y1}, RIP.getField @"unwrapEnumD_t" x0)
 
 {-| __C declaration:__ @D_FOO@
 

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/bindingspec.yaml
@@ -51,12 +51,13 @@ hstypes:
       - unwrapEnumA
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -74,12 +75,13 @@ hstypes:
       - unwrapEnumB
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -97,12 +99,13 @@ hstypes:
       - unwrapEnumC
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -120,12 +123,13 @@ hstypes:
       - unwrapEnumD_t
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -143,12 +147,13 @@ hstypes:
       - unwrapFirst
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -166,12 +171,13 @@ hstypes:
       - unwrapNonseq
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -188,12 +194,13 @@ hstypes:
       - unwrapPacked
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -211,12 +218,13 @@ hstypes:
       - unwrapSame
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -234,12 +242,13 @@ hstypes:
       - unwrapSecond
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/th.txt
@@ -39,15 +39,15 @@ instance Read First
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapFirst" First ty
+    where hasField = \x_0 -> (\y_1 -> First{unwrapFirst = y_1},
+                              getField @"unwrapFirst" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapFirst" (Ptr First) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFirst")
 instance HasCField First "unwrapFirst"
     where type CFieldType First "unwrapFirst" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapFirst" First ty
-    where hasField = \x_0 -> (\y_1 -> First{unwrapFirst = y_1},
-                              getField @"unwrapFirst" x_0)
 {-| __C declaration:__ @FIRST1@
 
     __defined at:__ @types\/enums\/enums.h 5:5@
@@ -105,15 +105,15 @@ instance Read Second
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CInt => HasField "unwrapSecond" Second ty
+    where hasField = \x_0 -> (\y_1 -> Second{unwrapSecond = y_1},
+                              getField @"unwrapSecond" x_0)
 instance (~) ty CInt =>
          HasField "unwrapSecond" (Ptr Second) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSecond")
 instance HasCField Second "unwrapSecond"
     where type CFieldType Second "unwrapSecond" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapSecond" Second ty
-    where hasField = \x_0 -> (\y_1 -> Second{unwrapSecond = y_1},
-                              getField @"unwrapSecond" x_0)
 {-| __C declaration:__ @SECOND_A@
 
     __defined at:__ @types\/enums\/enums.h 10:5@
@@ -177,14 +177,14 @@ instance Read Same
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapSame" Same ty
+    where hasField = \x_0 -> (\y_1 -> Same{unwrapSame = y_1},
+                              getField @"unwrapSame" x_0)
 instance (~) ty CUInt => HasField "unwrapSame" (Ptr Same) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapSame")
 instance HasCField Same "unwrapSame"
     where type CFieldType Same "unwrapSame" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapSame" Same ty
-    where hasField = \x_0 -> (\y_1 -> Same{unwrapSame = y_1},
-                              getField @"unwrapSame" x_0)
 {-| __C declaration:__ @SAME_A@
 
     __defined at:__ @types\/enums\/enums.h 16:5@
@@ -237,15 +237,15 @@ instance Read Nonseq
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapNonseq" Nonseq ty
+    where hasField = \x_0 -> (\y_1 -> Nonseq{unwrapNonseq = y_1},
+                              getField @"unwrapNonseq" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapNonseq" (Ptr Nonseq) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapNonseq")
 instance HasCField Nonseq "unwrapNonseq"
     where type CFieldType Nonseq "unwrapNonseq" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapNonseq" Nonseq ty
-    where hasField = \x_0 -> (\y_1 -> Nonseq{unwrapNonseq = y_1},
-                              getField @"unwrapNonseq" x_0)
 {-| __C declaration:__ @NONSEQ_A@
 
     __defined at:__ @types\/enums\/enums.h 21:5@
@@ -311,15 +311,15 @@ instance Read Packed
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUChar => HasField "unwrapPacked" Packed ty
+    where hasField = \x_0 -> (\y_1 -> Packed{unwrapPacked = y_1},
+                              getField @"unwrapPacked" x_0)
 instance (~) ty CUChar =>
          HasField "unwrapPacked" (Ptr Packed) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPacked")
 instance HasCField Packed "unwrapPacked"
     where type CFieldType Packed "unwrapPacked" = CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CUChar => HasField "unwrapPacked" Packed ty
-    where hasField = \x_0 -> (\y_1 -> Packed{unwrapPacked = y_1},
-                              getField @"unwrapPacked" x_0)
 {-| __C declaration:__ @PACKED_A@
 
     __defined at:__ @types\/enums\/enums.h 27:5@
@@ -384,15 +384,15 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapEnumA" EnumA ty
+    where hasField = \x_0 -> (\y_1 -> EnumA{unwrapEnumA = y_1},
+                              getField @"unwrapEnumA" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapEnumA" EnumA ty
-    where hasField = \x_0 -> (\y_1 -> EnumA{unwrapEnumA = y_1},
-                              getField @"unwrapEnumA" x_0)
 {-| __C declaration:__ @A_FOO@
 
     __defined at:__ @types\/enums\/enums.h 30:16@
@@ -449,15 +449,15 @@ instance Read EnumB
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapEnumB" EnumB ty
+    where hasField = \x_0 -> (\y_1 -> EnumB{unwrapEnumB = y_1},
+                              getField @"unwrapEnumB" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapEnumB" (Ptr EnumB) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumB")
 instance HasCField EnumB "unwrapEnumB"
     where type CFieldType EnumB "unwrapEnumB" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapEnumB" EnumB ty
-    where hasField = \x_0 -> (\y_1 -> EnumB{unwrapEnumB = y_1},
-                              getField @"unwrapEnumB" x_0)
 {-| __C declaration:__ @B_FOO@
 
     __defined at:__ @types\/enums\/enums.h 32:22@
@@ -514,15 +514,15 @@ instance Read EnumC
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapEnumC" EnumC ty
+    where hasField = \x_0 -> (\y_1 -> EnumC{unwrapEnumC = y_1},
+                              getField @"unwrapEnumC" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapEnumC" (Ptr EnumC) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumC")
 instance HasCField EnumC "unwrapEnumC"
     where type CFieldType EnumC "unwrapEnumC" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapEnumC" EnumC ty
-    where hasField = \x_0 -> (\y_1 -> EnumC{unwrapEnumC = y_1},
-                              getField @"unwrapEnumC" x_0)
 {-| __C declaration:__ @C_FOO@
 
     __defined at:__ @types\/enums\/enums.h 34:14@
@@ -579,15 +579,15 @@ instance Read EnumD_t
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapEnumD_t" EnumD_t ty
+    where hasField = \x_0 -> (\y_1 -> EnumD_t{unwrapEnumD_t = y_1},
+                              getField @"unwrapEnumD_t" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapEnumD_t" (Ptr EnumD_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumD_t")
 instance HasCField EnumD_t "unwrapEnumD_t"
     where type CFieldType EnumD_t "unwrapEnumD_t" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapEnumD_t" EnumD_t ty
-    where hasField = \x_0 -> (\y_1 -> EnumD_t{unwrapEnumD_t = y_1},
-                              getField @"unwrapEnumD_t" x_0)
 {-| __C declaration:__ @D_FOO@
 
     __defined at:__ @types\/enums\/enums.h 37:14@

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/Example.hs
@@ -112,6 +112,14 @@ instance Read EnumA where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapEnumA" EnumA ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         EnumA {unwrapEnumA = y1}, RIP.getField @"unwrapEnumA" x0)
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapEnumA" (RIP.Ptr EnumA) (RIP.Ptr ty) where
 
   getField =
@@ -122,14 +130,6 @@ instance HasCField.HasCField EnumA "unwrapEnumA" where
   type CFieldType EnumA "unwrapEnumA" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapEnumA" EnumA ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         EnumA {unwrapEnumA = y1}, RIP.getField @"unwrapEnumA" x0)
 
 {-| __C declaration:__ @VALA_1@
 
@@ -190,11 +190,12 @@ instance Marshal.WriteRaw ExA where
 
 deriving via Marshal.EquivStorable ExA instance RIP.Storable ExA
 
-instance HasCField.HasCField ExA "exA_fieldA1" where
+instance (ty ~ EnumA) => RIP.CompatHasField.HasField "exA_fieldA1" ExA ty where
 
-  type CFieldType ExA "exA_fieldA1" = EnumA
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 ->
+         ExA {exA_fieldA1 = y1}, RIP.getField @"exA_fieldA1" x0)
 
 instance ( ty ~ EnumA
          ) => RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr ty) where
@@ -202,12 +203,11 @@ instance ( ty ~ EnumA
   getField =
     HasCField.fromPtr (RIP.Proxy @"exA_fieldA1")
 
-instance (ty ~ EnumA) => RIP.CompatHasField.HasField "exA_fieldA1" ExA ty where
+instance HasCField.HasCField ExA "exA_fieldA1" where
 
-  hasField =
-    \x0 ->
-      (\y1 ->
-         ExA {exA_fieldA1 = y1}, RIP.getField @"exA_fieldA1" x0)
+  type CFieldType ExA "exA_fieldA1" = EnumA
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @enum \@exB_fieldB1@
 
@@ -288,6 +288,15 @@ instance Read ExB_fieldB1 where
   readListPrec = RIP.readListPrecDefault
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapExB_fieldB1" ExB_fieldB1 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> ExB_fieldB1 {unwrapExB_fieldB1 = y1}
+      , RIP.getField @"unwrapExB_fieldB1" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapExB_fieldB1" (RIP.Ptr ExB_fieldB1) (RIP.Ptr ty) where
 
   getField =
@@ -299,15 +308,6 @@ instance HasCField.HasCField ExB_fieldB1 "unwrapExB_fieldB1" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapExB_fieldB1" ExB_fieldB1 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> ExB_fieldB1 {unwrapExB_fieldB1 = y1}
-      , RIP.getField @"unwrapExB_fieldB1" x0
-      )
 
 {-| __C declaration:__ @VALB_1@
 
@@ -368,18 +368,6 @@ instance Marshal.WriteRaw ExB where
 
 deriving via Marshal.EquivStorable ExB instance RIP.Storable ExB
 
-instance HasCField.HasCField ExB "exB_fieldB1" where
-
-  type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ ExB_fieldB1
-         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")
-
 instance ( ty ~ ExB_fieldB1
          ) => RIP.CompatHasField.HasField "exB_fieldB1" ExB ty where
 
@@ -387,3 +375,15 @@ instance ( ty ~ ExB_fieldB1
     \x0 ->
       (\y1 ->
          ExB {exB_fieldB1 = y1}, RIP.getField @"exB_fieldB1" x0)
+
+instance ( ty ~ ExB_fieldB1
+         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")
+
+instance HasCField.HasCField ExB "exB_fieldB1" where
+
+  type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/bindingspec.yaml
@@ -24,12 +24,13 @@ hstypes:
       - unwrapEnumA
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -46,11 +47,12 @@ hstypes:
       fields:
       - exA_fieldA1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -63,11 +65,12 @@ hstypes:
       fields:
       - exB_fieldB1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -81,12 +84,13 @@ hstypes:
       - unwrapExB_fieldB1
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/th.txt
@@ -39,15 +39,15 @@ instance Read EnumA
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapEnumA" EnumA ty
+    where hasField = \x_0 -> (\y_1 -> EnumA{unwrapEnumA = y_1},
+                              getField @"unwrapEnumA" x_0)
 instance (~) ty CUInt =>
          HasField "unwrapEnumA" (Ptr EnumA) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapEnumA")
 instance HasCField EnumA "unwrapEnumA"
     where type CFieldType EnumA "unwrapEnumA" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapEnumA" EnumA ty
-    where hasField = \x_0 -> (\y_1 -> EnumA{unwrapEnumA = y_1},
-                              getField @"unwrapEnumA" x_0)
 {-| __C declaration:__ @VALA_1@
 
     __defined at:__ @types\/enums\/nested_enums.h 3:17@
@@ -88,14 +88,14 @@ instance WriteRaw ExA
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        ExA exA_fieldA1_2 -> writeRaw (Proxy @"exA_fieldA1") ptr_0 exA_fieldA1_2
 deriving via (EquivStorable ExA) instance Storable ExA
-instance HasCField ExA "exA_fieldA1"
-    where type CFieldType ExA "exA_fieldA1" = EnumA
-          offset# = \_ -> \_ -> 0
-instance (~) ty EnumA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
-    where getField = fromPtr (Proxy @"exA_fieldA1")
 instance (~) ty EnumA => HasField "exA_fieldA1" ExA ty
     where hasField = \x_0 -> (\y_1 -> ExA{exA_fieldA1 = y_1},
                               getField @"exA_fieldA1" x_0)
+instance (~) ty EnumA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+    where getField = fromPtr (Proxy @"exA_fieldA1")
+instance HasCField ExA "exA_fieldA1"
+    where type CFieldType ExA "exA_fieldA1" = EnumA
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @enum \@exB_fieldB1@
 
     __defined at:__ @types\/enums\/nested_enums.h 9:9@
@@ -137,15 +137,15 @@ instance Read ExB_fieldB1
           readList = readListDefault
           readListPrec = readListPrecDefault
 instance (~) ty CUInt =>
+         HasField "unwrapExB_fieldB1" ExB_fieldB1 ty
+    where hasField = \x_0 -> (\y_1 -> ExB_fieldB1{unwrapExB_fieldB1 = y_1},
+                              getField @"unwrapExB_fieldB1" x_0)
+instance (~) ty CUInt =>
          HasField "unwrapExB_fieldB1" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapExB_fieldB1")
 instance HasCField ExB_fieldB1 "unwrapExB_fieldB1"
     where type CFieldType ExB_fieldB1 "unwrapExB_fieldB1" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unwrapExB_fieldB1" ExB_fieldB1 ty
-    where hasField = \x_0 -> (\y_1 -> ExB_fieldB1{unwrapExB_fieldB1 = y_1},
-                              getField @"unwrapExB_fieldB1" x_0)
 {-| __C declaration:__ @VALB_1@
 
     __defined at:__ @types\/enums\/nested_enums.h 10:17@
@@ -186,12 +186,12 @@ instance WriteRaw ExB
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        ExB exB_fieldB1_2 -> writeRaw (Proxy @"exB_fieldB1") ptr_0 exB_fieldB1_2
 deriving via (EquivStorable ExB) instance Storable ExB
-instance HasCField ExB "exB_fieldB1"
-    where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
-          offset# = \_ -> \_ -> 0
-instance (~) ty ExB_fieldB1 =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
-    where getField = fromPtr (Proxy @"exB_fieldB1")
 instance (~) ty ExB_fieldB1 => HasField "exB_fieldB1" ExB ty
     where hasField = \x_0 -> (\y_1 -> ExB{exB_fieldB1 = y_1},
                               getField @"exB_fieldB1" x_0)
+instance (~) ty ExB_fieldB1 =>
+         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+    where getField = fromPtr (Proxy @"exB_fieldB1")
+instance HasCField ExB "exB_fieldB1"
+    where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/Example.hs
@@ -77,17 +77,6 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCField.HasCField Foo "foo_i" where
-
-  type CFieldType Foo "foo_i" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_i" Foo ty where
 
   hasField =
@@ -97,16 +86,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "foo_i" Foo ty where
       , RIP.getField @"foo_i" x0
       )
 
-instance HasCField.HasCField Foo "foo_c" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_i" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
-  type CFieldType Foo "foo_c" = RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_i")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField Foo "foo_i" where
 
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
+  type CFieldType Foo "foo_i" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
 
@@ -116,6 +105,17 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
           Foo {foo_c = y1, foo_i = RIP.getField @"foo_i" x0}
       , RIP.getField @"foo_c" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_c")
+
+instance HasCField.HasCField Foo "foo_c" where
+
+  type CFieldType Foo "foo_c" = RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct bar@
 
@@ -167,16 +167,6 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCField.HasCField Bar "bar_foo1" where
-
-  type CFieldType Bar "bar_foo1" = Foo
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ Foo) => RIP.HasField "bar_foo1" (RIP.Ptr Bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_foo1")
-
 instance (ty ~ Foo) => RIP.CompatHasField.HasField "bar_foo1" Bar ty where
 
   hasField =
@@ -186,15 +176,15 @@ instance (ty ~ Foo) => RIP.CompatHasField.HasField "bar_foo1" Bar ty where
       , RIP.getField @"bar_foo1" x0
       )
 
-instance HasCField.HasCField Bar "bar_foo2" where
+instance (ty ~ Foo) => RIP.HasField "bar_foo1" (RIP.Ptr Bar) (RIP.Ptr ty) where
 
-  type CFieldType Bar "bar_foo2" = Foo
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_foo1")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField Bar "bar_foo1" where
 
-instance (ty ~ Foo) => RIP.HasField "bar_foo2" (RIP.Ptr Bar) (RIP.Ptr ty) where
+  type CFieldType Bar "bar_foo1" = Foo
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_foo2")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ Foo) => RIP.CompatHasField.HasField "bar_foo2" Bar ty where
 
@@ -204,6 +194,16 @@ instance (ty ~ Foo) => RIP.CompatHasField.HasField "bar_foo2" Bar ty where
           Bar {bar_foo2 = y1, bar_foo1 = RIP.getField @"bar_foo1" x0}
       , RIP.getField @"bar_foo2" x0
       )
+
+instance (ty ~ Foo) => RIP.HasField "bar_foo2" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_foo2")
+
+instance HasCField.HasCField Bar "bar_foo2" where
+
+  type CFieldType Bar "bar_foo2" = Foo
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@ex3_ex3_struct@
 
@@ -255,19 +255,6 @@ instance Marshal.WriteRaw Ex3_ex3_struct where
 
 deriving via Marshal.EquivStorable Ex3_ex3_struct instance RIP.Storable Ex3_ex3_struct
 
-instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a" where
-
-  type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ex3_ex3_struct_ex3_a" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "ex3_ex3_struct_ex3_a" Ex3_ex3_struct ty where
 
@@ -280,18 +267,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"ex3_ex3_struct_ex3_a" x0
       )
 
-instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b" where
-
-  type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" =
-    RIP.CChar
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "ex3_ex3_struct_ex3_b" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "ex3_ex3_struct_ex3_a" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_b")
+    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_a")
+
+instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a" where
+
+  type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "ex3_ex3_struct_ex3_b" Ex3_ex3_struct ty where
@@ -304,6 +291,19 @@ instance ( ty ~ RIP.CChar
                          }
       , RIP.getField @"ex3_ex3_struct_ex3_b" x0
       )
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "ex3_ex3_struct_ex3_b" (RIP.Ptr Ex3_ex3_struct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct_ex3_b")
+
+instance HasCField.HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b" where
+
+  type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct ex3@
 
@@ -355,18 +355,6 @@ instance Marshal.WriteRaw Ex3 where
 
 deriving via Marshal.EquivStorable Ex3 instance RIP.Storable Ex3
 
-instance HasCField.HasCField Ex3 "ex3_ex3_struct" where
-
-  type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Ex3_ex3_struct
-         ) => RIP.HasField "ex3_ex3_struct" (RIP.Ptr Ex3) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct")
-
 instance ( ty ~ Ex3_ex3_struct
          ) => RIP.CompatHasField.HasField "ex3_ex3_struct" Ex3 ty where
 
@@ -377,16 +365,17 @@ instance ( ty ~ Ex3_ex3_struct
       , RIP.getField @"ex3_ex3_struct" x0
       )
 
-instance HasCField.HasCField Ex3 "ex3_ex3_c" where
+instance ( ty ~ Ex3_ex3_struct
+         ) => RIP.HasField "ex3_ex3_struct" (RIP.Ptr Ex3) (RIP.Ptr ty) where
 
-  type CFieldType Ex3 "ex3_ex3_c" = RIP.CFloat
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ex3_ex3_struct")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField Ex3 "ex3_ex3_struct" where
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "ex3_ex3_c" (RIP.Ptr Ex3) (RIP.Ptr ty) where
+  type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
 
-  getField = HasCField.fromPtr (RIP.Proxy @"ex3_ex3_c")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "ex3_ex3_c" Ex3 ty where
@@ -397,6 +386,17 @@ instance ( ty ~ RIP.CFloat
           Ex3 {ex3_ex3_c = y1, ex3_ex3_struct = RIP.getField @"ex3_ex3_struct" x0}
       , RIP.getField @"ex3_ex3_c" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "ex3_ex3_c" (RIP.Ptr Ex3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"ex3_ex3_c")
+
+instance HasCField.HasCField Ex3 "ex3_ex3_c" where
+
+  type CFieldType Ex3 "ex3_ex3_c" = RIP.CFloat
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct ex4_odd@
 
@@ -448,18 +448,6 @@ instance Marshal.WriteRaw Ex4_odd where
 
 deriving via Marshal.EquivStorable Ex4_odd instance RIP.Storable Ex4_odd
 
-instance HasCField.HasCField Ex4_odd "ex4_odd_value" where
-
-  type CFieldType Ex4_odd "ex4_odd_value" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "ex4_odd_value" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ex4_odd_value")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "ex4_odd_value" Ex4_odd ty where
 
@@ -470,18 +458,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"ex4_odd_value" x0
       )
 
-instance HasCField.HasCField Ex4_odd "ex4_odd_next" where
-
-  type CFieldType Ex4_odd "ex4_odd_next" =
-    RIP.Ptr Ex4_even
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Ex4_even
-         ) => RIP.HasField "ex4_odd_next" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "ex4_odd_value" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"ex4_odd_next")
+    HasCField.fromPtr (RIP.Proxy @"ex4_odd_value")
+
+instance HasCField.HasCField Ex4_odd "ex4_odd_value" where
+
+  type CFieldType Ex4_odd "ex4_odd_value" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Ex4_even
          ) => RIP.CompatHasField.HasField "ex4_odd_next" Ex4_odd ty where
@@ -492,6 +479,19 @@ instance ( ty ~ RIP.Ptr Ex4_even
           Ex4_odd {ex4_odd_next = y1, ex4_odd_value = RIP.getField @"ex4_odd_value" x0}
       , RIP.getField @"ex4_odd_next" x0
       )
+
+instance ( ty ~ RIP.Ptr Ex4_even
+         ) => RIP.HasField "ex4_odd_next" (RIP.Ptr Ex4_odd) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ex4_odd_next")
+
+instance HasCField.HasCField Ex4_odd "ex4_odd_next" where
+
+  type CFieldType Ex4_odd "ex4_odd_next" =
+    RIP.Ptr Ex4_even
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct ex4_even@
 
@@ -543,19 +543,6 @@ instance Marshal.WriteRaw Ex4_even where
 
 deriving via Marshal.EquivStorable Ex4_even instance RIP.Storable Ex4_even
 
-instance HasCField.HasCField Ex4_even "ex4_even_value" where
-
-  type CFieldType Ex4_even "ex4_even_value" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "ex4_even_value" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"ex4_even_value")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "ex4_even_value" Ex4_even ty where
 
@@ -566,18 +553,18 @@ instance ( ty ~ RIP.CDouble
       , RIP.getField @"ex4_even_value" x0
       )
 
-instance HasCField.HasCField Ex4_even "ex4_even_next" where
-
-  type CFieldType Ex4_even "ex4_even_next" =
-    RIP.Ptr Ex4_odd
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Ex4_odd
-         ) => RIP.HasField "ex4_even_next" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "ex4_even_value" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"ex4_even_next")
+    HasCField.fromPtr (RIP.Proxy @"ex4_even_value")
+
+instance HasCField.HasCField Ex4_even "ex4_even_value" where
+
+  type CFieldType Ex4_even "ex4_even_value" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Ex4_odd
          ) => RIP.CompatHasField.HasField "ex4_even_next" Ex4_even ty where
@@ -588,3 +575,16 @@ instance ( ty ~ RIP.Ptr Ex4_odd
           Ex4_even {ex4_even_next = y1, ex4_even_value = RIP.getField @"ex4_even_value" x0}
       , RIP.getField @"ex4_even_next" x0
       )
+
+instance ( ty ~ RIP.Ptr Ex4_odd
+         ) => RIP.HasField "ex4_even_next" (RIP.Ptr Ex4_even) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"ex4_even_next")
+
+instance HasCField.HasCField Ex4_even "ex4_even_next" where
+
+  type CFieldType Ex4_even "ex4_even_next" =
+    RIP.Ptr Ex4_odd
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/bindingspec.yaml
@@ -30,11 +30,12 @@ hstypes:
       - bar_foo1
       - bar_foo2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -48,11 +49,12 @@ hstypes:
       - ex3_ex3_struct
       - ex3_ex3_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -66,11 +68,12 @@ hstypes:
       - ex3_ex3_struct_ex3_a
       - ex3_ex3_struct_ex3_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -84,11 +87,12 @@ hstypes:
       - ex4_even_value
       - ex4_even_next
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -102,11 +106,12 @@ hstypes:
       - ex4_odd_value
       - ex4_odd_next
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -120,11 +125,12 @@ hstypes:
       - foo_i
       - foo_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/nested/nested_types/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw Foo
                                        Foo foo_i_2
                                            foo_c_3 -> writeRaw (Proxy @"foo_i") ptr_0 foo_i_2 >> writeRaw (Proxy @"foo_c") ptr_0 foo_c_3
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCField Foo "foo_i"
-    where type CFieldType Foo "foo_i" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_i")
 instance (~) ty CInt => HasField "foo_i" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_i = y_1,
                                           foo_c = getField @"foo_c" x_0},
                               getField @"foo_i" x_0)
-instance HasCField Foo "foo_c"
-    where type CFieldType Foo "foo_c" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_c")
+instance (~) ty CInt => HasField "foo_i" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_i")
+instance HasCField Foo "foo_i"
+    where type CFieldType Foo "foo_i" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar => HasField "foo_c" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_c = y_1,
                                           foo_i = getField @"foo_i" x_0},
                               getField @"foo_c" x_0)
+instance (~) ty CChar => HasField "foo_c" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_c")
+instance HasCField Foo "foo_c"
+    where type CFieldType Foo "foo_c" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct bar@
 
     __defined at:__ @types\/nested\/nested_types.h 6:8@
@@ -81,24 +81,24 @@ instance WriteRaw Bar
                                        Bar bar_foo1_2
                                            bar_foo2_3 -> writeRaw (Proxy @"bar_foo1") ptr_0 bar_foo1_2 >> writeRaw (Proxy @"bar_foo2") ptr_0 bar_foo2_3
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCField Bar "bar_foo1"
-    where type CFieldType Bar "bar_foo1" = Foo
-          offset# = \_ -> \_ -> 0
-instance (~) ty Foo => HasField "bar_foo1" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_foo1")
 instance (~) ty Foo => HasField "bar_foo1" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_foo1 = y_1,
                                           bar_foo2 = getField @"bar_foo2" x_0},
                               getField @"bar_foo1" x_0)
-instance HasCField Bar "bar_foo2"
-    where type CFieldType Bar "bar_foo2" = Foo
-          offset# = \_ -> \_ -> 8
-instance (~) ty Foo => HasField "bar_foo2" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_foo2")
+instance (~) ty Foo => HasField "bar_foo1" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_foo1")
+instance HasCField Bar "bar_foo1"
+    where type CFieldType Bar "bar_foo1" = Foo
+          offset# = \_ -> \_ -> 0
 instance (~) ty Foo => HasField "bar_foo2" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_foo2 = y_1,
                                           bar_foo1 = getField @"bar_foo1" x_0},
                               getField @"bar_foo2" x_0)
+instance (~) ty Foo => HasField "bar_foo2" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_foo2")
+instance HasCField Bar "bar_foo2"
+    where type CFieldType Bar "bar_foo2" = Foo
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@ex3_ex3_struct@
 
     __defined at:__ @types\/nested\/nested_types.h 12:5@
@@ -131,28 +131,28 @@ instance WriteRaw Ex3_ex3_struct
                                        Ex3_ex3_struct ex3_ex3_struct_ex3_a_2
                                                       ex3_ex3_struct_ex3_b_3 -> writeRaw (Proxy @"ex3_ex3_struct_ex3_a") ptr_0 ex3_ex3_struct_ex3_a_2 >> writeRaw (Proxy @"ex3_ex3_struct_ex3_b") ptr_0 ex3_ex3_struct_ex3_b_3
 deriving via (EquivStorable Ex3_ex3_struct) instance Storable Ex3_ex3_struct
-instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a"
-    where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "ex3_ex3_struct_ex3_a" (Ptr Ex3_ex3_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_a")
 instance (~) ty CInt =>
          HasField "ex3_ex3_struct_ex3_a" Ex3_ex3_struct ty
     where hasField = \x_0 -> (\y_1 -> Ex3_ex3_struct{ex3_ex3_struct_ex3_a = y_1,
                                                      ex3_ex3_struct_ex3_b = getField @"ex3_ex3_struct_ex3_b" x_0},
                               getField @"ex3_ex3_struct_ex3_a" x_0)
-instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b"
-    where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar =>
-         HasField "ex3_ex3_struct_ex3_b" (Ptr Ex3_ex3_struct) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_b")
+instance (~) ty CInt =>
+         HasField "ex3_ex3_struct_ex3_a" (Ptr Ex3_ex3_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_a")
+instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_a"
+    where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "ex3_ex3_struct_ex3_b" Ex3_ex3_struct ty
     where hasField = \x_0 -> (\y_1 -> Ex3_ex3_struct{ex3_ex3_struct_ex3_b = y_1,
                                                      ex3_ex3_struct_ex3_a = getField @"ex3_ex3_struct_ex3_a" x_0},
                               getField @"ex3_ex3_struct_ex3_b" x_0)
+instance (~) ty CChar =>
+         HasField "ex3_ex3_struct_ex3_b" (Ptr Ex3_ex3_struct) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex3_ex3_struct_ex3_b")
+instance HasCField Ex3_ex3_struct "ex3_ex3_struct_ex3_b"
+    where type CFieldType Ex3_ex3_struct "ex3_ex3_struct_ex3_b" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct ex3@
 
     __defined at:__ @types\/nested\/nested_types.h 11:8@
@@ -185,25 +185,25 @@ instance WriteRaw Ex3
                                        Ex3 ex3_ex3_struct_2
                                            ex3_ex3_c_3 -> writeRaw (Proxy @"ex3_ex3_struct") ptr_0 ex3_ex3_struct_2 >> writeRaw (Proxy @"ex3_ex3_c") ptr_0 ex3_ex3_c_3
 deriving via (EquivStorable Ex3) instance Storable Ex3
-instance HasCField Ex3 "ex3_ex3_struct"
-    where type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
-          offset# = \_ -> \_ -> 0
-instance (~) ty Ex3_ex3_struct =>
-         HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex3_ex3_struct")
 instance (~) ty Ex3_ex3_struct => HasField "ex3_ex3_struct" Ex3 ty
     where hasField = \x_0 -> (\y_1 -> Ex3{ex3_ex3_struct = y_1,
                                           ex3_ex3_c = getField @"ex3_ex3_c" x_0},
                               getField @"ex3_ex3_struct" x_0)
-instance HasCField Ex3 "ex3_ex3_c"
-    where type CFieldType Ex3 "ex3_ex3_c" = CFloat
-          offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "ex3_ex3_c" (Ptr Ex3) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex3_ex3_c")
+instance (~) ty Ex3_ex3_struct =>
+         HasField "ex3_ex3_struct" (Ptr Ex3) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex3_ex3_struct")
+instance HasCField Ex3 "ex3_ex3_struct"
+    where type CFieldType Ex3 "ex3_ex3_struct" = Ex3_ex3_struct
+          offset# = \_ -> \_ -> 0
 instance (~) ty CFloat => HasField "ex3_ex3_c" Ex3 ty
     where hasField = \x_0 -> (\y_1 -> Ex3{ex3_ex3_c = y_1,
                                           ex3_ex3_struct = getField @"ex3_ex3_struct" x_0},
                               getField @"ex3_ex3_c" x_0)
+instance (~) ty CFloat => HasField "ex3_ex3_c" (Ptr Ex3) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex3_ex3_c")
+instance HasCField Ex3 "ex3_ex3_c"
+    where type CFieldType Ex3 "ex3_ex3_c" = CFloat
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct ex4_odd@
 
     __defined at:__ @types\/nested\/nested_types.h 22:8@
@@ -236,27 +236,27 @@ instance WriteRaw Ex4_odd
                                        Ex4_odd ex4_odd_value_2
                                                ex4_odd_next_3 -> writeRaw (Proxy @"ex4_odd_value") ptr_0 ex4_odd_value_2 >> writeRaw (Proxy @"ex4_odd_next") ptr_0 ex4_odd_next_3
 deriving via (EquivStorable Ex4_odd) instance Storable Ex4_odd
-instance HasCField Ex4_odd "ex4_odd_value"
-    where type CFieldType Ex4_odd "ex4_odd_value" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex4_odd_value")
 instance (~) ty CInt => HasField "ex4_odd_value" Ex4_odd ty
     where hasField = \x_0 -> (\y_1 -> Ex4_odd{ex4_odd_value = y_1,
                                               ex4_odd_next = getField @"ex4_odd_next" x_0},
                               getField @"ex4_odd_value" x_0)
-instance HasCField Ex4_odd "ex4_odd_next"
-    where type CFieldType Ex4_odd "ex4_odd_next" = Ptr Ex4_even
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Ex4_even) =>
-         HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex4_odd_next")
+instance (~) ty CInt =>
+         HasField "ex4_odd_value" (Ptr Ex4_odd) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex4_odd_value")
+instance HasCField Ex4_odd "ex4_odd_value"
+    where type CFieldType Ex4_odd "ex4_odd_value" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Ex4_even) =>
          HasField "ex4_odd_next" Ex4_odd ty
     where hasField = \x_0 -> (\y_1 -> Ex4_odd{ex4_odd_next = y_1,
                                               ex4_odd_value = getField @"ex4_odd_value" x_0},
                               getField @"ex4_odd_next" x_0)
+instance (~) ty (Ptr Ex4_even) =>
+         HasField "ex4_odd_next" (Ptr Ex4_odd) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex4_odd_next")
+instance HasCField Ex4_odd "ex4_odd_next"
+    where type CFieldType Ex4_odd "ex4_odd_next" = Ptr Ex4_even
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct ex4_even@
 
     __defined at:__ @types\/nested\/nested_types.h 24:12@
@@ -289,24 +289,24 @@ instance WriteRaw Ex4_even
                                        Ex4_even ex4_even_value_2
                                                 ex4_even_next_3 -> writeRaw (Proxy @"ex4_even_value") ptr_0 ex4_even_value_2 >> writeRaw (Proxy @"ex4_even_next") ptr_0 ex4_even_next_3
 deriving via (EquivStorable Ex4_even) instance Storable Ex4_even
-instance HasCField Ex4_even "ex4_even_value"
-    where type CFieldType Ex4_even "ex4_even_value" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "ex4_even_value" (Ptr Ex4_even) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex4_even_value")
 instance (~) ty CDouble => HasField "ex4_even_value" Ex4_even ty
     where hasField = \x_0 -> (\y_1 -> Ex4_even{ex4_even_value = y_1,
                                                ex4_even_next = getField @"ex4_even_next" x_0},
                               getField @"ex4_even_value" x_0)
-instance HasCField Ex4_even "ex4_even_next"
-    where type CFieldType Ex4_even "ex4_even_next" = Ptr Ex4_odd
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Ex4_odd) =>
-         HasField "ex4_even_next" (Ptr Ex4_even) (Ptr ty)
-    where getField = fromPtr (Proxy @"ex4_even_next")
+instance (~) ty CDouble =>
+         HasField "ex4_even_value" (Ptr Ex4_even) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex4_even_value")
+instance HasCField Ex4_even "ex4_even_value"
+    where type CFieldType Ex4_even "ex4_even_value" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Ex4_odd) =>
          HasField "ex4_even_next" Ex4_even ty
     where hasField = \x_0 -> (\y_1 -> Ex4_even{ex4_even_next = y_1,
                                                ex4_even_value = getField @"ex4_even_value" x_0},
                               getField @"ex4_even_next" x_0)
+instance (~) ty (Ptr Ex4_odd) =>
+         HasField "ex4_even_next" (Ptr Ex4_even) (Ptr ty)
+    where getField = fromPtr (Proxy @"ex4_even_next")
+instance HasCField Ex4_even "ex4_even_next"
+    where type CFieldType Ex4_even "ex4_even_next" = Ptr Ex4_odd
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/Example.hs
@@ -77,17 +77,6 @@ instance Marshal.WriteRaw Bools1 where
 
 deriving via Marshal.EquivStorable Bools1 instance RIP.Storable Bools1
 
-instance HasCField.HasCField Bools1 "bools1_x" where
-
-  type CFieldType Bools1 "bools1_x" = RIP.CBool
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools1_x" (RIP.Ptr Bools1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bools1_x")
-
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "bools1_x" Bools1 ty where
 
@@ -98,16 +87,16 @@ instance ( ty ~ RIP.CBool
       , RIP.getField @"bools1_x" x0
       )
 
-instance HasCField.HasCField Bools1 "bools1_y" where
-
-  type CFieldType Bools1 "bools1_y" = RIP.CBool
-
-  offset# = \_ -> \_ -> 1
-
 instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools1_y" (RIP.Ptr Bools1) (RIP.Ptr ty) where
+         ) => RIP.HasField "bools1_x" (RIP.Ptr Bools1) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bools1_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"bools1_x")
+
+instance HasCField.HasCField Bools1 "bools1_x" where
+
+  type CFieldType Bools1 "bools1_x" = RIP.CBool
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "bools1_y" Bools1 ty where
@@ -118,6 +107,17 @@ instance ( ty ~ RIP.CBool
           Bools1 {bools1_y = y1, bools1_x = RIP.getField @"bools1_x" x0}
       , RIP.getField @"bools1_y" x0
       )
+
+instance ( ty ~ RIP.CBool
+         ) => RIP.HasField "bools1_y" (RIP.Ptr Bools1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bools1_y")
+
+instance HasCField.HasCField Bools1 "bools1_y" where
+
+  type CFieldType Bools1 "bools1_y" = RIP.CBool
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @struct bools2@
 
@@ -169,17 +169,6 @@ instance Marshal.WriteRaw Bools2 where
 
 deriving via Marshal.EquivStorable Bools2 instance RIP.Storable Bools2
 
-instance HasCField.HasCField Bools2 "bools2_x" where
-
-  type CFieldType Bools2 "bools2_x" = RIP.CBool
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools2_x" (RIP.Ptr Bools2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bools2_x")
-
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "bools2_x" Bools2 ty where
 
@@ -190,16 +179,16 @@ instance ( ty ~ RIP.CBool
       , RIP.getField @"bools2_x" x0
       )
 
-instance HasCField.HasCField Bools2 "bools2_y" where
-
-  type CFieldType Bools2 "bools2_y" = RIP.CBool
-
-  offset# = \_ -> \_ -> 1
-
 instance ( ty ~ RIP.CBool
-         ) => RIP.HasField "bools2_y" (RIP.Ptr Bools2) (RIP.Ptr ty) where
+         ) => RIP.HasField "bools2_x" (RIP.Ptr Bools2) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bools2_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"bools2_x")
+
+instance HasCField.HasCField Bools2 "bools2_x" where
+
+  type CFieldType Bools2 "bools2_x" = RIP.CBool
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CBool
          ) => RIP.CompatHasField.HasField "bools2_y" Bools2 ty where
@@ -210,6 +199,17 @@ instance ( ty ~ RIP.CBool
           Bools2 {bools2_y = y1, bools2_x = RIP.getField @"bools2_x" x0}
       , RIP.getField @"bools2_y" x0
       )
+
+instance ( ty ~ RIP.CBool
+         ) => RIP.HasField "bools2_y" (RIP.Ptr Bools2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bools2_y")
+
+instance HasCField.HasCField Bools2 "bools2_y" where
+
+  type CFieldType Bools2 "bools2_y" = RIP.CBool
+
+  offset# = \_ -> \_ -> 1
 
 {-| __C declaration:__ @macro BOOL@
 
@@ -240,6 +240,14 @@ newtype BOOL = BOOL
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapBOOL" (RIP.Ptr BOOL) (RIP.Ptr ty) where
 
   getField =
@@ -250,14 +258,6 @@ instance HasCField.HasCField BOOL "unwrapBOOL" where
   type CFieldType BOOL "unwrapBOOL" = RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapBOOL" BOOL ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         BOOL {unwrapBOOL = y1}, RIP.getField @"unwrapBOOL" x0)
 
 {-| __C declaration:__ @struct bools3@
 
@@ -309,17 +309,6 @@ instance Marshal.WriteRaw Bools3 where
 
 deriving via Marshal.EquivStorable Bools3 instance RIP.Storable Bools3
 
-instance HasCField.HasCField Bools3 "bools3_x" where
-
-  type CFieldType Bools3 "bools3_x" = BOOL
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ BOOL
-         ) => RIP.HasField "bools3_x" (RIP.Ptr Bools3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bools3_x")
-
 instance (ty ~ BOOL) => RIP.CompatHasField.HasField "bools3_x" Bools3 ty where
 
   hasField =
@@ -329,16 +318,16 @@ instance (ty ~ BOOL) => RIP.CompatHasField.HasField "bools3_x" Bools3 ty where
       , RIP.getField @"bools3_x" x0
       )
 
-instance HasCField.HasCField Bools3 "bools3_y" where
-
-  type CFieldType Bools3 "bools3_y" = BOOL
-
-  offset# = \_ -> \_ -> 1
-
 instance ( ty ~ BOOL
-         ) => RIP.HasField "bools3_y" (RIP.Ptr Bools3) (RIP.Ptr ty) where
+         ) => RIP.HasField "bools3_x" (RIP.Ptr Bools3) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"bools3_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"bools3_x")
+
+instance HasCField.HasCField Bools3 "bools3_x" where
+
+  type CFieldType Bools3 "bools3_x" = BOOL
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ BOOL) => RIP.CompatHasField.HasField "bools3_y" Bools3 ty where
 
@@ -348,3 +337,14 @@ instance (ty ~ BOOL) => RIP.CompatHasField.HasField "bools3_y" Bools3 ty where
           Bools3 {bools3_y = y1, bools3_x = RIP.getField @"bools3_x" x0}
       , RIP.getField @"bools3_y" x0
       )
+
+instance ( ty ~ BOOL
+         ) => RIP.HasField "bools3_y" (RIP.Ptr Bools3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bools3_y")
+
+instance HasCField.HasCField Bools3 "bools3_y" where
+
+  type CFieldType Bools3 "bools3_y" = BOOL
+
+  offset# = \_ -> \_ -> 1

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/bindingspec.yaml
@@ -26,7 +26,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -34,6 +33,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -54,11 +55,12 @@ hstypes:
       - bools1_x
       - bools1_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -72,11 +74,12 @@ hstypes:
       - bools2_x
       - bools2_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +93,12 @@ hstypes:
       - bools3_x
       - bools3_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool/th.txt
@@ -32,24 +32,24 @@ instance WriteRaw Bools1
                                        Bools1 bools1_x_2
                                               bools1_y_3 -> writeRaw (Proxy @"bools1_x") ptr_0 bools1_x_2 >> writeRaw (Proxy @"bools1_y") ptr_0 bools1_y_3
 deriving via (EquivStorable Bools1) instance Storable Bools1
-instance HasCField Bools1 "bools1_x"
-    where type CFieldType Bools1 "bools1_x" = CBool
-          offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "bools1_x" (Ptr Bools1) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools1_x")
 instance (~) ty CBool => HasField "bools1_x" Bools1 ty
     where hasField = \x_0 -> (\y_1 -> Bools1{bools1_x = y_1,
                                              bools1_y = getField @"bools1_y" x_0},
                               getField @"bools1_x" x_0)
-instance HasCField Bools1 "bools1_y"
-    where type CFieldType Bools1 "bools1_y" = CBool
-          offset# = \_ -> \_ -> 1
-instance (~) ty CBool => HasField "bools1_y" (Ptr Bools1) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools1_y")
+instance (~) ty CBool => HasField "bools1_x" (Ptr Bools1) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools1_x")
+instance HasCField Bools1 "bools1_x"
+    where type CFieldType Bools1 "bools1_x" = CBool
+          offset# = \_ -> \_ -> 0
 instance (~) ty CBool => HasField "bools1_y" Bools1 ty
     where hasField = \x_0 -> (\y_1 -> Bools1{bools1_y = y_1,
                                              bools1_x = getField @"bools1_x" x_0},
                               getField @"bools1_y" x_0)
+instance (~) ty CBool => HasField "bools1_y" (Ptr Bools1) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools1_y")
+instance HasCField Bools1 "bools1_y"
+    where type CFieldType Bools1 "bools1_y" = CBool
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @struct bools2@
 
     __defined at:__ @types\/primitives\/bool.h 8:8@
@@ -82,24 +82,24 @@ instance WriteRaw Bools2
                                        Bools2 bools2_x_2
                                               bools2_y_3 -> writeRaw (Proxy @"bools2_x") ptr_0 bools2_x_2 >> writeRaw (Proxy @"bools2_y") ptr_0 bools2_y_3
 deriving via (EquivStorable Bools2) instance Storable Bools2
-instance HasCField Bools2 "bools2_x"
-    where type CFieldType Bools2 "bools2_x" = CBool
-          offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "bools2_x" (Ptr Bools2) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools2_x")
 instance (~) ty CBool => HasField "bools2_x" Bools2 ty
     where hasField = \x_0 -> (\y_1 -> Bools2{bools2_x = y_1,
                                              bools2_y = getField @"bools2_y" x_0},
                               getField @"bools2_x" x_0)
-instance HasCField Bools2 "bools2_y"
-    where type CFieldType Bools2 "bools2_y" = CBool
-          offset# = \_ -> \_ -> 1
-instance (~) ty CBool => HasField "bools2_y" (Ptr Bools2) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools2_y")
+instance (~) ty CBool => HasField "bools2_x" (Ptr Bools2) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools2_x")
+instance HasCField Bools2 "bools2_x"
+    where type CFieldType Bools2 "bools2_x" = CBool
+          offset# = \_ -> \_ -> 0
 instance (~) ty CBool => HasField "bools2_y" Bools2 ty
     where hasField = \x_0 -> (\y_1 -> Bools2{bools2_y = y_1,
                                              bools2_x = getField @"bools2_x" x_0},
                               getField @"bools2_y" x_0)
+instance (~) ty CBool => HasField "bools2_y" (Ptr Bools2) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools2_y")
+instance HasCField Bools2 "bools2_y"
+    where type CFieldType Bools2 "bools2_y" = CBool
+          offset# = \_ -> \_ -> 1
 {-| __C declaration:__ @macro BOOL@
 
     __defined at:__ @types\/primitives\/bool.h 13:9@
@@ -124,14 +124,14 @@ newtype BOOL
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CBool => HasField "unwrapBOOL" BOOL ty
+    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
+                              getField @"unwrapBOOL" x_0)
 instance (~) ty CBool => HasField "unwrapBOOL" (Ptr BOOL) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBOOL")
 instance HasCField BOOL "unwrapBOOL"
     where type CFieldType BOOL "unwrapBOOL" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool => HasField "unwrapBOOL" BOOL ty
-    where hasField = \x_0 -> (\y_1 -> BOOL{unwrapBOOL = y_1},
-                              getField @"unwrapBOOL" x_0)
 {-| __C declaration:__ @struct bools3@
 
     __defined at:__ @types\/primitives\/bool.h 15:8@
@@ -164,21 +164,21 @@ instance WriteRaw Bools3
                                        Bools3 bools3_x_2
                                               bools3_y_3 -> writeRaw (Proxy @"bools3_x") ptr_0 bools3_x_2 >> writeRaw (Proxy @"bools3_y") ptr_0 bools3_y_3
 deriving via (EquivStorable Bools3) instance Storable Bools3
-instance HasCField Bools3 "bools3_x"
-    where type CFieldType Bools3 "bools3_x" = BOOL
-          offset# = \_ -> \_ -> 0
-instance (~) ty BOOL => HasField "bools3_x" (Ptr Bools3) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools3_x")
 instance (~) ty BOOL => HasField "bools3_x" Bools3 ty
     where hasField = \x_0 -> (\y_1 -> Bools3{bools3_x = y_1,
                                              bools3_y = getField @"bools3_y" x_0},
                               getField @"bools3_x" x_0)
-instance HasCField Bools3 "bools3_y"
-    where type CFieldType Bools3 "bools3_y" = BOOL
-          offset# = \_ -> \_ -> 1
-instance (~) ty BOOL => HasField "bools3_y" (Ptr Bools3) (Ptr ty)
-    where getField = fromPtr (Proxy @"bools3_y")
+instance (~) ty BOOL => HasField "bools3_x" (Ptr Bools3) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools3_x")
+instance HasCField Bools3 "bools3_x"
+    where type CFieldType Bools3 "bools3_x" = BOOL
+          offset# = \_ -> \_ -> 0
 instance (~) ty BOOL => HasField "bools3_y" Bools3 ty
     where hasField = \x_0 -> (\y_1 -> Bools3{bools3_y = y_1,
                                              bools3_x = getField @"bools3_x" x_0},
                               getField @"bools3_y" x_0)
+instance (~) ty BOOL => HasField "bools3_y" (Ptr Bools3) (Ptr ty)
+    where getField = fromPtr (Proxy @"bools3_y")
+instance HasCField Bools3 "bools3_y"
+    where type CFieldType Bools3 "bools3_y" = BOOL
+          offset# = \_ -> \_ -> 1

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/Example.hs
@@ -51,6 +51,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -61,12 +67,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @macro bool@
 
@@ -97,6 +97,14 @@ newtype Bool' = Bool'
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapBool'" Bool' ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bool' {unwrapBool' = y1}, RIP.getField @"unwrapBool'" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr ty) where
 
   getField =
@@ -107,11 +115,3 @@ instance HasCField.HasCField Bool' "unwrapBool'" where
   type CFieldType Bool' "unwrapBool'" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapBool'" Bool' ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bool' {unwrapBool' = y1}, RIP.getField @"unwrapBool'" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_macro_override/th.txt
@@ -70,14 +70,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @macro bool@
 
     __defined at:__ @types\/primitives\/bool_macro_override.h 12:9@
@@ -102,14 +102,14 @@ newtype Bool'
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapBool'" Bool' ty
+    where hasField = \x_0 -> (\y_1 -> Bool'{unwrapBool' = y_1},
+                              getField @"unwrapBool'" x_0)
 instance (~) ty CInt => HasField "unwrapBool'" (Ptr Bool') (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBool'")
 instance HasCField Bool' "unwrapBool'"
     where type CFieldType Bool' "unwrapBool'" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapBool'" Bool' ty
-    where hasField = \x_0 -> (\y_1 -> Bool'{unwrapBool' = y_1},
-                              getField @"unwrapBool'" x_0)
 -- __unique:__ @test_typesprimitivesbool_macro_ov_Example_Safe_f@
 foreign import ccall safe "hs_bindgen_fc2c0275afbb3c2e" hs_bindgen_fc2c0275afbb3c2e_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/Example.hs
@@ -51,6 +51,12 @@ newtype A = A
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapA" (RIP.Ptr A) (RIP.Ptr ty) where
 
@@ -61,12 +67,6 @@ instance HasCField.HasCField A "unwrapA" where
   type CFieldType A "unwrapA" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapA" A ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> A {unwrapA = y1}, RIP.getField @"unwrapA" x0)
 
 {-| __C declaration:__ @bool@
 
@@ -97,6 +97,14 @@ newtype Bool' = Bool'
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapBool'" Bool' ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Bool' {unwrapBool' = y1}, RIP.getField @"unwrapBool'" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapBool'" (RIP.Ptr Bool') (RIP.Ptr ty) where
 
   getField =
@@ -107,11 +115,3 @@ instance HasCField.HasCField Bool' "unwrapBool'" where
   type CFieldType Bool' "unwrapBool'" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapBool'" Bool' ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Bool' {unwrapBool' = y1}, RIP.getField @"unwrapBool'" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/bindingspec.yaml
@@ -20,7 +20,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -28,6 +27,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -50,7 +51,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -58,6 +58,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/bool_typedef_override/th.txt
@@ -47,14 +47,14 @@ newtype A
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapA" A ty
+    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
+                              getField @"unwrapA" x_0)
 instance (~) ty CInt => HasField "unwrapA" (Ptr A) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapA")
 instance HasCField A "unwrapA"
     where type CFieldType A "unwrapA" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapA" A ty
-    where hasField = \x_0 -> (\y_1 -> A{unwrapA = y_1},
-                              getField @"unwrapA" x_0)
 {-| __C declaration:__ @bool@
 
     __defined at:__ @types\/primitives\/bool_typedef_override.h 5:13@
@@ -79,14 +79,14 @@ newtype Bool'
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapBool'" Bool' ty
+    where hasField = \x_0 -> (\y_1 -> Bool'{unwrapBool' = y_1},
+                              getField @"unwrapBool'" x_0)
 instance (~) ty CInt => HasField "unwrapBool'" (Ptr Bool') (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapBool'")
 instance HasCField Bool' "unwrapBool'"
     where type CFieldType Bool' "unwrapBool'" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapBool'" Bool' ty
-    where hasField = \x_0 -> (\y_1 -> Bool'{unwrapBool' = y_1},
-                              getField @"unwrapBool'" x_0)
 -- __unique:__ @test_typesprimitivesbool_typedef__Example_Safe_f@
 foreign import ccall safe "hs_bindgen_ea0e9b7fd1e9560c" hs_bindgen_ea0e9b7fd1e9560c_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/Example.hs
@@ -73,19 +73,6 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCField.HasCField Foo "foo_sixty_four" where
-
-  type CFieldType Foo "foo_sixty_four" =
-    HsBindgen.Runtime.LibC.Word64
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
-
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.CompatHasField.HasField "foo_sixty_four" Foo ty where
 
@@ -96,18 +83,18 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word64
       , RIP.getField @"foo_sixty_four" x0
       )
 
-instance HasCField.HasCField Foo "foo_thirty_two" where
-
-  type CFieldType Foo "foo_thirty_two" =
-    HsBindgen.Runtime.LibC.Word32
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.HasField "foo_sixty_four" (RIP.Ptr Foo) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")
+    HasCField.fromPtr (RIP.Proxy @"foo_sixty_four")
+
+instance HasCField.HasCField Foo "foo_sixty_four" where
+
+  type CFieldType Foo "foo_sixty_four" =
+    HsBindgen.Runtime.LibC.Word64
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.CompatHasField.HasField "foo_thirty_two" Foo ty where
@@ -118,3 +105,16 @@ instance ( ty ~ HsBindgen.Runtime.LibC.Word32
           Foo {foo_thirty_two = y1, foo_sixty_four = RIP.getField @"foo_sixty_four" x0}
       , RIP.getField @"foo_thirty_two" x0
       )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.HasField "foo_thirty_two" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"foo_thirty_two")
+
+instance HasCField.HasCField Foo "foo_thirty_two" where
+
+  type CFieldType Foo "foo_thirty_two" =
+    HsBindgen.Runtime.LibC.Word32
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/bindingspec.yaml
@@ -15,11 +15,12 @@ hstypes:
       - foo_sixty_four
       - foo_thirty_two
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/fixedwidth/th.txt
@@ -34,27 +34,27 @@ instance WriteRaw Foo
                                        Foo foo_sixty_four_2
                                            foo_thirty_two_3 -> writeRaw (Proxy @"foo_sixty_four") ptr_0 foo_sixty_four_2 >> writeRaw (Proxy @"foo_thirty_two") ptr_0 foo_thirty_two_3
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCField Foo "foo_sixty_four"
-    where type CFieldType Foo
-                          "foo_sixty_four" = HsBindgen.Runtime.LibC.Word64
-          offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_sixty_four")
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "foo_sixty_four" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_sixty_four = y_1,
                                           foo_thirty_two = getField @"foo_thirty_two" x_0},
                               getField @"foo_sixty_four" x_0)
-instance HasCField Foo "foo_thirty_two"
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "foo_sixty_four" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_sixty_four")
+instance HasCField Foo "foo_sixty_four"
     where type CFieldType Foo
-                          "foo_thirty_two" = HsBindgen.Runtime.LibC.Word32
-          offset# = \_ -> \_ -> 8
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_thirty_two")
+                          "foo_sixty_four" = HsBindgen.Runtime.LibC.Word64
+          offset# = \_ -> \_ -> 0
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "foo_thirty_two" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_thirty_two = y_1,
                                           foo_sixty_four = getField @"foo_sixty_four" x_0},
                               getField @"foo_thirty_two" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "foo_thirty_two" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_thirty_two")
+instance HasCField Foo "foo_thirty_two"
+    where type CFieldType Foo
+                          "foo_thirty_two" = HsBindgen.Runtime.LibC.Word32
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/Example.hs
@@ -67,6 +67,15 @@ newtype Int_fast16_t = Int_fast16_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapInt_fast16_t" Int_fast16_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_fast16_t {unwrapInt_fast16_t = y1}
+      , RIP.getField @"unwrapInt_fast16_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapInt_fast16_t" (RIP.Ptr Int_fast16_t) (RIP.Ptr ty) where
 
   getField =
@@ -78,15 +87,6 @@ instance HasCField.HasCField Int_fast16_t "unwrapInt_fast16_t" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapInt_fast16_t" Int_fast16_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_fast16_t {unwrapInt_fast16_t = y1}
-      , RIP.getField @"unwrapInt_fast16_t" x0
-      )
 
 {-| __C declaration:__ @int_fast32_t@
 
@@ -117,6 +117,15 @@ newtype Int_fast32_t = Int_fast32_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapInt_fast32_t" Int_fast32_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_fast32_t {unwrapInt_fast32_t = y1}
+      , RIP.getField @"unwrapInt_fast32_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapInt_fast32_t" (RIP.Ptr Int_fast32_t) (RIP.Ptr ty) where
 
   getField =
@@ -128,15 +137,6 @@ instance HasCField.HasCField Int_fast32_t "unwrapInt_fast32_t" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapInt_fast32_t" Int_fast32_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_fast32_t {unwrapInt_fast32_t = y1}
-      , RIP.getField @"unwrapInt_fast32_t" x0
-      )
 
 {-| __C declaration:__ @uint_fast16_t@
 
@@ -167,6 +167,15 @@ newtype Uint_fast16_t = Uint_fast16_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapUint_fast16_t" Uint_fast16_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_fast16_t {unwrapUint_fast16_t = y1}
+      , RIP.getField @"unwrapUint_fast16_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapUint_fast16_t" (RIP.Ptr Uint_fast16_t) (RIP.Ptr ty) where
 
   getField =
@@ -178,15 +187,6 @@ instance HasCField.HasCField Uint_fast16_t "unwrapUint_fast16_t" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapUint_fast16_t" Uint_fast16_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_fast16_t {unwrapUint_fast16_t = y1}
-      , RIP.getField @"unwrapUint_fast16_t" x0
-      )
 
 {-| __C declaration:__ @uint_fast32_t@
 
@@ -217,6 +217,15 @@ newtype Uint_fast32_t = Uint_fast32_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapUint_fast32_t" Uint_fast32_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_fast32_t {unwrapUint_fast32_t = y1}
+      , RIP.getField @"unwrapUint_fast32_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapUint_fast32_t" (RIP.Ptr Uint_fast32_t) (RIP.Ptr ty) where
 
   getField =
@@ -228,15 +237,6 @@ instance HasCField.HasCField Uint_fast32_t "unwrapUint_fast32_t" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapUint_fast32_t" Uint_fast32_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_fast32_t {unwrapUint_fast32_t = y1}
-      , RIP.getField @"unwrapUint_fast32_t" x0
-      )
 
 {-| __C declaration:__ @int_fast8_t@
 
@@ -267,6 +267,15 @@ newtype Int_fast8_t = Int_fast8_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int8
+         ) => RIP.CompatHasField.HasField "unwrapInt_fast8_t" Int_fast8_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_fast8_t {unwrapInt_fast8_t = y1}
+      , RIP.getField @"unwrapInt_fast8_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int8
          ) => RIP.HasField "unwrapInt_fast8_t" (RIP.Ptr Int_fast8_t) (RIP.Ptr ty) where
 
   getField =
@@ -278,15 +287,6 @@ instance HasCField.HasCField Int_fast8_t "unwrapInt_fast8_t" where
     HsBindgen.Runtime.LibC.Int8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.CompatHasField.HasField "unwrapInt_fast8_t" Int_fast8_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_fast8_t {unwrapInt_fast8_t = y1}
-      , RIP.getField @"unwrapInt_fast8_t" x0
-      )
 
 {-| __C declaration:__ @int_fast64_t@
 
@@ -317,6 +317,15 @@ newtype Int_fast64_t = Int_fast64_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int64
+         ) => RIP.CompatHasField.HasField "unwrapInt_fast64_t" Int_fast64_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_fast64_t {unwrapInt_fast64_t = y1}
+      , RIP.getField @"unwrapInt_fast64_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int64
          ) => RIP.HasField "unwrapInt_fast64_t" (RIP.Ptr Int_fast64_t) (RIP.Ptr ty) where
 
   getField =
@@ -328,15 +337,6 @@ instance HasCField.HasCField Int_fast64_t "unwrapInt_fast64_t" where
     HsBindgen.Runtime.LibC.Int64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.CompatHasField.HasField "unwrapInt_fast64_t" Int_fast64_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_fast64_t {unwrapInt_fast64_t = y1}
-      , RIP.getField @"unwrapInt_fast64_t" x0
-      )
 
 {-| __C declaration:__ @int_least8_t@
 
@@ -367,6 +367,15 @@ newtype Int_least8_t = Int_least8_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int8
+         ) => RIP.CompatHasField.HasField "unwrapInt_least8_t" Int_least8_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_least8_t {unwrapInt_least8_t = y1}
+      , RIP.getField @"unwrapInt_least8_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int8
          ) => RIP.HasField "unwrapInt_least8_t" (RIP.Ptr Int_least8_t) (RIP.Ptr ty) where
 
   getField =
@@ -378,15 +387,6 @@ instance HasCField.HasCField Int_least8_t "unwrapInt_least8_t" where
     HsBindgen.Runtime.LibC.Int8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.CompatHasField.HasField "unwrapInt_least8_t" Int_least8_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_least8_t {unwrapInt_least8_t = y1}
-      , RIP.getField @"unwrapInt_least8_t" x0
-      )
 
 {-| __C declaration:__ @int_least16_t@
 
@@ -417,6 +417,15 @@ newtype Int_least16_t = Int_least16_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int16
+         ) => RIP.CompatHasField.HasField "unwrapInt_least16_t" Int_least16_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_least16_t {unwrapInt_least16_t = y1}
+      , RIP.getField @"unwrapInt_least16_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int16
          ) => RIP.HasField "unwrapInt_least16_t" (RIP.Ptr Int_least16_t) (RIP.Ptr ty) where
 
   getField =
@@ -428,15 +437,6 @@ instance HasCField.HasCField Int_least16_t "unwrapInt_least16_t" where
     HsBindgen.Runtime.LibC.Int16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.CompatHasField.HasField "unwrapInt_least16_t" Int_least16_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_least16_t {unwrapInt_least16_t = y1}
-      , RIP.getField @"unwrapInt_least16_t" x0
-      )
 
 {-| __C declaration:__ @int_least32_t@
 
@@ -467,6 +467,15 @@ newtype Int_least32_t = Int_least32_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapInt_least32_t" Int_least32_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_least32_t {unwrapInt_least32_t = y1}
+      , RIP.getField @"unwrapInt_least32_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapInt_least32_t" (RIP.Ptr Int_least32_t) (RIP.Ptr ty) where
 
   getField =
@@ -478,15 +487,6 @@ instance HasCField.HasCField Int_least32_t "unwrapInt_least32_t" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapInt_least32_t" Int_least32_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_least32_t {unwrapInt_least32_t = y1}
-      , RIP.getField @"unwrapInt_least32_t" x0
-      )
 
 {-| __C declaration:__ @int_least64_t@
 
@@ -517,6 +517,15 @@ newtype Int_least64_t = Int_least64_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int64
+         ) => RIP.CompatHasField.HasField "unwrapInt_least64_t" Int_least64_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Int_least64_t {unwrapInt_least64_t = y1}
+      , RIP.getField @"unwrapInt_least64_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int64
          ) => RIP.HasField "unwrapInt_least64_t" (RIP.Ptr Int_least64_t) (RIP.Ptr ty) where
 
   getField =
@@ -528,15 +537,6 @@ instance HasCField.HasCField Int_least64_t "unwrapInt_least64_t" where
     HsBindgen.Runtime.LibC.Int64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.CompatHasField.HasField "unwrapInt_least64_t" Int_least64_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Int_least64_t {unwrapInt_least64_t = y1}
-      , RIP.getField @"unwrapInt_least64_t" x0
-      )
 
 {-| __C declaration:__ @uint_fast8_t@
 
@@ -567,6 +567,15 @@ newtype Uint_fast8_t = Uint_fast8_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapUint_fast8_t" Uint_fast8_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_fast8_t {unwrapUint_fast8_t = y1}
+      , RIP.getField @"unwrapUint_fast8_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapUint_fast8_t" (RIP.Ptr Uint_fast8_t) (RIP.Ptr ty) where
 
   getField =
@@ -578,15 +587,6 @@ instance HasCField.HasCField Uint_fast8_t "unwrapUint_fast8_t" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapUint_fast8_t" Uint_fast8_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_fast8_t {unwrapUint_fast8_t = y1}
-      , RIP.getField @"unwrapUint_fast8_t" x0
-      )
 
 {-| __C declaration:__ @uint_fast64_t@
 
@@ -617,6 +617,15 @@ newtype Uint_fast64_t = Uint_fast64_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.CompatHasField.HasField "unwrapUint_fast64_t" Uint_fast64_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_fast64_t {unwrapUint_fast64_t = y1}
+      , RIP.getField @"unwrapUint_fast64_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.HasField "unwrapUint_fast64_t" (RIP.Ptr Uint_fast64_t) (RIP.Ptr ty) where
 
   getField =
@@ -628,15 +637,6 @@ instance HasCField.HasCField Uint_fast64_t "unwrapUint_fast64_t" where
     HsBindgen.Runtime.LibC.Word64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.CompatHasField.HasField "unwrapUint_fast64_t" Uint_fast64_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_fast64_t {unwrapUint_fast64_t = y1}
-      , RIP.getField @"unwrapUint_fast64_t" x0
-      )
 
 {-| __C declaration:__ @uint_least8_t@
 
@@ -667,6 +667,15 @@ newtype Uint_least8_t = Uint_least8_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapUint_least8_t" Uint_least8_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_least8_t {unwrapUint_least8_t = y1}
+      , RIP.getField @"unwrapUint_least8_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapUint_least8_t" (RIP.Ptr Uint_least8_t) (RIP.Ptr ty) where
 
   getField =
@@ -678,15 +687,6 @@ instance HasCField.HasCField Uint_least8_t "unwrapUint_least8_t" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapUint_least8_t" Uint_least8_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_least8_t {unwrapUint_least8_t = y1}
-      , RIP.getField @"unwrapUint_least8_t" x0
-      )
 
 {-| __C declaration:__ @uint_least16_t@
 
@@ -717,6 +717,15 @@ newtype Uint_least16_t = Uint_least16_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.CompatHasField.HasField "unwrapUint_least16_t" Uint_least16_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_least16_t {unwrapUint_least16_t = y1}
+      , RIP.getField @"unwrapUint_least16_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.HasField "unwrapUint_least16_t" (RIP.Ptr Uint_least16_t) (RIP.Ptr ty) where
 
   getField =
@@ -728,15 +737,6 @@ instance HasCField.HasCField Uint_least16_t "unwrapUint_least16_t" where
     HsBindgen.Runtime.LibC.Word16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.CompatHasField.HasField "unwrapUint_least16_t" Uint_least16_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_least16_t {unwrapUint_least16_t = y1}
-      , RIP.getField @"unwrapUint_least16_t" x0
-      )
 
 {-| __C declaration:__ @uint_least32_t@
 
@@ -767,6 +767,15 @@ newtype Uint_least32_t = Uint_least32_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapUint_least32_t" Uint_least32_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_least32_t {unwrapUint_least32_t = y1}
+      , RIP.getField @"unwrapUint_least32_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapUint_least32_t" (RIP.Ptr Uint_least32_t) (RIP.Ptr ty) where
 
   getField =
@@ -778,15 +787,6 @@ instance HasCField.HasCField Uint_least32_t "unwrapUint_least32_t" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapUint_least32_t" Uint_least32_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_least32_t {unwrapUint_least32_t = y1}
-      , RIP.getField @"unwrapUint_least32_t" x0
-      )
 
 {-| __C declaration:__ @uint_least64_t@
 
@@ -817,6 +817,15 @@ newtype Uint_least64_t = Uint_least64_t
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.CompatHasField.HasField "unwrapUint_least64_t" Uint_least64_t ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Uint_least64_t {unwrapUint_least64_t = y1}
+      , RIP.getField @"unwrapUint_least64_t" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.HasField "unwrapUint_least64_t" (RIP.Ptr Uint_least64_t) (RIP.Ptr ty) where
 
   getField =
@@ -828,12 +837,3 @@ instance HasCField.HasCField Uint_least64_t "unwrapUint_least64_t" where
     HsBindgen.Runtime.LibC.Word64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.CompatHasField.HasField "unwrapUint_least64_t" Uint_least64_t ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Uint_least64_t {unwrapUint_least64_t = y1}
-      , RIP.getField @"unwrapUint_least64_t" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/bindingspec.yaml
@@ -62,7 +62,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -70,6 +69,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -92,7 +93,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -100,6 +100,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -122,7 +124,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -130,6 +131,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -152,7 +155,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -160,6 +162,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -182,7 +186,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -190,6 +193,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -212,7 +217,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -220,6 +224,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -242,7 +248,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -250,6 +255,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -272,7 +279,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -280,6 +286,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -302,7 +310,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -310,6 +317,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -332,7 +341,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -340,6 +348,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -362,7 +372,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -370,6 +379,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -392,7 +403,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -400,6 +410,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -422,7 +434,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -430,6 +441,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -452,7 +465,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -460,6 +472,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -482,7 +496,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -490,6 +503,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -512,7 +527,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -520,6 +534,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/least_fast/th.txt
@@ -252,16 +252,16 @@ newtype Int_fast16_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_fast16_t" Int_fast16_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_fast16_t{unwrapInt_fast16_t = y_1},
+                              getField @"unwrapInt_fast16_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapInt_fast16_t" (Ptr Int_fast16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast16_t")
 instance HasCField Int_fast16_t "unwrapInt_fast16_t"
     where type CFieldType Int_fast16_t
                           "unwrapInt_fast16_t" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_fast16_t" Int_fast16_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_fast16_t{unwrapInt_fast16_t = y_1},
-                              getField @"unwrapInt_fast16_t" x_0)
 {-| __C declaration:__ @int_fast32_t@
 
     __defined at:__ @bits\/stdint.h 2:17@
@@ -287,16 +287,16 @@ newtype Int_fast32_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_fast32_t" Int_fast32_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_fast32_t{unwrapInt_fast32_t = y_1},
+                              getField @"unwrapInt_fast32_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapInt_fast32_t" (Ptr Int_fast32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast32_t")
 instance HasCField Int_fast32_t "unwrapInt_fast32_t"
     where type CFieldType Int_fast32_t
                           "unwrapInt_fast32_t" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_fast32_t" Int_fast32_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_fast32_t{unwrapInt_fast32_t = y_1},
-                              getField @"unwrapInt_fast32_t" x_0)
 {-| __C declaration:__ @uint_fast16_t@
 
     __defined at:__ @bits\/stdint.h 3:18@
@@ -322,16 +322,16 @@ newtype Uint_fast16_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_fast16_t" Uint_fast16_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_fast16_t{unwrapUint_fast16_t = y_1},
+                              getField @"unwrapUint_fast16_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapUint_fast16_t" (Ptr Uint_fast16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast16_t")
 instance HasCField Uint_fast16_t "unwrapUint_fast16_t"
     where type CFieldType Uint_fast16_t
                           "unwrapUint_fast16_t" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_fast16_t" Uint_fast16_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_fast16_t{unwrapUint_fast16_t = y_1},
-                              getField @"unwrapUint_fast16_t" x_0)
 {-| __C declaration:__ @uint_fast32_t@
 
     __defined at:__ @bits\/stdint.h 4:18@
@@ -357,16 +357,16 @@ newtype Uint_fast32_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_fast32_t" Uint_fast32_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_fast32_t{unwrapUint_fast32_t = y_1},
+                              getField @"unwrapUint_fast32_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapUint_fast32_t" (Ptr Uint_fast32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast32_t")
 instance HasCField Uint_fast32_t "unwrapUint_fast32_t"
     where type CFieldType Uint_fast32_t
                           "unwrapUint_fast32_t" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_fast32_t" Uint_fast32_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_fast32_t{unwrapUint_fast32_t = y_1},
-                              getField @"unwrapUint_fast32_t" x_0)
 {-| __C declaration:__ @int_fast8_t@
 
     __defined at:__ @stdint.h 22:16@
@@ -392,16 +392,16 @@ newtype Int_fast8_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapInt_fast8_t" Int_fast8_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_fast8_t{unwrapInt_fast8_t = y_1},
+                              getField @"unwrapInt_fast8_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
          HasField "unwrapInt_fast8_t" (Ptr Int_fast8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast8_t")
 instance HasCField Int_fast8_t "unwrapInt_fast8_t"
     where type CFieldType Int_fast8_t
                           "unwrapInt_fast8_t" = HsBindgen.Runtime.LibC.Int8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapInt_fast8_t" Int_fast8_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_fast8_t{unwrapInt_fast8_t = y_1},
-                              getField @"unwrapInt_fast8_t" x_0)
 {-| __C declaration:__ @int_fast64_t@
 
     __defined at:__ @stdint.h 23:17@
@@ -427,16 +427,16 @@ newtype Int_fast64_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapInt_fast64_t" Int_fast64_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_fast64_t{unwrapInt_fast64_t = y_1},
+                              getField @"unwrapInt_fast64_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
          HasField "unwrapInt_fast64_t" (Ptr Int_fast64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_fast64_t")
 instance HasCField Int_fast64_t "unwrapInt_fast64_t"
     where type CFieldType Int_fast64_t
                           "unwrapInt_fast64_t" = HsBindgen.Runtime.LibC.Int64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapInt_fast64_t" Int_fast64_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_fast64_t{unwrapInt_fast64_t = y_1},
-                              getField @"unwrapInt_fast64_t" x_0)
 {-| __C declaration:__ @int_least8_t@
 
     __defined at:__ @stdint.h 25:17@
@@ -462,16 +462,16 @@ newtype Int_least8_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapInt_least8_t" Int_least8_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_least8_t{unwrapInt_least8_t = y_1},
+                              getField @"unwrapInt_least8_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
          HasField "unwrapInt_least8_t" (Ptr Int_least8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least8_t")
 instance HasCField Int_least8_t "unwrapInt_least8_t"
     where type CFieldType Int_least8_t
                           "unwrapInt_least8_t" = HsBindgen.Runtime.LibC.Int8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapInt_least8_t" Int_least8_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_least8_t{unwrapInt_least8_t = y_1},
-                              getField @"unwrapInt_least8_t" x_0)
 {-| __C declaration:__ @int_least16_t@
 
     __defined at:__ @stdint.h 26:17@
@@ -497,16 +497,16 @@ newtype Int_least16_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapInt_least16_t" Int_least16_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_least16_t{unwrapInt_least16_t = y_1},
+                              getField @"unwrapInt_least16_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
          HasField "unwrapInt_least16_t" (Ptr Int_least16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least16_t")
 instance HasCField Int_least16_t "unwrapInt_least16_t"
     where type CFieldType Int_least16_t
                           "unwrapInt_least16_t" = HsBindgen.Runtime.LibC.Int16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapInt_least16_t" Int_least16_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_least16_t{unwrapInt_least16_t = y_1},
-                              getField @"unwrapInt_least16_t" x_0)
 {-| __C declaration:__ @int_least32_t@
 
     __defined at:__ @stdint.h 27:17@
@@ -532,16 +532,16 @@ newtype Int_least32_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapInt_least32_t" Int_least32_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_least32_t{unwrapInt_least32_t = y_1},
+                              getField @"unwrapInt_least32_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapInt_least32_t" (Ptr Int_least32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least32_t")
 instance HasCField Int_least32_t "unwrapInt_least32_t"
     where type CFieldType Int_least32_t
                           "unwrapInt_least32_t" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapInt_least32_t" Int_least32_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_least32_t{unwrapInt_least32_t = y_1},
-                              getField @"unwrapInt_least32_t" x_0)
 {-| __C declaration:__ @int_least64_t@
 
     __defined at:__ @stdint.h 28:17@
@@ -567,16 +567,16 @@ newtype Int_least64_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapInt_least64_t" Int_least64_t ty
+    where hasField = \x_0 -> (\y_1 -> Int_least64_t{unwrapInt_least64_t = y_1},
+                              getField @"unwrapInt_least64_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
          HasField "unwrapInt_least64_t" (Ptr Int_least64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt_least64_t")
 instance HasCField Int_least64_t "unwrapInt_least64_t"
     where type CFieldType Int_least64_t
                           "unwrapInt_least64_t" = HsBindgen.Runtime.LibC.Int64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapInt_least64_t" Int_least64_t ty
-    where hasField = \x_0 -> (\y_1 -> Int_least64_t{unwrapInt_least64_t = y_1},
-                              getField @"unwrapInt_least64_t" x_0)
 {-| __C declaration:__ @uint_fast8_t@
 
     __defined at:__ @stdint.h 30:17@
@@ -602,16 +602,16 @@ newtype Uint_fast8_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapUint_fast8_t" Uint_fast8_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_fast8_t{unwrapUint_fast8_t = y_1},
+                              getField @"unwrapUint_fast8_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapUint_fast8_t" (Ptr Uint_fast8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast8_t")
 instance HasCField Uint_fast8_t "unwrapUint_fast8_t"
     where type CFieldType Uint_fast8_t
                           "unwrapUint_fast8_t" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint_fast8_t" Uint_fast8_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_fast8_t{unwrapUint_fast8_t = y_1},
-                              getField @"unwrapUint_fast8_t" x_0)
 {-| __C declaration:__ @uint_fast64_t@
 
     __defined at:__ @stdint.h 31:18@
@@ -637,16 +637,16 @@ newtype Uint_fast64_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapUint_fast64_t" Uint_fast64_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_fast64_t{unwrapUint_fast64_t = y_1},
+                              getField @"unwrapUint_fast64_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "unwrapUint_fast64_t" (Ptr Uint_fast64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_fast64_t")
 instance HasCField Uint_fast64_t "unwrapUint_fast64_t"
     where type CFieldType Uint_fast64_t
                           "unwrapUint_fast64_t" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapUint_fast64_t" Uint_fast64_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_fast64_t{unwrapUint_fast64_t = y_1},
-                              getField @"unwrapUint_fast64_t" x_0)
 {-| __C declaration:__ @uint_least8_t@
 
     __defined at:__ @stdint.h 33:18@
@@ -672,16 +672,16 @@ newtype Uint_least8_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapUint_least8_t" Uint_least8_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_least8_t{unwrapUint_least8_t = y_1},
+                              getField @"unwrapUint_least8_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapUint_least8_t" (Ptr Uint_least8_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least8_t")
 instance HasCField Uint_least8_t "unwrapUint_least8_t"
     where type CFieldType Uint_least8_t
                           "unwrapUint_least8_t" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapUint_least8_t" Uint_least8_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_least8_t{unwrapUint_least8_t = y_1},
-                              getField @"unwrapUint_least8_t" x_0)
 {-| __C declaration:__ @uint_least16_t@
 
     __defined at:__ @stdint.h 34:18@
@@ -707,16 +707,16 @@ newtype Uint_least16_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapUint_least16_t" Uint_least16_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_least16_t{unwrapUint_least16_t = y_1},
+                              getField @"unwrapUint_least16_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "unwrapUint_least16_t" (Ptr Uint_least16_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least16_t")
 instance HasCField Uint_least16_t "unwrapUint_least16_t"
     where type CFieldType Uint_least16_t
                           "unwrapUint_least16_t" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapUint_least16_t" Uint_least16_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_least16_t{unwrapUint_least16_t = y_1},
-                              getField @"unwrapUint_least16_t" x_0)
 {-| __C declaration:__ @uint_least32_t@
 
     __defined at:__ @stdint.h 35:18@
@@ -742,16 +742,16 @@ newtype Uint_least32_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapUint_least32_t" Uint_least32_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_least32_t{unwrapUint_least32_t = y_1},
+                              getField @"unwrapUint_least32_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapUint_least32_t" (Ptr Uint_least32_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least32_t")
 instance HasCField Uint_least32_t "unwrapUint_least32_t"
     where type CFieldType Uint_least32_t
                           "unwrapUint_least32_t" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapUint_least32_t" Uint_least32_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_least32_t{unwrapUint_least32_t = y_1},
-                              getField @"unwrapUint_least32_t" x_0)
 {-| __C declaration:__ @uint_least64_t@
 
     __defined at:__ @stdint.h 36:18@
@@ -777,16 +777,16 @@ newtype Uint_least64_t
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapUint_least64_t" Uint_least64_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint_least64_t{unwrapUint_least64_t = y_1},
+                              getField @"unwrapUint_least64_t" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "unwrapUint_least64_t" (Ptr Uint_least64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint_least64_t")
 instance HasCField Uint_least64_t "unwrapUint_least64_t"
     where type CFieldType Uint_least64_t
                           "unwrapUint_least64_t" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapUint_least64_t" Uint_least64_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint_least64_t{unwrapUint_least64_t = y_1},
-                              getField @"unwrapUint_least64_t" x_0)
 -- __unique:__ @test_typesprimitivesleast_fast_Example_Safe_int_least8_t_fun@
 foreign import ccall safe "hs_bindgen_ad6572fbf5eadb77" hs_bindgen_ad6572fbf5eadb77_base ::
     IO Int8

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/Example.hs
@@ -74,6 +74,16 @@ newtype Prim_HsPrimCPtrdiff = Prim_HsPrimCPtrdiff
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCPtrdiff" Prim_HsPrimCPtrdiff ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCPtrdiff {unwrapPrim_HsPrimCPtrdiff = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCPtrdiff" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
          ) => RIP.HasField "unwrapPrim_HsPrimCPtrdiff" (RIP.Ptr Prim_HsPrimCPtrdiff) (RIP.Ptr ty) where
 
   getField =
@@ -85,16 +95,6 @@ instance HasCField.HasCField Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff" whe
     HsBindgen.Runtime.LibC.CPtrdiff
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.CPtrdiff
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCPtrdiff" Prim_HsPrimCPtrdiff ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCPtrdiff {unwrapPrim_HsPrimCPtrdiff = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCPtrdiff" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimInt8@
 
@@ -125,6 +125,15 @@ newtype Prim_HsPrimInt8 = Prim_HsPrimInt8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int8
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt8" Prim_HsPrimInt8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Prim_HsPrimInt8 {unwrapPrim_HsPrimInt8 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimInt8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int8
          ) => RIP.HasField "unwrapPrim_HsPrimInt8" (RIP.Ptr Prim_HsPrimInt8) (RIP.Ptr ty) where
 
   getField =
@@ -136,15 +145,6 @@ instance HasCField.HasCField Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8" where
     HsBindgen.Runtime.LibC.Int8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int8
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt8" Prim_HsPrimInt8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Prim_HsPrimInt8 {unwrapPrim_HsPrimInt8 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimInt8" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimInt16@
 
@@ -175,6 +175,16 @@ newtype Prim_HsPrimInt16 = Prim_HsPrimInt16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int16
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt16" Prim_HsPrimInt16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimInt16 {unwrapPrim_HsPrimInt16 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimInt16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int16
          ) => RIP.HasField "unwrapPrim_HsPrimInt16" (RIP.Ptr Prim_HsPrimInt16) (RIP.Ptr ty) where
 
   getField =
@@ -186,16 +196,6 @@ instance HasCField.HasCField Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16" where
     HsBindgen.Runtime.LibC.Int16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int16
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt16" Prim_HsPrimInt16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimInt16 {unwrapPrim_HsPrimInt16 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimInt16" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimInt32@
 
@@ -226,6 +226,16 @@ newtype Prim_HsPrimInt32 = Prim_HsPrimInt32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int32
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt32" Prim_HsPrimInt32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimInt32 {unwrapPrim_HsPrimInt32 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimInt32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int32
          ) => RIP.HasField "unwrapPrim_HsPrimInt32" (RIP.Ptr Prim_HsPrimInt32) (RIP.Ptr ty) where
 
   getField =
@@ -237,16 +247,6 @@ instance HasCField.HasCField Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32" where
     HsBindgen.Runtime.LibC.Int32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int32
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt32" Prim_HsPrimInt32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimInt32 {unwrapPrim_HsPrimInt32 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimInt32" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimInt64@
 
@@ -277,6 +277,16 @@ newtype Prim_HsPrimInt64 = Prim_HsPrimInt64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Int64
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt64" Prim_HsPrimInt64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimInt64 {unwrapPrim_HsPrimInt64 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimInt64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Int64
          ) => RIP.HasField "unwrapPrim_HsPrimInt64" (RIP.Ptr Prim_HsPrimInt64) (RIP.Ptr ty) where
 
   getField =
@@ -288,16 +298,6 @@ instance HasCField.HasCField Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64" where
     HsBindgen.Runtime.LibC.Int64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Int64
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimInt64" Prim_HsPrimInt64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimInt64 {unwrapPrim_HsPrimInt64 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimInt64" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimWord8@
 
@@ -328,6 +328,16 @@ newtype Prim_HsPrimWord8 = Prim_HsPrimWord8
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word8
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord8" Prim_HsPrimWord8 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimWord8 {unwrapPrim_HsPrimWord8 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimWord8" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word8
          ) => RIP.HasField "unwrapPrim_HsPrimWord8" (RIP.Ptr Prim_HsPrimWord8) (RIP.Ptr ty) where
 
   getField =
@@ -339,16 +349,6 @@ instance HasCField.HasCField Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8" where
     HsBindgen.Runtime.LibC.Word8
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word8
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord8" Prim_HsPrimWord8 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimWord8 {unwrapPrim_HsPrimWord8 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimWord8" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimWord16@
 
@@ -379,6 +379,16 @@ newtype Prim_HsPrimWord16 = Prim_HsPrimWord16
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word16
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord16" Prim_HsPrimWord16 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimWord16 {unwrapPrim_HsPrimWord16 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimWord16" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word16
          ) => RIP.HasField "unwrapPrim_HsPrimWord16" (RIP.Ptr Prim_HsPrimWord16) (RIP.Ptr ty) where
 
   getField =
@@ -390,16 +400,6 @@ instance HasCField.HasCField Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16" where
     HsBindgen.Runtime.LibC.Word16
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word16
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord16" Prim_HsPrimWord16 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimWord16 {unwrapPrim_HsPrimWord16 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimWord16" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimWord32@
 
@@ -430,6 +430,16 @@ newtype Prim_HsPrimWord32 = Prim_HsPrimWord32
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word32
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord32" Prim_HsPrimWord32 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimWord32 {unwrapPrim_HsPrimWord32 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimWord32" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word32
          ) => RIP.HasField "unwrapPrim_HsPrimWord32" (RIP.Ptr Prim_HsPrimWord32) (RIP.Ptr ty) where
 
   getField =
@@ -441,16 +451,6 @@ instance HasCField.HasCField Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32" where
     HsBindgen.Runtime.LibC.Word32
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word32
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord32" Prim_HsPrimWord32 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimWord32 {unwrapPrim_HsPrimWord32 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimWord32" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimWord64@
 
@@ -481,6 +481,16 @@ newtype Prim_HsPrimWord64 = Prim_HsPrimWord64
     )
 
 instance ( ty ~ HsBindgen.Runtime.LibC.Word64
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord64" Prim_HsPrimWord64 ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimWord64 {unwrapPrim_HsPrimWord64 = y1}
+      , RIP.getField @"unwrapPrim_HsPrimWord64" x0
+      )
+
+instance ( ty ~ HsBindgen.Runtime.LibC.Word64
          ) => RIP.HasField "unwrapPrim_HsPrimWord64" (RIP.Ptr Prim_HsPrimWord64) (RIP.Ptr ty) where
 
   getField =
@@ -492,16 +502,6 @@ instance HasCField.HasCField Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64" where
     HsBindgen.Runtime.LibC.Word64
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ HsBindgen.Runtime.LibC.Word64
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimWord64" Prim_HsPrimWord64 ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimWord64 {unwrapPrim_HsPrimWord64 = y1}
-      , RIP.getField @"unwrapPrim_HsPrimWord64" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCChar@
 
@@ -532,6 +532,16 @@ newtype Prim_HsPrimCChar = Prim_HsPrimCChar
     )
 
 instance ( ty ~ RIP.CChar
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCChar" Prim_HsPrimCChar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCChar {unwrapPrim_HsPrimCChar = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCChar" x0
+      )
+
+instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapPrim_HsPrimCChar" (RIP.Ptr Prim_HsPrimCChar) (RIP.Ptr ty) where
 
   getField =
@@ -543,16 +553,6 @@ instance HasCField.HasCField Prim_HsPrimCChar "unwrapPrim_HsPrimCChar" where
     RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCChar" Prim_HsPrimCChar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCChar {unwrapPrim_HsPrimCChar = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCChar" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCSChar@
 
@@ -583,6 +583,16 @@ newtype Prim_HsPrimCSChar = Prim_HsPrimCSChar
     )
 
 instance ( ty ~ RIP.CSChar
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCSChar" Prim_HsPrimCSChar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCSChar {unwrapPrim_HsPrimCSChar = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCSChar" x0
+      )
+
+instance ( ty ~ RIP.CSChar
          ) => RIP.HasField "unwrapPrim_HsPrimCSChar" (RIP.Ptr Prim_HsPrimCSChar) (RIP.Ptr ty) where
 
   getField =
@@ -594,16 +604,6 @@ instance HasCField.HasCField Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar" where
     RIP.CSChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCSChar" Prim_HsPrimCSChar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCSChar {unwrapPrim_HsPrimCSChar = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCSChar" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCUChar@
 
@@ -634,6 +634,16 @@ newtype Prim_HsPrimCUChar = Prim_HsPrimCUChar
     )
 
 instance ( ty ~ RIP.CUChar
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUChar" Prim_HsPrimCUChar ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCUChar {unwrapPrim_HsPrimCUChar = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCUChar" x0
+      )
+
+instance ( ty ~ RIP.CUChar
          ) => RIP.HasField "unwrapPrim_HsPrimCUChar" (RIP.Ptr Prim_HsPrimCUChar) (RIP.Ptr ty) where
 
   getField =
@@ -645,16 +655,6 @@ instance HasCField.HasCField Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar" where
     RIP.CUChar
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUChar" Prim_HsPrimCUChar ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCUChar {unwrapPrim_HsPrimCUChar = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCUChar" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCShort@
 
@@ -685,6 +685,16 @@ newtype Prim_HsPrimCShort = Prim_HsPrimCShort
     )
 
 instance ( ty ~ RIP.CShort
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCShort" Prim_HsPrimCShort ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCShort {unwrapPrim_HsPrimCShort = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCShort" x0
+      )
+
+instance ( ty ~ RIP.CShort
          ) => RIP.HasField "unwrapPrim_HsPrimCShort" (RIP.Ptr Prim_HsPrimCShort) (RIP.Ptr ty) where
 
   getField =
@@ -696,16 +706,6 @@ instance HasCField.HasCField Prim_HsPrimCShort "unwrapPrim_HsPrimCShort" where
     RIP.CShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCShort" Prim_HsPrimCShort ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCShort {unwrapPrim_HsPrimCShort = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCShort" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCUShort@
 
@@ -736,6 +736,16 @@ newtype Prim_HsPrimCUShort = Prim_HsPrimCUShort
     )
 
 instance ( ty ~ RIP.CUShort
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUShort" Prim_HsPrimCUShort ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCUShort {unwrapPrim_HsPrimCUShort = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCUShort" x0
+      )
+
+instance ( ty ~ RIP.CUShort
          ) => RIP.HasField "unwrapPrim_HsPrimCUShort" (RIP.Ptr Prim_HsPrimCUShort) (RIP.Ptr ty) where
 
   getField =
@@ -747,16 +757,6 @@ instance HasCField.HasCField Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort" where
     RIP.CUShort
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUShort
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUShort" Prim_HsPrimCUShort ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCUShort {unwrapPrim_HsPrimCUShort = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCUShort" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCInt@
 
@@ -787,6 +787,15 @@ newtype Prim_HsPrimCInt = Prim_HsPrimCInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCInt" Prim_HsPrimCInt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 -> Prim_HsPrimCInt {unwrapPrim_HsPrimCInt = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCInt" x0
+      )
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapPrim_HsPrimCInt" (RIP.Ptr Prim_HsPrimCInt) (RIP.Ptr ty) where
 
   getField =
@@ -798,15 +807,6 @@ instance HasCField.HasCField Prim_HsPrimCInt "unwrapPrim_HsPrimCInt" where
     RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCInt" Prim_HsPrimCInt ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 -> Prim_HsPrimCInt {unwrapPrim_HsPrimCInt = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCInt" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCUInt@
 
@@ -837,6 +837,16 @@ newtype Prim_HsPrimCUInt = Prim_HsPrimCUInt
     )
 
 instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUInt" Prim_HsPrimCUInt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCUInt {unwrapPrim_HsPrimCUInt = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCUInt" x0
+      )
+
+instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapPrim_HsPrimCUInt" (RIP.Ptr Prim_HsPrimCUInt) (RIP.Ptr ty) where
 
   getField =
@@ -848,16 +858,6 @@ instance HasCField.HasCField Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt" where
     RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCUInt" Prim_HsPrimCUInt ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCUInt {unwrapPrim_HsPrimCUInt = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCUInt" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCLong@
 
@@ -888,6 +888,16 @@ newtype Prim_HsPrimCLong = Prim_HsPrimCLong
     )
 
 instance ( ty ~ RIP.CLong
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCLong" Prim_HsPrimCLong ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCLong {unwrapPrim_HsPrimCLong = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCLong" x0
+      )
+
+instance ( ty ~ RIP.CLong
          ) => RIP.HasField "unwrapPrim_HsPrimCLong" (RIP.Ptr Prim_HsPrimCLong) (RIP.Ptr ty) where
 
   getField =
@@ -899,16 +909,6 @@ instance HasCField.HasCField Prim_HsPrimCLong "unwrapPrim_HsPrimCLong" where
     RIP.CLong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCLong" Prim_HsPrimCLong ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCLong {unwrapPrim_HsPrimCLong = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCLong" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCULong@
 
@@ -939,6 +939,16 @@ newtype Prim_HsPrimCULong = Prim_HsPrimCULong
     )
 
 instance ( ty ~ RIP.CULong
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCULong" Prim_HsPrimCULong ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCULong {unwrapPrim_HsPrimCULong = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCULong" x0
+      )
+
+instance ( ty ~ RIP.CULong
          ) => RIP.HasField "unwrapPrim_HsPrimCULong" (RIP.Ptr Prim_HsPrimCULong) (RIP.Ptr ty) where
 
   getField =
@@ -950,16 +960,6 @@ instance HasCField.HasCField Prim_HsPrimCULong "unwrapPrim_HsPrimCULong" where
     RIP.CULong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CULong
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCULong" Prim_HsPrimCULong ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCULong {unwrapPrim_HsPrimCULong = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCULong" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCLLong@
 
@@ -990,6 +990,16 @@ newtype Prim_HsPrimCLLong = Prim_HsPrimCLLong
     )
 
 instance ( ty ~ RIP.CLLong
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCLLong" Prim_HsPrimCLLong ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCLLong {unwrapPrim_HsPrimCLLong = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCLLong" x0
+      )
+
+instance ( ty ~ RIP.CLLong
          ) => RIP.HasField "unwrapPrim_HsPrimCLLong" (RIP.Ptr Prim_HsPrimCLLong) (RIP.Ptr ty) where
 
   getField =
@@ -1001,16 +1011,6 @@ instance HasCField.HasCField Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong" where
     RIP.CLLong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCLLong" Prim_HsPrimCLLong ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCLLong {unwrapPrim_HsPrimCLLong = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCLLong" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCULLong@
 
@@ -1041,6 +1041,16 @@ newtype Prim_HsPrimCULLong = Prim_HsPrimCULLong
     )
 
 instance ( ty ~ RIP.CULLong
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCULLong" Prim_HsPrimCULLong ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCULLong {unwrapPrim_HsPrimCULLong = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCULLong" x0
+      )
+
+instance ( ty ~ RIP.CULLong
          ) => RIP.HasField "unwrapPrim_HsPrimCULLong" (RIP.Ptr Prim_HsPrimCULLong) (RIP.Ptr ty) where
 
   getField =
@@ -1052,16 +1062,6 @@ instance HasCField.HasCField Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong" where
     RIP.CULLong
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CULLong
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCULLong" Prim_HsPrimCULLong ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCULLong {unwrapPrim_HsPrimCULLong = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCULLong" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCBool@
 
@@ -1092,6 +1092,16 @@ newtype Prim_HsPrimCBool = Prim_HsPrimCBool
     )
 
 instance ( ty ~ RIP.CBool
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCBool" Prim_HsPrimCBool ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCBool {unwrapPrim_HsPrimCBool = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCBool" x0
+      )
+
+instance ( ty ~ RIP.CBool
          ) => RIP.HasField "unwrapPrim_HsPrimCBool" (RIP.Ptr Prim_HsPrimCBool) (RIP.Ptr ty) where
 
   getField =
@@ -1103,16 +1113,6 @@ instance HasCField.HasCField Prim_HsPrimCBool "unwrapPrim_HsPrimCBool" where
     RIP.CBool
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CBool
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCBool" Prim_HsPrimCBool ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCBool {unwrapPrim_HsPrimCBool = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCBool" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCFloat@
 
@@ -1141,6 +1141,16 @@ newtype Prim_HsPrimCFloat = Prim_HsPrimCFloat
     )
 
 instance ( ty ~ RIP.CFloat
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCFloat" Prim_HsPrimCFloat ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCFloat {unwrapPrim_HsPrimCFloat = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCFloat" x0
+      )
+
+instance ( ty ~ RIP.CFloat
          ) => RIP.HasField "unwrapPrim_HsPrimCFloat" (RIP.Ptr Prim_HsPrimCFloat) (RIP.Ptr ty) where
 
   getField =
@@ -1152,16 +1162,6 @@ instance HasCField.HasCField Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat" where
     RIP.CFloat
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCFloat" Prim_HsPrimCFloat ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCFloat {unwrapPrim_HsPrimCFloat = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCFloat" x0
-      )
 
 {-| __C declaration:__ @prim_HsPrimCDouble@
 
@@ -1190,6 +1190,16 @@ newtype Prim_HsPrimCDouble = Prim_HsPrimCDouble
     )
 
 instance ( ty ~ RIP.CDouble
+         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCDouble" Prim_HsPrimCDouble ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Prim_HsPrimCDouble {unwrapPrim_HsPrimCDouble = y1}
+      , RIP.getField @"unwrapPrim_HsPrimCDouble" x0
+      )
+
+instance ( ty ~ RIP.CDouble
          ) => RIP.HasField "unwrapPrim_HsPrimCDouble" (RIP.Ptr Prim_HsPrimCDouble) (RIP.Ptr ty) where
 
   getField =
@@ -1201,13 +1211,3 @@ instance HasCField.HasCField Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble" where
     RIP.CDouble
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.CompatHasField.HasField "unwrapPrim_HsPrimCDouble" Prim_HsPrimCDouble ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          Prim_HsPrimCDouble {unwrapPrim_HsPrimCDouble = y1}
-      , RIP.getField @"unwrapPrim_HsPrimCDouble" x0
-      )

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/bindingspec.yaml
@@ -83,7 +83,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -91,6 +90,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -113,7 +114,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -121,6 +121,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -140,7 +142,6 @@ hstypes:
       fields:
       - unwrapPrim_HsPrimCDouble
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -149,6 +150,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -168,7 +171,6 @@ hstypes:
       fields:
       - unwrapPrim_HsPrimCFloat
   instances:
-  - CompatHasField
   - Enum
   - Eq
   - Floating
@@ -177,6 +179,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Num
   - Ord
   - Prim
@@ -199,7 +203,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -207,6 +210,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -229,7 +234,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -237,6 +241,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -259,7 +265,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -267,6 +272,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -289,7 +296,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -297,6 +303,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -319,7 +327,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -327,6 +334,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -349,7 +358,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -357,6 +365,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -379,7 +389,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -387,6 +396,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -409,7 +420,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -417,6 +427,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -439,7 +451,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -447,6 +458,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -469,7 +482,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -477,6 +489,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -499,7 +513,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -507,6 +520,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -529,7 +544,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -537,6 +551,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -559,7 +575,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -567,6 +582,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -589,7 +606,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -597,6 +613,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -619,7 +637,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -627,6 +644,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -649,7 +668,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -657,6 +675,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -679,7 +699,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -687,6 +706,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -709,7 +730,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -717,6 +737,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -739,7 +761,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -747,6 +768,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_insts/th.txt
@@ -29,6 +29,10 @@ newtype Prim_HsPrimCPtrdiff
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
+         HasField "unwrapPrim_HsPrimCPtrdiff" Prim_HsPrimCPtrdiff ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCPtrdiff{unwrapPrim_HsPrimCPtrdiff = y_1},
+                              getField @"unwrapPrim_HsPrimCPtrdiff" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
          HasField "unwrapPrim_HsPrimCPtrdiff"
                   (Ptr Prim_HsPrimCPtrdiff)
                   (Ptr ty)
@@ -37,10 +41,6 @@ instance HasCField Prim_HsPrimCPtrdiff "unwrapPrim_HsPrimCPtrdiff"
     where type CFieldType Prim_HsPrimCPtrdiff
                           "unwrapPrim_HsPrimCPtrdiff" = HsBindgen.Runtime.LibC.CPtrdiff
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.CPtrdiff =>
-         HasField "unwrapPrim_HsPrimCPtrdiff" Prim_HsPrimCPtrdiff ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCPtrdiff{unwrapPrim_HsPrimCPtrdiff = y_1},
-                              getField @"unwrapPrim_HsPrimCPtrdiff" x_0)
 {-| __C declaration:__ @prim_HsPrimInt8@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 19:28@
@@ -66,16 +66,16 @@ newtype Prim_HsPrimInt8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
+         HasField "unwrapPrim_HsPrimInt8" Prim_HsPrimInt8 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt8{unwrapPrim_HsPrimInt8 = y_1},
+                              getField @"unwrapPrim_HsPrimInt8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
          HasField "unwrapPrim_HsPrimInt8" (Ptr Prim_HsPrimInt8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt8")
 instance HasCField Prim_HsPrimInt8 "unwrapPrim_HsPrimInt8"
     where type CFieldType Prim_HsPrimInt8
                           "unwrapPrim_HsPrimInt8" = HsBindgen.Runtime.LibC.Int8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int8 =>
-         HasField "unwrapPrim_HsPrimInt8" Prim_HsPrimInt8 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt8{unwrapPrim_HsPrimInt8 = y_1},
-                              getField @"unwrapPrim_HsPrimInt8" x_0)
 {-| __C declaration:__ @prim_HsPrimInt16@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 20:28@
@@ -101,16 +101,16 @@ newtype Prim_HsPrimInt16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
+         HasField "unwrapPrim_HsPrimInt16" Prim_HsPrimInt16 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt16{unwrapPrim_HsPrimInt16 = y_1},
+                              getField @"unwrapPrim_HsPrimInt16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
          HasField "unwrapPrim_HsPrimInt16" (Ptr Prim_HsPrimInt16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt16")
 instance HasCField Prim_HsPrimInt16 "unwrapPrim_HsPrimInt16"
     where type CFieldType Prim_HsPrimInt16
                           "unwrapPrim_HsPrimInt16" = HsBindgen.Runtime.LibC.Int16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int16 =>
-         HasField "unwrapPrim_HsPrimInt16" Prim_HsPrimInt16 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt16{unwrapPrim_HsPrimInt16 = y_1},
-                              getField @"unwrapPrim_HsPrimInt16" x_0)
 {-| __C declaration:__ @prim_HsPrimInt32@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 21:28@
@@ -136,16 +136,16 @@ newtype Prim_HsPrimInt32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
+         HasField "unwrapPrim_HsPrimInt32" Prim_HsPrimInt32 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt32{unwrapPrim_HsPrimInt32 = y_1},
+                              getField @"unwrapPrim_HsPrimInt32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
          HasField "unwrapPrim_HsPrimInt32" (Ptr Prim_HsPrimInt32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt32")
 instance HasCField Prim_HsPrimInt32 "unwrapPrim_HsPrimInt32"
     where type CFieldType Prim_HsPrimInt32
                           "unwrapPrim_HsPrimInt32" = HsBindgen.Runtime.LibC.Int32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int32 =>
-         HasField "unwrapPrim_HsPrimInt32" Prim_HsPrimInt32 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt32{unwrapPrim_HsPrimInt32 = y_1},
-                              getField @"unwrapPrim_HsPrimInt32" x_0)
 {-| __C declaration:__ @prim_HsPrimInt64@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 22:28@
@@ -171,16 +171,16 @@ newtype Prim_HsPrimInt64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
+         HasField "unwrapPrim_HsPrimInt64" Prim_HsPrimInt64 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt64{unwrapPrim_HsPrimInt64 = y_1},
+                              getField @"unwrapPrim_HsPrimInt64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
          HasField "unwrapPrim_HsPrimInt64" (Ptr Prim_HsPrimInt64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimInt64")
 instance HasCField Prim_HsPrimInt64 "unwrapPrim_HsPrimInt64"
     where type CFieldType Prim_HsPrimInt64
                           "unwrapPrim_HsPrimInt64" = HsBindgen.Runtime.LibC.Int64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Int64 =>
-         HasField "unwrapPrim_HsPrimInt64" Prim_HsPrimInt64 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimInt64{unwrapPrim_HsPrimInt64 = y_1},
-                              getField @"unwrapPrim_HsPrimInt64" x_0)
 {-| __C declaration:__ @prim_HsPrimWord8@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 24:28@
@@ -206,16 +206,16 @@ newtype Prim_HsPrimWord8
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
+         HasField "unwrapPrim_HsPrimWord8" Prim_HsPrimWord8 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord8{unwrapPrim_HsPrimWord8 = y_1},
+                              getField @"unwrapPrim_HsPrimWord8" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
          HasField "unwrapPrim_HsPrimWord8" (Ptr Prim_HsPrimWord8) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord8")
 instance HasCField Prim_HsPrimWord8 "unwrapPrim_HsPrimWord8"
     where type CFieldType Prim_HsPrimWord8
                           "unwrapPrim_HsPrimWord8" = HsBindgen.Runtime.LibC.Word8
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word8 =>
-         HasField "unwrapPrim_HsPrimWord8" Prim_HsPrimWord8 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord8{unwrapPrim_HsPrimWord8 = y_1},
-                              getField @"unwrapPrim_HsPrimWord8" x_0)
 {-| __C declaration:__ @prim_HsPrimWord16@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 25:28@
@@ -241,16 +241,16 @@ newtype Prim_HsPrimWord16
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
+         HasField "unwrapPrim_HsPrimWord16" Prim_HsPrimWord16 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord16{unwrapPrim_HsPrimWord16 = y_1},
+                              getField @"unwrapPrim_HsPrimWord16" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
          HasField "unwrapPrim_HsPrimWord16" (Ptr Prim_HsPrimWord16) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord16")
 instance HasCField Prim_HsPrimWord16 "unwrapPrim_HsPrimWord16"
     where type CFieldType Prim_HsPrimWord16
                           "unwrapPrim_HsPrimWord16" = HsBindgen.Runtime.LibC.Word16
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word16 =>
-         HasField "unwrapPrim_HsPrimWord16" Prim_HsPrimWord16 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord16{unwrapPrim_HsPrimWord16 = y_1},
-                              getField @"unwrapPrim_HsPrimWord16" x_0)
 {-| __C declaration:__ @prim_HsPrimWord32@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 26:28@
@@ -276,16 +276,16 @@ newtype Prim_HsPrimWord32
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
+         HasField "unwrapPrim_HsPrimWord32" Prim_HsPrimWord32 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord32{unwrapPrim_HsPrimWord32 = y_1},
+                              getField @"unwrapPrim_HsPrimWord32" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
          HasField "unwrapPrim_HsPrimWord32" (Ptr Prim_HsPrimWord32) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord32")
 instance HasCField Prim_HsPrimWord32 "unwrapPrim_HsPrimWord32"
     where type CFieldType Prim_HsPrimWord32
                           "unwrapPrim_HsPrimWord32" = HsBindgen.Runtime.LibC.Word32
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word32 =>
-         HasField "unwrapPrim_HsPrimWord32" Prim_HsPrimWord32 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord32{unwrapPrim_HsPrimWord32 = y_1},
-                              getField @"unwrapPrim_HsPrimWord32" x_0)
 {-| __C declaration:__ @prim_HsPrimWord64@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 27:28@
@@ -311,16 +311,16 @@ newtype Prim_HsPrimWord64
                       Storable,
                       WriteRaw)
 instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
+         HasField "unwrapPrim_HsPrimWord64" Prim_HsPrimWord64 ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord64{unwrapPrim_HsPrimWord64 = y_1},
+                              getField @"unwrapPrim_HsPrimWord64" x_0)
+instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
          HasField "unwrapPrim_HsPrimWord64" (Ptr Prim_HsPrimWord64) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimWord64")
 instance HasCField Prim_HsPrimWord64 "unwrapPrim_HsPrimWord64"
     where type CFieldType Prim_HsPrimWord64
                           "unwrapPrim_HsPrimWord64" = HsBindgen.Runtime.LibC.Word64
           offset# = \_ -> \_ -> 0
-instance (~) ty HsBindgen.Runtime.LibC.Word64 =>
-         HasField "unwrapPrim_HsPrimWord64" Prim_HsPrimWord64 ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimWord64{unwrapPrim_HsPrimWord64 = y_1},
-                              getField @"unwrapPrim_HsPrimWord64" x_0)
 {-| __C declaration:__ @prim_HsPrimCChar@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 28:28@
@@ -346,16 +346,16 @@ newtype Prim_HsPrimCChar
                       Storable,
                       WriteRaw)
 instance (~) ty CChar =>
+         HasField "unwrapPrim_HsPrimCChar" Prim_HsPrimCChar ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCChar{unwrapPrim_HsPrimCChar = y_1},
+                              getField @"unwrapPrim_HsPrimCChar" x_0)
+instance (~) ty CChar =>
          HasField "unwrapPrim_HsPrimCChar" (Ptr Prim_HsPrimCChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCChar")
 instance HasCField Prim_HsPrimCChar "unwrapPrim_HsPrimCChar"
     where type CFieldType Prim_HsPrimCChar
                           "unwrapPrim_HsPrimCChar" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "unwrapPrim_HsPrimCChar" Prim_HsPrimCChar ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCChar{unwrapPrim_HsPrimCChar = y_1},
-                              getField @"unwrapPrim_HsPrimCChar" x_0)
 {-| __C declaration:__ @prim_HsPrimCSChar@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 29:28@
@@ -381,16 +381,16 @@ newtype Prim_HsPrimCSChar
                       Storable,
                       WriteRaw)
 instance (~) ty CSChar =>
+         HasField "unwrapPrim_HsPrimCSChar" Prim_HsPrimCSChar ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCSChar{unwrapPrim_HsPrimCSChar = y_1},
+                              getField @"unwrapPrim_HsPrimCSChar" x_0)
+instance (~) ty CSChar =>
          HasField "unwrapPrim_HsPrimCSChar" (Ptr Prim_HsPrimCSChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCSChar")
 instance HasCField Prim_HsPrimCSChar "unwrapPrim_HsPrimCSChar"
     where type CFieldType Prim_HsPrimCSChar
                           "unwrapPrim_HsPrimCSChar" = CSChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CSChar =>
-         HasField "unwrapPrim_HsPrimCSChar" Prim_HsPrimCSChar ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCSChar{unwrapPrim_HsPrimCSChar = y_1},
-                              getField @"unwrapPrim_HsPrimCSChar" x_0)
 {-| __C declaration:__ @prim_HsPrimCUChar@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 30:28@
@@ -416,16 +416,16 @@ newtype Prim_HsPrimCUChar
                       Storable,
                       WriteRaw)
 instance (~) ty CUChar =>
+         HasField "unwrapPrim_HsPrimCUChar" Prim_HsPrimCUChar ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUChar{unwrapPrim_HsPrimCUChar = y_1},
+                              getField @"unwrapPrim_HsPrimCUChar" x_0)
+instance (~) ty CUChar =>
          HasField "unwrapPrim_HsPrimCUChar" (Ptr Prim_HsPrimCUChar) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUChar")
 instance HasCField Prim_HsPrimCUChar "unwrapPrim_HsPrimCUChar"
     where type CFieldType Prim_HsPrimCUChar
                           "unwrapPrim_HsPrimCUChar" = CUChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CUChar =>
-         HasField "unwrapPrim_HsPrimCUChar" Prim_HsPrimCUChar ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUChar{unwrapPrim_HsPrimCUChar = y_1},
-                              getField @"unwrapPrim_HsPrimCUChar" x_0)
 {-| __C declaration:__ @prim_HsPrimCShort@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 31:28@
@@ -451,16 +451,16 @@ newtype Prim_HsPrimCShort
                       Storable,
                       WriteRaw)
 instance (~) ty CShort =>
+         HasField "unwrapPrim_HsPrimCShort" Prim_HsPrimCShort ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCShort{unwrapPrim_HsPrimCShort = y_1},
+                              getField @"unwrapPrim_HsPrimCShort" x_0)
+instance (~) ty CShort =>
          HasField "unwrapPrim_HsPrimCShort" (Ptr Prim_HsPrimCShort) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCShort")
 instance HasCField Prim_HsPrimCShort "unwrapPrim_HsPrimCShort"
     where type CFieldType Prim_HsPrimCShort
                           "unwrapPrim_HsPrimCShort" = CShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CShort =>
-         HasField "unwrapPrim_HsPrimCShort" Prim_HsPrimCShort ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCShort{unwrapPrim_HsPrimCShort = y_1},
-                              getField @"unwrapPrim_HsPrimCShort" x_0)
 {-| __C declaration:__ @prim_HsPrimCUShort@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 32:28@
@@ -486,6 +486,10 @@ newtype Prim_HsPrimCUShort
                       Storable,
                       WriteRaw)
 instance (~) ty CUShort =>
+         HasField "unwrapPrim_HsPrimCUShort" Prim_HsPrimCUShort ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUShort{unwrapPrim_HsPrimCUShort = y_1},
+                              getField @"unwrapPrim_HsPrimCUShort" x_0)
+instance (~) ty CUShort =>
          HasField "unwrapPrim_HsPrimCUShort"
                   (Ptr Prim_HsPrimCUShort)
                   (Ptr ty)
@@ -494,10 +498,6 @@ instance HasCField Prim_HsPrimCUShort "unwrapPrim_HsPrimCUShort"
     where type CFieldType Prim_HsPrimCUShort
                           "unwrapPrim_HsPrimCUShort" = CUShort
           offset# = \_ -> \_ -> 0
-instance (~) ty CUShort =>
-         HasField "unwrapPrim_HsPrimCUShort" Prim_HsPrimCUShort ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUShort{unwrapPrim_HsPrimCUShort = y_1},
-                              getField @"unwrapPrim_HsPrimCUShort" x_0)
 {-| __C declaration:__ @prim_HsPrimCInt@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 33:28@
@@ -523,16 +523,16 @@ newtype Prim_HsPrimCInt
                       Storable,
                       WriteRaw)
 instance (~) ty CInt =>
+         HasField "unwrapPrim_HsPrimCInt" Prim_HsPrimCInt ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCInt{unwrapPrim_HsPrimCInt = y_1},
+                              getField @"unwrapPrim_HsPrimCInt" x_0)
+instance (~) ty CInt =>
          HasField "unwrapPrim_HsPrimCInt" (Ptr Prim_HsPrimCInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCInt")
 instance HasCField Prim_HsPrimCInt "unwrapPrim_HsPrimCInt"
     where type CFieldType Prim_HsPrimCInt
                           "unwrapPrim_HsPrimCInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "unwrapPrim_HsPrimCInt" Prim_HsPrimCInt ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCInt{unwrapPrim_HsPrimCInt = y_1},
-                              getField @"unwrapPrim_HsPrimCInt" x_0)
 {-| __C declaration:__ @prim_HsPrimCUInt@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 34:28@
@@ -558,16 +558,16 @@ newtype Prim_HsPrimCUInt
                       Storable,
                       WriteRaw)
 instance (~) ty CUInt =>
+         HasField "unwrapPrim_HsPrimCUInt" Prim_HsPrimCUInt ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUInt{unwrapPrim_HsPrimCUInt = y_1},
+                              getField @"unwrapPrim_HsPrimCUInt" x_0)
+instance (~) ty CUInt =>
          HasField "unwrapPrim_HsPrimCUInt" (Ptr Prim_HsPrimCUInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCUInt")
 instance HasCField Prim_HsPrimCUInt "unwrapPrim_HsPrimCUInt"
     where type CFieldType Prim_HsPrimCUInt
                           "unwrapPrim_HsPrimCUInt" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt =>
-         HasField "unwrapPrim_HsPrimCUInt" Prim_HsPrimCUInt ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCUInt{unwrapPrim_HsPrimCUInt = y_1},
-                              getField @"unwrapPrim_HsPrimCUInt" x_0)
 {-| __C declaration:__ @prim_HsPrimCLong@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 35:28@
@@ -593,16 +593,16 @@ newtype Prim_HsPrimCLong
                       Storable,
                       WriteRaw)
 instance (~) ty CLong =>
+         HasField "unwrapPrim_HsPrimCLong" Prim_HsPrimCLong ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCLong{unwrapPrim_HsPrimCLong = y_1},
+                              getField @"unwrapPrim_HsPrimCLong" x_0)
+instance (~) ty CLong =>
          HasField "unwrapPrim_HsPrimCLong" (Ptr Prim_HsPrimCLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLong")
 instance HasCField Prim_HsPrimCLong "unwrapPrim_HsPrimCLong"
     where type CFieldType Prim_HsPrimCLong
                           "unwrapPrim_HsPrimCLong" = CLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLong =>
-         HasField "unwrapPrim_HsPrimCLong" Prim_HsPrimCLong ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCLong{unwrapPrim_HsPrimCLong = y_1},
-                              getField @"unwrapPrim_HsPrimCLong" x_0)
 {-| __C declaration:__ @prim_HsPrimCULong@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 36:28@
@@ -628,16 +628,16 @@ newtype Prim_HsPrimCULong
                       Storable,
                       WriteRaw)
 instance (~) ty CULong =>
+         HasField "unwrapPrim_HsPrimCULong" Prim_HsPrimCULong ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCULong{unwrapPrim_HsPrimCULong = y_1},
+                              getField @"unwrapPrim_HsPrimCULong" x_0)
+instance (~) ty CULong =>
          HasField "unwrapPrim_HsPrimCULong" (Ptr Prim_HsPrimCULong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCULong")
 instance HasCField Prim_HsPrimCULong "unwrapPrim_HsPrimCULong"
     where type CFieldType Prim_HsPrimCULong
                           "unwrapPrim_HsPrimCULong" = CULong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULong =>
-         HasField "unwrapPrim_HsPrimCULong" Prim_HsPrimCULong ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCULong{unwrapPrim_HsPrimCULong = y_1},
-                              getField @"unwrapPrim_HsPrimCULong" x_0)
 {-| __C declaration:__ @prim_HsPrimCLLong@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 37:28@
@@ -663,16 +663,16 @@ newtype Prim_HsPrimCLLong
                       Storable,
                       WriteRaw)
 instance (~) ty CLLong =>
+         HasField "unwrapPrim_HsPrimCLLong" Prim_HsPrimCLLong ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCLLong{unwrapPrim_HsPrimCLLong = y_1},
+                              getField @"unwrapPrim_HsPrimCLLong" x_0)
+instance (~) ty CLLong =>
          HasField "unwrapPrim_HsPrimCLLong" (Ptr Prim_HsPrimCLLong) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCLLong")
 instance HasCField Prim_HsPrimCLLong "unwrapPrim_HsPrimCLLong"
     where type CFieldType Prim_HsPrimCLLong
                           "unwrapPrim_HsPrimCLLong" = CLLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CLLong =>
-         HasField "unwrapPrim_HsPrimCLLong" Prim_HsPrimCLLong ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCLLong{unwrapPrim_HsPrimCLLong = y_1},
-                              getField @"unwrapPrim_HsPrimCLLong" x_0)
 {-| __C declaration:__ @prim_HsPrimCULLong@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 38:28@
@@ -698,6 +698,10 @@ newtype Prim_HsPrimCULLong
                       Storable,
                       WriteRaw)
 instance (~) ty CULLong =>
+         HasField "unwrapPrim_HsPrimCULLong" Prim_HsPrimCULLong ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCULLong{unwrapPrim_HsPrimCULLong = y_1},
+                              getField @"unwrapPrim_HsPrimCULLong" x_0)
+instance (~) ty CULLong =>
          HasField "unwrapPrim_HsPrimCULLong"
                   (Ptr Prim_HsPrimCULLong)
                   (Ptr ty)
@@ -706,10 +710,6 @@ instance HasCField Prim_HsPrimCULLong "unwrapPrim_HsPrimCULLong"
     where type CFieldType Prim_HsPrimCULLong
                           "unwrapPrim_HsPrimCULLong" = CULLong
           offset# = \_ -> \_ -> 0
-instance (~) ty CULLong =>
-         HasField "unwrapPrim_HsPrimCULLong" Prim_HsPrimCULLong ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCULLong{unwrapPrim_HsPrimCULLong = y_1},
-                              getField @"unwrapPrim_HsPrimCULLong" x_0)
 {-| __C declaration:__ @prim_HsPrimCBool@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 39:28@
@@ -735,16 +735,16 @@ newtype Prim_HsPrimCBool
                       Storable,
                       WriteRaw)
 instance (~) ty CBool =>
+         HasField "unwrapPrim_HsPrimCBool" Prim_HsPrimCBool ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCBool{unwrapPrim_HsPrimCBool = y_1},
+                              getField @"unwrapPrim_HsPrimCBool" x_0)
+instance (~) ty CBool =>
          HasField "unwrapPrim_HsPrimCBool" (Ptr Prim_HsPrimCBool) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCBool")
 instance HasCField Prim_HsPrimCBool "unwrapPrim_HsPrimCBool"
     where type CFieldType Prim_HsPrimCBool
                           "unwrapPrim_HsPrimCBool" = CBool
           offset# = \_ -> \_ -> 0
-instance (~) ty CBool =>
-         HasField "unwrapPrim_HsPrimCBool" Prim_HsPrimCBool ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCBool{unwrapPrim_HsPrimCBool = y_1},
-                              getField @"unwrapPrim_HsPrimCBool" x_0)
 {-| __C declaration:__ @prim_HsPrimCFloat@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 40:28@
@@ -768,16 +768,16 @@ newtype Prim_HsPrimCFloat
                       Storable,
                       WriteRaw)
 instance (~) ty CFloat =>
+         HasField "unwrapPrim_HsPrimCFloat" Prim_HsPrimCFloat ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCFloat{unwrapPrim_HsPrimCFloat = y_1},
+                              getField @"unwrapPrim_HsPrimCFloat" x_0)
+instance (~) ty CFloat =>
          HasField "unwrapPrim_HsPrimCFloat" (Ptr Prim_HsPrimCFloat) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapPrim_HsPrimCFloat")
 instance HasCField Prim_HsPrimCFloat "unwrapPrim_HsPrimCFloat"
     where type CFieldType Prim_HsPrimCFloat
                           "unwrapPrim_HsPrimCFloat" = CFloat
           offset# = \_ -> \_ -> 0
-instance (~) ty CFloat =>
-         HasField "unwrapPrim_HsPrimCFloat" Prim_HsPrimCFloat ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCFloat{unwrapPrim_HsPrimCFloat = y_1},
-                              getField @"unwrapPrim_HsPrimCFloat" x_0)
 {-| __C declaration:__ @prim_HsPrimCDouble@
 
     __defined at:__ @types\/primitives\/primitive_insts.h 41:28@
@@ -801,6 +801,10 @@ newtype Prim_HsPrimCDouble
                       Storable,
                       WriteRaw)
 instance (~) ty CDouble =>
+         HasField "unwrapPrim_HsPrimCDouble" Prim_HsPrimCDouble ty
+    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCDouble{unwrapPrim_HsPrimCDouble = y_1},
+                              getField @"unwrapPrim_HsPrimCDouble" x_0)
+instance (~) ty CDouble =>
          HasField "unwrapPrim_HsPrimCDouble"
                   (Ptr Prim_HsPrimCDouble)
                   (Ptr ty)
@@ -809,7 +813,3 @@ instance HasCField Prim_HsPrimCDouble "unwrapPrim_HsPrimCDouble"
     where type CFieldType Prim_HsPrimCDouble
                           "unwrapPrim_HsPrimCDouble" = CDouble
           offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "unwrapPrim_HsPrimCDouble" Prim_HsPrimCDouble ty
-    where hasField = \x_0 -> (\y_1 -> Prim_HsPrimCDouble{unwrapPrim_HsPrimCDouble = y_1},
-                              getField @"unwrapPrim_HsPrimCDouble" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/Example.hs
@@ -334,18 +334,6 @@ instance Marshal.WriteRaw Primitive where
 
 deriving via Marshal.EquivStorable Primitive instance RIP.Storable Primitive
 
-instance HasCField.HasCField Primitive "primitive_c" where
-
-  type CFieldType Primitive "primitive_c" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "primitive_c" (RIP.Ptr Primitive) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_c")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "primitive_c" Primitive ty where
 
@@ -384,17 +372,17 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"primitive_c" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_sc" where
-
-  type CFieldType Primitive "primitive_sc" = RIP.CSChar
-
-  offset# = \_ -> \_ -> 1
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "primitive_sc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "primitive_c" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_sc")
+    HasCField.fromPtr (RIP.Proxy @"primitive_c")
+
+instance HasCField.HasCField Primitive "primitive_c" where
+
+  type CFieldType Primitive "primitive_c" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "primitive_sc" Primitive ty where
@@ -434,17 +422,17 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"primitive_sc" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_uc" where
-
-  type CFieldType Primitive "primitive_uc" = RIP.CUChar
-
-  offset# = \_ -> \_ -> 2
-
-instance ( ty ~ RIP.CUChar
-         ) => RIP.HasField "primitive_uc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "primitive_sc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_uc")
+    HasCField.fromPtr (RIP.Proxy @"primitive_sc")
+
+instance HasCField.HasCField Primitive "primitive_sc" where
+
+  type CFieldType Primitive "primitive_sc" = RIP.CSChar
+
+  offset# = \_ -> \_ -> 1
 
 instance ( ty ~ RIP.CUChar
          ) => RIP.CompatHasField.HasField "primitive_uc" Primitive ty where
@@ -484,17 +472,17 @@ instance ( ty ~ RIP.CUChar
       , RIP.getField @"primitive_uc" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_s" where
-
-  type CFieldType Primitive "primitive_s" = RIP.CShort
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_s" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CUChar
+         ) => RIP.HasField "primitive_uc" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_s")
+    HasCField.fromPtr (RIP.Proxy @"primitive_uc")
+
+instance HasCField.HasCField Primitive "primitive_uc" where
+
+  type CFieldType Primitive "primitive_uc" = RIP.CUChar
+
+  offset# = \_ -> \_ -> 2
 
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "primitive_s" Primitive ty where
@@ -534,17 +522,17 @@ instance ( ty ~ RIP.CShort
       , RIP.getField @"primitive_s" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_si" where
-
-  type CFieldType Primitive "primitive_si" = RIP.CShort
-
-  offset# = \_ -> \_ -> 6
-
 instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_si" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_s" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_si")
+    HasCField.fromPtr (RIP.Proxy @"primitive_s")
+
+instance HasCField.HasCField Primitive "primitive_s" where
+
+  type CFieldType Primitive "primitive_s" = RIP.CShort
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "primitive_si" Primitive ty where
@@ -584,17 +572,17 @@ instance ( ty ~ RIP.CShort
       , RIP.getField @"primitive_si" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ss" where
-
-  type CFieldType Primitive "primitive_ss" = RIP.CShort
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_ss" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_si" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ss")
+    HasCField.fromPtr (RIP.Proxy @"primitive_si")
+
+instance HasCField.HasCField Primitive "primitive_si" where
+
+  type CFieldType Primitive "primitive_si" = RIP.CShort
+
+  offset# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "primitive_ss" Primitive ty where
@@ -634,18 +622,17 @@ instance ( ty ~ RIP.CShort
       , RIP.getField @"primitive_ss" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ssi" where
-
-  type CFieldType Primitive "primitive_ssi" =
-    RIP.CShort
-
-  offset# = \_ -> \_ -> 10
-
 instance ( ty ~ RIP.CShort
-         ) => RIP.HasField "primitive_ssi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_ss" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ssi")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ss")
+
+instance HasCField.HasCField Primitive "primitive_ss" where
+
+  type CFieldType Primitive "primitive_ss" = RIP.CShort
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.CShort
          ) => RIP.CompatHasField.HasField "primitive_ssi" Primitive ty where
@@ -685,18 +672,18 @@ instance ( ty ~ RIP.CShort
       , RIP.getField @"primitive_ssi" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_us" where
-
-  type CFieldType Primitive "primitive_us" =
-    RIP.CUShort
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "primitive_us" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CShort
+         ) => RIP.HasField "primitive_ssi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_us")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ssi")
+
+instance HasCField.HasCField Primitive "primitive_ssi" where
+
+  type CFieldType Primitive "primitive_ssi" =
+    RIP.CShort
+
+  offset# = \_ -> \_ -> 10
 
 instance ( ty ~ RIP.CUShort
          ) => RIP.CompatHasField.HasField "primitive_us" Primitive ty where
@@ -736,18 +723,18 @@ instance ( ty ~ RIP.CUShort
       , RIP.getField @"primitive_us" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_usi" where
-
-  type CFieldType Primitive "primitive_usi" =
-    RIP.CUShort
-
-  offset# = \_ -> \_ -> 14
-
 instance ( ty ~ RIP.CUShort
-         ) => RIP.HasField "primitive_usi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_us" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_usi")
+    HasCField.fromPtr (RIP.Proxy @"primitive_us")
+
+instance HasCField.HasCField Primitive "primitive_us" where
+
+  type CFieldType Primitive "primitive_us" =
+    RIP.CUShort
+
+  offset# = \_ -> \_ -> 12
 
 instance ( ty ~ RIP.CUShort
          ) => RIP.CompatHasField.HasField "primitive_usi" Primitive ty where
@@ -787,17 +774,18 @@ instance ( ty ~ RIP.CUShort
       , RIP.getField @"primitive_usi" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_i" where
-
-  type CFieldType Primitive "primitive_i" = RIP.CInt
-
-  offset# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_i" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CUShort
+         ) => RIP.HasField "primitive_usi" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_i")
+    HasCField.fromPtr (RIP.Proxy @"primitive_usi")
+
+instance HasCField.HasCField Primitive "primitive_usi" where
+
+  type CFieldType Primitive "primitive_usi" =
+    RIP.CUShort
+
+  offset# = \_ -> \_ -> 14
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "primitive_i" Primitive ty where
@@ -837,17 +825,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"primitive_i" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_s2" where
-
-  type CFieldType Primitive "primitive_s2" = RIP.CInt
-
-  offset# = \_ -> \_ -> 20
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_s2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_i" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_s2")
+    HasCField.fromPtr (RIP.Proxy @"primitive_i")
+
+instance HasCField.HasCField Primitive "primitive_i" where
+
+  type CFieldType Primitive "primitive_i" = RIP.CInt
+
+  offset# = \_ -> \_ -> 16
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "primitive_s2" Primitive ty where
@@ -887,17 +875,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"primitive_s2" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_si2" where
-
-  type CFieldType Primitive "primitive_si2" = RIP.CInt
-
-  offset# = \_ -> \_ -> 24
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "primitive_si2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_s2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_si2")
+    HasCField.fromPtr (RIP.Proxy @"primitive_s2")
+
+instance HasCField.HasCField Primitive "primitive_s2" where
+
+  type CFieldType Primitive "primitive_s2" = RIP.CInt
+
+  offset# = \_ -> \_ -> 20
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "primitive_si2" Primitive ty where
@@ -937,17 +925,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"primitive_si2" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_u" where
-
-  type CFieldType Primitive "primitive_u" = RIP.CUInt
-
-  offset# = \_ -> \_ -> 28
-
-instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "primitive_u" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "primitive_si2" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_u")
+    HasCField.fromPtr (RIP.Proxy @"primitive_si2")
+
+instance HasCField.HasCField Primitive "primitive_si2" where
+
+  type CFieldType Primitive "primitive_si2" = RIP.CInt
+
+  offset# = \_ -> \_ -> 24
 
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "primitive_u" Primitive ty where
@@ -987,17 +975,17 @@ instance ( ty ~ RIP.CUInt
       , RIP.getField @"primitive_u" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ui" where
-
-  type CFieldType Primitive "primitive_ui" = RIP.CUInt
-
-  offset# = \_ -> \_ -> 32
-
 instance ( ty ~ RIP.CUInt
-         ) => RIP.HasField "primitive_ui" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_u" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ui")
+    HasCField.fromPtr (RIP.Proxy @"primitive_u")
+
+instance HasCField.HasCField Primitive "primitive_u" where
+
+  type CFieldType Primitive "primitive_u" = RIP.CUInt
+
+  offset# = \_ -> \_ -> 28
 
 instance ( ty ~ RIP.CUInt
          ) => RIP.CompatHasField.HasField "primitive_ui" Primitive ty where
@@ -1037,17 +1025,17 @@ instance ( ty ~ RIP.CUInt
       , RIP.getField @"primitive_ui" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_l" where
-
-  type CFieldType Primitive "primitive_l" = RIP.CLong
-
-  offset# = \_ -> \_ -> 40
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_l" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CUInt
+         ) => RIP.HasField "primitive_ui" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_l")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ui")
+
+instance HasCField.HasCField Primitive "primitive_ui" where
+
+  type CFieldType Primitive "primitive_ui" = RIP.CUInt
+
+  offset# = \_ -> \_ -> 32
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "primitive_l" Primitive ty where
@@ -1087,17 +1075,17 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"primitive_l" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_li" where
-
-  type CFieldType Primitive "primitive_li" = RIP.CLong
-
-  offset# = \_ -> \_ -> 48
-
 instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_li" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_l" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_li")
+    HasCField.fromPtr (RIP.Proxy @"primitive_l")
+
+instance HasCField.HasCField Primitive "primitive_l" where
+
+  type CFieldType Primitive "primitive_l" = RIP.CLong
+
+  offset# = \_ -> \_ -> 40
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "primitive_li" Primitive ty where
@@ -1137,17 +1125,17 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"primitive_li" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_sl" where
-
-  type CFieldType Primitive "primitive_sl" = RIP.CLong
-
-  offset# = \_ -> \_ -> 56
-
 instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_sl" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_li" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_sl")
+    HasCField.fromPtr (RIP.Proxy @"primitive_li")
+
+instance HasCField.HasCField Primitive "primitive_li" where
+
+  type CFieldType Primitive "primitive_li" = RIP.CLong
+
+  offset# = \_ -> \_ -> 48
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "primitive_sl" Primitive ty where
@@ -1187,17 +1175,17 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"primitive_sl" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_sli" where
-
-  type CFieldType Primitive "primitive_sli" = RIP.CLong
-
-  offset# = \_ -> \_ -> 64
-
 instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "primitive_sli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_sl" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_sli")
+    HasCField.fromPtr (RIP.Proxy @"primitive_sl")
+
+instance HasCField.HasCField Primitive "primitive_sl" where
+
+  type CFieldType Primitive "primitive_sl" = RIP.CLong
+
+  offset# = \_ -> \_ -> 56
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "primitive_sli" Primitive ty where
@@ -1237,17 +1225,17 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"primitive_sli" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ul" where
-
-  type CFieldType Primitive "primitive_ul" = RIP.CULong
-
-  offset# = \_ -> \_ -> 72
-
-instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "primitive_ul" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "primitive_sli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ul")
+    HasCField.fromPtr (RIP.Proxy @"primitive_sli")
+
+instance HasCField.HasCField Primitive "primitive_sli" where
+
+  type CFieldType Primitive "primitive_sli" = RIP.CLong
+
+  offset# = \_ -> \_ -> 64
 
 instance ( ty ~ RIP.CULong
          ) => RIP.CompatHasField.HasField "primitive_ul" Primitive ty where
@@ -1287,18 +1275,17 @@ instance ( ty ~ RIP.CULong
       , RIP.getField @"primitive_ul" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_uli" where
-
-  type CFieldType Primitive "primitive_uli" =
-    RIP.CULong
-
-  offset# = \_ -> \_ -> 80
-
 instance ( ty ~ RIP.CULong
-         ) => RIP.HasField "primitive_uli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_ul" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_uli")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ul")
+
+instance HasCField.HasCField Primitive "primitive_ul" where
+
+  type CFieldType Primitive "primitive_ul" = RIP.CULong
+
+  offset# = \_ -> \_ -> 72
 
 instance ( ty ~ RIP.CULong
          ) => RIP.CompatHasField.HasField "primitive_uli" Primitive ty where
@@ -1338,17 +1325,18 @@ instance ( ty ~ RIP.CULong
       , RIP.getField @"primitive_uli" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ll" where
-
-  type CFieldType Primitive "primitive_ll" = RIP.CLLong
-
-  offset# = \_ -> \_ -> 88
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_ll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CULong
+         ) => RIP.HasField "primitive_uli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ll")
+    HasCField.fromPtr (RIP.Proxy @"primitive_uli")
+
+instance HasCField.HasCField Primitive "primitive_uli" where
+
+  type CFieldType Primitive "primitive_uli" =
+    RIP.CULong
+
+  offset# = \_ -> \_ -> 80
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "primitive_ll" Primitive ty where
@@ -1388,18 +1376,17 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"primitive_ll" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_lli" where
-
-  type CFieldType Primitive "primitive_lli" =
-    RIP.CLLong
-
-  offset# = \_ -> \_ -> 96
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_lli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_ll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_lli")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ll")
+
+instance HasCField.HasCField Primitive "primitive_ll" where
+
+  type CFieldType Primitive "primitive_ll" = RIP.CLLong
+
+  offset# = \_ -> \_ -> 88
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "primitive_lli" Primitive ty where
@@ -1439,18 +1426,18 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"primitive_lli" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_sll" where
-
-  type CFieldType Primitive "primitive_sll" =
-    RIP.CLLong
-
-  offset# = \_ -> \_ -> 104
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_sll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_lli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_sll")
+    HasCField.fromPtr (RIP.Proxy @"primitive_lli")
+
+instance HasCField.HasCField Primitive "primitive_lli" where
+
+  type CFieldType Primitive "primitive_lli" =
+    RIP.CLLong
+
+  offset# = \_ -> \_ -> 96
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "primitive_sll" Primitive ty where
@@ -1490,18 +1477,18 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"primitive_sll" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_slli" where
-
-  type CFieldType Primitive "primitive_slli" =
-    RIP.CLLong
-
-  offset# = \_ -> \_ -> 112
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "primitive_slli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_sll" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_slli")
+    HasCField.fromPtr (RIP.Proxy @"primitive_sll")
+
+instance HasCField.HasCField Primitive "primitive_sll" where
+
+  type CFieldType Primitive "primitive_sll" =
+    RIP.CLLong
+
+  offset# = \_ -> \_ -> 104
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "primitive_slli" Primitive ty where
@@ -1541,18 +1528,18 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"primitive_slli" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ull" where
-
-  type CFieldType Primitive "primitive_ull" =
-    RIP.CULLong
-
-  offset# = \_ -> \_ -> 120
-
-instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "primitive_ull" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "primitive_slli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ull")
+    HasCField.fromPtr (RIP.Proxy @"primitive_slli")
+
+instance HasCField.HasCField Primitive "primitive_slli" where
+
+  type CFieldType Primitive "primitive_slli" =
+    RIP.CLLong
+
+  offset# = \_ -> \_ -> 112
 
 instance ( ty ~ RIP.CULLong
          ) => RIP.CompatHasField.HasField "primitive_ull" Primitive ty where
@@ -1592,18 +1579,18 @@ instance ( ty ~ RIP.CULLong
       , RIP.getField @"primitive_ull" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_ulli" where
-
-  type CFieldType Primitive "primitive_ulli" =
-    RIP.CULLong
-
-  offset# = \_ -> \_ -> 128
-
 instance ( ty ~ RIP.CULLong
-         ) => RIP.HasField "primitive_ulli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+         ) => RIP.HasField "primitive_ull" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_ulli")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ull")
+
+instance HasCField.HasCField Primitive "primitive_ull" where
+
+  type CFieldType Primitive "primitive_ull" =
+    RIP.CULLong
+
+  offset# = \_ -> \_ -> 120
 
 instance ( ty ~ RIP.CULLong
          ) => RIP.CompatHasField.HasField "primitive_ulli" Primitive ty where
@@ -1643,17 +1630,18 @@ instance ( ty ~ RIP.CULLong
       , RIP.getField @"primitive_ulli" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_f" where
-
-  type CFieldType Primitive "primitive_f" = RIP.CFloat
-
-  offset# = \_ -> \_ -> 136
-
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "primitive_f" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CULLong
+         ) => RIP.HasField "primitive_ulli" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_f")
+    HasCField.fromPtr (RIP.Proxy @"primitive_ulli")
+
+instance HasCField.HasCField Primitive "primitive_ulli" where
+
+  type CFieldType Primitive "primitive_ulli" =
+    RIP.CULLong
+
+  offset# = \_ -> \_ -> 128
 
 instance ( ty ~ RIP.CFloat
          ) => RIP.CompatHasField.HasField "primitive_f" Primitive ty where
@@ -1693,17 +1681,17 @@ instance ( ty ~ RIP.CFloat
       , RIP.getField @"primitive_f" x0
       )
 
-instance HasCField.HasCField Primitive "primitive_d" where
-
-  type CFieldType Primitive "primitive_d" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 144
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "primitive_d" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "primitive_f" (RIP.Ptr Primitive) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"primitive_d")
+    HasCField.fromPtr (RIP.Proxy @"primitive_f")
+
+instance HasCField.HasCField Primitive "primitive_f" where
+
+  type CFieldType Primitive "primitive_f" = RIP.CFloat
+
+  offset# = \_ -> \_ -> 136
 
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "primitive_d" Primitive ty where
@@ -1742,3 +1730,15 @@ instance ( ty ~ RIP.CDouble
                     }
       , RIP.getField @"primitive_d" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "primitive_d" (RIP.Ptr Primitive) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"primitive_d")
+
+instance HasCField.HasCField Primitive "primitive_d" where
+
+  type CFieldType Primitive "primitive_d" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 144

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/bindingspec.yaml
@@ -41,11 +41,12 @@ hstypes:
       - primitive_f
       - primitive_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/primitives/primitive_types/th.txt
@@ -239,12 +239,6 @@ instance WriteRaw Primitive
                                                  primitive_f_28
                                                  primitive_d_29 -> writeRaw (Proxy @"primitive_c") ptr_0 primitive_c_2 >> (writeRaw (Proxy @"primitive_sc") ptr_0 primitive_sc_3 >> (writeRaw (Proxy @"primitive_uc") ptr_0 primitive_uc_4 >> (writeRaw (Proxy @"primitive_s") ptr_0 primitive_s_5 >> (writeRaw (Proxy @"primitive_si") ptr_0 primitive_si_6 >> (writeRaw (Proxy @"primitive_ss") ptr_0 primitive_ss_7 >> (writeRaw (Proxy @"primitive_ssi") ptr_0 primitive_ssi_8 >> (writeRaw (Proxy @"primitive_us") ptr_0 primitive_us_9 >> (writeRaw (Proxy @"primitive_usi") ptr_0 primitive_usi_10 >> (writeRaw (Proxy @"primitive_i") ptr_0 primitive_i_11 >> (writeRaw (Proxy @"primitive_s2") ptr_0 primitive_s2_12 >> (writeRaw (Proxy @"primitive_si2") ptr_0 primitive_si2_13 >> (writeRaw (Proxy @"primitive_u") ptr_0 primitive_u_14 >> (writeRaw (Proxy @"primitive_ui") ptr_0 primitive_ui_15 >> (writeRaw (Proxy @"primitive_l") ptr_0 primitive_l_16 >> (writeRaw (Proxy @"primitive_li") ptr_0 primitive_li_17 >> (writeRaw (Proxy @"primitive_sl") ptr_0 primitive_sl_18 >> (writeRaw (Proxy @"primitive_sli") ptr_0 primitive_sli_19 >> (writeRaw (Proxy @"primitive_ul") ptr_0 primitive_ul_20 >> (writeRaw (Proxy @"primitive_uli") ptr_0 primitive_uli_21 >> (writeRaw (Proxy @"primitive_ll") ptr_0 primitive_ll_22 >> (writeRaw (Proxy @"primitive_lli") ptr_0 primitive_lli_23 >> (writeRaw (Proxy @"primitive_sll") ptr_0 primitive_sll_24 >> (writeRaw (Proxy @"primitive_slli") ptr_0 primitive_slli_25 >> (writeRaw (Proxy @"primitive_ull") ptr_0 primitive_ull_26 >> (writeRaw (Proxy @"primitive_ulli") ptr_0 primitive_ulli_27 >> (writeRaw (Proxy @"primitive_f") ptr_0 primitive_f_28 >> writeRaw (Proxy @"primitive_d") ptr_0 primitive_d_29))))))))))))))))))))))))))
 deriving via (EquivStorable Primitive) instance Storable Primitive
-instance HasCField Primitive "primitive_c"
-    where type CFieldType Primitive "primitive_c" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "primitive_c" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_c")
 instance (~) ty CChar => HasField "primitive_c" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_c = y_1,
                                                 primitive_sc = getField @"primitive_sc" x_0,
@@ -275,12 +269,12 @@ instance (~) ty CChar => HasField "primitive_c" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_c" x_0)
-instance HasCField Primitive "primitive_sc"
-    where type CFieldType Primitive "primitive_sc" = CSChar
-          offset# = \_ -> \_ -> 1
-instance (~) ty CSChar =>
-         HasField "primitive_sc" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_sc")
+instance (~) ty CChar =>
+         HasField "primitive_c" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_c")
+instance HasCField Primitive "primitive_c"
+    where type CFieldType Primitive "primitive_c" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CSChar => HasField "primitive_sc" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_sc = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -311,12 +305,12 @@ instance (~) ty CSChar => HasField "primitive_sc" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_sc" x_0)
-instance HasCField Primitive "primitive_uc"
-    where type CFieldType Primitive "primitive_uc" = CUChar
-          offset# = \_ -> \_ -> 2
-instance (~) ty CUChar =>
-         HasField "primitive_uc" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_uc")
+instance (~) ty CSChar =>
+         HasField "primitive_sc" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_sc")
+instance HasCField Primitive "primitive_sc"
+    where type CFieldType Primitive "primitive_sc" = CSChar
+          offset# = \_ -> \_ -> 1
 instance (~) ty CUChar => HasField "primitive_uc" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_uc = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -347,12 +341,12 @@ instance (~) ty CUChar => HasField "primitive_uc" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_uc" x_0)
-instance HasCField Primitive "primitive_s"
-    where type CFieldType Primitive "primitive_s" = CShort
-          offset# = \_ -> \_ -> 4
-instance (~) ty CShort =>
-         HasField "primitive_s" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_s")
+instance (~) ty CUChar =>
+         HasField "primitive_uc" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_uc")
+instance HasCField Primitive "primitive_uc"
+    where type CFieldType Primitive "primitive_uc" = CUChar
+          offset# = \_ -> \_ -> 2
 instance (~) ty CShort => HasField "primitive_s" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_s = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -383,12 +377,12 @@ instance (~) ty CShort => HasField "primitive_s" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_s" x_0)
-instance HasCField Primitive "primitive_si"
-    where type CFieldType Primitive "primitive_si" = CShort
-          offset# = \_ -> \_ -> 6
 instance (~) ty CShort =>
-         HasField "primitive_si" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_si")
+         HasField "primitive_s" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_s")
+instance HasCField Primitive "primitive_s"
+    where type CFieldType Primitive "primitive_s" = CShort
+          offset# = \_ -> \_ -> 4
 instance (~) ty CShort => HasField "primitive_si" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_si = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -419,12 +413,12 @@ instance (~) ty CShort => HasField "primitive_si" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_si" x_0)
-instance HasCField Primitive "primitive_ss"
-    where type CFieldType Primitive "primitive_ss" = CShort
-          offset# = \_ -> \_ -> 8
 instance (~) ty CShort =>
-         HasField "primitive_ss" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ss")
+         HasField "primitive_si" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_si")
+instance HasCField Primitive "primitive_si"
+    where type CFieldType Primitive "primitive_si" = CShort
+          offset# = \_ -> \_ -> 6
 instance (~) ty CShort => HasField "primitive_ss" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ss = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -455,12 +449,12 @@ instance (~) ty CShort => HasField "primitive_ss" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ss" x_0)
-instance HasCField Primitive "primitive_ssi"
-    where type CFieldType Primitive "primitive_ssi" = CShort
-          offset# = \_ -> \_ -> 10
 instance (~) ty CShort =>
-         HasField "primitive_ssi" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ssi")
+         HasField "primitive_ss" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ss")
+instance HasCField Primitive "primitive_ss"
+    where type CFieldType Primitive "primitive_ss" = CShort
+          offset# = \_ -> \_ -> 8
 instance (~) ty CShort => HasField "primitive_ssi" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ssi = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -491,12 +485,12 @@ instance (~) ty CShort => HasField "primitive_ssi" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ssi" x_0)
-instance HasCField Primitive "primitive_us"
-    where type CFieldType Primitive "primitive_us" = CUShort
-          offset# = \_ -> \_ -> 12
-instance (~) ty CUShort =>
-         HasField "primitive_us" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_us")
+instance (~) ty CShort =>
+         HasField "primitive_ssi" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ssi")
+instance HasCField Primitive "primitive_ssi"
+    where type CFieldType Primitive "primitive_ssi" = CShort
+          offset# = \_ -> \_ -> 10
 instance (~) ty CUShort => HasField "primitive_us" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_us = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -527,12 +521,12 @@ instance (~) ty CUShort => HasField "primitive_us" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_us" x_0)
-instance HasCField Primitive "primitive_usi"
-    where type CFieldType Primitive "primitive_usi" = CUShort
-          offset# = \_ -> \_ -> 14
 instance (~) ty CUShort =>
-         HasField "primitive_usi" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_usi")
+         HasField "primitive_us" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_us")
+instance HasCField Primitive "primitive_us"
+    where type CFieldType Primitive "primitive_us" = CUShort
+          offset# = \_ -> \_ -> 12
 instance (~) ty CUShort => HasField "primitive_usi" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_usi = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -563,12 +557,12 @@ instance (~) ty CUShort => HasField "primitive_usi" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_usi" x_0)
-instance HasCField Primitive "primitive_i"
-    where type CFieldType Primitive "primitive_i" = CInt
-          offset# = \_ -> \_ -> 16
-instance (~) ty CInt =>
-         HasField "primitive_i" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_i")
+instance (~) ty CUShort =>
+         HasField "primitive_usi" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_usi")
+instance HasCField Primitive "primitive_usi"
+    where type CFieldType Primitive "primitive_usi" = CUShort
+          offset# = \_ -> \_ -> 14
 instance (~) ty CInt => HasField "primitive_i" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_i = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -599,12 +593,12 @@ instance (~) ty CInt => HasField "primitive_i" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_i" x_0)
-instance HasCField Primitive "primitive_s2"
-    where type CFieldType Primitive "primitive_s2" = CInt
-          offset# = \_ -> \_ -> 20
 instance (~) ty CInt =>
-         HasField "primitive_s2" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_s2")
+         HasField "primitive_i" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_i")
+instance HasCField Primitive "primitive_i"
+    where type CFieldType Primitive "primitive_i" = CInt
+          offset# = \_ -> \_ -> 16
 instance (~) ty CInt => HasField "primitive_s2" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_s2 = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -635,12 +629,12 @@ instance (~) ty CInt => HasField "primitive_s2" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_s2" x_0)
-instance HasCField Primitive "primitive_si2"
-    where type CFieldType Primitive "primitive_si2" = CInt
-          offset# = \_ -> \_ -> 24
 instance (~) ty CInt =>
-         HasField "primitive_si2" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_si2")
+         HasField "primitive_s2" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_s2")
+instance HasCField Primitive "primitive_s2"
+    where type CFieldType Primitive "primitive_s2" = CInt
+          offset# = \_ -> \_ -> 20
 instance (~) ty CInt => HasField "primitive_si2" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_si2 = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -671,12 +665,12 @@ instance (~) ty CInt => HasField "primitive_si2" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_si2" x_0)
-instance HasCField Primitive "primitive_u"
-    where type CFieldType Primitive "primitive_u" = CUInt
-          offset# = \_ -> \_ -> 28
-instance (~) ty CUInt =>
-         HasField "primitive_u" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_u")
+instance (~) ty CInt =>
+         HasField "primitive_si2" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_si2")
+instance HasCField Primitive "primitive_si2"
+    where type CFieldType Primitive "primitive_si2" = CInt
+          offset# = \_ -> \_ -> 24
 instance (~) ty CUInt => HasField "primitive_u" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_u = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -707,12 +701,12 @@ instance (~) ty CUInt => HasField "primitive_u" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_u" x_0)
-instance HasCField Primitive "primitive_ui"
-    where type CFieldType Primitive "primitive_ui" = CUInt
-          offset# = \_ -> \_ -> 32
 instance (~) ty CUInt =>
-         HasField "primitive_ui" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ui")
+         HasField "primitive_u" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_u")
+instance HasCField Primitive "primitive_u"
+    where type CFieldType Primitive "primitive_u" = CUInt
+          offset# = \_ -> \_ -> 28
 instance (~) ty CUInt => HasField "primitive_ui" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ui = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -743,12 +737,12 @@ instance (~) ty CUInt => HasField "primitive_ui" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ui" x_0)
-instance HasCField Primitive "primitive_l"
-    where type CFieldType Primitive "primitive_l" = CLong
-          offset# = \_ -> \_ -> 40
-instance (~) ty CLong =>
-         HasField "primitive_l" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_l")
+instance (~) ty CUInt =>
+         HasField "primitive_ui" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ui")
+instance HasCField Primitive "primitive_ui"
+    where type CFieldType Primitive "primitive_ui" = CUInt
+          offset# = \_ -> \_ -> 32
 instance (~) ty CLong => HasField "primitive_l" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_l = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -779,12 +773,12 @@ instance (~) ty CLong => HasField "primitive_l" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_l" x_0)
-instance HasCField Primitive "primitive_li"
-    where type CFieldType Primitive "primitive_li" = CLong
-          offset# = \_ -> \_ -> 48
 instance (~) ty CLong =>
-         HasField "primitive_li" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_li")
+         HasField "primitive_l" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_l")
+instance HasCField Primitive "primitive_l"
+    where type CFieldType Primitive "primitive_l" = CLong
+          offset# = \_ -> \_ -> 40
 instance (~) ty CLong => HasField "primitive_li" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_li = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -815,12 +809,12 @@ instance (~) ty CLong => HasField "primitive_li" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_li" x_0)
-instance HasCField Primitive "primitive_sl"
-    where type CFieldType Primitive "primitive_sl" = CLong
-          offset# = \_ -> \_ -> 56
 instance (~) ty CLong =>
-         HasField "primitive_sl" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_sl")
+         HasField "primitive_li" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_li")
+instance HasCField Primitive "primitive_li"
+    where type CFieldType Primitive "primitive_li" = CLong
+          offset# = \_ -> \_ -> 48
 instance (~) ty CLong => HasField "primitive_sl" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_sl = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -851,12 +845,12 @@ instance (~) ty CLong => HasField "primitive_sl" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_sl" x_0)
-instance HasCField Primitive "primitive_sli"
-    where type CFieldType Primitive "primitive_sli" = CLong
-          offset# = \_ -> \_ -> 64
 instance (~) ty CLong =>
-         HasField "primitive_sli" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_sli")
+         HasField "primitive_sl" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_sl")
+instance HasCField Primitive "primitive_sl"
+    where type CFieldType Primitive "primitive_sl" = CLong
+          offset# = \_ -> \_ -> 56
 instance (~) ty CLong => HasField "primitive_sli" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_sli = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -887,12 +881,12 @@ instance (~) ty CLong => HasField "primitive_sli" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_sli" x_0)
-instance HasCField Primitive "primitive_ul"
-    where type CFieldType Primitive "primitive_ul" = CULong
-          offset# = \_ -> \_ -> 72
-instance (~) ty CULong =>
-         HasField "primitive_ul" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ul")
+instance (~) ty CLong =>
+         HasField "primitive_sli" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_sli")
+instance HasCField Primitive "primitive_sli"
+    where type CFieldType Primitive "primitive_sli" = CLong
+          offset# = \_ -> \_ -> 64
 instance (~) ty CULong => HasField "primitive_ul" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ul = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -923,12 +917,12 @@ instance (~) ty CULong => HasField "primitive_ul" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ul" x_0)
-instance HasCField Primitive "primitive_uli"
-    where type CFieldType Primitive "primitive_uli" = CULong
-          offset# = \_ -> \_ -> 80
 instance (~) ty CULong =>
-         HasField "primitive_uli" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_uli")
+         HasField "primitive_ul" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ul")
+instance HasCField Primitive "primitive_ul"
+    where type CFieldType Primitive "primitive_ul" = CULong
+          offset# = \_ -> \_ -> 72
 instance (~) ty CULong => HasField "primitive_uli" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_uli = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -959,12 +953,12 @@ instance (~) ty CULong => HasField "primitive_uli" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_uli" x_0)
-instance HasCField Primitive "primitive_ll"
-    where type CFieldType Primitive "primitive_ll" = CLLong
-          offset# = \_ -> \_ -> 88
-instance (~) ty CLLong =>
-         HasField "primitive_ll" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ll")
+instance (~) ty CULong =>
+         HasField "primitive_uli" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_uli")
+instance HasCField Primitive "primitive_uli"
+    where type CFieldType Primitive "primitive_uli" = CULong
+          offset# = \_ -> \_ -> 80
 instance (~) ty CLLong => HasField "primitive_ll" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ll = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -995,12 +989,12 @@ instance (~) ty CLLong => HasField "primitive_ll" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ll" x_0)
-instance HasCField Primitive "primitive_lli"
-    where type CFieldType Primitive "primitive_lli" = CLLong
-          offset# = \_ -> \_ -> 96
 instance (~) ty CLLong =>
-         HasField "primitive_lli" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_lli")
+         HasField "primitive_ll" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ll")
+instance HasCField Primitive "primitive_ll"
+    where type CFieldType Primitive "primitive_ll" = CLLong
+          offset# = \_ -> \_ -> 88
 instance (~) ty CLLong => HasField "primitive_lli" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_lli = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1031,12 +1025,12 @@ instance (~) ty CLLong => HasField "primitive_lli" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_lli" x_0)
-instance HasCField Primitive "primitive_sll"
-    where type CFieldType Primitive "primitive_sll" = CLLong
-          offset# = \_ -> \_ -> 104
 instance (~) ty CLLong =>
-         HasField "primitive_sll" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_sll")
+         HasField "primitive_lli" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_lli")
+instance HasCField Primitive "primitive_lli"
+    where type CFieldType Primitive "primitive_lli" = CLLong
+          offset# = \_ -> \_ -> 96
 instance (~) ty CLLong => HasField "primitive_sll" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_sll = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1067,12 +1061,12 @@ instance (~) ty CLLong => HasField "primitive_sll" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_sll" x_0)
-instance HasCField Primitive "primitive_slli"
-    where type CFieldType Primitive "primitive_slli" = CLLong
-          offset# = \_ -> \_ -> 112
 instance (~) ty CLLong =>
-         HasField "primitive_slli" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_slli")
+         HasField "primitive_sll" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_sll")
+instance HasCField Primitive "primitive_sll"
+    where type CFieldType Primitive "primitive_sll" = CLLong
+          offset# = \_ -> \_ -> 104
 instance (~) ty CLLong => HasField "primitive_slli" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_slli = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1103,12 +1097,12 @@ instance (~) ty CLLong => HasField "primitive_slli" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_slli" x_0)
-instance HasCField Primitive "primitive_ull"
-    where type CFieldType Primitive "primitive_ull" = CULLong
-          offset# = \_ -> \_ -> 120
-instance (~) ty CULLong =>
-         HasField "primitive_ull" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ull")
+instance (~) ty CLLong =>
+         HasField "primitive_slli" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_slli")
+instance HasCField Primitive "primitive_slli"
+    where type CFieldType Primitive "primitive_slli" = CLLong
+          offset# = \_ -> \_ -> 112
 instance (~) ty CULLong => HasField "primitive_ull" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ull = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1139,12 +1133,12 @@ instance (~) ty CULLong => HasField "primitive_ull" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ull" x_0)
-instance HasCField Primitive "primitive_ulli"
-    where type CFieldType Primitive "primitive_ulli" = CULLong
-          offset# = \_ -> \_ -> 128
 instance (~) ty CULLong =>
-         HasField "primitive_ulli" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_ulli")
+         HasField "primitive_ull" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ull")
+instance HasCField Primitive "primitive_ull"
+    where type CFieldType Primitive "primitive_ull" = CULLong
+          offset# = \_ -> \_ -> 120
 instance (~) ty CULLong => HasField "primitive_ulli" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_ulli = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1175,12 +1169,12 @@ instance (~) ty CULLong => HasField "primitive_ulli" Primitive ty
                                                 primitive_f = getField @"primitive_f" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_ulli" x_0)
-instance HasCField Primitive "primitive_f"
-    where type CFieldType Primitive "primitive_f" = CFloat
-          offset# = \_ -> \_ -> 136
-instance (~) ty CFloat =>
-         HasField "primitive_f" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_f")
+instance (~) ty CULLong =>
+         HasField "primitive_ulli" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_ulli")
+instance HasCField Primitive "primitive_ulli"
+    where type CFieldType Primitive "primitive_ulli" = CULLong
+          offset# = \_ -> \_ -> 128
 instance (~) ty CFloat => HasField "primitive_f" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_f = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1211,12 +1205,12 @@ instance (~) ty CFloat => HasField "primitive_f" Primitive ty
                                                 primitive_ulli = getField @"primitive_ulli" x_0,
                                                 primitive_d = getField @"primitive_d" x_0},
                               getField @"primitive_f" x_0)
-instance HasCField Primitive "primitive_d"
-    where type CFieldType Primitive "primitive_d" = CDouble
-          offset# = \_ -> \_ -> 144
-instance (~) ty CDouble =>
-         HasField "primitive_d" (Ptr Primitive) (Ptr ty)
-    where getField = fromPtr (Proxy @"primitive_d")
+instance (~) ty CFloat =>
+         HasField "primitive_f" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_f")
+instance HasCField Primitive "primitive_f"
+    where type CFieldType Primitive "primitive_f" = CFloat
+          offset# = \_ -> \_ -> 136
 instance (~) ty CDouble => HasField "primitive_d" Primitive ty
     where hasField = \x_0 -> (\y_1 -> Primitive{primitive_d = y_1,
                                                 primitive_c = getField @"primitive_c" x_0,
@@ -1247,3 +1241,9 @@ instance (~) ty CDouble => HasField "primitive_d" Primitive ty
                                                 primitive_ulli = getField @"primitive_ulli" x_0,
                                                 primitive_f = getField @"primitive_f" x_0},
                               getField @"primitive_d" x_0)
+instance (~) ty CDouble =>
+         HasField "primitive_d" (Ptr Primitive) (Ptr ty)
+    where getField = fromPtr (Proxy @"primitive_d")
+instance HasCField Primitive "primitive_d"
+    where type CFieldType Primitive "primitive_d" = CDouble
+          offset# = \_ -> \_ -> 144

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/Example.hs
@@ -66,6 +66,12 @@ newtype I = I
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapI" I ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> I {unwrapI = y1}, RIP.getField @"unwrapI" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapI" (RIP.Ptr I) (RIP.Ptr ty) where
 
@@ -76,12 +82,6 @@ instance HasCField.HasCField I "unwrapI" where
   type CFieldType I "unwrapI" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapI" I ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> I {unwrapI = y1}, RIP.getField @"unwrapI" x0)
 
 {-| __C declaration:__ @struct S@
 
@@ -209,6 +209,12 @@ instance Read E where
 
   readListPrec = RIP.readListPrecDefault
 
+instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE" E ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
+
 instance ( ty ~ RIP.CUInt
          ) => RIP.HasField "unwrapE" (RIP.Ptr E) (RIP.Ptr ty) where
 
@@ -219,12 +225,6 @@ instance HasCField.HasCField E "unwrapE" where
   type CFieldType E "unwrapE" = RIP.CUInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CUInt) => RIP.CompatHasField.HasField "unwrapE" E ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> E {unwrapE = y1}, RIP.getField @"unwrapE" x0)
 
 {-| __C declaration:__ @foo@
 
@@ -263,6 +263,13 @@ newtype TI = TI
     , Marshal.WriteRaw
     )
 
+instance (ty ~ I) => RIP.CompatHasField.HasField "unwrapTI" TI ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TI {unwrapTI = y1}, RIP.getField @"unwrapTI" x0)
+
 instance (ty ~ I) => RIP.HasField "unwrapTI" (RIP.Ptr TI) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTI")
@@ -272,13 +279,6 @@ instance HasCField.HasCField TI "unwrapTI" where
   type CFieldType TI "unwrapTI" = I
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ I) => RIP.CompatHasField.HasField "unwrapTI" TI ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TI {unwrapTI = y1}, RIP.getField @"unwrapTI" x0)
 
 {-| __C declaration:__ @TS@
 
@@ -297,6 +297,13 @@ newtype TS = TS
     , Marshal.WriteRaw
     )
 
+instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapTS" TS ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TS {unwrapTS = y1}, RIP.getField @"unwrapTS" x0)
+
 instance (ty ~ S) => RIP.HasField "unwrapTS" (RIP.Ptr TS) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTS")
@@ -306,13 +313,6 @@ instance HasCField.HasCField TS "unwrapTS" where
   type CFieldType TS "unwrapTS" = S
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ S) => RIP.CompatHasField.HasField "unwrapTS" TS ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TS {unwrapTS = y1}, RIP.getField @"unwrapTS" x0)
 
 {-| __C declaration:__ @TU@
 
@@ -331,6 +331,13 @@ newtype TU = TU
     , Marshal.WriteRaw
     )
 
+instance (ty ~ U) => RIP.CompatHasField.HasField "unwrapTU" TU ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TU {unwrapTU = y1}, RIP.getField @"unwrapTU" x0)
+
 instance (ty ~ U) => RIP.HasField "unwrapTU" (RIP.Ptr TU) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTU")
@@ -340,13 +347,6 @@ instance HasCField.HasCField TU "unwrapTU" where
   type CFieldType TU "unwrapTU" = U
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ U) => RIP.CompatHasField.HasField "unwrapTU" TU ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TU {unwrapTU = y1}, RIP.getField @"unwrapTU" x0)
 
 {-| __C declaration:__ @TE@
 
@@ -367,6 +367,13 @@ newtype TE = TE
     , Marshal.WriteRaw
     )
 
+instance (ty ~ E) => RIP.CompatHasField.HasField "unwrapTE" TE ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TE {unwrapTE = y1}, RIP.getField @"unwrapTE" x0)
+
 instance (ty ~ E) => RIP.HasField "unwrapTE" (RIP.Ptr TE) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTE")
@@ -376,13 +383,6 @@ instance HasCField.HasCField TE "unwrapTE" where
   type CFieldType TE "unwrapTE" = E
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ E) => RIP.CompatHasField.HasField "unwrapTE" TE ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TE {unwrapTE = y1}, RIP.getField @"unwrapTE" x0)
 
 {-| __C declaration:__ @TTI@
 
@@ -412,6 +412,13 @@ newtype TTI = TTI
     , Marshal.WriteRaw
     )
 
+instance (ty ~ TI) => RIP.CompatHasField.HasField "unwrapTTI" TTI ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TTI {unwrapTTI = y1}, RIP.getField @"unwrapTTI" x0)
+
 instance (ty ~ TI) => RIP.HasField "unwrapTTI" (RIP.Ptr TTI) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTI")
@@ -421,13 +428,6 @@ instance HasCField.HasCField TTI "unwrapTTI" where
   type CFieldType TTI "unwrapTTI" = TI
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ TI) => RIP.CompatHasField.HasField "unwrapTTI" TTI ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TTI {unwrapTTI = y1}, RIP.getField @"unwrapTTI" x0)
 
 {-| __C declaration:__ @TTS@
 
@@ -446,6 +446,13 @@ newtype TTS = TTS
     , Marshal.WriteRaw
     )
 
+instance (ty ~ TS) => RIP.CompatHasField.HasField "unwrapTTS" TTS ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TTS {unwrapTTS = y1}, RIP.getField @"unwrapTTS" x0)
+
 instance (ty ~ TS) => RIP.HasField "unwrapTTS" (RIP.Ptr TTS) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTS")
@@ -455,13 +462,6 @@ instance HasCField.HasCField TTS "unwrapTTS" where
   type CFieldType TTS "unwrapTTS" = TS
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ TS) => RIP.CompatHasField.HasField "unwrapTTS" TTS ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TTS {unwrapTTS = y1}, RIP.getField @"unwrapTTS" x0)
 
 {-| __C declaration:__ @TTU@
 
@@ -480,6 +480,13 @@ newtype TTU = TTU
     , Marshal.WriteRaw
     )
 
+instance (ty ~ TU) => RIP.CompatHasField.HasField "unwrapTTU" TTU ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TTU {unwrapTTU = y1}, RIP.getField @"unwrapTTU" x0)
+
 instance (ty ~ TU) => RIP.HasField "unwrapTTU" (RIP.Ptr TTU) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTU")
@@ -489,13 +496,6 @@ instance HasCField.HasCField TTU "unwrapTTU" where
   type CFieldType TTU "unwrapTTU" = TU
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ TU) => RIP.CompatHasField.HasField "unwrapTTU" TTU ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TTU {unwrapTTU = y1}, RIP.getField @"unwrapTTU" x0)
 
 {-| __C declaration:__ @TTE@
 
@@ -516,6 +516,13 @@ newtype TTE = TTE
     , Marshal.WriteRaw
     )
 
+instance (ty ~ TE) => RIP.CompatHasField.HasField "unwrapTTE" TTE ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         TTE {unwrapTTE = y1}, RIP.getField @"unwrapTTE" x0)
+
 instance (ty ~ TE) => RIP.HasField "unwrapTTE" (RIP.Ptr TTE) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapTTE")
@@ -525,10 +532,3 @@ instance HasCField.HasCField TTE "unwrapTTE" where
   type CFieldType TTE "unwrapTTE" = TE
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ TE) => RIP.CompatHasField.HasField "unwrapTTE" TTE ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         TTE {unwrapTTE = y1}, RIP.getField @"unwrapTTE" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
@@ -48,12 +48,13 @@ hstypes:
       - unwrapE
   instances:
   - CEnum
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -73,7 +74,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -81,6 +81,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -113,12 +115,13 @@ hstypes:
       fields:
       - unwrapTE
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -137,7 +140,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -145,6 +147,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -164,11 +168,12 @@ hstypes:
       fields:
       - unwrapTS
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -181,12 +186,13 @@ hstypes:
       fields:
       - unwrapTTE
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - Prim
   - Read
@@ -205,7 +211,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -213,6 +218,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -232,11 +239,12 @@ hstypes:
       fields:
       - unwrapTTS
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -249,10 +257,11 @@ hstypes:
       fields:
       - unwrapTTU
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -264,10 +273,11 @@ hstypes:
       fields:
       - unwrapTU
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/th.txt
@@ -96,14 +96,14 @@ newtype I
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapI" I ty
+    where hasField = \x_0 -> (\y_1 -> I{unwrapI = y_1},
+                              getField @"unwrapI" x_0)
 instance (~) ty CInt => HasField "unwrapI" (Ptr I) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapI")
 instance HasCField I "unwrapI"
     where type CFieldType I "unwrapI" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapI" I ty
-    where hasField = \x_0 -> (\y_1 -> I{unwrapI = y_1},
-                              getField @"unwrapI" x_0)
 {-| __C declaration:__ @struct S@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 11:8@
@@ -170,14 +170,14 @@ instance Read E
     where readPrec = readPrec
           readList = readListDefault
           readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapE" E ty
+    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
+                              getField @"unwrapE" x_0)
 instance (~) ty CUInt => HasField "unwrapE" (Ptr E) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapE")
 instance HasCField E "unwrapE"
     where type CFieldType E "unwrapE" = CUInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CUInt => HasField "unwrapE" E ty
-    where hasField = \x_0 -> (\y_1 -> E{unwrapE = y_1},
-                              getField @"unwrapE" x_0)
 {-| __C declaration:__ @foo@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 13:9@
@@ -210,14 +210,14 @@ newtype TI
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty I => HasField "unwrapTI" TI ty
+    where hasField = \x_0 -> (\y_1 -> TI{unwrapTI = y_1},
+                              getField @"unwrapTI" x_0)
 instance (~) ty I => HasField "unwrapTI" (Ptr TI) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTI")
 instance HasCField TI "unwrapTI"
     where type CFieldType TI "unwrapTI" = I
           offset# = \_ -> \_ -> 0
-instance (~) ty I => HasField "unwrapTI" TI ty
-    where hasField = \x_0 -> (\y_1 -> TI{unwrapTI = y_1},
-                              getField @"unwrapTI" x_0)
 {-| __C declaration:__ @TS@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 21:24@
@@ -228,14 +228,14 @@ newtype TS
     = TS {unwrapTS :: S}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty S => HasField "unwrapTS" TS ty
+    where hasField = \x_0 -> (\y_1 -> TS{unwrapTS = y_1},
+                              getField @"unwrapTS" x_0)
 instance (~) ty S => HasField "unwrapTS" (Ptr TS) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTS")
 instance HasCField TS "unwrapTS"
     where type CFieldType TS "unwrapTS" = S
           offset# = \_ -> \_ -> 0
-instance (~) ty S => HasField "unwrapTS" TS ty
-    where hasField = \x_0 -> (\y_1 -> TS{unwrapTS = y_1},
-                              getField @"unwrapTS" x_0)
 {-| __C declaration:__ @TU@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 22:23@
@@ -246,14 +246,14 @@ newtype TU
     = TU {unwrapTU :: U}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty U => HasField "unwrapTU" TU ty
+    where hasField = \x_0 -> (\y_1 -> TU{unwrapTU = y_1},
+                              getField @"unwrapTU" x_0)
 instance (~) ty U => HasField "unwrapTU" (Ptr TU) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTU")
 instance HasCField TU "unwrapTU"
     where type CFieldType TU "unwrapTU" = U
           offset# = \_ -> \_ -> 0
-instance (~) ty U => HasField "unwrapTU" TU ty
-    where hasField = \x_0 -> (\y_1 -> TU{unwrapTU = y_1},
-                              getField @"unwrapTU" x_0)
 {-| __C declaration:__ @TE@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 23:22@
@@ -269,14 +269,14 @@ newtype TE
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty E => HasField "unwrapTE" TE ty
+    where hasField = \x_0 -> (\y_1 -> TE{unwrapTE = y_1},
+                              getField @"unwrapTE" x_0)
 instance (~) ty E => HasField "unwrapTE" (Ptr TE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTE")
 instance HasCField TE "unwrapTE"
     where type CFieldType TE "unwrapTE" = E
           offset# = \_ -> \_ -> 0
-instance (~) ty E => HasField "unwrapTE" TE ty
-    where hasField = \x_0 -> (\y_1 -> TE{unwrapTE = y_1},
-                              getField @"unwrapTE" x_0)
 {-| __C declaration:__ @TTI@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 30:12@
@@ -301,14 +301,14 @@ newtype TTI
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty TI => HasField "unwrapTTI" TTI ty
+    where hasField = \x_0 -> (\y_1 -> TTI{unwrapTTI = y_1},
+                              getField @"unwrapTTI" x_0)
 instance (~) ty TI => HasField "unwrapTTI" (Ptr TTI) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTI")
 instance HasCField TTI "unwrapTTI"
     where type CFieldType TTI "unwrapTTI" = TI
           offset# = \_ -> \_ -> 0
-instance (~) ty TI => HasField "unwrapTTI" TTI ty
-    where hasField = \x_0 -> (\y_1 -> TTI{unwrapTTI = y_1},
-                              getField @"unwrapTTI" x_0)
 {-| __C declaration:__ @TTS@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 31:12@
@@ -319,14 +319,14 @@ newtype TTS
     = TTS {unwrapTTS :: TS}
     deriving stock (Eq, Generic, Show)
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty TS => HasField "unwrapTTS" TTS ty
+    where hasField = \x_0 -> (\y_1 -> TTS{unwrapTTS = y_1},
+                              getField @"unwrapTTS" x_0)
 instance (~) ty TS => HasField "unwrapTTS" (Ptr TTS) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTS")
 instance HasCField TTS "unwrapTTS"
     where type CFieldType TTS "unwrapTTS" = TS
           offset# = \_ -> \_ -> 0
-instance (~) ty TS => HasField "unwrapTTS" TTS ty
-    where hasField = \x_0 -> (\y_1 -> TTS{unwrapTTS = y_1},
-                              getField @"unwrapTTS" x_0)
 {-| __C declaration:__ @TTU@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 32:12@
@@ -337,14 +337,14 @@ newtype TTU
     = TTU {unwrapTTU :: TU}
     deriving stock Generic
     deriving newtype (ReadRaw, StaticSize, Storable, WriteRaw)
+instance (~) ty TU => HasField "unwrapTTU" TTU ty
+    where hasField = \x_0 -> (\y_1 -> TTU{unwrapTTU = y_1},
+                              getField @"unwrapTTU" x_0)
 instance (~) ty TU => HasField "unwrapTTU" (Ptr TTU) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTU")
 instance HasCField TTU "unwrapTTU"
     where type CFieldType TTU "unwrapTTU" = TU
           offset# = \_ -> \_ -> 0
-instance (~) ty TU => HasField "unwrapTTU" TTU ty
-    where hasField = \x_0 -> (\y_1 -> TTU{unwrapTTU = y_1},
-                              getField @"unwrapTTU" x_0)
 {-| __C declaration:__ @TTE@
 
     __defined at:__ @types\/qualifiers\/const_typedefs.h 33:12@
@@ -360,14 +360,14 @@ newtype TTE
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty TE => HasField "unwrapTTE" TTE ty
+    where hasField = \x_0 -> (\y_1 -> TTE{unwrapTTE = y_1},
+                              getField @"unwrapTTE" x_0)
 instance (~) ty TE => HasField "unwrapTTE" (Ptr TTE) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapTTE")
 instance HasCField TTE "unwrapTTE"
     where type CFieldType TTE "unwrapTTE" = TE
           offset# = \_ -> \_ -> 0
-instance (~) ty TE => HasField "unwrapTTE" TTE ty
-    where hasField = \x_0 -> (\y_1 -> TTE{unwrapTTE = y_1},
-                              getField @"unwrapTTE" x_0)
 -- __unique:__ @test_typesqualifiersconst_typedef_Example_get_i@
 foreign import ccall unsafe "hs_bindgen_bb40525ba9109d7a" hs_bindgen_bb40525ba9109d7a_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/Example.hs
@@ -63,18 +63,6 @@ instance Marshal.WriteRaw Baz where
 
 deriving via Marshal.EquivStorable Baz instance RIP.Storable Baz
 
-instance HasCField.HasCField Baz "baz_x1_2_1" where
-
-  type CFieldType Baz "baz_x1_2_1" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_x1_2_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"baz_x1_2_1")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "baz_x1_2_1" Baz ty where
 
@@ -82,3 +70,15 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Baz {baz_x1_2_1 = y1}, RIP.getField @"baz_x1_2_1" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "baz_x1_2_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"baz_x1_2_1")
+
+instance HasCField.HasCField Baz "baz_x1_2_1" where
+
+  type CFieldType Baz "baz_x1_2_1" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - baz_x1_2_1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/deep_nesting/th.txt
@@ -30,14 +30,14 @@ instance WriteRaw Baz
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Baz baz_x1_2_1_2 -> writeRaw (Proxy @"baz_x1_2_1") ptr_0 baz_x1_2_1_2
 deriving via (EquivStorable Baz) instance Storable Baz
-instance HasCField Baz "baz_x1_2_1"
-    where type CFieldType Baz "baz_x1_2_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "baz_x1_2_1" (Ptr Baz) (Ptr ty)
-    where getField = fromPtr (Proxy @"baz_x1_2_1")
 instance (~) ty CInt => HasField "baz_x1_2_1" Baz ty
     where hasField = \x_0 -> (\y_1 -> Baz{baz_x1_2_1 = y_1},
                               getField @"baz_x1_2_1" x_0)
+instance (~) ty CInt => HasField "baz_x1_2_1" (Ptr Baz) (Ptr ty)
+    where getField = fromPtr (Proxy @"baz_x1_2_1")
+instance HasCField Baz "baz_x1_2_1"
+    where type CFieldType Baz "baz_x1_2_1" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_typesscopingdeep_nesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_d6029a840689b228" hs_bindgen_d6029a840689b228_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/Example.hs
@@ -67,20 +67,20 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCField.HasCField Bar "bar_x1_1" where
-
-  type CFieldType Bar "bar_x1_1" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_x1_1" (RIP.Ptr Bar) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"bar_x1_1")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "bar_x1_1" Bar ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          Bar {bar_x1_1 = y1}, RIP.getField @"bar_x1_1" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_x1_1" (RIP.Ptr Bar) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"bar_x1_1")
+
+instance HasCField.HasCField Bar "bar_x1_1" where
+
+  type CFieldType Bar "bar_x1_1" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - bar_x1_1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/nesting/th.txt
@@ -34,14 +34,14 @@ instance WriteRaw Bar
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Bar bar_x1_1_2 -> writeRaw (Proxy @"bar_x1_1") ptr_0 bar_x1_1_2
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCField Bar "bar_x1_1"
-    where type CFieldType Bar "bar_x1_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "bar_x1_1" (Ptr Bar) (Ptr ty)
-    where getField = fromPtr (Proxy @"bar_x1_1")
 instance (~) ty CInt => HasField "bar_x1_1" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_x1_1 = y_1},
                               getField @"bar_x1_1" x_0)
+instance (~) ty CInt => HasField "bar_x1_1" (Ptr Bar) (Ptr ty)
+    where getField = fromPtr (Proxy @"bar_x1_1")
+instance HasCField Bar "bar_x1_1"
+    where type CFieldType Bar "bar_x1_1" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_typesscopingnesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_7640032abd722ca9" hs_bindgen_7640032abd722ca9_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/Example.hs
@@ -63,20 +63,20 @@ instance Marshal.WriteRaw Baz where
 
 deriving via Marshal.EquivStorable Baz instance RIP.Storable Baz
 
-instance HasCField.HasCField Baz "baz_x3_1" where
-
-  type CFieldType Baz "baz_x3_1" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "baz_x3_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"baz_x3_1")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "baz_x3_1" Baz ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          Baz {baz_x3_1 = y1}, RIP.getField @"baz_x3_1" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "baz_x3_1" (RIP.Ptr Baz) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"baz_x3_1")
+
+instance HasCField.HasCField Baz "baz_x3_1" where
+
+  type CFieldType Baz "baz_x3_1" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - baz_x3_1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/scoping/wide_nesting/th.txt
@@ -30,14 +30,14 @@ instance WriteRaw Baz
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Baz baz_x3_1_2 -> writeRaw (Proxy @"baz_x3_1") ptr_0 baz_x3_1_2
 deriving via (EquivStorable Baz) instance Storable Baz
-instance HasCField Baz "baz_x3_1"
-    where type CFieldType Baz "baz_x3_1" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "baz_x3_1" (Ptr Baz) (Ptr ty)
-    where getField = fromPtr (Proxy @"baz_x3_1")
 instance (~) ty CInt => HasField "baz_x3_1" Baz ty
     where hasField = \x_0 -> (\y_1 -> Baz{baz_x3_1 = y_1},
                               getField @"baz_x3_1" x_0)
+instance (~) ty CInt => HasField "baz_x3_1" (Ptr Baz) (Ptr ty)
+    where getField = fromPtr (Proxy @"baz_x3_1")
+instance HasCField Baz "baz_x3_1"
+    where type CFieldType Baz "baz_x3_1" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_typesscopingwide_nesting_Example_get_X@
 foreign import ccall unsafe "hs_bindgen_a295757aed8ccce9" hs_bindgen_a295757aed8ccce9_base ::
     IO (Ptr Void)

--- a/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/Example.hs
@@ -63,17 +63,6 @@ instance Marshal.WriteRaw Struct2 where
 
 deriving via Marshal.EquivStorable Struct2 instance RIP.Storable Struct2
 
-instance HasCField.HasCField Struct2 "struct2_x" where
-
-  type CFieldType Struct2 "struct2_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "struct2_x" (RIP.Ptr Struct2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"struct2_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "struct2_x" Struct2 ty where
 
@@ -81,3 +70,14 @@ instance ( ty ~ RIP.CInt
     \x0 ->
       (\y1 ->
          Struct2 {struct2_x = y1}, RIP.getField @"struct2_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "struct2_x" (RIP.Ptr Struct2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"struct2_x")
+
+instance HasCField.HasCField Struct2 "struct2_x" where
+
+  type CFieldType Struct2 "struct2_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - struct2_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/parse_failure_long_double/th.txt
@@ -44,14 +44,14 @@ instance WriteRaw Struct2
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Struct2 struct2_x_2 -> writeRaw (Proxy @"struct2_x") ptr_0 struct2_x_2
 deriving via (EquivStorable Struct2) instance Storable Struct2
-instance HasCField Struct2 "struct2_x"
-    where type CFieldType Struct2 "struct2_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "struct2_x" (Ptr Struct2) (Ptr ty)
-    where getField = fromPtr (Proxy @"struct2_x")
 instance (~) ty CInt => HasField "struct2_x" Struct2 ty
     where hasField = \x_0 -> (\y_1 -> Struct2{struct2_x = y_1},
                               getField @"struct2_x" x_0)
+instance (~) ty CInt => HasField "struct2_x" (Ptr Struct2) (Ptr ty)
+    where getField = fromPtr (Proxy @"struct2_x")
+instance HasCField Struct2 "struct2_x"
+    where type CFieldType Struct2 "struct2_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_typesspecialparse_failure_lo_Example_Safe_fun2@
 foreign import ccall safe "hs_bindgen_a1252a3becef09a6" hs_bindgen_a1252a3becef09a6_base ::
     Int32

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/Example.hs
@@ -78,17 +78,6 @@ instance Marshal.WriteRaw S1_c where
 
 deriving via Marshal.EquivStorable S1_c instance RIP.Storable S1_c
 
-instance HasCField.HasCField S1_c "s1_c_a" where
-
-  type CFieldType S1_c "s1_c_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_c_a" (RIP.Ptr S1_c) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_c_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_c_a" S1_c ty where
 
   hasField =
@@ -98,16 +87,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_c_a" S1_c ty where
       , RIP.getField @"s1_c_a" x0
       )
 
-instance HasCField.HasCField S1_c "s1_c_b" where
-
-  type CFieldType S1_c "s1_c_b" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s1_c_b" (RIP.Ptr S1_c) (RIP.Ptr ty) where
+         ) => RIP.HasField "s1_c_a" (RIP.Ptr S1_c) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_c_b")
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_c_a")
+
+instance HasCField.HasCField S1_c "s1_c_a" where
+
+  type CFieldType S1_c "s1_c_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_c_b" S1_c ty where
 
@@ -117,6 +106,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_c_b" S1_c ty where
           S1_c {s1_c_b = y1, s1_c_a = RIP.getField @"s1_c_a" x0}
       , RIP.getField @"s1_c_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s1_c_b" (RIP.Ptr S1_c) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_c_b")
+
+instance HasCField.HasCField S1_c "s1_c_b" where
+
+  type CFieldType S1_c "s1_c_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S1@
 
@@ -168,16 +168,6 @@ instance Marshal.WriteRaw S1 where
 
 deriving via Marshal.EquivStorable S1 instance RIP.Storable S1
 
-instance HasCField.HasCField S1 "s1_c" where
-
-  type CFieldType S1 "s1_c" = S1_c
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ S1_c) => RIP.HasField "s1_c" (RIP.Ptr S1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_c")
-
 instance (ty ~ S1_c) => RIP.CompatHasField.HasField "s1_c" S1 ty where
 
   hasField =
@@ -187,15 +177,15 @@ instance (ty ~ S1_c) => RIP.CompatHasField.HasField "s1_c" S1 ty where
       , RIP.getField @"s1_c" x0
       )
 
-instance HasCField.HasCField S1 "s1_d" where
+instance (ty ~ S1_c) => RIP.HasField "s1_c" (RIP.Ptr S1) (RIP.Ptr ty) where
 
-  type CFieldType S1 "s1_d" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_c")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S1 "s1_c" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_d" (RIP.Ptr S1) (RIP.Ptr ty) where
+  type CFieldType S1 "s1_c" = S1_c
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_d")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_d" S1 ty where
 
@@ -205,6 +195,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_d" S1 ty where
           S1 {s1_d = y1, s1_c = RIP.getField @"s1_c" x0}
       , RIP.getField @"s1_d" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s1_d" (RIP.Ptr S1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_d")
+
+instance HasCField.HasCField S1 "s1_d" where
+
+  type CFieldType S1 "s1_d" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@S2_inner_deep@
 
@@ -247,19 +247,6 @@ instance Marshal.WriteRaw S2_inner_deep where
 
 deriving via Marshal.EquivStorable S2_inner_deep instance RIP.Storable S2_inner_deep
 
-instance HasCField.HasCField S2_inner_deep "s2_inner_deep_b" where
-
-  type CFieldType S2_inner_deep "s2_inner_deep_b" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_inner_deep_b" (RIP.Ptr S2_inner_deep) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_inner_deep_b")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s2_inner_deep_b" S2_inner_deep ty where
 
@@ -268,6 +255,19 @@ instance ( ty ~ RIP.CInt
       ( \y1 -> S2_inner_deep {s2_inner_deep_b = y1}
       , RIP.getField @"s2_inner_deep_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s2_inner_deep_b" (RIP.Ptr S2_inner_deep) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s2_inner_deep_b")
+
+instance HasCField.HasCField S2_inner_deep "s2_inner_deep_b" where
+
+  type CFieldType S2_inner_deep "s2_inner_deep_b" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct \@S2_inner@
 
@@ -319,18 +319,6 @@ instance Marshal.WriteRaw S2_inner where
 
 deriving via Marshal.EquivStorable S2_inner instance RIP.Storable S2_inner
 
-instance HasCField.HasCField S2_inner "s2_inner_a" where
-
-  type CFieldType S2_inner "s2_inner_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_inner_a" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_inner_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s2_inner_a" S2_inner ty where
 
@@ -341,18 +329,17 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"s2_inner_a" x0
       )
 
-instance HasCField.HasCField S2_inner "s2_inner_deep" where
-
-  type CFieldType S2_inner "s2_inner_deep" =
-    S2_inner_deep
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ S2_inner_deep
-         ) => RIP.HasField "s2_inner_deep" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s2_inner_a" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"s2_inner_deep")
+    HasCField.fromPtr (RIP.Proxy @"s2_inner_a")
+
+instance HasCField.HasCField S2_inner "s2_inner_a" where
+
+  type CFieldType S2_inner "s2_inner_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ S2_inner_deep
          ) => RIP.CompatHasField.HasField "s2_inner_deep" S2_inner ty where
@@ -363,6 +350,19 @@ instance ( ty ~ S2_inner_deep
           S2_inner {s2_inner_deep = y1, s2_inner_a = RIP.getField @"s2_inner_a" x0}
       , RIP.getField @"s2_inner_deep" x0
       )
+
+instance ( ty ~ S2_inner_deep
+         ) => RIP.HasField "s2_inner_deep" (RIP.Ptr S2_inner) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"s2_inner_deep")
+
+instance HasCField.HasCField S2_inner "s2_inner_deep" where
+
+  type CFieldType S2_inner "s2_inner_deep" =
+    S2_inner_deep
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S2@
 
@@ -414,17 +414,6 @@ instance Marshal.WriteRaw S2 where
 
 deriving via Marshal.EquivStorable S2 instance RIP.Storable S2
 
-instance HasCField.HasCField S2 "s2_inner" where
-
-  type CFieldType S2 "s2_inner" = S2_inner
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ S2_inner
-         ) => RIP.HasField "s2_inner" (RIP.Ptr S2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_inner")
-
 instance (ty ~ S2_inner) => RIP.CompatHasField.HasField "s2_inner" S2 ty where
 
   hasField =
@@ -434,15 +423,16 @@ instance (ty ~ S2_inner) => RIP.CompatHasField.HasField "s2_inner" S2 ty where
       , RIP.getField @"s2_inner" x0
       )
 
-instance HasCField.HasCField S2 "s2_d" where
+instance ( ty ~ S2_inner
+         ) => RIP.HasField "s2_inner" (RIP.Ptr S2) (RIP.Ptr ty) where
 
-  type CFieldType S2 "s2_d" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_inner")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S2 "s2_inner" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s2_d" (RIP.Ptr S2) (RIP.Ptr ty) where
+  type CFieldType S2 "s2_inner" = S2_inner
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_d")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_d" S2 ty where
 
@@ -452,6 +442,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_d" S2 ty where
           S2 {s2_d = y1, s2_inner = RIP.getField @"s2_inner" x0}
       , RIP.getField @"s2_d" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s2_d" (RIP.Ptr S2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_d")
+
+instance HasCField.HasCField S2 "s2_d" where
+
+  type CFieldType S2 "s2_d" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S3@
 
@@ -503,17 +503,6 @@ instance Marshal.WriteRaw S3 where
 
 deriving via Marshal.EquivStorable S3 instance RIP.Storable S3
 
-instance HasCField.HasCField S3 "s3_c" where
-
-  type CFieldType S3 "s3_c" = RIP.Ptr (RIP.Ptr S3_c)
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr S3_c)
-         ) => RIP.HasField "s3_c" (RIP.Ptr S3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_c")
-
 instance ( ty ~ RIP.Ptr (RIP.Ptr S3_c)
          ) => RIP.CompatHasField.HasField "s3_c" S3 ty where
 
@@ -524,15 +513,16 @@ instance ( ty ~ RIP.Ptr (RIP.Ptr S3_c)
       , RIP.getField @"s3_c" x0
       )
 
-instance HasCField.HasCField S3 "s3_d" where
+instance ( ty ~ RIP.Ptr (RIP.Ptr S3_c)
+         ) => RIP.HasField "s3_c" (RIP.Ptr S3) (RIP.Ptr ty) where
 
-  type CFieldType S3 "s3_d" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_c")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S3 "s3_c" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s3_d" (RIP.Ptr S3) (RIP.Ptr ty) where
+  type CFieldType S3 "s3_c" = RIP.Ptr (RIP.Ptr S3_c)
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_d")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_d" S3 ty where
 
@@ -542,6 +532,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_d" S3 ty where
           S3 {s3_d = y1, s3_c = RIP.getField @"s3_c" x0}
       , RIP.getField @"s3_d" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s3_d" (RIP.Ptr S3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_d")
+
+instance HasCField.HasCField S3 "s3_d" where
+
+  type CFieldType S3 "s3_d" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@S3_c@
 
@@ -593,17 +593,6 @@ instance Marshal.WriteRaw S3_c where
 
 deriving via Marshal.EquivStorable S3_c instance RIP.Storable S3_c
 
-instance HasCField.HasCField S3_c "s3_c_a" where
-
-  type CFieldType S3_c "s3_c_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s3_c_a" (RIP.Ptr S3_c) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_c_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_c_a" S3_c ty where
 
   hasField =
@@ -613,16 +602,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_c_a" S3_c ty where
       , RIP.getField @"s3_c_a" x0
       )
 
-instance HasCField.HasCField S3_c "s3_c_b" where
-
-  type CFieldType S3_c "s3_c_b" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s3_c_b" (RIP.Ptr S3_c) (RIP.Ptr ty) where
+         ) => RIP.HasField "s3_c_a" (RIP.Ptr S3_c) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_c_b")
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_c_a")
+
+instance HasCField.HasCField S3_c "s3_c_a" where
+
+  type CFieldType S3_c "s3_c_a" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_c_b" S3_c ty where
 
@@ -632,3 +621,14 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s3_c_b" S3_c ty where
           S3_c {s3_c_b = y1, s3_c_a = RIP.getField @"s3_c_a" x0}
       , RIP.getField @"s3_c_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s3_c_b" (RIP.Ptr S3_c) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_c_b")
+
+instance HasCField.HasCField S3_c "s3_c_b" where
+
+  type CFieldType S3_c "s3_c_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/bindingspec.yaml
@@ -33,11 +33,12 @@ hstypes:
       - s1_c
       - s1_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -51,11 +52,12 @@ hstypes:
       - s1_c_a
       - s1_c_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -69,11 +71,12 @@ hstypes:
       - s2_inner
       - s2_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -87,11 +90,12 @@ hstypes:
       - s2_inner_a
       - s2_inner_deep
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -104,11 +108,12 @@ hstypes:
       fields:
       - s2_inner_deep_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -122,11 +127,12 @@ hstypes:
       - s3_c
       - s3_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -140,11 +146,12 @@ hstypes:
       - s3_c_a
       - s3_c_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/anonymous/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw S1_c
                                        S1_c s1_c_a_2
                                             s1_c_b_3 -> writeRaw (Proxy @"s1_c_a") ptr_0 s1_c_a_2 >> writeRaw (Proxy @"s1_c_b") ptr_0 s1_c_b_3
 deriving via (EquivStorable S1_c) instance Storable S1_c
-instance HasCField S1_c "s1_c_a"
-    where type CFieldType S1_c "s1_c_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_c_a" (Ptr S1_c) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_c_a")
 instance (~) ty CInt => HasField "s1_c_a" S1_c ty
     where hasField = \x_0 -> (\y_1 -> S1_c{s1_c_a = y_1,
                                            s1_c_b = getField @"s1_c_b" x_0},
                               getField @"s1_c_a" x_0)
-instance HasCField S1_c "s1_c_b"
-    where type CFieldType S1_c "s1_c_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s1_c_b" (Ptr S1_c) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_c_b")
+instance (~) ty CInt => HasField "s1_c_a" (Ptr S1_c) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_c_a")
+instance HasCField S1_c "s1_c_a"
+    where type CFieldType S1_c "s1_c_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s1_c_b" S1_c ty
     where hasField = \x_0 -> (\y_1 -> S1_c{s1_c_b = y_1,
                                            s1_c_a = getField @"s1_c_a" x_0},
                               getField @"s1_c_b" x_0)
+instance (~) ty CInt => HasField "s1_c_b" (Ptr S1_c) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_c_b")
+instance HasCField S1_c "s1_c_b"
+    where type CFieldType S1_c "s1_c_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S1@
 
     __defined at:__ @types\/structs\/anonymous.h 2:8@
@@ -81,24 +81,24 @@ instance WriteRaw S1
                                        S1 s1_c_2
                                           s1_d_3 -> writeRaw (Proxy @"s1_c") ptr_0 s1_c_2 >> writeRaw (Proxy @"s1_d") ptr_0 s1_d_3
 deriving via (EquivStorable S1) instance Storable S1
-instance HasCField S1 "s1_c"
-    where type CFieldType S1 "s1_c" = S1_c
-          offset# = \_ -> \_ -> 0
-instance (~) ty S1_c => HasField "s1_c" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_c")
 instance (~) ty S1_c => HasField "s1_c" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_c = y_1,
                                          s1_d = getField @"s1_d" x_0},
                               getField @"s1_c" x_0)
-instance HasCField S1 "s1_d"
-    where type CFieldType S1 "s1_d" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s1_d" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_d")
+instance (~) ty S1_c => HasField "s1_c" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_c")
+instance HasCField S1 "s1_c"
+    where type CFieldType S1 "s1_c" = S1_c
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s1_d" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_d = y_1,
                                          s1_c = getField @"s1_c" x_0},
                               getField @"s1_d" x_0)
+instance (~) ty CInt => HasField "s1_d" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_d")
+instance HasCField S1 "s1_d"
+    where type CFieldType S1 "s1_d" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@S2_inner_deep@
 
     __defined at:__ @types\/structs\/anonymous.h 15:5@
@@ -123,15 +123,15 @@ instance WriteRaw S2_inner_deep
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S2_inner_deep s2_inner_deep_b_2 -> writeRaw (Proxy @"s2_inner_deep_b") ptr_0 s2_inner_deep_b_2
 deriving via (EquivStorable S2_inner_deep) instance Storable S2_inner_deep
-instance HasCField S2_inner_deep "s2_inner_deep_b"
-    where type CFieldType S2_inner_deep "s2_inner_deep_b" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_inner_deep_b")
 instance (~) ty CInt => HasField "s2_inner_deep_b" S2_inner_deep ty
     where hasField = \x_0 -> (\y_1 -> S2_inner_deep{s2_inner_deep_b = y_1},
                               getField @"s2_inner_deep_b" x_0)
+instance (~) ty CInt =>
+         HasField "s2_inner_deep_b" (Ptr S2_inner_deep) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_inner_deep_b")
+instance HasCField S2_inner_deep "s2_inner_deep_b"
+    where type CFieldType S2_inner_deep "s2_inner_deep_b" = CInt
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S2_inner@
 
     __defined at:__ @types\/structs\/anonymous.h 13:3@
@@ -164,27 +164,27 @@ instance WriteRaw S2_inner
                                        S2_inner s2_inner_a_2
                                                 s2_inner_deep_3 -> writeRaw (Proxy @"s2_inner_a") ptr_0 s2_inner_a_2 >> writeRaw (Proxy @"s2_inner_deep") ptr_0 s2_inner_deep_3
 deriving via (EquivStorable S2_inner) instance Storable S2_inner
-instance HasCField S2_inner "s2_inner_a"
-    where type CFieldType S2_inner "s2_inner_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "s2_inner_a" (Ptr S2_inner) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_inner_a")
 instance (~) ty CInt => HasField "s2_inner_a" S2_inner ty
     where hasField = \x_0 -> (\y_1 -> S2_inner{s2_inner_a = y_1,
                                                s2_inner_deep = getField @"s2_inner_deep" x_0},
                               getField @"s2_inner_a" x_0)
-instance HasCField S2_inner "s2_inner_deep"
-    where type CFieldType S2_inner "s2_inner_deep" = S2_inner_deep
-          offset# = \_ -> \_ -> 4
-instance (~) ty S2_inner_deep =>
-         HasField "s2_inner_deep" (Ptr S2_inner) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_inner_deep")
+instance (~) ty CInt =>
+         HasField "s2_inner_a" (Ptr S2_inner) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_inner_a")
+instance HasCField S2_inner "s2_inner_a"
+    where type CFieldType S2_inner "s2_inner_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty S2_inner_deep =>
          HasField "s2_inner_deep" S2_inner ty
     where hasField = \x_0 -> (\y_1 -> S2_inner{s2_inner_deep = y_1,
                                                s2_inner_a = getField @"s2_inner_a" x_0},
                               getField @"s2_inner_deep" x_0)
+instance (~) ty S2_inner_deep =>
+         HasField "s2_inner_deep" (Ptr S2_inner) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_inner_deep")
+instance HasCField S2_inner "s2_inner_deep"
+    where type CFieldType S2_inner "s2_inner_deep" = S2_inner_deep
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @types\/structs\/anonymous.h 12:8@
@@ -217,24 +217,24 @@ instance WriteRaw S2
                                        S2 s2_inner_2
                                           s2_d_3 -> writeRaw (Proxy @"s2_inner") ptr_0 s2_inner_2 >> writeRaw (Proxy @"s2_d") ptr_0 s2_d_3
 deriving via (EquivStorable S2) instance Storable S2
-instance HasCField S2 "s2_inner"
-    where type CFieldType S2 "s2_inner" = S2_inner
-          offset# = \_ -> \_ -> 0
-instance (~) ty S2_inner => HasField "s2_inner" (Ptr S2) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_inner")
 instance (~) ty S2_inner => HasField "s2_inner" S2 ty
     where hasField = \x_0 -> (\y_1 -> S2{s2_inner = y_1,
                                          s2_d = getField @"s2_d" x_0},
                               getField @"s2_inner" x_0)
-instance HasCField S2 "s2_d"
-    where type CFieldType S2 "s2_d" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s2_d" (Ptr S2) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_d")
+instance (~) ty S2_inner => HasField "s2_inner" (Ptr S2) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_inner")
+instance HasCField S2 "s2_inner"
+    where type CFieldType S2 "s2_inner" = S2_inner
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s2_d" S2 ty
     where hasField = \x_0 -> (\y_1 -> S2{s2_d = y_1,
                                          s2_inner = getField @"s2_inner" x_0},
                               getField @"s2_d" x_0)
+instance (~) ty CInt => HasField "s2_d" (Ptr S2) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_d")
+instance HasCField S2 "s2_d"
+    where type CFieldType S2 "s2_d" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S3@
 
     __defined at:__ @types\/structs\/anonymous.h 24:8@
@@ -267,25 +267,25 @@ instance WriteRaw S3
                                        S3 s3_c_2
                                           s3_d_3 -> writeRaw (Proxy @"s3_c") ptr_0 s3_c_2 >> writeRaw (Proxy @"s3_d") ptr_0 s3_d_3
 deriving via (EquivStorable S3) instance Storable S3
-instance HasCField S3 "s3_c"
-    where type CFieldType S3 "s3_c" = Ptr (Ptr S3_c)
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr S3_c)) =>
-         HasField "s3_c" (Ptr S3) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_c")
 instance (~) ty (Ptr (Ptr S3_c)) => HasField "s3_c" S3 ty
     where hasField = \x_0 -> (\y_1 -> S3{s3_c = y_1,
                                          s3_d = getField @"s3_d" x_0},
                               getField @"s3_c" x_0)
-instance HasCField S3 "s3_d"
-    where type CFieldType S3 "s3_d" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "s3_d" (Ptr S3) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_d")
+instance (~) ty (Ptr (Ptr S3_c)) =>
+         HasField "s3_c" (Ptr S3) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_c")
+instance HasCField S3 "s3_c"
+    where type CFieldType S3 "s3_c" = Ptr (Ptr S3_c)
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s3_d" S3 ty
     where hasField = \x_0 -> (\y_1 -> S3{s3_d = y_1,
                                          s3_c = getField @"s3_c" x_0},
                               getField @"s3_d" x_0)
+instance (~) ty CInt => HasField "s3_d" (Ptr S3) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_d")
+instance HasCField S3 "s3_d"
+    where type CFieldType S3 "s3_d" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@S3_c@
 
     __defined at:__ @types\/structs\/anonymous.h 25:3@
@@ -318,21 +318,21 @@ instance WriteRaw S3_c
                                        S3_c s3_c_a_2
                                             s3_c_b_3 -> writeRaw (Proxy @"s3_c_a") ptr_0 s3_c_a_2 >> writeRaw (Proxy @"s3_c_b") ptr_0 s3_c_b_3
 deriving via (EquivStorable S3_c) instance Storable S3_c
-instance HasCField S3_c "s3_c_a"
-    where type CFieldType S3_c "s3_c_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s3_c_a" (Ptr S3_c) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_c_a")
 instance (~) ty CInt => HasField "s3_c_a" S3_c ty
     where hasField = \x_0 -> (\y_1 -> S3_c{s3_c_a = y_1,
                                            s3_c_b = getField @"s3_c_b" x_0},
                               getField @"s3_c_a" x_0)
-instance HasCField S3_c "s3_c_b"
-    where type CFieldType S3_c "s3_c_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s3_c_b" (Ptr S3_c) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_c_b")
+instance (~) ty CInt => HasField "s3_c_a" (Ptr S3_c) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_c_a")
+instance HasCField S3_c "s3_c_a"
+    where type CFieldType S3_c "s3_c_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s3_c_b" S3_c ty
     where hasField = \x_0 -> (\y_1 -> S3_c{s3_c_b = y_1,
                                            s3_c_a = getField @"s3_c_a" x_0},
                               getField @"s3_c_b" x_0)
+instance (~) ty CInt => HasField "s3_c_b" (Ptr S3_c) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_c_b")
+instance HasCField S3_c "s3_c_b"
+    where type CFieldType S3_c "s3_c_b" = CInt
+          offset# = \_ -> \_ -> 4

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/Example.hs
@@ -122,19 +122,6 @@ instance Marshal.WriteRaw Foo_8 where
 
 deriving via Marshal.EquivStorable Foo_8 instance RIP.Storable Foo_8
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_a" where
-
-  type CBitfieldType Foo_8 "foo_8_a" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_a" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_a")
-
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_a" Foo_8 ty where
 
@@ -151,18 +138,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_8_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_b" where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_8_a" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_8 "foo_8_b" = RIP.CSChar
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_a")
 
-  bitfieldOffset# = \_ -> \_ -> 3
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_a" where
+
+  type CBitfieldType Foo_8 "foo_8_a" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
 
   bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_b" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_b")
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_b" Foo_8 ty where
@@ -180,18 +167,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_8_b" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_c" where
-
-  type CBitfieldType Foo_8 "foo_8_c" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 6
-
-  bitfieldWidth# = \_ -> \_ -> 2
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_c" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_8_b" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_c")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_b")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_b" where
+
+  type CBitfieldType Foo_8 "foo_8_b" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 3
+
+  bitfieldWidth# = \_ -> \_ -> 3
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_c" Foo_8 ty where
@@ -209,18 +196,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_8_c" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_d" where
-
-  type CBitfieldType Foo_8 "foo_8_d" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 8
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_d" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_8_c" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_d")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_c")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_c" where
+
+  type CBitfieldType Foo_8 "foo_8_c" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 2
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_d" Foo_8 ty where
@@ -238,18 +225,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_8_d" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_e" where
-
-  type CBitfieldType Foo_8 "foo_8_e" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 16
-
-  bitfieldWidth# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_e" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_8_d" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_e")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_d")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_d" where
+
+  type CBitfieldType Foo_8 "foo_8_d" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 8
+
+  bitfieldWidth# = \_ -> \_ -> 3
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_e" Foo_8 ty where
@@ -267,18 +254,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_8_e" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_8 "foo_8_f" where
-
-  type CBitfieldType Foo_8 "foo_8_f" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 24
-
-  bitfieldWidth# = \_ -> \_ -> 5
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_8_f" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_8_e" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_f")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_e")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_e" where
+
+  type CBitfieldType Foo_8 "foo_8_e" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 16
+
+  bitfieldWidth# = \_ -> \_ -> 8
 
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_8_f" Foo_8 ty where
@@ -295,6 +282,19 @@ instance ( ty ~ RIP.CSChar
                 }
       , RIP.getField @"foo_8_f" x0
       )
+
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_8_f" (RIP.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_8_f")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_f" where
+
+  type CBitfieldType Foo_8 "foo_8_f" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 24
+
+  bitfieldWidth# = \_ -> \_ -> 5
 
 {-| __C declaration:__ @struct foo_16@
 
@@ -382,19 +382,6 @@ instance Marshal.WriteRaw Foo_16 where
 
 deriving via Marshal.EquivStorable Foo_16 instance RIP.Storable Foo_16
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_a" where
-
-  type CBitfieldType Foo_16 "foo_16_a" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 6
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_16_a" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_a")
-
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_16_a" Foo_16 ty where
 
@@ -411,18 +398,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_16_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_b" where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_16_a" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_16 "foo_16_b" = RIP.CInt
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_a")
 
-  bitfieldOffset# = \_ -> \_ -> 6
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_a" where
 
-  bitfieldWidth# = \_ -> \_ -> 10
+  type CBitfieldType Foo_16 "foo_16_a" = RIP.CSChar
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_b" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 0
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_b")
+  bitfieldWidth# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_16_b" Foo_16 ty where
@@ -440,18 +427,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_16_b" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_c" where
-
-  type CBitfieldType Foo_16 "foo_16_c" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 16
-
-  bitfieldWidth# = \_ -> \_ -> 16
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_c" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_16_b" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_c")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_b")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_b" where
+
+  type CBitfieldType Foo_16 "foo_16_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 10
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_16_c" Foo_16 ty where
@@ -469,18 +456,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_16_c" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_d" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_16_c" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_16 "foo_16_d" = RIP.CInt
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_c")
 
-  bitfieldOffset# = \_ -> \_ -> 32
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_c" where
+
+  type CBitfieldType Foo_16 "foo_16_c" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 16
 
   bitfieldWidth# = \_ -> \_ -> 16
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_d" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_d")
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_16_d" Foo_16 ty where
@@ -498,18 +485,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_16_d" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_e" where
-
-  type CBitfieldType Foo_16 "foo_16_e" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 48
-
-  bitfieldWidth# = \_ -> \_ -> 12
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_e" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_16_d" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_e")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_d")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_d" where
+
+  type CBitfieldType Foo_16 "foo_16_d" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 32
+
+  bitfieldWidth# = \_ -> \_ -> 16
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_16_e" Foo_16 ty where
@@ -527,18 +514,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_16_e" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_16 "foo_16_f" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_16_e" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_16 "foo_16_f" = RIP.CInt
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_e")
 
-  bitfieldOffset# = \_ -> \_ -> 64
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_e" where
+
+  type CBitfieldType Foo_16 "foo_16_e" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 48
 
   bitfieldWidth# = \_ -> \_ -> 12
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_16_f" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_f")
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_16_f" Foo_16 ty where
@@ -555,6 +542,19 @@ instance ( ty ~ RIP.CInt
                  }
       , RIP.getField @"foo_16_f" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_16_f" (RIP.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_16_f")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_f" where
+
+  type CBitfieldType Foo_16 "foo_16_f" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 64
+
+  bitfieldWidth# = \_ -> \_ -> 12
 
 {-| __C declaration:__ @struct foo_32@
 
@@ -651,19 +651,6 @@ instance Marshal.WriteRaw Foo_32 where
 
 deriving via Marshal.EquivStorable Foo_32 instance RIP.Storable Foo_32
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_a" where
-
-  type CBitfieldType Foo_32 "foo_32_a" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 6
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_32_a" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_a")
-
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "foo_32_a" Foo_32 ty where
 
@@ -681,18 +668,18 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"foo_32_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_b" where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_32_a" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_32 "foo_32_b" = RIP.CInt
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_a")
 
-  bitfieldOffset# = \_ -> \_ -> 6
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_a" where
 
-  bitfieldWidth# = \_ -> \_ -> 12
+  type CBitfieldType Foo_32 "foo_32_a" = RIP.CSChar
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_b" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 0
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_b")
+  bitfieldWidth# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_32_b" Foo_32 ty where
@@ -711,18 +698,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_32_b" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_c" where
-
-  type CBitfieldType Foo_32 "foo_32_c" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 18
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_c" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_32_b" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_c")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_b")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_b" where
+
+  type CBitfieldType Foo_32 "foo_32_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 12
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_32_c" Foo_32 ty where
@@ -741,18 +728,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_32_c" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_d" where
-
-  type CBitfieldType Foo_32 "foo_32_d" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 32
-
-  bitfieldWidth# = \_ -> \_ -> 10
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_d" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_32_c" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_d")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_c")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_c" where
+
+  type CBitfieldType Foo_32 "foo_32_c" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 18
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_32_d" Foo_32 ty where
@@ -771,18 +758,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_32_d" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_e" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_32_d" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_32 "foo_32_e" = RIP.CLong
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_d")
 
-  bitfieldOffset# = \_ -> \_ -> 64
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_d" where
 
-  bitfieldWidth# = \_ -> \_ -> 32
+  type CBitfieldType Foo_32 "foo_32_d" = RIP.CInt
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_32_e" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 32
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_e")
+  bitfieldWidth# = \_ -> \_ -> 10
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "foo_32_e" Foo_32 ty where
@@ -801,18 +788,18 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"foo_32_e" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_f" where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "foo_32_e" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_32 "foo_32_f" = RIP.CInt
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_e")
 
-  bitfieldOffset# = \_ -> \_ -> 96
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_e" where
 
-  bitfieldWidth# = \_ -> \_ -> 6
+  type CBitfieldType Foo_32 "foo_32_e" = RIP.CLong
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "foo_32_f" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 64
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_f")
+  bitfieldWidth# = \_ -> \_ -> 32
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "foo_32_f" Foo_32 ty where
@@ -831,18 +818,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"foo_32_f" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_32 "foo_32_g" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "foo_32_f" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_32 "foo_32_g" = RIP.CLong
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_f")
 
-  bitfieldOffset# = \_ -> \_ -> 102
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_f" where
 
-  bitfieldWidth# = \_ -> \_ -> 24
+  type CBitfieldType Foo_32 "foo_32_f" = RIP.CInt
 
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_32_g" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 96
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_g")
+  bitfieldWidth# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "foo_32_g" Foo_32 ty where
@@ -860,6 +847,19 @@ instance ( ty ~ RIP.CLong
                  }
       , RIP.getField @"foo_32_g" x0
       )
+
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "foo_32_g" (RIP.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_32_g")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_g" where
+
+  type CBitfieldType Foo_32 "foo_32_g" = RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 102
+
+  bitfieldWidth# = \_ -> \_ -> 24
 
 {-| __C declaration:__ @struct foo_64@
 
@@ -929,19 +929,6 @@ instance Marshal.WriteRaw Foo_64 where
 
 deriving via Marshal.EquivStorable Foo_64 instance RIP.Storable Foo_64
 
-instance HasCBitfield.HasCBitfield Foo_64 "foo_64_a" where
-
-  type CBitfieldType Foo_64 "foo_64_a" = RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 24
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "foo_64_a" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_a")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "foo_64_a" Foo_64 ty where
 
@@ -956,18 +943,18 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"foo_64_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_64 "foo_64_b" where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "foo_64_a" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo_64 "foo_64_b" = RIP.CLLong
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_a")
 
-  bitfieldOffset# = \_ -> \_ -> 24
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_a" where
 
-  bitfieldWidth# = \_ -> \_ -> 40
+  type CBitfieldType Foo_64 "foo_64_a" = RIP.CLong
 
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_b" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+  bitfieldOffset# = \_ -> \_ -> 0
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_b")
+  bitfieldWidth# = \_ -> \_ -> 24
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "foo_64_b" Foo_64 ty where
@@ -983,18 +970,18 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"foo_64_b" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_64 "foo_64_c" where
-
-  type CBitfieldType Foo_64 "foo_64_c" = RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 64
-
-  bitfieldWidth# = \_ -> \_ -> 64
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_c" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_64_b" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_c")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_b")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_b" where
+
+  type CBitfieldType Foo_64 "foo_64_b" = RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 24
+
+  bitfieldWidth# = \_ -> \_ -> 40
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "foo_64_c" Foo_64 ty where
@@ -1010,18 +997,18 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"foo_64_c" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo_64 "foo_64_d" where
-
-  type CBitfieldType Foo_64 "foo_64_d" = RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 128
-
-  bitfieldWidth# = \_ -> \_ -> 36
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "foo_64_d" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_64_c" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_d")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_c")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_c" where
+
+  type CBitfieldType Foo_64 "foo_64_c" = RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 64
+
+  bitfieldWidth# = \_ -> \_ -> 64
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "foo_64_d" Foo_64 ty where
@@ -1036,6 +1023,19 @@ instance ( ty ~ RIP.CLLong
                  }
       , RIP.getField @"foo_64_d" x0
       )
+
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "foo_64_d" (RIP.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_64_d")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_d" where
+
+  type CBitfieldType Foo_64 "foo_64_d" = RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 128
+
+  bitfieldWidth# = \_ -> \_ -> 36
 
 {-| __C declaration:__ @struct bar_8_8@
 
@@ -1087,20 +1087,6 @@ instance Marshal.WriteRaw Bar_8_8 where
 
 deriving via Marshal.EquivStorable Bar_8_8 instance RIP.Storable Bar_8_8
 
-instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_a" where
-
-  type CBitfieldType Bar_8_8 "bar_8_8_a" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 6
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_8_8_a" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_a")
-
 instance ( ty ~ RIP.CSChar
          ) => RIP.CompatHasField.HasField "bar_8_8_a" Bar_8_8 ty where
 
@@ -1111,19 +1097,19 @@ instance ( ty ~ RIP.CSChar
       , RIP.getField @"bar_8_8_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_b" where
-
-  type CBitfieldType Bar_8_8 "bar_8_8_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 6
-
-  bitfieldWidth# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_8_b" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "bar_8_8_a" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_a")
+
+instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_a" where
+
+  type CBitfieldType Bar_8_8 "bar_8_8_a" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_8_8_b" Bar_8_8 ty where
@@ -1134,6 +1120,20 @@ instance ( ty ~ RIP.CInt
           Bar_8_8 {bar_8_8_b = y1, bar_8_8_a = RIP.getField @"bar_8_8_a" x0}
       , RIP.getField @"bar_8_8_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_8_8_b" (RIP.Ptr Bar_8_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_8_b")
+
+instance HasCBitfield.HasCBitfield Bar_8_8 "bar_8_8_b" where
+
+  type CBitfieldType Bar_8_8 "bar_8_8_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct bar_8_16@
 
@@ -1185,20 +1185,6 @@ instance Marshal.WriteRaw Bar_8_16 where
 
 deriving via Marshal.EquivStorable Bar_8_16 instance RIP.Storable Bar_8_16
 
-instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_a" where
-
-  type CBitfieldType Bar_8_16 "bar_8_16_a" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_16_a" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_8_16_a" Bar_8_16 ty where
 
@@ -1209,19 +1195,19 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"bar_8_16_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_b" where
-
-  type CBitfieldType Bar_8_16 "bar_8_16_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 14
-
-  bitfieldWidth# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_16_b" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bar_8_16_a" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_a")
+
+instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_a" where
+
+  type CBitfieldType Bar_8_16 "bar_8_16_a" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_8_16_b" Bar_8_16 ty where
@@ -1232,6 +1218,20 @@ instance ( ty ~ RIP.CInt
           Bar_8_16 {bar_8_16_b = y1, bar_8_16_a = RIP.getField @"bar_8_16_a" x0}
       , RIP.getField @"bar_8_16_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_8_16_b" (RIP.Ptr Bar_8_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_16_b")
+
+instance HasCBitfield.HasCBitfield Bar_8_16 "bar_8_16_b" where
+
+  type CBitfieldType Bar_8_16 "bar_8_16_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 14
+
+  bitfieldWidth# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct bar_8_32@
 
@@ -1283,20 +1283,6 @@ instance Marshal.WriteRaw Bar_8_32 where
 
 deriving via Marshal.EquivStorable Bar_8_32 instance RIP.Storable Bar_8_32
 
-instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_a" where
-
-  type CBitfieldType Bar_8_32 "bar_8_32_a" = RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 30
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_8_32_a" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_a")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "bar_8_32_a" Bar_8_32 ty where
 
@@ -1307,19 +1293,19 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"bar_8_32_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_b" where
-
-  type CBitfieldType Bar_8_32 "bar_8_32_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 30
-
-  bitfieldWidth# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_32_b" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "bar_8_32_a" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_a")
+
+instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_a" where
+
+  type CBitfieldType Bar_8_32 "bar_8_32_a" = RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 30
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_8_32_b" Bar_8_32 ty where
@@ -1330,6 +1316,20 @@ instance ( ty ~ RIP.CInt
           Bar_8_32 {bar_8_32_b = y1, bar_8_32_a = RIP.getField @"bar_8_32_a" x0}
       , RIP.getField @"bar_8_32_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_8_32_b" (RIP.Ptr Bar_8_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_32_b")
+
+instance HasCBitfield.HasCBitfield Bar_8_32 "bar_8_32_b" where
+
+  type CBitfieldType Bar_8_32 "bar_8_32_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 30
+
+  bitfieldWidth# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct bar_8_64@
 
@@ -1381,20 +1381,6 @@ instance Marshal.WriteRaw Bar_8_64 where
 
 deriving via Marshal.EquivStorable Bar_8_64 instance RIP.Storable Bar_8_64
 
-instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_a" where
-
-  type CBitfieldType Bar_8_64 "bar_8_64_a" = RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 62
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_8_64_a" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_a")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "bar_8_64_a" Bar_8_64 ty where
 
@@ -1405,19 +1391,19 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"bar_8_64_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_b" where
-
-  type CBitfieldType Bar_8_64 "bar_8_64_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 62
-
-  bitfieldWidth# = \_ -> \_ -> 4
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_8_64_b" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "bar_8_64_a" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_a")
+
+instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_a" where
+
+  type CBitfieldType Bar_8_64 "bar_8_64_a" = RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 62
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_8_64_b" Bar_8_64 ty where
@@ -1428,6 +1414,20 @@ instance ( ty ~ RIP.CInt
           Bar_8_64 {bar_8_64_b = y1, bar_8_64_a = RIP.getField @"bar_8_64_a" x0}
       , RIP.getField @"bar_8_64_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_8_64_b" (RIP.Ptr Bar_8_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_8_64_b")
+
+instance HasCBitfield.HasCBitfield Bar_8_64 "bar_8_64_b" where
+
+  type CBitfieldType Bar_8_64 "bar_8_64_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 62
+
+  bitfieldWidth# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct bar_16_16@
 
@@ -1479,20 +1479,6 @@ instance Marshal.WriteRaw Bar_16_16 where
 
 deriving via Marshal.EquivStorable Bar_16_16 instance RIP.Storable Bar_16_16
 
-instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_a" where
-
-  type CBitfieldType Bar_16_16 "bar_16_16_a" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_16_a" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_a")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_16_16_a" Bar_16_16 ty where
 
@@ -1503,19 +1489,19 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"bar_16_16_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_b" where
-
-  type CBitfieldType Bar_16_16 "bar_16_16_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 14
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_16_b" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bar_16_16_a" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_a")
+
+instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_a" where
+
+  type CBitfieldType Bar_16_16 "bar_16_16_a" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_16_16_b" Bar_16_16 ty where
@@ -1526,6 +1512,20 @@ instance ( ty ~ RIP.CInt
           Bar_16_16 {bar_16_16_b = y1, bar_16_16_a = RIP.getField @"bar_16_16_a" x0}
       , RIP.getField @"bar_16_16_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_16_16_b" (RIP.Ptr Bar_16_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_16_b")
+
+instance HasCBitfield.HasCBitfield Bar_16_16 "bar_16_16_b" where
+
+  type CBitfieldType Bar_16_16 "bar_16_16_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 14
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 {-| __C declaration:__ @struct bar_16_32@
 
@@ -1577,21 +1577,6 @@ instance Marshal.WriteRaw Bar_16_32 where
 
 deriving via Marshal.EquivStorable Bar_16_32 instance RIP.Storable Bar_16_32
 
-instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_a" where
-
-  type CBitfieldType Bar_16_32 "bar_16_32_a" =
-    RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 24
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_16_32_a" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_a")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "bar_16_32_a" Bar_16_32 ty where
 
@@ -1602,19 +1587,20 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"bar_16_32_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_b" where
-
-  type CBitfieldType Bar_16_32 "bar_16_32_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 24
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_32_b" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "bar_16_32_a" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_a")
+
+instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_a" where
+
+  type CBitfieldType Bar_16_32 "bar_16_32_a" =
+    RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 24
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_16_32_b" Bar_16_32 ty where
@@ -1625,6 +1611,20 @@ instance ( ty ~ RIP.CInt
           Bar_16_32 {bar_16_32_b = y1, bar_16_32_a = RIP.getField @"bar_16_32_a" x0}
       , RIP.getField @"bar_16_32_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_16_32_b" (RIP.Ptr Bar_16_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_32_b")
+
+instance HasCBitfield.HasCBitfield Bar_16_32 "bar_16_32_b" where
+
+  type CBitfieldType Bar_16_32 "bar_16_32_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 24
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 {-| __C declaration:__ @struct bar_16_64@
 
@@ -1676,21 +1676,6 @@ instance Marshal.WriteRaw Bar_16_64 where
 
 deriving via Marshal.EquivStorable Bar_16_64 instance RIP.Storable Bar_16_64
 
-instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_a" where
-
-  type CBitfieldType Bar_16_64 "bar_16_64_a" =
-    RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 56
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_16_64_a" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_a")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "bar_16_64_a" Bar_16_64 ty where
 
@@ -1701,19 +1686,20 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"bar_16_64_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_b" where
-
-  type CBitfieldType Bar_16_64 "bar_16_64_b" = RIP.CInt
-
-  bitfieldOffset# = \_ -> \_ -> 56
-
-  bitfieldWidth# = \_ -> \_ -> 14
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "bar_16_64_b" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "bar_16_64_a" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_a")
+
+instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_a" where
+
+  type CBitfieldType Bar_16_64 "bar_16_64_a" =
+    RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 56
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "bar_16_64_b" Bar_16_64 ty where
@@ -1724,6 +1710,20 @@ instance ( ty ~ RIP.CInt
           Bar_16_64 {bar_16_64_b = y1, bar_16_64_a = RIP.getField @"bar_16_64_a" x0}
       , RIP.getField @"bar_16_64_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "bar_16_64_b" (RIP.Ptr Bar_16_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_16_64_b")
+
+instance HasCBitfield.HasCBitfield Bar_16_64 "bar_16_64_b" where
+
+  type CBitfieldType Bar_16_64 "bar_16_64_b" = RIP.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 56
+
+  bitfieldWidth# = \_ -> \_ -> 14
 
 {-| __C declaration:__ @struct bar_32_32@
 
@@ -1775,21 +1775,6 @@ instance Marshal.WriteRaw Bar_32_32 where
 
 deriving via Marshal.EquivStorable Bar_32_32 instance RIP.Storable Bar_32_32
 
-instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_a" where
-
-  type CBitfieldType Bar_32_32 "bar_32_32_a" =
-    RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 30
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_32_a" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_a")
-
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "bar_32_32_a" Bar_32_32 ty where
 
@@ -1800,20 +1785,20 @@ instance ( ty ~ RIP.CLong
       , RIP.getField @"bar_32_32_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_b" where
-
-  type CBitfieldType Bar_32_32 "bar_32_32_b" =
-    RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 30
-
-  bitfieldWidth# = \_ -> \_ -> 30
-
 instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_32_b" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bar_32_32_a" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_a")
+
+instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_a" where
+
+  type CBitfieldType Bar_32_32 "bar_32_32_a" =
+    RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 30
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "bar_32_32_b" Bar_32_32 ty where
@@ -1824,6 +1809,21 @@ instance ( ty ~ RIP.CLong
           Bar_32_32 {bar_32_32_b = y1, bar_32_32_a = RIP.getField @"bar_32_32_a" x0}
       , RIP.getField @"bar_32_32_b" x0
       )
+
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "bar_32_32_b" (RIP.Ptr Bar_32_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_32_32_b")
+
+instance HasCBitfield.HasCBitfield Bar_32_32 "bar_32_32_b" where
+
+  type CBitfieldType Bar_32_32 "bar_32_32_b" =
+    RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 30
+
+  bitfieldWidth# = \_ -> \_ -> 30
 
 {-| __C declaration:__ @struct bar_32_64@
 
@@ -1875,21 +1875,6 @@ instance Marshal.WriteRaw Bar_32_64 where
 
 deriving via Marshal.EquivStorable Bar_32_64 instance RIP.Storable Bar_32_64
 
-instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_a" where
-
-  type CBitfieldType Bar_32_64 "bar_32_64_a" =
-    RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 56
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_32_64_a" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_a")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "bar_32_64_a" Bar_32_64 ty where
 
@@ -1900,20 +1885,20 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"bar_32_64_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_b" where
-
-  type CBitfieldType Bar_32_64 "bar_32_64_b" =
-    RIP.CLong
-
-  bitfieldOffset# = \_ -> \_ -> 56
-
-  bitfieldWidth# = \_ -> \_ -> 30
-
-instance ( ty ~ RIP.CLong
-         ) => RIP.HasField "bar_32_64_b" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "bar_32_64_a" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_a")
+
+instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_a" where
+
+  type CBitfieldType Bar_32_64 "bar_32_64_a" =
+    RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 56
 
 instance ( ty ~ RIP.CLong
          ) => RIP.CompatHasField.HasField "bar_32_64_b" Bar_32_64 ty where
@@ -1924,6 +1909,21 @@ instance ( ty ~ RIP.CLong
           Bar_32_64 {bar_32_64_b = y1, bar_32_64_a = RIP.getField @"bar_32_64_a" x0}
       , RIP.getField @"bar_32_64_b" x0
       )
+
+instance ( ty ~ RIP.CLong
+         ) => RIP.HasField "bar_32_64_b" (RIP.Ptr Bar_32_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_32_64_b")
+
+instance HasCBitfield.HasCBitfield Bar_32_64 "bar_32_64_b" where
+
+  type CBitfieldType Bar_32_64 "bar_32_64_b" =
+    RIP.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 56
+
+  bitfieldWidth# = \_ -> \_ -> 30
 
 {-| __C declaration:__ @struct bar_64_64@
 
@@ -1975,21 +1975,6 @@ instance Marshal.WriteRaw Bar_64_64 where
 
 deriving via Marshal.EquivStorable Bar_64_64 instance RIP.Storable Bar_64_64
 
-instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_a" where
-
-  type CBitfieldType Bar_64_64 "bar_64_64_a" =
-    RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 56
-
-instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_64_64_a" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_a")
-
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "bar_64_64_a" Bar_64_64 ty where
 
@@ -2000,20 +1985,20 @@ instance ( ty ~ RIP.CLLong
       , RIP.getField @"bar_64_64_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_b" where
-
-  type CBitfieldType Bar_64_64 "bar_64_64_b" =
-    RIP.CLLong
-
-  bitfieldOffset# = \_ -> \_ -> 56
-
-  bitfieldWidth# = \_ -> \_ -> 40
-
 instance ( ty ~ RIP.CLLong
-         ) => RIP.HasField "bar_64_64_b" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bar_64_64_a" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
 
   getField =
-    HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_b")
+    HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_a")
+
+instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_a" where
+
+  type CBitfieldType Bar_64_64 "bar_64_64_a" =
+    RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 56
 
 instance ( ty ~ RIP.CLLong
          ) => RIP.CompatHasField.HasField "bar_64_64_b" Bar_64_64 ty where
@@ -2024,3 +2009,18 @@ instance ( ty ~ RIP.CLLong
           Bar_64_64 {bar_64_64_b = y1, bar_64_64_a = RIP.getField @"bar_64_64_a" x0}
       , RIP.getField @"bar_64_64_b" x0
       )
+
+instance ( ty ~ RIP.CLLong
+         ) => RIP.HasField "bar_64_64_b" (RIP.Ptr Bar_64_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (RIP.Proxy @"bar_64_64_b")
+
+instance HasCBitfield.HasCBitfield Bar_64_64 "bar_64_64_b" where
+
+  type CBitfieldType Bar_64_64 "bar_64_64_b" =
+    RIP.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 56
+
+  bitfieldWidth# = \_ -> \_ -> 40

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/bindingspec.yaml
@@ -54,11 +54,12 @@ hstypes:
       - bar_16_16_a
       - bar_16_16_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -72,11 +73,12 @@ hstypes:
       - bar_16_32_a
       - bar_16_32_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +92,12 @@ hstypes:
       - bar_16_64_a
       - bar_16_64_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -108,11 +111,12 @@ hstypes:
       - bar_32_32_a
       - bar_32_32_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -126,11 +130,12 @@ hstypes:
       - bar_32_64_a
       - bar_32_64_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -144,11 +149,12 @@ hstypes:
       - bar_64_64_a
       - bar_64_64_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -162,11 +168,12 @@ hstypes:
       - bar_8_16_a
       - bar_8_16_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -180,11 +187,12 @@ hstypes:
       - bar_8_32_a
       - bar_8_32_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -198,11 +206,12 @@ hstypes:
       - bar_8_64_a
       - bar_8_64_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -216,11 +225,12 @@ hstypes:
       - bar_8_8_a
       - bar_8_8_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -238,11 +248,12 @@ hstypes:
       - foo_16_e
       - foo_16_f
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -261,11 +272,12 @@ hstypes:
       - foo_32_f
       - foo_32_g
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -281,11 +293,12 @@ hstypes:
       - foo_64_c
       - foo_64_d
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -303,11 +316,12 @@ hstypes:
       - foo_8_e
       - foo_8_f
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/bitfields/th.txt
@@ -63,13 +63,6 @@ instance WriteRaw Foo_8
                                              foo_8_e_6
                                              foo_8_f_7 -> poke (Proxy @"foo_8_a") ptr_0 foo_8_a_2 >> (poke (Proxy @"foo_8_b") ptr_0 foo_8_b_3 >> (poke (Proxy @"foo_8_c") ptr_0 foo_8_c_4 >> (poke (Proxy @"foo_8_d") ptr_0 foo_8_d_5 >> (poke (Proxy @"foo_8_e") ptr_0 foo_8_e_6 >> poke (Proxy @"foo_8_f") ptr_0 foo_8_f_7))))
 deriving via (EquivStorable Foo_8) instance Storable Foo_8
-instance HasCBitfield Foo_8 "foo_8_a"
-    where type CBitfieldType Foo_8 "foo_8_a" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_8_a" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_a")
 instance (~) ty CSChar => HasField "foo_8_a" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_a = y_1,
                                             foo_8_b = getField @"foo_8_b" x_0,
@@ -78,13 +71,13 @@ instance (~) ty CSChar => HasField "foo_8_a" Foo_8 ty
                                             foo_8_e = getField @"foo_8_e" x_0,
                                             foo_8_f = getField @"foo_8_f" x_0},
                               getField @"foo_8_a" x_0)
-instance HasCBitfield Foo_8 "foo_8_b"
-    where type CBitfieldType Foo_8 "foo_8_b" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 3
-          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar =>
-         HasField "foo_8_b" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_b")
+         HasField "foo_8_a" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_a")
+instance HasCBitfield Foo_8 "foo_8_a"
+    where type CBitfieldType Foo_8 "foo_8_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "foo_8_b" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_b = y_1,
                                             foo_8_a = getField @"foo_8_a" x_0,
@@ -93,13 +86,13 @@ instance (~) ty CSChar => HasField "foo_8_b" Foo_8 ty
                                             foo_8_e = getField @"foo_8_e" x_0,
                                             foo_8_f = getField @"foo_8_f" x_0},
                               getField @"foo_8_b" x_0)
-instance HasCBitfield Foo_8 "foo_8_c"
-    where type CBitfieldType Foo_8 "foo_8_c" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 2
 instance (~) ty CSChar =>
-         HasField "foo_8_c" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_c")
+         HasField "foo_8_b" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_b")
+instance HasCBitfield Foo_8 "foo_8_b"
+    where type CBitfieldType Foo_8 "foo_8_b" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 3
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "foo_8_c" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_c = y_1,
                                             foo_8_a = getField @"foo_8_a" x_0,
@@ -108,13 +101,13 @@ instance (~) ty CSChar => HasField "foo_8_c" Foo_8 ty
                                             foo_8_e = getField @"foo_8_e" x_0,
                                             foo_8_f = getField @"foo_8_f" x_0},
                               getField @"foo_8_c" x_0)
-instance HasCBitfield Foo_8 "foo_8_d"
-    where type CBitfieldType Foo_8 "foo_8_d" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 8
-          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar =>
-         HasField "foo_8_d" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_d")
+         HasField "foo_8_c" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_c")
+instance HasCBitfield Foo_8 "foo_8_c"
+    where type CBitfieldType Foo_8 "foo_8_c" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 2
 instance (~) ty CSChar => HasField "foo_8_d" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_d = y_1,
                                             foo_8_a = getField @"foo_8_a" x_0,
@@ -123,13 +116,13 @@ instance (~) ty CSChar => HasField "foo_8_d" Foo_8 ty
                                             foo_8_e = getField @"foo_8_e" x_0,
                                             foo_8_f = getField @"foo_8_f" x_0},
                               getField @"foo_8_d" x_0)
-instance HasCBitfield Foo_8 "foo_8_e"
-    where type CBitfieldType Foo_8 "foo_8_e" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 16
-          bitfieldWidth# = \_ -> \_ -> 8
 instance (~) ty CSChar =>
-         HasField "foo_8_e" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_e")
+         HasField "foo_8_d" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_d")
+instance HasCBitfield Foo_8 "foo_8_d"
+    where type CBitfieldType Foo_8 "foo_8_d" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 8
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "foo_8_e" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_e = y_1,
                                             foo_8_a = getField @"foo_8_a" x_0,
@@ -138,13 +131,13 @@ instance (~) ty CSChar => HasField "foo_8_e" Foo_8 ty
                                             foo_8_d = getField @"foo_8_d" x_0,
                                             foo_8_f = getField @"foo_8_f" x_0},
                               getField @"foo_8_e" x_0)
-instance HasCBitfield Foo_8 "foo_8_f"
-    where type CBitfieldType Foo_8 "foo_8_f" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 24
-          bitfieldWidth# = \_ -> \_ -> 5
 instance (~) ty CSChar =>
-         HasField "foo_8_f" (Ptr Foo_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_8_f")
+         HasField "foo_8_e" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_e")
+instance HasCBitfield Foo_8 "foo_8_e"
+    where type CBitfieldType Foo_8 "foo_8_e" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 16
+          bitfieldWidth# = \_ -> \_ -> 8
 instance (~) ty CSChar => HasField "foo_8_f" Foo_8 ty
     where hasField = \x_0 -> (\y_1 -> Foo_8{foo_8_f = y_1,
                                             foo_8_a = getField @"foo_8_a" x_0,
@@ -153,6 +146,13 @@ instance (~) ty CSChar => HasField "foo_8_f" Foo_8 ty
                                             foo_8_d = getField @"foo_8_d" x_0,
                                             foo_8_e = getField @"foo_8_e" x_0},
                               getField @"foo_8_f" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_f" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_f")
+instance HasCBitfield Foo_8 "foo_8_f"
+    where type CBitfieldType Foo_8 "foo_8_f" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 24
+          bitfieldWidth# = \_ -> \_ -> 5
 {-| __C declaration:__ @struct foo_16@
 
     __defined at:__ @types\/structs\/bitfields.h 15:8@
@@ -217,13 +217,6 @@ instance WriteRaw Foo_16
                                               foo_16_e_6
                                               foo_16_f_7 -> poke (Proxy @"foo_16_a") ptr_0 foo_16_a_2 >> (poke (Proxy @"foo_16_b") ptr_0 foo_16_b_3 >> (poke (Proxy @"foo_16_c") ptr_0 foo_16_c_4 >> (poke (Proxy @"foo_16_d") ptr_0 foo_16_d_5 >> (poke (Proxy @"foo_16_e") ptr_0 foo_16_e_6 >> poke (Proxy @"foo_16_f") ptr_0 foo_16_f_7))))
 deriving via (EquivStorable Foo_16) instance Storable Foo_16
-instance HasCBitfield Foo_16 "foo_16_a"
-    where type CBitfieldType Foo_16 "foo_16_a" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "foo_16_a" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_a")
 instance (~) ty CSChar => HasField "foo_16_a" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_a = y_1,
                                              foo_16_b = getField @"foo_16_b" x_0,
@@ -232,13 +225,13 @@ instance (~) ty CSChar => HasField "foo_16_a" Foo_16 ty
                                              foo_16_e = getField @"foo_16_e" x_0,
                                              foo_16_f = getField @"foo_16_f" x_0},
                               getField @"foo_16_a" x_0)
-instance HasCBitfield Foo_16 "foo_16_b"
-    where type CBitfieldType Foo_16 "foo_16_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 10
-instance (~) ty CInt =>
-         HasField "foo_16_b" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_b")
+instance (~) ty CSChar =>
+         HasField "foo_16_a" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_a")
+instance HasCBitfield Foo_16 "foo_16_a"
+    where type CBitfieldType Foo_16 "foo_16_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CInt => HasField "foo_16_b" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_b = y_1,
                                              foo_16_a = getField @"foo_16_a" x_0,
@@ -247,13 +240,13 @@ instance (~) ty CInt => HasField "foo_16_b" Foo_16 ty
                                              foo_16_e = getField @"foo_16_e" x_0,
                                              foo_16_f = getField @"foo_16_f" x_0},
                               getField @"foo_16_b" x_0)
-instance HasCBitfield Foo_16 "foo_16_c"
-    where type CBitfieldType Foo_16 "foo_16_c" = CInt
-          bitfieldOffset# = \_ -> \_ -> 16
-          bitfieldWidth# = \_ -> \_ -> 16
 instance (~) ty CInt =>
-         HasField "foo_16_c" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_c")
+         HasField "foo_16_b" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_b")
+instance HasCBitfield Foo_16 "foo_16_b"
+    where type CBitfieldType Foo_16 "foo_16_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 10
 instance (~) ty CInt => HasField "foo_16_c" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_c = y_1,
                                              foo_16_a = getField @"foo_16_a" x_0,
@@ -262,13 +255,13 @@ instance (~) ty CInt => HasField "foo_16_c" Foo_16 ty
                                              foo_16_e = getField @"foo_16_e" x_0,
                                              foo_16_f = getField @"foo_16_f" x_0},
                               getField @"foo_16_c" x_0)
-instance HasCBitfield Foo_16 "foo_16_d"
-    where type CBitfieldType Foo_16 "foo_16_d" = CInt
-          bitfieldOffset# = \_ -> \_ -> 32
-          bitfieldWidth# = \_ -> \_ -> 16
 instance (~) ty CInt =>
-         HasField "foo_16_d" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_d")
+         HasField "foo_16_c" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_c")
+instance HasCBitfield Foo_16 "foo_16_c"
+    where type CBitfieldType Foo_16 "foo_16_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 16
+          bitfieldWidth# = \_ -> \_ -> 16
 instance (~) ty CInt => HasField "foo_16_d" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_d = y_1,
                                              foo_16_a = getField @"foo_16_a" x_0,
@@ -277,13 +270,13 @@ instance (~) ty CInt => HasField "foo_16_d" Foo_16 ty
                                              foo_16_e = getField @"foo_16_e" x_0,
                                              foo_16_f = getField @"foo_16_f" x_0},
                               getField @"foo_16_d" x_0)
-instance HasCBitfield Foo_16 "foo_16_e"
-    where type CBitfieldType Foo_16 "foo_16_e" = CInt
-          bitfieldOffset# = \_ -> \_ -> 48
-          bitfieldWidth# = \_ -> \_ -> 12
 instance (~) ty CInt =>
-         HasField "foo_16_e" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_e")
+         HasField "foo_16_d" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_d")
+instance HasCBitfield Foo_16 "foo_16_d"
+    where type CBitfieldType Foo_16 "foo_16_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 32
+          bitfieldWidth# = \_ -> \_ -> 16
 instance (~) ty CInt => HasField "foo_16_e" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_e = y_1,
                                              foo_16_a = getField @"foo_16_a" x_0,
@@ -292,13 +285,13 @@ instance (~) ty CInt => HasField "foo_16_e" Foo_16 ty
                                              foo_16_d = getField @"foo_16_d" x_0,
                                              foo_16_f = getField @"foo_16_f" x_0},
                               getField @"foo_16_e" x_0)
-instance HasCBitfield Foo_16 "foo_16_f"
-    where type CBitfieldType Foo_16 "foo_16_f" = CInt
-          bitfieldOffset# = \_ -> \_ -> 64
-          bitfieldWidth# = \_ -> \_ -> 12
 instance (~) ty CInt =>
-         HasField "foo_16_f" (Ptr Foo_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_16_f")
+         HasField "foo_16_e" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_e")
+instance HasCBitfield Foo_16 "foo_16_e"
+    where type CBitfieldType Foo_16 "foo_16_e" = CInt
+          bitfieldOffset# = \_ -> \_ -> 48
+          bitfieldWidth# = \_ -> \_ -> 12
 instance (~) ty CInt => HasField "foo_16_f" Foo_16 ty
     where hasField = \x_0 -> (\y_1 -> Foo_16{foo_16_f = y_1,
                                              foo_16_a = getField @"foo_16_a" x_0,
@@ -307,6 +300,13 @@ instance (~) ty CInt => HasField "foo_16_f" Foo_16 ty
                                              foo_16_d = getField @"foo_16_d" x_0,
                                              foo_16_e = getField @"foo_16_e" x_0},
                               getField @"foo_16_f" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_f" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_f")
+instance HasCBitfield Foo_16 "foo_16_f"
+    where type CBitfieldType Foo_16 "foo_16_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 64
+          bitfieldWidth# = \_ -> \_ -> 12
 {-| __C declaration:__ @struct foo_32@
 
     __defined at:__ @types\/structs\/bitfields.h 25:8@
@@ -379,13 +379,6 @@ instance WriteRaw Foo_32
                                               foo_32_f_7
                                               foo_32_g_8 -> poke (Proxy @"foo_32_a") ptr_0 foo_32_a_2 >> (poke (Proxy @"foo_32_b") ptr_0 foo_32_b_3 >> (poke (Proxy @"foo_32_c") ptr_0 foo_32_c_4 >> (poke (Proxy @"foo_32_d") ptr_0 foo_32_d_5 >> (poke (Proxy @"foo_32_e") ptr_0 foo_32_e_6 >> (poke (Proxy @"foo_32_f") ptr_0 foo_32_f_7 >> poke (Proxy @"foo_32_g") ptr_0 foo_32_g_8)))))
 deriving via (EquivStorable Foo_32) instance Storable Foo_32
-instance HasCBitfield Foo_32 "foo_32_a"
-    where type CBitfieldType Foo_32 "foo_32_a" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "foo_32_a" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_a")
 instance (~) ty CSChar => HasField "foo_32_a" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_a = y_1,
                                              foo_32_b = getField @"foo_32_b" x_0,
@@ -395,13 +388,13 @@ instance (~) ty CSChar => HasField "foo_32_a" Foo_32 ty
                                              foo_32_f = getField @"foo_32_f" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_a" x_0)
-instance HasCBitfield Foo_32 "foo_32_b"
-    where type CBitfieldType Foo_32 "foo_32_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 12
-instance (~) ty CInt =>
-         HasField "foo_32_b" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_b")
+instance (~) ty CSChar =>
+         HasField "foo_32_a" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_a")
+instance HasCBitfield Foo_32 "foo_32_a"
+    where type CBitfieldType Foo_32 "foo_32_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CInt => HasField "foo_32_b" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_b = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -411,13 +404,13 @@ instance (~) ty CInt => HasField "foo_32_b" Foo_32 ty
                                              foo_32_f = getField @"foo_32_f" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_b" x_0)
-instance HasCBitfield Foo_32 "foo_32_c"
-    where type CBitfieldType Foo_32 "foo_32_c" = CInt
-          bitfieldOffset# = \_ -> \_ -> 18
-          bitfieldWidth# = \_ -> \_ -> 14
 instance (~) ty CInt =>
-         HasField "foo_32_c" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_c")
+         HasField "foo_32_b" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_b")
+instance HasCBitfield Foo_32 "foo_32_b"
+    where type CBitfieldType Foo_32 "foo_32_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 12
 instance (~) ty CInt => HasField "foo_32_c" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_c = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -427,13 +420,13 @@ instance (~) ty CInt => HasField "foo_32_c" Foo_32 ty
                                              foo_32_f = getField @"foo_32_f" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_c" x_0)
-instance HasCBitfield Foo_32 "foo_32_d"
-    where type CBitfieldType Foo_32 "foo_32_d" = CInt
-          bitfieldOffset# = \_ -> \_ -> 32
-          bitfieldWidth# = \_ -> \_ -> 10
 instance (~) ty CInt =>
-         HasField "foo_32_d" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_d")
+         HasField "foo_32_c" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_c")
+instance HasCBitfield Foo_32 "foo_32_c"
+    where type CBitfieldType Foo_32 "foo_32_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 18
+          bitfieldWidth# = \_ -> \_ -> 14
 instance (~) ty CInt => HasField "foo_32_d" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_d = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -443,13 +436,13 @@ instance (~) ty CInt => HasField "foo_32_d" Foo_32 ty
                                              foo_32_f = getField @"foo_32_f" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_d" x_0)
-instance HasCBitfield Foo_32 "foo_32_e"
-    where type CBitfieldType Foo_32 "foo_32_e" = CLong
-          bitfieldOffset# = \_ -> \_ -> 64
-          bitfieldWidth# = \_ -> \_ -> 32
-instance (~) ty CLong =>
-         HasField "foo_32_e" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_e")
+instance (~) ty CInt =>
+         HasField "foo_32_d" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_d")
+instance HasCBitfield Foo_32 "foo_32_d"
+    where type CBitfieldType Foo_32 "foo_32_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 32
+          bitfieldWidth# = \_ -> \_ -> 10
 instance (~) ty CLong => HasField "foo_32_e" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_e = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -459,13 +452,13 @@ instance (~) ty CLong => HasField "foo_32_e" Foo_32 ty
                                              foo_32_f = getField @"foo_32_f" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_e" x_0)
-instance HasCBitfield Foo_32 "foo_32_f"
-    where type CBitfieldType Foo_32 "foo_32_f" = CInt
-          bitfieldOffset# = \_ -> \_ -> 96
-          bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CInt =>
-         HasField "foo_32_f" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_f")
+instance (~) ty CLong =>
+         HasField "foo_32_e" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_e")
+instance HasCBitfield Foo_32 "foo_32_e"
+    where type CBitfieldType Foo_32 "foo_32_e" = CLong
+          bitfieldOffset# = \_ -> \_ -> 64
+          bitfieldWidth# = \_ -> \_ -> 32
 instance (~) ty CInt => HasField "foo_32_f" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_f = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -475,13 +468,13 @@ instance (~) ty CInt => HasField "foo_32_f" Foo_32 ty
                                              foo_32_e = getField @"foo_32_e" x_0,
                                              foo_32_g = getField @"foo_32_g" x_0},
                               getField @"foo_32_f" x_0)
-instance HasCBitfield Foo_32 "foo_32_g"
-    where type CBitfieldType Foo_32 "foo_32_g" = CLong
-          bitfieldOffset# = \_ -> \_ -> 102
-          bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "foo_32_g" (Ptr Foo_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_32_g")
+instance (~) ty CInt =>
+         HasField "foo_32_f" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_f")
+instance HasCBitfield Foo_32 "foo_32_f"
+    where type CBitfieldType Foo_32 "foo_32_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 96
+          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CLong => HasField "foo_32_g" Foo_32 ty
     where hasField = \x_0 -> (\y_1 -> Foo_32{foo_32_g = y_1,
                                              foo_32_a = getField @"foo_32_a" x_0,
@@ -491,6 +484,13 @@ instance (~) ty CLong => HasField "foo_32_g" Foo_32 ty
                                              foo_32_e = getField @"foo_32_e" x_0,
                                              foo_32_f = getField @"foo_32_f" x_0},
                               getField @"foo_32_g" x_0)
+instance (~) ty CLong =>
+         HasField "foo_32_g" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_g")
+instance HasCBitfield Foo_32 "foo_32_g"
+    where type CBitfieldType Foo_32 "foo_32_g" = CLong
+          bitfieldOffset# = \_ -> \_ -> 102
+          bitfieldWidth# = \_ -> \_ -> 24
 {-| __C declaration:__ @struct foo_64@
 
     __defined at:__ @types\/structs\/bitfields.h 36:8@
@@ -539,58 +539,58 @@ instance WriteRaw Foo_64
                                               foo_64_c_4
                                               foo_64_d_5 -> poke (Proxy @"foo_64_a") ptr_0 foo_64_a_2 >> (poke (Proxy @"foo_64_b") ptr_0 foo_64_b_3 >> (poke (Proxy @"foo_64_c") ptr_0 foo_64_c_4 >> poke (Proxy @"foo_64_d") ptr_0 foo_64_d_5))
 deriving via (EquivStorable Foo_64) instance Storable Foo_64
-instance HasCBitfield Foo_64 "foo_64_a"
-    where type CBitfieldType Foo_64 "foo_64_a" = CLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "foo_64_a" (Ptr Foo_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_64_a")
 instance (~) ty CLong => HasField "foo_64_a" Foo_64 ty
     where hasField = \x_0 -> (\y_1 -> Foo_64{foo_64_a = y_1,
                                              foo_64_b = getField @"foo_64_b" x_0,
                                              foo_64_c = getField @"foo_64_c" x_0,
                                              foo_64_d = getField @"foo_64_d" x_0},
                               getField @"foo_64_a" x_0)
-instance HasCBitfield Foo_64 "foo_64_b"
-    where type CBitfieldType Foo_64 "foo_64_b" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 24
-          bitfieldWidth# = \_ -> \_ -> 40
-instance (~) ty CLLong =>
-         HasField "foo_64_b" (Ptr Foo_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_64_b")
+instance (~) ty CLong =>
+         HasField "foo_64_a" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_a")
+instance HasCBitfield Foo_64 "foo_64_a"
+    where type CBitfieldType Foo_64 "foo_64_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
 instance (~) ty CLLong => HasField "foo_64_b" Foo_64 ty
     where hasField = \x_0 -> (\y_1 -> Foo_64{foo_64_b = y_1,
                                              foo_64_a = getField @"foo_64_a" x_0,
                                              foo_64_c = getField @"foo_64_c" x_0,
                                              foo_64_d = getField @"foo_64_d" x_0},
                               getField @"foo_64_b" x_0)
-instance HasCBitfield Foo_64 "foo_64_c"
-    where type CBitfieldType Foo_64 "foo_64_c" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 64
-          bitfieldWidth# = \_ -> \_ -> 64
 instance (~) ty CLLong =>
-         HasField "foo_64_c" (Ptr Foo_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_64_c")
+         HasField "foo_64_b" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_b")
+instance HasCBitfield Foo_64 "foo_64_b"
+    where type CBitfieldType Foo_64 "foo_64_b" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 24
+          bitfieldWidth# = \_ -> \_ -> 40
 instance (~) ty CLLong => HasField "foo_64_c" Foo_64 ty
     where hasField = \x_0 -> (\y_1 -> Foo_64{foo_64_c = y_1,
                                              foo_64_a = getField @"foo_64_a" x_0,
                                              foo_64_b = getField @"foo_64_b" x_0,
                                              foo_64_d = getField @"foo_64_d" x_0},
                               getField @"foo_64_c" x_0)
-instance HasCBitfield Foo_64 "foo_64_d"
-    where type CBitfieldType Foo_64 "foo_64_d" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 128
-          bitfieldWidth# = \_ -> \_ -> 36
 instance (~) ty CLLong =>
-         HasField "foo_64_d" (Ptr Foo_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_64_d")
+         HasField "foo_64_c" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_c")
+instance HasCBitfield Foo_64 "foo_64_c"
+    where type CBitfieldType Foo_64 "foo_64_c" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 64
+          bitfieldWidth# = \_ -> \_ -> 64
 instance (~) ty CLLong => HasField "foo_64_d" Foo_64 ty
     where hasField = \x_0 -> (\y_1 -> Foo_64{foo_64_d = y_1,
                                              foo_64_a = getField @"foo_64_a" x_0,
                                              foo_64_b = getField @"foo_64_b" x_0,
                                              foo_64_c = getField @"foo_64_c" x_0},
                               getField @"foo_64_d" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_d" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_d")
+instance HasCBitfield Foo_64 "foo_64_d"
+    where type CBitfieldType Foo_64 "foo_64_d" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 128
+          bitfieldWidth# = \_ -> \_ -> 36
 {-| __C declaration:__ @struct bar_8_8@
 
     __defined at:__ @types\/structs\/bitfields.h 44:32@
@@ -623,28 +623,28 @@ instance WriteRaw Bar_8_8
                                        Bar_8_8 bar_8_8_a_2
                                                bar_8_8_b_3 -> poke (Proxy @"bar_8_8_a") ptr_0 bar_8_8_a_2 >> poke (Proxy @"bar_8_8_b") ptr_0 bar_8_8_b_3
 deriving via (EquivStorable Bar_8_8) instance Storable Bar_8_8
-instance HasCBitfield Bar_8_8 "bar_8_8_a"
-    where type CBitfieldType Bar_8_8 "bar_8_8_a" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 6
-instance (~) ty CSChar =>
-         HasField "bar_8_8_a" (Ptr Bar_8_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_8_a")
 instance (~) ty CSChar => HasField "bar_8_8_a" Bar_8_8 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_8{bar_8_8_a = y_1,
                                               bar_8_8_b = getField @"bar_8_8_b" x_0},
                               getField @"bar_8_8_a" x_0)
-instance HasCBitfield Bar_8_8 "bar_8_8_b"
-    where type CBitfieldType Bar_8_8 "bar_8_8_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_8_b" (Ptr Bar_8_8) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_8_b")
+instance (~) ty CSChar =>
+         HasField "bar_8_8_a" (Ptr Bar_8_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_8_a")
+instance HasCBitfield Bar_8_8 "bar_8_8_a"
+    where type CBitfieldType Bar_8_8 "bar_8_8_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
 instance (~) ty CInt => HasField "bar_8_8_b" Bar_8_8 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_8{bar_8_8_b = y_1,
                                               bar_8_8_a = getField @"bar_8_8_a" x_0},
                               getField @"bar_8_8_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_8_8_b" (Ptr Bar_8_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_8_b")
+instance HasCBitfield Bar_8_8 "bar_8_8_b"
+    where type CBitfieldType Bar_8_8 "bar_8_8_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct bar_8_16@
 
     __defined at:__ @types\/structs\/bitfields.h 50:32@
@@ -677,28 +677,28 @@ instance WriteRaw Bar_8_16
                                        Bar_8_16 bar_8_16_a_2
                                                 bar_8_16_b_3 -> poke (Proxy @"bar_8_16_a") ptr_0 bar_8_16_a_2 >> poke (Proxy @"bar_8_16_b") ptr_0 bar_8_16_b_3
 deriving via (EquivStorable Bar_8_16) instance Storable Bar_8_16
-instance HasCBitfield Bar_8_16 "bar_8_16_a"
-    where type CBitfieldType Bar_8_16 "bar_8_16_a" = CInt
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_8_16_a" (Ptr Bar_8_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_16_a")
 instance (~) ty CInt => HasField "bar_8_16_a" Bar_8_16 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_16{bar_8_16_a = y_1,
                                                bar_8_16_b = getField @"bar_8_16_b" x_0},
                               getField @"bar_8_16_a" x_0)
-instance HasCBitfield Bar_8_16 "bar_8_16_b"
-    where type CBitfieldType Bar_8_16 "bar_8_16_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 14
-          bitfieldWidth# = \_ -> \_ -> 4
 instance (~) ty CInt =>
-         HasField "bar_8_16_b" (Ptr Bar_8_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_16_b")
+         HasField "bar_8_16_a" (Ptr Bar_8_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_16_a")
+instance HasCBitfield Bar_8_16 "bar_8_16_a"
+    where type CBitfieldType Bar_8_16 "bar_8_16_a" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 14
 instance (~) ty CInt => HasField "bar_8_16_b" Bar_8_16 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_16{bar_8_16_b = y_1,
                                                bar_8_16_a = getField @"bar_8_16_a" x_0},
                               getField @"bar_8_16_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_8_16_b" (Ptr Bar_8_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_16_b")
+instance HasCBitfield Bar_8_16 "bar_8_16_b"
+    where type CBitfieldType Bar_8_16 "bar_8_16_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 14
+          bitfieldWidth# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct bar_8_32@
 
     __defined at:__ @types\/structs\/bitfields.h 56:32@
@@ -731,28 +731,28 @@ instance WriteRaw Bar_8_32
                                        Bar_8_32 bar_8_32_a_2
                                                 bar_8_32_b_3 -> poke (Proxy @"bar_8_32_a") ptr_0 bar_8_32_a_2 >> poke (Proxy @"bar_8_32_b") ptr_0 bar_8_32_b_3
 deriving via (EquivStorable Bar_8_32) instance Storable Bar_8_32
-instance HasCBitfield Bar_8_32 "bar_8_32_a"
-    where type CBitfieldType Bar_8_32 "bar_8_32_a" = CLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_8_32_a" (Ptr Bar_8_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_32_a")
 instance (~) ty CLong => HasField "bar_8_32_a" Bar_8_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_32{bar_8_32_a = y_1,
                                                bar_8_32_b = getField @"bar_8_32_b" x_0},
                               getField @"bar_8_32_a" x_0)
-instance HasCBitfield Bar_8_32 "bar_8_32_b"
-    where type CBitfieldType Bar_8_32 "bar_8_32_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 30
-          bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_32_b" (Ptr Bar_8_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_32_b")
+instance (~) ty CLong =>
+         HasField "bar_8_32_a" (Ptr Bar_8_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_32_a")
+instance HasCBitfield Bar_8_32 "bar_8_32_a"
+    where type CBitfieldType Bar_8_32 "bar_8_32_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 30
 instance (~) ty CInt => HasField "bar_8_32_b" Bar_8_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_32{bar_8_32_b = y_1,
                                                bar_8_32_a = getField @"bar_8_32_a" x_0},
                               getField @"bar_8_32_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_8_32_b" (Ptr Bar_8_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_32_b")
+instance HasCBitfield Bar_8_32 "bar_8_32_b"
+    where type CBitfieldType Bar_8_32 "bar_8_32_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 30
+          bitfieldWidth# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct bar_8_64@
 
     __defined at:__ @types\/structs\/bitfields.h 62:32@
@@ -785,28 +785,28 @@ instance WriteRaw Bar_8_64
                                        Bar_8_64 bar_8_64_a_2
                                                 bar_8_64_b_3 -> poke (Proxy @"bar_8_64_a") ptr_0 bar_8_64_a_2 >> poke (Proxy @"bar_8_64_b") ptr_0 bar_8_64_b_3
 deriving via (EquivStorable Bar_8_64) instance Storable Bar_8_64
-instance HasCBitfield Bar_8_64 "bar_8_64_a"
-    where type CBitfieldType Bar_8_64 "bar_8_64_a" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 62
-instance (~) ty CLLong =>
-         HasField "bar_8_64_a" (Ptr Bar_8_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_64_a")
 instance (~) ty CLLong => HasField "bar_8_64_a" Bar_8_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_64{bar_8_64_a = y_1,
                                                bar_8_64_b = getField @"bar_8_64_b" x_0},
                               getField @"bar_8_64_a" x_0)
-instance HasCBitfield Bar_8_64 "bar_8_64_b"
-    where type CBitfieldType Bar_8_64 "bar_8_64_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 62
-          bitfieldWidth# = \_ -> \_ -> 4
-instance (~) ty CInt =>
-         HasField "bar_8_64_b" (Ptr Bar_8_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_8_64_b")
+instance (~) ty CLLong =>
+         HasField "bar_8_64_a" (Ptr Bar_8_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_64_a")
+instance HasCBitfield Bar_8_64 "bar_8_64_a"
+    where type CBitfieldType Bar_8_64 "bar_8_64_a" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 62
 instance (~) ty CInt => HasField "bar_8_64_b" Bar_8_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_8_64{bar_8_64_b = y_1,
                                                bar_8_64_a = getField @"bar_8_64_a" x_0},
                               getField @"bar_8_64_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_8_64_b" (Ptr Bar_8_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_8_64_b")
+instance HasCBitfield Bar_8_64 "bar_8_64_b"
+    where type CBitfieldType Bar_8_64 "bar_8_64_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 62
+          bitfieldWidth# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct bar_16_16@
 
     __defined at:__ @types\/structs\/bitfields.h 68:32@
@@ -839,28 +839,28 @@ instance WriteRaw Bar_16_16
                                        Bar_16_16 bar_16_16_a_2
                                                  bar_16_16_b_3 -> poke (Proxy @"bar_16_16_a") ptr_0 bar_16_16_a_2 >> poke (Proxy @"bar_16_16_b") ptr_0 bar_16_16_b_3
 deriving via (EquivStorable Bar_16_16) instance Storable Bar_16_16
-instance HasCBitfield Bar_16_16 "bar_16_16_a"
-    where type CBitfieldType Bar_16_16 "bar_16_16_a" = CInt
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_16_a" (Ptr Bar_16_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_16_a")
 instance (~) ty CInt => HasField "bar_16_16_a" Bar_16_16 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_16{bar_16_16_a = y_1,
                                                 bar_16_16_b = getField @"bar_16_16_b" x_0},
                               getField @"bar_16_16_a" x_0)
-instance HasCBitfield Bar_16_16 "bar_16_16_b"
-    where type CBitfieldType Bar_16_16 "bar_16_16_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 14
-          bitfieldWidth# = \_ -> \_ -> 14
 instance (~) ty CInt =>
-         HasField "bar_16_16_b" (Ptr Bar_16_16) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_16_b")
+         HasField "bar_16_16_a" (Ptr Bar_16_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_16_a")
+instance HasCBitfield Bar_16_16 "bar_16_16_a"
+    where type CBitfieldType Bar_16_16 "bar_16_16_a" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 14
 instance (~) ty CInt => HasField "bar_16_16_b" Bar_16_16 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_16{bar_16_16_b = y_1,
                                                 bar_16_16_a = getField @"bar_16_16_a" x_0},
                               getField @"bar_16_16_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_16_16_b" (Ptr Bar_16_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_16_b")
+instance HasCBitfield Bar_16_16 "bar_16_16_b"
+    where type CBitfieldType Bar_16_16 "bar_16_16_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 14
+          bitfieldWidth# = \_ -> \_ -> 14
 {-| __C declaration:__ @struct bar_16_32@
 
     __defined at:__ @types\/structs\/bitfields.h 74:32@
@@ -893,28 +893,28 @@ instance WriteRaw Bar_16_32
                                        Bar_16_32 bar_16_32_a_2
                                                  bar_16_32_b_3 -> poke (Proxy @"bar_16_32_a") ptr_0 bar_16_32_a_2 >> poke (Proxy @"bar_16_32_b") ptr_0 bar_16_32_b_3
 deriving via (EquivStorable Bar_16_32) instance Storable Bar_16_32
-instance HasCBitfield Bar_16_32 "bar_16_32_a"
-    where type CBitfieldType Bar_16_32 "bar_16_32_a" = CLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 24
-instance (~) ty CLong =>
-         HasField "bar_16_32_a" (Ptr Bar_16_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_32_a")
 instance (~) ty CLong => HasField "bar_16_32_a" Bar_16_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_32{bar_16_32_a = y_1,
                                                 bar_16_32_b = getField @"bar_16_32_b" x_0},
                               getField @"bar_16_32_a" x_0)
-instance HasCBitfield Bar_16_32 "bar_16_32_b"
-    where type CBitfieldType Bar_16_32 "bar_16_32_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 24
-          bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_32_b" (Ptr Bar_16_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_32_b")
+instance (~) ty CLong =>
+         HasField "bar_16_32_a" (Ptr Bar_16_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_32_a")
+instance HasCBitfield Bar_16_32 "bar_16_32_a"
+    where type CBitfieldType Bar_16_32 "bar_16_32_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
 instance (~) ty CInt => HasField "bar_16_32_b" Bar_16_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_32{bar_16_32_b = y_1,
                                                 bar_16_32_a = getField @"bar_16_32_a" x_0},
                               getField @"bar_16_32_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_16_32_b" (Ptr Bar_16_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_32_b")
+instance HasCBitfield Bar_16_32 "bar_16_32_b"
+    where type CBitfieldType Bar_16_32 "bar_16_32_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 24
+          bitfieldWidth# = \_ -> \_ -> 14
 {-| __C declaration:__ @struct bar_16_64@
 
     __defined at:__ @types\/structs\/bitfields.h 80:32@
@@ -947,28 +947,28 @@ instance WriteRaw Bar_16_64
                                        Bar_16_64 bar_16_64_a_2
                                                  bar_16_64_b_3 -> poke (Proxy @"bar_16_64_a") ptr_0 bar_16_64_a_2 >> poke (Proxy @"bar_16_64_b") ptr_0 bar_16_64_b_3
 deriving via (EquivStorable Bar_16_64) instance Storable Bar_16_64
-instance HasCBitfield Bar_16_64 "bar_16_64_a"
-    where type CBitfieldType Bar_16_64 "bar_16_64_a" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_16_64_a" (Ptr Bar_16_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_64_a")
 instance (~) ty CLLong => HasField "bar_16_64_a" Bar_16_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_64{bar_16_64_a = y_1,
                                                 bar_16_64_b = getField @"bar_16_64_b" x_0},
                               getField @"bar_16_64_a" x_0)
-instance HasCBitfield Bar_16_64 "bar_16_64_b"
-    where type CBitfieldType Bar_16_64 "bar_16_64_b" = CInt
-          bitfieldOffset# = \_ -> \_ -> 56
-          bitfieldWidth# = \_ -> \_ -> 14
-instance (~) ty CInt =>
-         HasField "bar_16_64_b" (Ptr Bar_16_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_16_64_b")
+instance (~) ty CLLong =>
+         HasField "bar_16_64_a" (Ptr Bar_16_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_64_a")
+instance HasCBitfield Bar_16_64 "bar_16_64_a"
+    where type CBitfieldType Bar_16_64 "bar_16_64_a" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 56
 instance (~) ty CInt => HasField "bar_16_64_b" Bar_16_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_16_64{bar_16_64_b = y_1,
                                                 bar_16_64_a = getField @"bar_16_64_a" x_0},
                               getField @"bar_16_64_b" x_0)
+instance (~) ty CInt =>
+         HasField "bar_16_64_b" (Ptr Bar_16_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_16_64_b")
+instance HasCBitfield Bar_16_64 "bar_16_64_b"
+    where type CBitfieldType Bar_16_64 "bar_16_64_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 56
+          bitfieldWidth# = \_ -> \_ -> 14
 {-| __C declaration:__ @struct bar_32_32@
 
     __defined at:__ @types\/structs\/bitfields.h 86:32@
@@ -1001,28 +1001,28 @@ instance WriteRaw Bar_32_32
                                        Bar_32_32 bar_32_32_a_2
                                                  bar_32_32_b_3 -> poke (Proxy @"bar_32_32_a") ptr_0 bar_32_32_a_2 >> poke (Proxy @"bar_32_32_b") ptr_0 bar_32_32_b_3
 deriving via (EquivStorable Bar_32_32) instance Storable Bar_32_32
-instance HasCBitfield Bar_32_32 "bar_32_32_a"
-    where type CBitfieldType Bar_32_32 "bar_32_32_a" = CLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_32_32_a" (Ptr Bar_32_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_32_32_a")
 instance (~) ty CLong => HasField "bar_32_32_a" Bar_32_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_32_32{bar_32_32_a = y_1,
                                                 bar_32_32_b = getField @"bar_32_32_b" x_0},
                               getField @"bar_32_32_a" x_0)
-instance HasCBitfield Bar_32_32 "bar_32_32_b"
-    where type CBitfieldType Bar_32_32 "bar_32_32_b" = CLong
-          bitfieldOffset# = \_ -> \_ -> 30
-          bitfieldWidth# = \_ -> \_ -> 30
 instance (~) ty CLong =>
-         HasField "bar_32_32_b" (Ptr Bar_32_32) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_32_32_b")
+         HasField "bar_32_32_a" (Ptr Bar_32_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_32_32_a")
+instance HasCBitfield Bar_32_32 "bar_32_32_a"
+    where type CBitfieldType Bar_32_32 "bar_32_32_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 30
 instance (~) ty CLong => HasField "bar_32_32_b" Bar_32_32 ty
     where hasField = \x_0 -> (\y_1 -> Bar_32_32{bar_32_32_b = y_1,
                                                 bar_32_32_a = getField @"bar_32_32_a" x_0},
                               getField @"bar_32_32_b" x_0)
+instance (~) ty CLong =>
+         HasField "bar_32_32_b" (Ptr Bar_32_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_32_32_b")
+instance HasCBitfield Bar_32_32 "bar_32_32_b"
+    where type CBitfieldType Bar_32_32 "bar_32_32_b" = CLong
+          bitfieldOffset# = \_ -> \_ -> 30
+          bitfieldWidth# = \_ -> \_ -> 30
 {-| __C declaration:__ @struct bar_32_64@
 
     __defined at:__ @types\/structs\/bitfields.h 92:32@
@@ -1055,28 +1055,28 @@ instance WriteRaw Bar_32_64
                                        Bar_32_64 bar_32_64_a_2
                                                  bar_32_64_b_3 -> poke (Proxy @"bar_32_64_a") ptr_0 bar_32_64_a_2 >> poke (Proxy @"bar_32_64_b") ptr_0 bar_32_64_b_3
 deriving via (EquivStorable Bar_32_64) instance Storable Bar_32_64
-instance HasCBitfield Bar_32_64 "bar_32_64_a"
-    where type CBitfieldType Bar_32_64 "bar_32_64_a" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_32_64_a" (Ptr Bar_32_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_32_64_a")
 instance (~) ty CLLong => HasField "bar_32_64_a" Bar_32_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_32_64{bar_32_64_a = y_1,
                                                 bar_32_64_b = getField @"bar_32_64_b" x_0},
                               getField @"bar_32_64_a" x_0)
-instance HasCBitfield Bar_32_64 "bar_32_64_b"
-    where type CBitfieldType Bar_32_64 "bar_32_64_b" = CLong
-          bitfieldOffset# = \_ -> \_ -> 56
-          bitfieldWidth# = \_ -> \_ -> 30
-instance (~) ty CLong =>
-         HasField "bar_32_64_b" (Ptr Bar_32_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_32_64_b")
+instance (~) ty CLLong =>
+         HasField "bar_32_64_a" (Ptr Bar_32_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_32_64_a")
+instance HasCBitfield Bar_32_64 "bar_32_64_a"
+    where type CBitfieldType Bar_32_64 "bar_32_64_a" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 56
 instance (~) ty CLong => HasField "bar_32_64_b" Bar_32_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_32_64{bar_32_64_b = y_1,
                                                 bar_32_64_a = getField @"bar_32_64_a" x_0},
                               getField @"bar_32_64_b" x_0)
+instance (~) ty CLong =>
+         HasField "bar_32_64_b" (Ptr Bar_32_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_32_64_b")
+instance HasCBitfield Bar_32_64 "bar_32_64_b"
+    where type CBitfieldType Bar_32_64 "bar_32_64_b" = CLong
+          bitfieldOffset# = \_ -> \_ -> 56
+          bitfieldWidth# = \_ -> \_ -> 30
 {-| __C declaration:__ @struct bar_64_64@
 
     __defined at:__ @types\/structs\/bitfields.h 98:32@
@@ -1109,25 +1109,25 @@ instance WriteRaw Bar_64_64
                                        Bar_64_64 bar_64_64_a_2
                                                  bar_64_64_b_3 -> poke (Proxy @"bar_64_64_a") ptr_0 bar_64_64_a_2 >> poke (Proxy @"bar_64_64_b") ptr_0 bar_64_64_b_3
 deriving via (EquivStorable Bar_64_64) instance Storable Bar_64_64
-instance HasCBitfield Bar_64_64 "bar_64_64_a"
-    where type CBitfieldType Bar_64_64 "bar_64_64_a" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 56
-instance (~) ty CLLong =>
-         HasField "bar_64_64_a" (Ptr Bar_64_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_64_64_a")
 instance (~) ty CLLong => HasField "bar_64_64_a" Bar_64_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_64_64{bar_64_64_a = y_1,
                                                 bar_64_64_b = getField @"bar_64_64_b" x_0},
                               getField @"bar_64_64_a" x_0)
-instance HasCBitfield Bar_64_64 "bar_64_64_b"
-    where type CBitfieldType Bar_64_64 "bar_64_64_b" = CLLong
-          bitfieldOffset# = \_ -> \_ -> 56
-          bitfieldWidth# = \_ -> \_ -> 40
 instance (~) ty CLLong =>
-         HasField "bar_64_64_b" (Ptr Bar_64_64) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_64_64_b")
+         HasField "bar_64_64_a" (Ptr Bar_64_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_64_64_a")
+instance HasCBitfield Bar_64_64 "bar_64_64_a"
+    where type CBitfieldType Bar_64_64 "bar_64_64_a" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 56
 instance (~) ty CLLong => HasField "bar_64_64_b" Bar_64_64 ty
     where hasField = \x_0 -> (\y_1 -> Bar_64_64{bar_64_64_b = y_1,
                                                 bar_64_64_a = getField @"bar_64_64_a" x_0},
                               getField @"bar_64_64_b" x_0)
+instance (~) ty CLLong =>
+         HasField "bar_64_64_b" (Ptr Bar_64_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_64_64_b")
+instance HasCBitfield Bar_64_64 "bar_64_64_b"
+    where type CBitfieldType Bar_64_64 "bar_64_64_b" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 56
+          bitfieldWidth# = \_ -> \_ -> 40

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/Example.hs
@@ -64,21 +64,21 @@ instance Marshal.WriteRaw B where
 
 deriving via Marshal.EquivStorable B instance RIP.Storable B
 
-instance HasCField.HasCField B "b_toA" where
-
-  type CFieldType B "b_toA" = RIP.Ptr A
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.Ptr A) => RIP.HasField "b_toA" (RIP.Ptr B) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"b_toA")
-
 instance (ty ~ RIP.Ptr A) => RIP.CompatHasField.HasField "b_toA" B ty where
 
   hasField =
     \x0 ->
       (\y1 -> B {b_toA = y1}, RIP.getField @"b_toA" x0)
+
+instance (ty ~ RIP.Ptr A) => RIP.HasField "b_toA" (RIP.Ptr B) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b_toA")
+
+instance HasCField.HasCField B "b_toA" where
+
+  type CFieldType B "b_toA" = RIP.Ptr A
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct a@
 
@@ -121,18 +121,18 @@ instance Marshal.WriteRaw A where
 
 deriving via Marshal.EquivStorable A instance RIP.Storable A
 
-instance HasCField.HasCField A "a_toB" where
-
-  type CFieldType A "a_toB" = B
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ B) => RIP.HasField "a_toB" (RIP.Ptr A) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a_toB")
-
 instance (ty ~ B) => RIP.CompatHasField.HasField "a_toB" A ty where
 
   hasField =
     \x0 ->
       (\y1 -> A {a_toB = y1}, RIP.getField @"a_toB" x0)
+
+instance (ty ~ B) => RIP.HasField "a_toB" (RIP.Ptr A) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"a_toB")
+
+instance HasCField.HasCField A "a_toB" where
+
+  type CFieldType A "a_toB" = B
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - a_toB
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -34,11 +35,12 @@ hstypes:
       fields:
       - b_toA
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/circular_dependency_struct/th.txt
@@ -23,14 +23,14 @@ instance WriteRaw B
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        B b_toA_2 -> writeRaw (Proxy @"b_toA") ptr_0 b_toA_2
 deriving via (EquivStorable B) instance Storable B
-instance HasCField B "b_toA"
-    where type CFieldType B "b_toA" = Ptr A
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr A) => HasField "b_toA" (Ptr B) (Ptr ty)
-    where getField = fromPtr (Proxy @"b_toA")
 instance (~) ty (Ptr A) => HasField "b_toA" B ty
     where hasField = \x_0 -> (\y_1 -> B{b_toA = y_1},
                               getField @"b_toA" x_0)
+instance (~) ty (Ptr A) => HasField "b_toA" (Ptr B) (Ptr ty)
+    where getField = fromPtr (Proxy @"b_toA")
+instance HasCField B "b_toA"
+    where type CFieldType B "b_toA" = Ptr A
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct a@
 
     __defined at:__ @types\/structs\/circular_dependency_struct.h 7:8@
@@ -55,11 +55,11 @@ instance WriteRaw A
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        A a_toB_2 -> writeRaw (Proxy @"a_toB") ptr_0 a_toB_2
 deriving via (EquivStorable A) instance Storable A
-instance HasCField A "a_toB"
-    where type CFieldType A "a_toB" = B
-          offset# = \_ -> \_ -> 0
-instance (~) ty B => HasField "a_toB" (Ptr A) (Ptr ty)
-    where getField = fromPtr (Proxy @"a_toB")
 instance (~) ty B => HasField "a_toB" A ty
     where hasField = \x_0 -> (\y_1 -> A{a_toB = y_1},
                               getField @"a_toB" x_0)
+instance (~) ty B => HasField "a_toB" (Ptr A) (Ptr ty)
+    where getField = fromPtr (Proxy @"a_toB")
+instance HasCField A "a_toB"
+    where type CFieldType A "a_toB" = B
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/padding/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/padding/Example.hs
@@ -83,19 +83,6 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCBitfield.HasCBitfield Foo "foo_a" where
-
-  type CBitfieldType Foo "foo_a" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_a")
-
 instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_a" Foo ty where
 
   hasField =
@@ -105,18 +92,18 @@ instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_a" Foo ty where
       , RIP.getField @"foo_a" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo "foo_b" where
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
 
-  type CBitfieldType Foo "foo_b" = RIP.CSChar
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_a")
 
-  bitfieldOffset# = \_ -> \_ -> 3
+instance HasCBitfield.HasCBitfield Foo "foo_a" where
+
+  type CBitfieldType Foo "foo_a" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
 
   bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_b" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_b")
 
 instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_b" Foo ty where
 
@@ -127,18 +114,18 @@ instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_b" Foo ty where
       , RIP.getField @"foo_b" x0
       )
 
-instance HasCBitfield.HasCBitfield Foo "foo_c" where
-
-  type CBitfieldType Foo "foo_c" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 8
-
-  bitfieldWidth# = \_ -> \_ -> 2
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "foo_b" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_c")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_b")
+
+instance HasCBitfield.HasCBitfield Foo "foo_b" where
+
+  type CBitfieldType Foo "foo_b" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 3
+
+  bitfieldWidth# = \_ -> \_ -> 3
 
 instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
 
@@ -148,6 +135,19 @@ instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "foo_c" Foo ty where
           Foo {foo_c = y1, foo_a = RIP.getField @"foo_a" x0, foo_b = RIP.getField @"foo_b" x0}
       , RIP.getField @"foo_c" x0
       )
+
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "foo_c" (RIP.Ptr Foo) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"foo_c")
+
+instance HasCBitfield.HasCBitfield Foo "foo_c" where
+
+  type CBitfieldType Foo "foo_c" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 8
+
+  bitfieldWidth# = \_ -> \_ -> 2
 
 {-| __C declaration:__ @struct bar@
 
@@ -199,19 +199,6 @@ instance Marshal.WriteRaw Bar where
 
 deriving via Marshal.EquivStorable Bar instance RIP.Storable Bar
 
-instance HasCBitfield.HasCBitfield Bar "bar_x" where
-
-  type CBitfieldType Bar "bar_x" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 0
-
-  bitfieldWidth# = \_ -> \_ -> 3
-
-instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
-
-  getField = HasCBitfield.toPtr (RIP.Proxy @"bar_x")
-
 instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "bar_x" Bar ty where
 
   hasField =
@@ -221,18 +208,18 @@ instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "bar_x" Bar ty where
       , RIP.getField @"bar_x" x0
       )
 
-instance HasCBitfield.HasCBitfield Bar "bar_y" where
-
-  type CBitfieldType Bar "bar_y" = RIP.CSChar
-
-  bitfieldOffset# = \_ -> \_ -> 6
-
-  bitfieldWidth# = \_ -> \_ -> 2
-
 instance ( ty ~ RIP.CSChar
-         ) => RIP.HasField "bar_y" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
+         ) => RIP.HasField "bar_x" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
 
-  getField = HasCBitfield.toPtr (RIP.Proxy @"bar_y")
+  getField = HasCBitfield.toPtr (RIP.Proxy @"bar_x")
+
+instance HasCBitfield.HasCBitfield Bar "bar_x" where
+
+  type CBitfieldType Bar "bar_x" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
 
 instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "bar_y" Bar ty where
 
@@ -242,3 +229,16 @@ instance (ty ~ RIP.CSChar) => RIP.CompatHasField.HasField "bar_y" Bar ty where
           Bar {bar_y = y1, bar_x = RIP.getField @"bar_x" x0}
       , RIP.getField @"bar_y" x0
       )
+
+instance ( ty ~ RIP.CSChar
+         ) => RIP.HasField "bar_y" (RIP.Ptr Bar) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (RIP.Proxy @"bar_y")
+
+instance HasCBitfield.HasCBitfield Bar "bar_y" where
+
+  type CBitfieldType Bar "bar_y" = RIP.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 6
+
+  bitfieldWidth# = \_ -> \_ -> 2

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/padding/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/padding/bindingspec.yaml
@@ -18,11 +18,12 @@ hstypes:
       - bar_x
       - bar_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -37,11 +38,12 @@ hstypes:
       - foo_b
       - foo_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCBitfield
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/padding/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/padding/th.txt
@@ -39,42 +39,42 @@ instance WriteRaw Foo
                                            foo_b_3
                                            foo_c_4 -> poke (Proxy @"foo_a") ptr_0 foo_a_2 >> (poke (Proxy @"foo_b") ptr_0 foo_b_3 >> poke (Proxy @"foo_c") ptr_0 foo_c_4)
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCBitfield Foo "foo_a"
-    where type CBitfieldType Foo "foo_a" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "foo_a" (Ptr Foo) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_a")
 instance (~) ty CSChar => HasField "foo_a" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_a = y_1,
                                           foo_b = getField @"foo_b" x_0,
                                           foo_c = getField @"foo_c" x_0},
                               getField @"foo_a" x_0)
-instance HasCBitfield Foo "foo_b"
-    where type CBitfieldType Foo "foo_b" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 3
-          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar =>
-         HasField "foo_b" (Ptr Foo) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_b")
+         HasField "foo_a" (Ptr Foo) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_a")
+instance HasCBitfield Foo "foo_a"
+    where type CBitfieldType Foo "foo_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "foo_b" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_b = y_1,
                                           foo_a = getField @"foo_a" x_0,
                                           foo_c = getField @"foo_c" x_0},
                               getField @"foo_b" x_0)
-instance HasCBitfield Foo "foo_c"
-    where type CBitfieldType Foo "foo_c" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 8
-          bitfieldWidth# = \_ -> \_ -> 2
 instance (~) ty CSChar =>
-         HasField "foo_c" (Ptr Foo) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"foo_c")
+         HasField "foo_b" (Ptr Foo) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_b")
+instance HasCBitfield Foo "foo_b"
+    where type CBitfieldType Foo "foo_b" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 3
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "foo_c" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_c = y_1,
                                           foo_a = getField @"foo_a" x_0,
                                           foo_b = getField @"foo_b" x_0},
                               getField @"foo_c" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_c" (Ptr Foo) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_c")
+instance HasCBitfield Foo "foo_c"
+    where type CBitfieldType Foo "foo_c" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 8
+          bitfieldWidth# = \_ -> \_ -> 2
 {-| __C declaration:__ @struct bar@
 
     __defined at:__ @types\/structs\/padding.h 8:8@
@@ -107,25 +107,25 @@ instance WriteRaw Bar
                                        Bar bar_x_2
                                            bar_y_3 -> poke (Proxy @"bar_x") ptr_0 bar_x_2 >> poke (Proxy @"bar_y") ptr_0 bar_y_3
 deriving via (EquivStorable Bar) instance Storable Bar
-instance HasCBitfield Bar "bar_x"
-    where type CBitfieldType Bar "bar_x" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 0
-          bitfieldWidth# = \_ -> \_ -> 3
-instance (~) ty CSChar =>
-         HasField "bar_x" (Ptr Bar) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_x")
 instance (~) ty CSChar => HasField "bar_x" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_x = y_1,
                                           bar_y = getField @"bar_y" x_0},
                               getField @"bar_x" x_0)
-instance HasCBitfield Bar "bar_y"
-    where type CBitfieldType Bar "bar_y" = CSChar
-          bitfieldOffset# = \_ -> \_ -> 6
-          bitfieldWidth# = \_ -> \_ -> 2
 instance (~) ty CSChar =>
-         HasField "bar_y" (Ptr Bar) (BitfieldPtr ty)
-    where getField = toPtr (Proxy @"bar_y")
+         HasField "bar_x" (Ptr Bar) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_x")
+instance HasCBitfield Bar "bar_x"
+    where type CBitfieldType Bar "bar_x" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
 instance (~) ty CSChar => HasField "bar_y" Bar ty
     where hasField = \x_0 -> (\y_1 -> Bar{bar_y = y_1,
                                           bar_x = getField @"bar_x" x_0},
                               getField @"bar_y" x_0)
+instance (~) ty CSChar =>
+         HasField "bar_y" (Ptr Bar) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"bar_y")
+instance HasCBitfield Bar "bar_y"
+    where type CBitfieldType Bar "bar_y" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 6
+          bitfieldWidth# = \_ -> \_ -> 2

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/Example.hs
@@ -73,19 +73,6 @@ instance Marshal.WriteRaw Linked_list_A_t where
 
 deriving via Marshal.EquivStorable Linked_list_A_t instance RIP.Storable Linked_list_A_t
 
-instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_x" where
-
-  type CFieldType Linked_list_A_t "linked_list_A_t_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "linked_list_A_t_x" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "linked_list_A_t_x" Linked_list_A_t ty where
 
@@ -98,18 +85,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"linked_list_A_t_x" x0
       )
 
-instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_next" where
-
-  type CFieldType Linked_list_A_t "linked_list_A_t_next" =
-    RIP.Ptr Linked_list_A_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Linked_list_A_t
-         ) => RIP.HasField "linked_list_A_t_next" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "linked_list_A_t_x" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_next")
+    HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_x")
+
+instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_x" where
+
+  type CFieldType Linked_list_A_t "linked_list_A_t_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Linked_list_A_t
          ) => RIP.CompatHasField.HasField "linked_list_A_t_next" Linked_list_A_t ty where
@@ -122,6 +109,19 @@ instance ( ty ~ RIP.Ptr Linked_list_A_t
                           }
       , RIP.getField @"linked_list_A_t_next" x0
       )
+
+instance ( ty ~ RIP.Ptr Linked_list_A_t
+         ) => RIP.HasField "linked_list_A_t_next" (RIP.Ptr Linked_list_A_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"linked_list_A_t_next")
+
+instance HasCField.HasCField Linked_list_A_t "linked_list_A_t_next" where
+
+  type CFieldType Linked_list_A_t "linked_list_A_t_next" =
+    RIP.Ptr Linked_list_A_t
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct linked_list_B_t@
 
@@ -173,19 +173,6 @@ instance Marshal.WriteRaw Linked_list_B_t where
 
 deriving via Marshal.EquivStorable Linked_list_B_t instance RIP.Storable Linked_list_B_t
 
-instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_x" where
-
-  type CFieldType Linked_list_B_t "linked_list_B_t_x" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "linked_list_B_t_x" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_x")
-
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "linked_list_B_t_x" Linked_list_B_t ty where
 
@@ -198,18 +185,18 @@ instance ( ty ~ RIP.CInt
       , RIP.getField @"linked_list_B_t_x" x0
       )
 
-instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_next" where
-
-  type CFieldType Linked_list_B_t "linked_list_B_t_next" =
-    RIP.Ptr Linked_list_B_t
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ RIP.Ptr Linked_list_B_t
-         ) => RIP.HasField "linked_list_B_t_next" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "linked_list_B_t_x" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_next")
+    HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_x")
+
+instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_x" where
+
+  type CFieldType Linked_list_B_t "linked_list_B_t_x" =
+    RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.Ptr Linked_list_B_t
          ) => RIP.CompatHasField.HasField "linked_list_B_t_next" Linked_list_B_t ty where
@@ -222,3 +209,16 @@ instance ( ty ~ RIP.Ptr Linked_list_B_t
                           }
       , RIP.getField @"linked_list_B_t_next" x0
       )
+
+instance ( ty ~ RIP.Ptr Linked_list_B_t
+         ) => RIP.HasField "linked_list_B_t_next" (RIP.Ptr Linked_list_B_t) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"linked_list_B_t_next")
+
+instance HasCField.HasCField Linked_list_B_t "linked_list_B_t_next" where
+
+  type CFieldType Linked_list_B_t "linked_list_B_t_next" =
+    RIP.Ptr Linked_list_B_t
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/bindingspec.yaml
@@ -24,11 +24,12 @@ hstypes:
       - linked_list_A_t_x
       - linked_list_A_t_next
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -42,11 +43,12 @@ hstypes:
       - linked_list_B_t_x
       - linked_list_B_t_next
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/recursive_struct/th.txt
@@ -31,29 +31,29 @@ instance WriteRaw Linked_list_A_t
                                        Linked_list_A_t linked_list_A_t_x_2
                                                        linked_list_A_t_next_3 -> writeRaw (Proxy @"linked_list_A_t_x") ptr_0 linked_list_A_t_x_2 >> writeRaw (Proxy @"linked_list_A_t_next") ptr_0 linked_list_A_t_next_3
 deriving via (EquivStorable Linked_list_A_t) instance Storable Linked_list_A_t
-instance HasCField Linked_list_A_t "linked_list_A_t_x"
-    where type CFieldType Linked_list_A_t "linked_list_A_t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "linked_list_A_t_x" (Ptr Linked_list_A_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"linked_list_A_t_x")
 instance (~) ty CInt =>
          HasField "linked_list_A_t_x" Linked_list_A_t ty
     where hasField = \x_0 -> (\y_1 -> Linked_list_A_t{linked_list_A_t_x = y_1,
                                                       linked_list_A_t_next = getField @"linked_list_A_t_next" x_0},
                               getField @"linked_list_A_t_x" x_0)
-instance HasCField Linked_list_A_t "linked_list_A_t_next"
-    where type CFieldType Linked_list_A_t
-                          "linked_list_A_t_next" = Ptr Linked_list_A_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Linked_list_A_t) =>
-         HasField "linked_list_A_t_next" (Ptr Linked_list_A_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"linked_list_A_t_next")
+instance (~) ty CInt =>
+         HasField "linked_list_A_t_x" (Ptr Linked_list_A_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"linked_list_A_t_x")
+instance HasCField Linked_list_A_t "linked_list_A_t_x"
+    where type CFieldType Linked_list_A_t "linked_list_A_t_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Linked_list_A_t) =>
          HasField "linked_list_A_t_next" Linked_list_A_t ty
     where hasField = \x_0 -> (\y_1 -> Linked_list_A_t{linked_list_A_t_next = y_1,
                                                       linked_list_A_t_x = getField @"linked_list_A_t_x" x_0},
                               getField @"linked_list_A_t_next" x_0)
+instance (~) ty (Ptr Linked_list_A_t) =>
+         HasField "linked_list_A_t_next" (Ptr Linked_list_A_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"linked_list_A_t_next")
+instance HasCField Linked_list_A_t "linked_list_A_t_next"
+    where type CFieldType Linked_list_A_t
+                          "linked_list_A_t_next" = Ptr Linked_list_A_t
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct linked_list_B_t@
 
     __defined at:__ @types\/structs\/recursive_struct.h 9:8@
@@ -86,26 +86,26 @@ instance WriteRaw Linked_list_B_t
                                        Linked_list_B_t linked_list_B_t_x_2
                                                        linked_list_B_t_next_3 -> writeRaw (Proxy @"linked_list_B_t_x") ptr_0 linked_list_B_t_x_2 >> writeRaw (Proxy @"linked_list_B_t_next") ptr_0 linked_list_B_t_next_3
 deriving via (EquivStorable Linked_list_B_t) instance Storable Linked_list_B_t
-instance HasCField Linked_list_B_t "linked_list_B_t_x"
-    where type CFieldType Linked_list_B_t "linked_list_B_t_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt =>
-         HasField "linked_list_B_t_x" (Ptr Linked_list_B_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"linked_list_B_t_x")
 instance (~) ty CInt =>
          HasField "linked_list_B_t_x" Linked_list_B_t ty
     where hasField = \x_0 -> (\y_1 -> Linked_list_B_t{linked_list_B_t_x = y_1,
                                                       linked_list_B_t_next = getField @"linked_list_B_t_next" x_0},
                               getField @"linked_list_B_t_x" x_0)
-instance HasCField Linked_list_B_t "linked_list_B_t_next"
-    where type CFieldType Linked_list_B_t
-                          "linked_list_B_t_next" = Ptr Linked_list_B_t
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr Linked_list_B_t) =>
-         HasField "linked_list_B_t_next" (Ptr Linked_list_B_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"linked_list_B_t_next")
+instance (~) ty CInt =>
+         HasField "linked_list_B_t_x" (Ptr Linked_list_B_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"linked_list_B_t_x")
+instance HasCField Linked_list_B_t "linked_list_B_t_x"
+    where type CFieldType Linked_list_B_t "linked_list_B_t_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty (Ptr Linked_list_B_t) =>
          HasField "linked_list_B_t_next" Linked_list_B_t ty
     where hasField = \x_0 -> (\y_1 -> Linked_list_B_t{linked_list_B_t_next = y_1,
                                                       linked_list_B_t_x = getField @"linked_list_B_t_x" x_0},
                               getField @"linked_list_B_t_next" x_0)
+instance (~) ty (Ptr Linked_list_B_t) =>
+         HasField "linked_list_B_t_next" (Ptr Linked_list_B_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"linked_list_B_t_next")
+instance HasCField Linked_list_B_t "linked_list_B_t_next"
+    where type CFieldType Linked_list_B_t
+                          "linked_list_B_t_next" = Ptr Linked_list_B_t
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/Example.hs
@@ -83,16 +83,6 @@ instance Marshal.WriteRaw S1 where
 
 deriving via Marshal.EquivStorable S1 instance RIP.Storable S1
 
-instance HasCField.HasCField S1 "a" where
-
-  type CFieldType S1 "a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" S1 ty where
 
   hasField =
@@ -100,15 +90,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" S1 ty where
       (\y1 ->
          S1 {a = y1, b = RIP.getField @"b" x0}, RIP.getField @"a" x0)
 
-instance HasCField.HasCField S1 "b" where
+instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S1) (RIP.Ptr ty) where
 
-  type CFieldType S1 "b" = RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S1 "a" where
 
-instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S1) (RIP.Ptr ty) where
+  type CFieldType S1 "a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "b" S1 ty where
 
@@ -116,6 +106,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "b" S1 ty where
     \x0 ->
       (\y1 ->
          S1 {b = y1, a = RIP.getField @"a" x0}, RIP.getField @"b" x0)
+
+instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
+
+instance HasCField.HasCField S1 "b" where
+
+  type CFieldType S1 "b" = RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S2@
 
@@ -176,16 +176,6 @@ instance Marshal.WriteRaw S2_t where
 
 deriving via Marshal.EquivStorable S2_t instance RIP.Storable S2_t
 
-instance HasCField.HasCField S2_t "a" where
-
-  type CFieldType S2_t "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S2_t ty where
 
   hasField =
@@ -195,15 +185,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S2_t ty where
       , RIP.getField @"a" x0
       )
 
-instance HasCField.HasCField S2_t "b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S2_t "a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S2_t ty where
 
@@ -214,15 +204,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S2_t ty where
       , RIP.getField @"b" x0
       )
 
-instance HasCField.HasCField S2_t "c" where
+instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "c" = RIP.CFloat
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S2_t "b" where
 
-instance (ty ~ RIP.CFloat) => RIP.HasField "c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "b" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"c")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "c" S2_t ty where
 
@@ -232,6 +222,16 @@ instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "c" S2_t ty where
           S2_t {c = y1, a = RIP.getField @"a" x0, b = RIP.getField @"b" x0}
       , RIP.getField @"c" x0
       )
+
+instance (ty ~ RIP.CFloat) => RIP.HasField "c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"c")
+
+instance HasCField.HasCField S2_t "c" where
+
+  type CFieldType S2_t "c" = RIP.CFloat
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S3_t@
 
@@ -274,20 +274,20 @@ instance Marshal.WriteRaw S3_t where
 
 deriving via Marshal.EquivStorable S3_t instance RIP.Storable S3_t
 
-instance HasCField.HasCField S3_t "a" where
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S3_t ty where
 
-  type CFieldType S3_t "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 -> (\y1 -> S3_t {a = y1}, RIP.getField @"a" x0)
 
 instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S3_t ty where
+instance HasCField.HasCField S3_t "a" where
 
-  hasField =
-    \x0 -> (\y1 -> S3_t {a = y1}, RIP.getField @"a" x0)
+  type CFieldType S3_t "a" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S4@
 
@@ -348,16 +348,6 @@ instance Marshal.WriteRaw S4 where
 
 deriving via Marshal.EquivStorable S4 instance RIP.Storable S4
 
-instance HasCField.HasCField S4 "b" where
-
-  type CFieldType S4 "b" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S4) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "b" S4 ty where
 
   hasField =
@@ -367,15 +357,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "b" S4 ty where
       , RIP.getField @"b" x0
       )
 
-instance HasCField.HasCField S4 "a" where
+instance (ty ~ RIP.CChar) => RIP.HasField "b" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "a" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S4 "b" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "b" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" S4 ty where
 
@@ -386,16 +376,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "a" S4 ty where
       , RIP.getField @"a" x0
       )
 
-instance HasCField.HasCField S4 "c" where
+instance (ty ~ RIP.CInt) => RIP.HasField "a" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "c" = RIP.Ptr RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S4 "a" where
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "c" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"c")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.Ptr RIP.CInt) => RIP.CompatHasField.HasField "c" S4 ty where
 
@@ -405,6 +394,17 @@ instance (ty ~ RIP.Ptr RIP.CInt) => RIP.CompatHasField.HasField "c" S4 ty where
           S4 {c = y1, b = RIP.getField @"b" x0, a = RIP.getField @"a" x0}
       , RIP.getField @"c" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "c" (RIP.Ptr S4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"c")
+
+instance HasCField.HasCField S4 "c" where
+
+  type CFieldType S4 "c" = RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S5@
 
@@ -456,16 +456,6 @@ instance Marshal.WriteRaw S5 where
 
 deriving via Marshal.EquivStorable S5 instance RIP.Storable S5
 
-instance HasCField.HasCField S5 "a" where
-
-  type CFieldType S5 "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S5) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S5 ty where
 
   hasField =
@@ -473,15 +463,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S5 ty where
       (\y1 ->
          S5 {a = y1, b = RIP.getField @"b" x0}, RIP.getField @"a" x0)
 
-instance HasCField.HasCField S5 "b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S5) (RIP.Ptr ty) where
 
-  type CFieldType S5 "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S5 "a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S5) (RIP.Ptr ty) where
+  type CFieldType S5 "a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S5 ty where
 
@@ -489,6 +479,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S5 ty where
     \x0 ->
       (\y1 ->
          S5 {b = y1, a = RIP.getField @"a" x0}, RIP.getField @"b" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S5) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
+
+instance HasCField.HasCField S5 "b" where
+
+  type CFieldType S5 "b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S6@
 
@@ -540,16 +540,6 @@ instance Marshal.WriteRaw S6 where
 
 deriving via Marshal.EquivStorable S6 instance RIP.Storable S6
 
-instance HasCField.HasCField S6 "a" where
-
-  type CFieldType S6 "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S6) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S6 ty where
 
   hasField =
@@ -557,15 +547,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S6 ty where
       (\y1 ->
          S6 {a = y1, b = RIP.getField @"b" x0}, RIP.getField @"a" x0)
 
-instance HasCField.HasCField S6 "b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "a" (RIP.Ptr S6) (RIP.Ptr ty) where
 
-  type CFieldType S6 "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S6 "a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S6) (RIP.Ptr ty) where
+  type CFieldType S6 "a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S6 ty where
 
@@ -573,6 +563,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S6 ty where
     \x0 ->
       (\y1 ->
          S6 {b = y1, a = RIP.getField @"a" x0}, RIP.getField @"b" x0)
+
+instance (ty ~ RIP.CInt) => RIP.HasField "b" (RIP.Ptr S6) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
+
+instance HasCField.HasCField S6 "b" where
+
+  type CFieldType S6 "b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -624,17 +624,6 @@ instance Marshal.WriteRaw S7a_Aux where
 
 deriving via Marshal.EquivStorable S7a_Aux instance RIP.Storable S7a_Aux
 
-instance HasCField.HasCField S7a_Aux "a" where
-
-  type CFieldType S7a_Aux "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S7a_Aux ty where
 
   hasField =
@@ -642,16 +631,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S7a_Aux ty where
       (\y1 ->
          S7a_Aux {a = y1, b = RIP.getField @"b" x0}, RIP.getField @"a" x0)
 
-instance HasCField.HasCField S7a_Aux "b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7a_Aux "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7a_Aux "a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+  type CFieldType S7a_Aux "a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S7a_Aux ty where
 
@@ -659,6 +648,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S7a_Aux ty where
     \x0 ->
       (\y1 ->
          S7a_Aux {b = y1, a = RIP.getField @"a" x0}, RIP.getField @"b" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
+
+instance HasCField.HasCField S7a_Aux "b" where
+
+  type CFieldType S7a_Aux "b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7a@
 
@@ -679,6 +679,13 @@ newtype S7a = S7a
     )
 
 instance ( ty ~ RIP.Ptr S7a_Aux
+         ) => RIP.CompatHasField.HasField "unwrap" S7a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> S7a {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.Ptr S7a_Aux
          ) => RIP.HasField "unwrap" (RIP.Ptr S7a) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -688,13 +695,6 @@ instance HasCField.HasCField S7a "unwrap" where
   type CFieldType S7a "unwrap" = RIP.Ptr S7a_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.CompatHasField.HasField "unwrap" S7a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> S7a {unwrap = y1}, RIP.getField @"unwrap" x0)
 
 {-| __C declaration:__ @struct \@S7b_Aux@
 
@@ -746,17 +746,6 @@ instance Marshal.WriteRaw S7b_Aux where
 
 deriving via Marshal.EquivStorable S7b_Aux instance RIP.Storable S7b_Aux
 
-instance HasCField.HasCField S7b_Aux "a" where
-
-  type CFieldType S7b_Aux "a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S7b_Aux ty where
 
   hasField =
@@ -764,16 +753,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "a" S7b_Aux ty where
       (\y1 ->
          S7b_Aux {a = y1, b = RIP.getField @"b" x0}, RIP.getField @"a" x0)
 
-instance HasCField.HasCField S7b_Aux "b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7b_Aux "b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7b_Aux "a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+  type CFieldType S7b_Aux "a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S7b_Aux ty where
 
@@ -781,6 +770,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "b" S7b_Aux ty where
     \x0 ->
       (\y1 ->
          S7b_Aux {b = y1, a = RIP.getField @"a" x0}, RIP.getField @"b" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"b")
+
+instance HasCField.HasCField S7b_Aux "b" where
+
+  type CFieldType S7b_Aux "b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7b@
 
@@ -801,6 +801,13 @@ newtype S7b = S7b
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
+         ) => RIP.CompatHasField.HasField "unwrap" S7b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> S7b {unwrap = y1}, RIP.getField @"unwrap" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
          ) => RIP.HasField "unwrap" (RIP.Ptr S7b) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrap")
@@ -811,10 +818,3 @@ instance HasCField.HasCField S7b "unwrap" where
     RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.CompatHasField.HasField "unwrap" S7b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> S7b {unwrap = y1}, RIP.getField @"unwrap" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/bindingspec.yaml
@@ -54,11 +54,12 @@ hstypes:
       - a
       - b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,11 +74,12 @@ hstypes:
       - b
       - c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +92,12 @@ hstypes:
       fields:
       - a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,11 +112,12 @@ hstypes:
       - a
       - c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -127,11 +131,12 @@ hstypes:
       - a
       - b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -145,11 +150,12 @@ hstypes:
       - a
       - b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -162,12 +168,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -182,11 +189,12 @@ hstypes:
       - a
       - b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -199,12 +207,13 @@ hstypes:
       fields:
       - unwrap
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -219,11 +228,12 @@ hstypes:
       - a
       - b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.omit_field_prefixes/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw S1
                                        S1 a_2
                                           b_3 -> writeRaw (Proxy @"a") ptr_0 a_2 >> writeRaw (Proxy @"b") ptr_0 b_3
 deriving via (EquivStorable S1) instance Storable S1
-instance HasCField S1 "a"
-    where type CFieldType S1 "a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "a" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CInt => HasField "a" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{a = y_1,
                                          b = getField @"b" x_0},
                               getField @"a" x_0)
-instance HasCField S1 "b"
-    where type CFieldType S1 "b" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "b" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CInt => HasField "a" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S1 "a"
+    where type CFieldType S1 "a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar => HasField "b" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{b = y_1,
                                          a = getField @"a" x_0},
                               getField @"b" x_0)
+instance (~) ty CChar => HasField "b" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S1 "b"
+    where type CFieldType S1 "b" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @types\/structs\/simple_structs.h 8:16@
@@ -89,36 +89,36 @@ instance WriteRaw S2_t
                                             b_3
                                             c_4 -> writeRaw (Proxy @"a") ptr_0 a_2 >> (writeRaw (Proxy @"b") ptr_0 b_3 >> writeRaw (Proxy @"c") ptr_0 c_4)
 deriving via (EquivStorable S2_t) instance Storable S2_t
-instance HasCField S2_t "a"
-    where type CFieldType S2_t "a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CChar => HasField "a" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{a = y_1,
                                            b = getField @"b" x_0,
                                            c = getField @"c" x_0},
                               getField @"a" x_0)
-instance HasCField S2_t "b"
-    where type CFieldType S2_t "b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CChar => HasField "a" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S2_t "a"
+    where type CFieldType S2_t "a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{b = y_1,
                                            a = getField @"a" x_0,
                                            c = getField @"c" x_0},
                               getField @"b" x_0)
-instance HasCField S2_t "c"
-    where type CFieldType S2_t "c" = CFloat
-          offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "c" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"c")
+instance (~) ty CInt => HasField "b" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S2_t "b"
+    where type CFieldType S2_t "b" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty CFloat => HasField "c" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{c = y_1,
                                            a = getField @"a" x_0,
                                            b = getField @"b" x_0},
                               getField @"c" x_0)
+instance (~) ty CFloat => HasField "c" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"c")
+instance HasCField S2_t "c"
+    where type CFieldType S2_t "c" = CFloat
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S3_t@
 
     __defined at:__ @types\/structs\/simple_structs.h 15:9@
@@ -143,13 +143,13 @@ instance WriteRaw S3_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S3_t a_2 -> writeRaw (Proxy @"a") ptr_0 a_2
 deriving via (EquivStorable S3_t) instance Storable S3_t
+instance (~) ty CChar => HasField "a" S3_t ty
+    where hasField = \x_0 -> (\y_1 -> S3_t{a = y_1}, getField @"a" x_0)
+instance (~) ty CChar => HasField "a" (Ptr S3_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
 instance HasCField S3_t "a"
     where type CFieldType S3_t "a" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S3_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
-instance (~) ty CChar => HasField "a" S3_t ty
-    where hasField = \x_0 -> (\y_1 -> S3_t{a = y_1}, getField @"a" x_0)
 {-| __C declaration:__ @struct S4@
 
     __defined at:__ @types\/structs\/simple_structs.h 19:8@
@@ -190,36 +190,36 @@ instance WriteRaw S4
                                           a_3
                                           c_4 -> writeRaw (Proxy @"b") ptr_0 b_2 >> (writeRaw (Proxy @"a") ptr_0 a_3 >> writeRaw (Proxy @"c") ptr_0 c_4)
 deriving via (EquivStorable S4) instance Storable S4
-instance HasCField S4 "b"
-    where type CFieldType S4 "b" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "b" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
 instance (~) ty CChar => HasField "b" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{b = y_1,
                                          a = getField @"a" x_0,
                                          c = getField @"c" x_0},
                               getField @"b" x_0)
-instance HasCField S4 "a"
-    where type CFieldType S4 "a" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "a" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
+instance (~) ty CChar => HasField "b" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S4 "b"
+    where type CFieldType S4 "b" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "a" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{a = y_1,
                                          b = getField @"b" x_0,
                                          c = getField @"c" x_0},
                               getField @"a" x_0)
-instance HasCField S4 "c"
-    where type CFieldType S4 "c" = Ptr CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "c" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"c")
+instance (~) ty CInt => HasField "a" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S4 "a"
+    where type CFieldType S4 "a" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty (Ptr CInt) => HasField "c" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{c = y_1,
                                          b = getField @"b" x_0,
                                          a = getField @"a" x_0},
                               getField @"c" x_0)
+instance (~) ty (Ptr CInt) => HasField "c" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"c")
+instance HasCField S4 "c"
+    where type CFieldType S4 "c" = Ptr CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S5@
 
     __defined at:__ @types\/structs\/simple_structs.h 26:16@
@@ -252,24 +252,24 @@ instance WriteRaw S5
                                        S5 a_2
                                           b_3 -> writeRaw (Proxy @"a") ptr_0 a_2 >> writeRaw (Proxy @"b") ptr_0 b_3
 deriving via (EquivStorable S5) instance Storable S5
-instance HasCField S5 "a"
-    where type CFieldType S5 "a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CChar => HasField "a" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{a = y_1,
                                          b = getField @"b" x_0},
                               getField @"a" x_0)
-instance HasCField S5 "b"
-    where type CFieldType S5 "b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CChar => HasField "a" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S5 "a"
+    where type CFieldType S5 "a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{b = y_1,
                                          a = getField @"a" x_0},
                               getField @"b" x_0)
+instance (~) ty CInt => HasField "b" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S5 "b"
+    where type CFieldType S5 "b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S6@
 
     __defined at:__ @types\/structs\/simple_structs.h 31:8@
@@ -302,24 +302,24 @@ instance WriteRaw S6
                                        S6 a_2
                                           b_3 -> writeRaw (Proxy @"a") ptr_0 a_2 >> writeRaw (Proxy @"b") ptr_0 b_3
 deriving via (EquivStorable S6) instance Storable S6
-instance HasCField S6 "a"
-    where type CFieldType S6 "a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CChar => HasField "a" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{a = y_1,
                                          b = getField @"b" x_0},
                               getField @"a" x_0)
-instance HasCField S6 "b"
-    where type CFieldType S6 "b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CChar => HasField "a" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S6 "a"
+    where type CFieldType S6 "a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{b = y_1,
                                          a = getField @"a" x_0},
                               getField @"b" x_0)
+instance (~) ty CInt => HasField "b" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S6 "b"
+    where type CFieldType S6 "b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@S7a_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:9@
@@ -352,24 +352,24 @@ instance WriteRaw S7a_Aux
                                        S7a_Aux a_2
                                                b_3 -> writeRaw (Proxy @"a") ptr_0 a_2 >> writeRaw (Proxy @"b") ptr_0 b_3
 deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
-instance HasCField S7a_Aux "a"
-    where type CFieldType S7a_Aux "a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CChar => HasField "a" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{a = y_1,
                                               b = getField @"b" x_0},
                               getField @"a" x_0)
-instance HasCField S7a_Aux "b"
-    where type CFieldType S7a_Aux "b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CChar => HasField "a" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S7a_Aux "a"
+    where type CFieldType S7a_Aux "a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{b = y_1,
                                               a = getField @"a" x_0},
                               getField @"b" x_0)
+instance (~) ty CInt => HasField "b" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S7a_Aux "b"
+    where type CFieldType S7a_Aux "b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7a@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:36@
@@ -384,15 +384,15 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr S7a_Aux) => HasField "unwrap" S7a ty
+    where hasField = \x_0 -> (\y_1 -> S7a{unwrap = y_1},
+                              getField @"unwrap" x_0)
 instance (~) ty (Ptr S7a_Aux) =>
          HasField "unwrap" (Ptr S7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7a "unwrap"
     where type CFieldType S7a "unwrap" = Ptr S7a_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr S7a_Aux) => HasField "unwrap" S7a ty
-    where hasField = \x_0 -> (\y_1 -> S7a{unwrap = y_1},
-                              getField @"unwrap" x_0)
 {-| __C declaration:__ @struct \@S7b_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:9@
@@ -425,24 +425,24 @@ instance WriteRaw S7b_Aux
                                        S7b_Aux a_2
                                                b_3 -> writeRaw (Proxy @"a") ptr_0 a_2 >> writeRaw (Proxy @"b") ptr_0 b_3
 deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
-instance HasCField S7b_Aux "a"
-    where type CFieldType S7b_Aux "a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "a" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"a")
 instance (~) ty CChar => HasField "a" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{a = y_1,
                                               b = getField @"b" x_0},
                               getField @"a" x_0)
-instance HasCField S7b_Aux "b"
-    where type CFieldType S7b_Aux "b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "b" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"b")
+instance (~) ty CChar => HasField "a" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"a")
+instance HasCField S7b_Aux "a"
+    where type CFieldType S7b_Aux "a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "b" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{b = y_1,
                                               a = getField @"a" x_0},
                               getField @"b" x_0)
+instance (~) ty CInt => HasField "b" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"b")
+instance HasCField S7b_Aux "b"
+    where type CFieldType S7b_Aux "b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7b@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:38@
@@ -458,12 +458,12 @@ newtype S7b
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
+         HasField "unwrap" S7b ty
+    where hasField = \x_0 -> (\y_1 -> S7b{unwrap = y_1},
+                              getField @"unwrap" x_0)
+instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
          HasField "unwrap" (Ptr S7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrap")
 instance HasCField S7b "unwrap"
     where type CFieldType S7b "unwrap" = Ptr (Ptr (Ptr S7b_Aux))
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrap" S7b ty
-    where hasField = \x_0 -> (\y_1 -> S7b{unwrap = y_1},
-                              getField @"unwrap" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/Example.hs
@@ -83,16 +83,6 @@ instance Marshal.WriteRaw S1 where
 
 deriving via Marshal.EquivStorable S1 instance RIP.Storable S1
 
-instance HasCField.HasCField S1 "s1_a" where
-
-  type CFieldType S1 "s1_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_a" S1 ty where
 
   hasField =
@@ -102,15 +92,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_a" S1 ty where
       , RIP.getField @"s1_a" x0
       )
 
-instance HasCField.HasCField S1 "s1_b" where
+instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
 
-  type CFieldType S1 "s1_b" = RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S1 "s1_a" where
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+  type CFieldType S1 "s1_a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s1_b" S1 ty where
 
@@ -120,6 +110,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s1_b" S1 ty where
           S1 {s1_b = y1, s1_a = RIP.getField @"s1_a" x0}
       , RIP.getField @"s1_b" x0
       )
+
+instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
+
+instance HasCField.HasCField S1 "s1_b" where
+
+  type CFieldType S1 "s1_b" = RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S2@
 
@@ -180,17 +180,6 @@ instance Marshal.WriteRaw S2_t where
 
 deriving via Marshal.EquivStorable S2_t instance RIP.Storable S2_t
 
-instance HasCField.HasCField S2_t "s2_t_a" where
-
-  type CFieldType S2_t "s2_t_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s2_t_a" S2_t ty where
 
   hasField =
@@ -203,16 +192,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s2_t_a" S2_t ty where
       , RIP.getField @"s2_t_a" x0
       )
 
-instance HasCField.HasCField S2_t "s2_t_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "s2_t_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S2_t "s2_t_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "s2_t_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_t_b" S2_t ty where
 
@@ -226,16 +215,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_t_b" S2_t ty where
       , RIP.getField @"s2_t_b" x0
       )
 
-instance HasCField.HasCField S2_t "s2_t_c" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "s2_t_c" = RIP.CFloat
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S2_t "s2_t_b" where
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "s2_t_b" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "s2_t_c" S2_t ty where
 
@@ -248,6 +237,17 @@ instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "s2_t_c" S2_t ty where
                }
       , RIP.getField @"s2_t_c" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
+
+instance HasCField.HasCField S2_t "s2_t_c" where
+
+  type CFieldType S2_t "s2_t_c" = RIP.CFloat
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S3_t@
 
@@ -290,23 +290,23 @@ instance Marshal.WriteRaw S3_t where
 
 deriving via Marshal.EquivStorable S3_t instance RIP.Storable S3_t
 
-instance HasCField.HasCField S3_t "s3_t_a" where
-
-  type CFieldType S3_t "s3_t_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s3_t_a" S3_t ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          S3_t {s3_t_a = y1}, RIP.getField @"s3_t_a" x0)
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
+
+instance HasCField.HasCField S3_t "s3_t_a" where
+
+  type CFieldType S3_t "s3_t_a" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S4@
 
@@ -367,16 +367,6 @@ instance Marshal.WriteRaw S4 where
 
 deriving via Marshal.EquivStorable S4 instance RIP.Storable S4
 
-instance HasCField.HasCField S4 "s4_b" where
-
-  type CFieldType S4 "s4_b" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s4_b" S4 ty where
 
   hasField =
@@ -386,15 +376,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s4_b" S4 ty where
       , RIP.getField @"s4_b" x0
       )
 
-instance HasCField.HasCField S4 "s4_a" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "s4_a" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S4 "s4_b" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "s4_b" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s4_a" S4 ty where
 
@@ -405,16 +395,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s4_a" S4 ty where
       , RIP.getField @"s4_a" x0
       )
 
-instance HasCField.HasCField S4 "s4_c" where
+instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "s4_c" = RIP.Ptr RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S4 "s4_a" where
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "s4_a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.CompatHasField.HasField "s4_c" S4 ty where
@@ -425,6 +414,17 @@ instance ( ty ~ RIP.Ptr RIP.CInt
           S4 {s4_c = y1, s4_b = RIP.getField @"s4_b" x0, s4_a = RIP.getField @"s4_a" x0}
       , RIP.getField @"s4_c" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
+
+instance HasCField.HasCField S4 "s4_c" where
+
+  type CFieldType S4 "s4_c" = RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S5@
 
@@ -476,16 +476,6 @@ instance Marshal.WriteRaw S5 where
 
 deriving via Marshal.EquivStorable S5 instance RIP.Storable S5
 
-instance HasCField.HasCField S5 "s5_a" where
-
-  type CFieldType S5 "s5_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s5_a" S5 ty where
 
   hasField =
@@ -495,15 +485,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s5_a" S5 ty where
       , RIP.getField @"s5_a" x0
       )
 
-instance HasCField.HasCField S5 "s5_b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
 
-  type CFieldType S5 "s5_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S5 "s5_a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+  type CFieldType S5 "s5_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s5_b" S5 ty where
 
@@ -513,6 +503,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s5_b" S5 ty where
           S5 {s5_b = y1, s5_a = RIP.getField @"s5_a" x0}
       , RIP.getField @"s5_b" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
+
+instance HasCField.HasCField S5 "s5_b" where
+
+  type CFieldType S5 "s5_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S6@
 
@@ -564,16 +564,6 @@ instance Marshal.WriteRaw S6 where
 
 deriving via Marshal.EquivStorable S6 instance RIP.Storable S6
 
-instance HasCField.HasCField S6 "s6_a" where
-
-  type CFieldType S6 "s6_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s6_a" S6 ty where
 
   hasField =
@@ -583,15 +573,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s6_a" S6 ty where
       , RIP.getField @"s6_a" x0
       )
 
-instance HasCField.HasCField S6 "s6_b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
 
-  type CFieldType S6 "s6_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S6 "s6_a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+  type CFieldType S6 "s6_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s6_b" S6 ty where
 
@@ -601,6 +591,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s6_b" S6 ty where
           S6 {s6_b = y1, s6_a = RIP.getField @"s6_a" x0}
       , RIP.getField @"s6_b" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
+
+instance HasCField.HasCField S6 "s6_b" where
+
+  type CFieldType S6 "s6_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -652,17 +652,6 @@ instance Marshal.WriteRaw S7a_Aux where
 
 deriving via Marshal.EquivStorable S7a_Aux instance RIP.Storable S7a_Aux
 
-instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
-
-  type CFieldType S7a_Aux "s7a_Aux_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "s7a_Aux_a" S7a_Aux ty where
 
@@ -673,16 +662,16 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"s7a_Aux_a" x0
       )
 
-instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7a_Aux "s7a_Aux_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+  type CFieldType S7a_Aux "s7a_Aux_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s7a_Aux_b" S7a_Aux ty where
@@ -693,6 +682,17 @@ instance ( ty ~ RIP.CInt
           S7a_Aux {s7a_Aux_b = y1, s7a_Aux_a = RIP.getField @"s7a_Aux_a" x0}
       , RIP.getField @"s7a_Aux_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
+
+instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
+
+  type CFieldType S7a_Aux "s7a_Aux_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7a@
 
@@ -713,6 +713,14 @@ newtype S7a = S7a
     )
 
 instance ( ty ~ RIP.Ptr S7a_Aux
+         ) => RIP.CompatHasField.HasField "unwrapS7a" S7a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         S7a {unwrapS7a = y1}, RIP.getField @"unwrapS7a" x0)
+
+instance ( ty ~ RIP.Ptr S7a_Aux
          ) => RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7a")
@@ -722,14 +730,6 @@ instance HasCField.HasCField S7a "unwrapS7a" where
   type CFieldType S7a "unwrapS7a" = RIP.Ptr S7a_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.CompatHasField.HasField "unwrapS7a" S7a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         S7a {unwrapS7a = y1}, RIP.getField @"unwrapS7a" x0)
 
 {-| __C declaration:__ @struct \@S7b_Aux@
 
@@ -781,17 +781,6 @@ instance Marshal.WriteRaw S7b_Aux where
 
 deriving via Marshal.EquivStorable S7b_Aux instance RIP.Storable S7b_Aux
 
-instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
-
-  type CFieldType S7b_Aux "s7b_Aux_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "s7b_Aux_a" S7b_Aux ty where
 
@@ -802,16 +791,16 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"s7b_Aux_a" x0
       )
 
-instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7b_Aux "s7b_Aux_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+  type CFieldType S7b_Aux "s7b_Aux_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s7b_Aux_b" S7b_Aux ty where
@@ -822,6 +811,17 @@ instance ( ty ~ RIP.CInt
           S7b_Aux {s7b_Aux_b = y1, s7b_Aux_a = RIP.getField @"s7b_Aux_a" x0}
       , RIP.getField @"s7b_Aux_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
+
+instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
+
+  type CFieldType S7b_Aux "s7b_Aux_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7b@
 
@@ -842,6 +842,14 @@ newtype S7b = S7b
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
+         ) => RIP.CompatHasField.HasField "unwrapS7b" S7b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         S7b {unwrapS7b = y1}, RIP.getField @"unwrapS7b" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
          ) => RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7b")
@@ -852,11 +860,3 @@ instance HasCField.HasCField S7b "unwrapS7b" where
     RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.CompatHasField.HasField "unwrapS7b" S7b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         S7b {unwrapS7b = y1}, RIP.getField @"unwrapS7b" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/bindingspec.yaml
@@ -54,11 +54,12 @@ hstypes:
       - s1_a
       - s1_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,11 +74,12 @@ hstypes:
       - s2_t_b
       - s2_t_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +92,12 @@ hstypes:
       fields:
       - s3_t_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,11 +112,12 @@ hstypes:
       - s4_a
       - s4_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -127,11 +131,12 @@ hstypes:
       - s5_a
       - s5_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -145,11 +150,12 @@ hstypes:
       - s6_a
       - s6_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -162,12 +168,13 @@ hstypes:
       fields:
       - unwrapS7a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -182,11 +189,12 @@ hstypes:
       - s7a_Aux_a
       - s7a_Aux_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -199,12 +207,13 @@ hstypes:
       fields:
       - unwrapS7b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -219,11 +228,12 @@ hstypes:
       - s7b_Aux_a
       - s7b_Aux_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs.post_qualified/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw S1
                                        S1 s1_a_2
                                           s1_b_3 -> writeRaw (Proxy @"s1_a") ptr_0 s1_a_2 >> writeRaw (Proxy @"s1_b") ptr_0 s1_b_3
 deriving via (EquivStorable S1) instance Storable S1
-instance HasCField S1 "s1_a"
-    where type CFieldType S1 "s1_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_a")
 instance (~) ty CInt => HasField "s1_a" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_a = y_1,
                                          s1_b = getField @"s1_b" x_0},
                               getField @"s1_a" x_0)
-instance HasCField S1 "s1_b"
-    where type CFieldType S1 "s1_b" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_b")
+instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_a")
+instance HasCField S1 "s1_a"
+    where type CFieldType S1 "s1_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar => HasField "s1_b" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_b = y_1,
                                          s1_a = getField @"s1_a" x_0},
                               getField @"s1_b" x_0)
+instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_b")
+instance HasCField S1 "s1_b"
+    where type CFieldType S1 "s1_b" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @types\/structs\/simple_structs.h 8:16@
@@ -89,36 +89,36 @@ instance WriteRaw S2_t
                                             s2_t_b_3
                                             s2_t_c_4 -> writeRaw (Proxy @"s2_t_a") ptr_0 s2_t_a_2 >> (writeRaw (Proxy @"s2_t_b") ptr_0 s2_t_b_3 >> writeRaw (Proxy @"s2_t_c") ptr_0 s2_t_c_4)
 deriving via (EquivStorable S2_t) instance Storable S2_t
-instance HasCField S2_t "s2_t_a"
-    where type CFieldType S2_t "s2_t_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_a")
 instance (~) ty CChar => HasField "s2_t_a" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_a = y_1,
                                            s2_t_b = getField @"s2_t_b" x_0,
                                            s2_t_c = getField @"s2_t_c" x_0},
                               getField @"s2_t_a" x_0)
-instance HasCField S2_t "s2_t_b"
-    where type CFieldType S2_t "s2_t_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_b")
+instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_a")
+instance HasCField S2_t "s2_t_a"
+    where type CFieldType S2_t "s2_t_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s2_t_b" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_b = y_1,
                                            s2_t_a = getField @"s2_t_a" x_0,
                                            s2_t_c = getField @"s2_t_c" x_0},
                               getField @"s2_t_b" x_0)
-instance HasCField S2_t "s2_t_c"
-    where type CFieldType S2_t "s2_t_c" = CFloat
-          offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_c")
+instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_b")
+instance HasCField S2_t "s2_t_b"
+    where type CFieldType S2_t "s2_t_b" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty CFloat => HasField "s2_t_c" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_c = y_1,
                                            s2_t_a = getField @"s2_t_a" x_0,
                                            s2_t_b = getField @"s2_t_b" x_0},
                               getField @"s2_t_c" x_0)
+instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_c")
+instance HasCField S2_t "s2_t_c"
+    where type CFieldType S2_t "s2_t_c" = CFloat
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S3_t@
 
     __defined at:__ @types\/structs\/simple_structs.h 15:9@
@@ -143,14 +143,14 @@ instance WriteRaw S3_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S3_t s3_t_a_2 -> writeRaw (Proxy @"s3_t_a") ptr_0 s3_t_a_2
 deriving via (EquivStorable S3_t) instance Storable S3_t
-instance HasCField S3_t "s3_t_a"
-    where type CFieldType S3_t "s3_t_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_t_a")
 instance (~) ty CChar => HasField "s3_t_a" S3_t ty
     where hasField = \x_0 -> (\y_1 -> S3_t{s3_t_a = y_1},
                               getField @"s3_t_a" x_0)
+instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_t_a")
+instance HasCField S3_t "s3_t_a"
+    where type CFieldType S3_t "s3_t_a" = CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S4@
 
     __defined at:__ @types\/structs\/simple_structs.h 19:8@
@@ -191,36 +191,36 @@ instance WriteRaw S4
                                           s4_a_3
                                           s4_c_4 -> writeRaw (Proxy @"s4_b") ptr_0 s4_b_2 >> (writeRaw (Proxy @"s4_a") ptr_0 s4_a_3 >> writeRaw (Proxy @"s4_c") ptr_0 s4_c_4)
 deriving via (EquivStorable S4) instance Storable S4
-instance HasCField S4 "s4_b"
-    where type CFieldType S4 "s4_b" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_b")
 instance (~) ty CChar => HasField "s4_b" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_b = y_1,
                                          s4_a = getField @"s4_a" x_0,
                                          s4_c = getField @"s4_c" x_0},
                               getField @"s4_b" x_0)
-instance HasCField S4 "s4_a"
-    where type CFieldType S4 "s4_a" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_a")
+instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_b")
+instance HasCField S4 "s4_b"
+    where type CFieldType S4 "s4_b" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s4_a" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_a = y_1,
                                          s4_b = getField @"s4_b" x_0,
                                          s4_c = getField @"s4_c" x_0},
                               getField @"s4_a" x_0)
-instance HasCField S4 "s4_c"
-    where type CFieldType S4 "s4_c" = Ptr CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_c")
+instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_a")
+instance HasCField S4 "s4_a"
+    where type CFieldType S4 "s4_a" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty (Ptr CInt) => HasField "s4_c" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_c = y_1,
                                          s4_b = getField @"s4_b" x_0,
                                          s4_a = getField @"s4_a" x_0},
                               getField @"s4_c" x_0)
+instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_c")
+instance HasCField S4 "s4_c"
+    where type CFieldType S4 "s4_c" = Ptr CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S5@
 
     __defined at:__ @types\/structs\/simple_structs.h 26:16@
@@ -253,24 +253,24 @@ instance WriteRaw S5
                                        S5 s5_a_2
                                           s5_b_3 -> writeRaw (Proxy @"s5_a") ptr_0 s5_a_2 >> writeRaw (Proxy @"s5_b") ptr_0 s5_b_3
 deriving via (EquivStorable S5) instance Storable S5
-instance HasCField S5 "s5_a"
-    where type CFieldType S5 "s5_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"s5_a")
 instance (~) ty CChar => HasField "s5_a" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{s5_a = y_1,
                                          s5_b = getField @"s5_b" x_0},
                               getField @"s5_a" x_0)
-instance HasCField S5 "s5_b"
-    where type CFieldType S5 "s5_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"s5_b")
+instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"s5_a")
+instance HasCField S5 "s5_a"
+    where type CFieldType S5 "s5_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s5_b" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{s5_b = y_1,
                                          s5_a = getField @"s5_a" x_0},
                               getField @"s5_b" x_0)
+instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"s5_b")
+instance HasCField S5 "s5_b"
+    where type CFieldType S5 "s5_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S6@
 
     __defined at:__ @types\/structs\/simple_structs.h 31:8@
@@ -303,24 +303,24 @@ instance WriteRaw S6
                                        S6 s6_a_2
                                           s6_b_3 -> writeRaw (Proxy @"s6_a") ptr_0 s6_a_2 >> writeRaw (Proxy @"s6_b") ptr_0 s6_b_3
 deriving via (EquivStorable S6) instance Storable S6
-instance HasCField S6 "s6_a"
-    where type CFieldType S6 "s6_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"s6_a")
 instance (~) ty CChar => HasField "s6_a" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{s6_a = y_1,
                                          s6_b = getField @"s6_b" x_0},
                               getField @"s6_a" x_0)
-instance HasCField S6 "s6_b"
-    where type CFieldType S6 "s6_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"s6_b")
+instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"s6_a")
+instance HasCField S6 "s6_a"
+    where type CFieldType S6 "s6_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s6_b" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{s6_b = y_1,
                                          s6_a = getField @"s6_a" x_0},
                               getField @"s6_b" x_0)
+instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"s6_b")
+instance HasCField S6 "s6_b"
+    where type CFieldType S6 "s6_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@S7a_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:9@
@@ -353,25 +353,25 @@ instance WriteRaw S7a_Aux
                                        S7a_Aux s7a_Aux_a_2
                                                s7a_Aux_b_3 -> writeRaw (Proxy @"s7a_Aux_a") ptr_0 s7a_Aux_a_2 >> writeRaw (Proxy @"s7a_Aux_b") ptr_0 s7a_Aux_b_3
 deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
-instance HasCField S7a_Aux "s7a_Aux_a"
-    where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance (~) ty CChar => HasField "s7a_Aux_a" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{s7a_Aux_a = y_1,
                                               s7a_Aux_b = getField @"s7a_Aux_b" x_0},
                               getField @"s7a_Aux_a" x_0)
-instance HasCField S7a_Aux "s7a_Aux_b"
-    where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7a_Aux_b")
+instance (~) ty CChar =>
+         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7a_Aux_a")
+instance HasCField S7a_Aux "s7a_Aux_a"
+    where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s7a_Aux_b" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{s7a_Aux_b = y_1,
                                               s7a_Aux_a = getField @"s7a_Aux_a" x_0},
                               getField @"s7a_Aux_b" x_0)
+instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7a_Aux_b")
+instance HasCField S7a_Aux "s7a_Aux_b"
+    where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7a@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:36@
@@ -386,15 +386,15 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr S7a_Aux) => HasField "unwrapS7a" S7a ty
+    where hasField = \x_0 -> (\y_1 -> S7a{unwrapS7a = y_1},
+                              getField @"unwrapS7a" x_0)
 instance (~) ty (Ptr S7a_Aux) =>
          HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr S7a_Aux) => HasField "unwrapS7a" S7a ty
-    where hasField = \x_0 -> (\y_1 -> S7a{unwrapS7a = y_1},
-                              getField @"unwrapS7a" x_0)
 {-| __C declaration:__ @struct \@S7b_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:9@
@@ -427,25 +427,25 @@ instance WriteRaw S7b_Aux
                                        S7b_Aux s7b_Aux_a_2
                                                s7b_Aux_b_3 -> writeRaw (Proxy @"s7b_Aux_a") ptr_0 s7b_Aux_a_2 >> writeRaw (Proxy @"s7b_Aux_b") ptr_0 s7b_Aux_b_3
 deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
-instance HasCField S7b_Aux "s7b_Aux_a"
-    where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance (~) ty CChar => HasField "s7b_Aux_a" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{s7b_Aux_a = y_1,
                                               s7b_Aux_b = getField @"s7b_Aux_b" x_0},
                               getField @"s7b_Aux_a" x_0)
-instance HasCField S7b_Aux "s7b_Aux_b"
-    where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7b_Aux_b")
+instance (~) ty CChar =>
+         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7b_Aux_a")
+instance HasCField S7b_Aux "s7b_Aux_a"
+    where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s7b_Aux_b" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{s7b_Aux_b = y_1,
                                               s7b_Aux_a = getField @"s7b_Aux_a" x_0},
                               getField @"s7b_Aux_b" x_0)
+instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7b_Aux_b")
+instance HasCField S7b_Aux "s7b_Aux_b"
+    where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7b@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:38@
@@ -461,12 +461,12 @@ newtype S7b
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
+         HasField "unwrapS7b" S7b ty
+    where hasField = \x_0 -> (\y_1 -> S7b{unwrapS7b = y_1},
+                              getField @"unwrapS7b" x_0)
+instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
          HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrapS7b" S7b ty
-    where hasField = \x_0 -> (\y_1 -> S7b{unwrapS7b = y_1},
-                              getField @"unwrapS7b" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/Example.hs
@@ -82,16 +82,6 @@ instance Marshal.WriteRaw S1 where
 
 deriving via Marshal.EquivStorable S1 instance RIP.Storable S1
 
-instance HasCField.HasCField S1 "s1_a" where
-
-  type CFieldType S1 "s1_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_a" S1 ty where
 
   hasField =
@@ -101,15 +91,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s1_a" S1 ty where
       , RIP.getField @"s1_a" x0
       )
 
-instance HasCField.HasCField S1 "s1_b" where
+instance (ty ~ RIP.CInt) => RIP.HasField "s1_a" (RIP.Ptr S1) (RIP.Ptr ty) where
 
-  type CFieldType S1 "s1_b" = RIP.CChar
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S1 "s1_a" where
 
-instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+  type CFieldType S1 "s1_a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s1_b" S1 ty where
 
@@ -119,6 +109,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s1_b" S1 ty where
           S1 {s1_b = y1, s1_a = RIP.getField @"s1_a" x0}
       , RIP.getField @"s1_b" x0
       )
+
+instance (ty ~ RIP.CChar) => RIP.HasField "s1_b" (RIP.Ptr S1) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s1_b")
+
+instance HasCField.HasCField S1 "s1_b" where
+
+  type CFieldType S1 "s1_b" = RIP.CChar
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S2@
 
@@ -179,17 +179,6 @@ instance Marshal.WriteRaw S2_t where
 
 deriving via Marshal.EquivStorable S2_t instance RIP.Storable S2_t
 
-instance HasCField.HasCField S2_t "s2_t_a" where
-
-  type CFieldType S2_t "s2_t_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s2_t_a" S2_t ty where
 
   hasField =
@@ -202,16 +191,16 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s2_t_a" S2_t ty where
       , RIP.getField @"s2_t_a" x0
       )
 
-instance HasCField.HasCField S2_t "s2_t_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s2_t_a" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "s2_t_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S2_t "s2_t_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "s2_t_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_t_b" S2_t ty where
 
@@ -225,16 +214,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s2_t_b" S2_t ty where
       , RIP.getField @"s2_t_b" x0
       )
 
-instance HasCField.HasCField S2_t "s2_t_c" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s2_t_b" (RIP.Ptr S2_t) (RIP.Ptr ty) where
 
-  type CFieldType S2_t "s2_t_c" = RIP.CFloat
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_b")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S2_t "s2_t_b" where
 
-instance ( ty ~ RIP.CFloat
-         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+  type CFieldType S2_t "s2_t_b" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "s2_t_c" S2_t ty where
 
@@ -247,6 +236,17 @@ instance (ty ~ RIP.CFloat) => RIP.CompatHasField.HasField "s2_t_c" S2_t ty where
                }
       , RIP.getField @"s2_t_c" x0
       )
+
+instance ( ty ~ RIP.CFloat
+         ) => RIP.HasField "s2_t_c" (RIP.Ptr S2_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s2_t_c")
+
+instance HasCField.HasCField S2_t "s2_t_c" where
+
+  type CFieldType S2_t "s2_t_c" = RIP.CFloat
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S3_t@
 
@@ -289,23 +289,23 @@ instance Marshal.WriteRaw S3_t where
 
 deriving via Marshal.EquivStorable S3_t instance RIP.Storable S3_t
 
-instance HasCField.HasCField S3_t "s3_t_a" where
-
-  type CFieldType S3_t "s3_t_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s3_t_a" S3_t ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          S3_t {s3_t_a = y1}, RIP.getField @"s3_t_a" x0)
+
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s3_t_a" (RIP.Ptr S3_t) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s3_t_a")
+
+instance HasCField.HasCField S3_t "s3_t_a" where
+
+  type CFieldType S3_t "s3_t_a" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct S4@
 
@@ -366,16 +366,6 @@ instance Marshal.WriteRaw S4 where
 
 deriving via Marshal.EquivStorable S4 instance RIP.Storable S4
 
-instance HasCField.HasCField S4 "s4_b" where
-
-  type CFieldType S4 "s4_b" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s4_b" S4 ty where
 
   hasField =
@@ -385,15 +375,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s4_b" S4 ty where
       , RIP.getField @"s4_b" x0
       )
 
-instance HasCField.HasCField S4 "s4_a" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s4_b" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "s4_a" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_b")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S4 "s4_b" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "s4_b" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s4_a" S4 ty where
 
@@ -404,16 +394,15 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s4_a" S4 ty where
       , RIP.getField @"s4_a" x0
       )
 
-instance HasCField.HasCField S4 "s4_c" where
+instance (ty ~ RIP.CInt) => RIP.HasField "s4_a" (RIP.Ptr S4) (RIP.Ptr ty) where
 
-  type CFieldType S4 "s4_c" = RIP.Ptr RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_a")
 
-  offset# = \_ -> \_ -> 8
+instance HasCField.HasCField S4 "s4_a" where
 
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+  type CFieldType S4 "s4_a" = RIP.CInt
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.CompatHasField.HasField "s4_c" S4 ty where
@@ -424,6 +413,17 @@ instance ( ty ~ RIP.Ptr RIP.CInt
           S4 {s4_c = y1, s4_b = RIP.getField @"s4_b" x0, s4_a = RIP.getField @"s4_a" x0}
       , RIP.getField @"s4_c" x0
       )
+
+instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.HasField "s4_c" (RIP.Ptr S4) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s4_c")
+
+instance HasCField.HasCField S4 "s4_c" where
+
+  type CFieldType S4 "s4_c" = RIP.Ptr RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct S5@
 
@@ -475,16 +475,6 @@ instance Marshal.WriteRaw S5 where
 
 deriving via Marshal.EquivStorable S5 instance RIP.Storable S5
 
-instance HasCField.HasCField S5 "s5_a" where
-
-  type CFieldType S5 "s5_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s5_a" S5 ty where
 
   hasField =
@@ -494,15 +484,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s5_a" S5 ty where
       , RIP.getField @"s5_a" x0
       )
 
-instance HasCField.HasCField S5 "s5_b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s5_a" (RIP.Ptr S5) (RIP.Ptr ty) where
 
-  type CFieldType S5 "s5_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s5_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S5 "s5_a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+  type CFieldType S5 "s5_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s5_b" S5 ty where
 
@@ -512,6 +502,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s5_b" S5 ty where
           S5 {s5_b = y1, s5_a = RIP.getField @"s5_a" x0}
       , RIP.getField @"s5_b" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s5_b" (RIP.Ptr S5) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s5_b")
+
+instance HasCField.HasCField S5 "s5_b" where
+
+  type CFieldType S5 "s5_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct S6@
 
@@ -563,16 +563,6 @@ instance Marshal.WriteRaw S6 where
 
 deriving via Marshal.EquivStorable S6 instance RIP.Storable S6
 
-instance HasCField.HasCField S6 "s6_a" where
-
-  type CFieldType S6 "s6_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
-
 instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s6_a" S6 ty where
 
   hasField =
@@ -582,15 +572,15 @@ instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "s6_a" S6 ty where
       , RIP.getField @"s6_a" x0
       )
 
-instance HasCField.HasCField S6 "s6_b" where
+instance (ty ~ RIP.CChar) => RIP.HasField "s6_a" (RIP.Ptr S6) (RIP.Ptr ty) where
 
-  type CFieldType S6 "s6_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s6_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S6 "s6_a" where
 
-instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+  type CFieldType S6 "s6_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s6_b" S6 ty where
 
@@ -600,6 +590,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "s6_b" S6 ty where
           S6 {s6_b = y1, s6_a = RIP.getField @"s6_a" x0}
       , RIP.getField @"s6_b" x0
       )
+
+instance (ty ~ RIP.CInt) => RIP.HasField "s6_b" (RIP.Ptr S6) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s6_b")
+
+instance HasCField.HasCField S6 "s6_b" where
+
+  type CFieldType S6 "s6_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@S7a_Aux@
 
@@ -651,17 +651,6 @@ instance Marshal.WriteRaw S7a_Aux where
 
 deriving via Marshal.EquivStorable S7a_Aux instance RIP.Storable S7a_Aux
 
-instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
-
-  type CFieldType S7a_Aux "s7a_Aux_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "s7a_Aux_a" S7a_Aux ty where
 
@@ -672,16 +661,16 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"s7a_Aux_a" x0
       )
 
-instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s7a_Aux_a" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7a_Aux "s7a_Aux_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7a_Aux "s7a_Aux_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+  type CFieldType S7a_Aux "s7a_Aux_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s7a_Aux_b" S7a_Aux ty where
@@ -692,6 +681,17 @@ instance ( ty ~ RIP.CInt
           S7a_Aux {s7a_Aux_b = y1, s7a_Aux_a = RIP.getField @"s7a_Aux_a" x0}
       , RIP.getField @"s7a_Aux_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s7a_Aux_b" (RIP.Ptr S7a_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s7a_Aux_b")
+
+instance HasCField.HasCField S7a_Aux "s7a_Aux_b" where
+
+  type CFieldType S7a_Aux "s7a_Aux_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7a@
 
@@ -712,6 +712,14 @@ newtype S7a = S7a
     )
 
 instance ( ty ~ RIP.Ptr S7a_Aux
+         ) => RIP.CompatHasField.HasField "unwrapS7a" S7a ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         S7a {unwrapS7a = y1}, RIP.getField @"unwrapS7a" x0)
+
+instance ( ty ~ RIP.Ptr S7a_Aux
          ) => RIP.HasField "unwrapS7a" (RIP.Ptr S7a) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7a")
@@ -721,14 +729,6 @@ instance HasCField.HasCField S7a "unwrapS7a" where
   type CFieldType S7a "unwrapS7a" = RIP.Ptr S7a_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr S7a_Aux
-         ) => RIP.CompatHasField.HasField "unwrapS7a" S7a ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         S7a {unwrapS7a = y1}, RIP.getField @"unwrapS7a" x0)
 
 {-| __C declaration:__ @struct \@S7b_Aux@
 
@@ -780,17 +780,6 @@ instance Marshal.WriteRaw S7b_Aux where
 
 deriving via Marshal.EquivStorable S7b_Aux instance RIP.Storable S7b_Aux
 
-instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
-
-  type CFieldType S7b_Aux "s7b_Aux_a" = RIP.CChar
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CChar
-         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
-
 instance ( ty ~ RIP.CChar
          ) => RIP.CompatHasField.HasField "s7b_Aux_a" S7b_Aux ty where
 
@@ -801,16 +790,16 @@ instance ( ty ~ RIP.CChar
       , RIP.getField @"s7b_Aux_a" x0
       )
 
-instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
+instance ( ty ~ RIP.CChar
+         ) => RIP.HasField "s7b_Aux_a" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
 
-  type CFieldType S7b_Aux "s7b_Aux_b" = RIP.CInt
+  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_a")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField S7b_Aux "s7b_Aux_a" where
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+  type CFieldType S7b_Aux "s7b_Aux_a" = RIP.CChar
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CInt
          ) => RIP.CompatHasField.HasField "s7b_Aux_b" S7b_Aux ty where
@@ -821,6 +810,17 @@ instance ( ty ~ RIP.CInt
           S7b_Aux {s7b_Aux_b = y1, s7b_Aux_a = RIP.getField @"s7b_Aux_a" x0}
       , RIP.getField @"s7b_Aux_b" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "s7b_Aux_b" (RIP.Ptr S7b_Aux) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s7b_Aux_b")
+
+instance HasCField.HasCField S7b_Aux "s7b_Aux_b" where
+
+  type CFieldType S7b_Aux "s7b_Aux_b" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @S7b@
 
@@ -841,6 +841,14 @@ newtype S7b = S7b
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
+         ) => RIP.CompatHasField.HasField "unwrapS7b" S7b ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         S7b {unwrapS7b = y1}, RIP.getField @"unwrapS7b" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
          ) => RIP.HasField "unwrapS7b" (RIP.Ptr S7b) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapS7b")
@@ -851,11 +859,3 @@ instance HasCField.HasCField S7b "unwrapS7b" where
     RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.Ptr S7b_Aux))
-         ) => RIP.CompatHasField.HasField "unwrapS7b" S7b ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         S7b {unwrapS7b = y1}, RIP.getField @"unwrapS7b" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/bindingspec.yaml
@@ -54,11 +54,12 @@ hstypes:
       - s1_a
       - s1_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -73,11 +74,12 @@ hstypes:
       - s2_t_b
       - s2_t_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -90,11 +92,12 @@ hstypes:
       fields:
       - s3_t_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -109,11 +112,12 @@ hstypes:
       - s4_a
       - s4_c
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -127,11 +131,12 @@ hstypes:
       - s5_a
       - s5_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -145,11 +150,12 @@ hstypes:
       - s6_a
       - s6_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -162,12 +168,13 @@ hstypes:
       fields:
       - unwrapS7a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -182,11 +189,12 @@ hstypes:
       - s7a_Aux_a
       - s7a_Aux_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -199,12 +207,13 @@ hstypes:
       fields:
       - unwrapS7b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -219,11 +228,12 @@ hstypes:
       - s7b_Aux_a
       - s7b_Aux_b
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/simple_structs/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw S1
                                        S1 s1_a_2
                                           s1_b_3 -> writeRaw (Proxy @"s1_a") ptr_0 s1_a_2 >> writeRaw (Proxy @"s1_b") ptr_0 s1_b_3
 deriving via (EquivStorable S1) instance Storable S1
-instance HasCField S1 "s1_a"
-    where type CFieldType S1 "s1_a" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_a")
 instance (~) ty CInt => HasField "s1_a" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_a = y_1,
                                          s1_b = getField @"s1_b" x_0},
                               getField @"s1_a" x_0)
-instance HasCField S1 "s1_b"
-    where type CFieldType S1 "s1_b" = CChar
-          offset# = \_ -> \_ -> 4
-instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
-    where getField = fromPtr (Proxy @"s1_b")
+instance (~) ty CInt => HasField "s1_a" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_a")
+instance HasCField S1 "s1_a"
+    where type CFieldType S1 "s1_a" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CChar => HasField "s1_b" S1 ty
     where hasField = \x_0 -> (\y_1 -> S1{s1_b = y_1,
                                          s1_a = getField @"s1_a" x_0},
                               getField @"s1_b" x_0)
+instance (~) ty CChar => HasField "s1_b" (Ptr S1) (Ptr ty)
+    where getField = fromPtr (Proxy @"s1_b")
+instance HasCField S1 "s1_b"
+    where type CFieldType S1 "s1_b" = CChar
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S2@
 
     __defined at:__ @types\/structs\/simple_structs.h 8:16@
@@ -89,36 +89,36 @@ instance WriteRaw S2_t
                                             s2_t_b_3
                                             s2_t_c_4 -> writeRaw (Proxy @"s2_t_a") ptr_0 s2_t_a_2 >> (writeRaw (Proxy @"s2_t_b") ptr_0 s2_t_b_3 >> writeRaw (Proxy @"s2_t_c") ptr_0 s2_t_c_4)
 deriving via (EquivStorable S2_t) instance Storable S2_t
-instance HasCField S2_t "s2_t_a"
-    where type CFieldType S2_t "s2_t_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_a")
 instance (~) ty CChar => HasField "s2_t_a" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_a = y_1,
                                            s2_t_b = getField @"s2_t_b" x_0,
                                            s2_t_c = getField @"s2_t_c" x_0},
                               getField @"s2_t_a" x_0)
-instance HasCField S2_t "s2_t_b"
-    where type CFieldType S2_t "s2_t_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_b")
+instance (~) ty CChar => HasField "s2_t_a" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_a")
+instance HasCField S2_t "s2_t_a"
+    where type CFieldType S2_t "s2_t_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s2_t_b" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_b = y_1,
                                            s2_t_a = getField @"s2_t_a" x_0,
                                            s2_t_c = getField @"s2_t_c" x_0},
                               getField @"s2_t_b" x_0)
-instance HasCField S2_t "s2_t_c"
-    where type CFieldType S2_t "s2_t_c" = CFloat
-          offset# = \_ -> \_ -> 8
-instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s2_t_c")
+instance (~) ty CInt => HasField "s2_t_b" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_b")
+instance HasCField S2_t "s2_t_b"
+    where type CFieldType S2_t "s2_t_b" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty CFloat => HasField "s2_t_c" S2_t ty
     where hasField = \x_0 -> (\y_1 -> S2_t{s2_t_c = y_1,
                                            s2_t_a = getField @"s2_t_a" x_0,
                                            s2_t_b = getField @"s2_t_b" x_0},
                               getField @"s2_t_c" x_0)
+instance (~) ty CFloat => HasField "s2_t_c" (Ptr S2_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s2_t_c")
+instance HasCField S2_t "s2_t_c"
+    where type CFieldType S2_t "s2_t_c" = CFloat
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S3_t@
 
     __defined at:__ @types\/structs\/simple_structs.h 15:9@
@@ -143,14 +143,14 @@ instance WriteRaw S3_t
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        S3_t s3_t_a_2 -> writeRaw (Proxy @"s3_t_a") ptr_0 s3_t_a_2
 deriving via (EquivStorable S3_t) instance Storable S3_t
-instance HasCField S3_t "s3_t_a"
-    where type CFieldType S3_t "s3_t_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
-    where getField = fromPtr (Proxy @"s3_t_a")
 instance (~) ty CChar => HasField "s3_t_a" S3_t ty
     where hasField = \x_0 -> (\y_1 -> S3_t{s3_t_a = y_1},
                               getField @"s3_t_a" x_0)
+instance (~) ty CChar => HasField "s3_t_a" (Ptr S3_t) (Ptr ty)
+    where getField = fromPtr (Proxy @"s3_t_a")
+instance HasCField S3_t "s3_t_a"
+    where type CFieldType S3_t "s3_t_a" = CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S4@
 
     __defined at:__ @types\/structs\/simple_structs.h 19:8@
@@ -191,36 +191,36 @@ instance WriteRaw S4
                                           s4_a_3
                                           s4_c_4 -> writeRaw (Proxy @"s4_b") ptr_0 s4_b_2 >> (writeRaw (Proxy @"s4_a") ptr_0 s4_a_3 >> writeRaw (Proxy @"s4_c") ptr_0 s4_c_4)
 deriving via (EquivStorable S4) instance Storable S4
-instance HasCField S4 "s4_b"
-    where type CFieldType S4 "s4_b" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_b")
 instance (~) ty CChar => HasField "s4_b" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_b = y_1,
                                          s4_a = getField @"s4_a" x_0,
                                          s4_c = getField @"s4_c" x_0},
                               getField @"s4_b" x_0)
-instance HasCField S4 "s4_a"
-    where type CFieldType S4 "s4_a" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_a")
+instance (~) ty CChar => HasField "s4_b" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_b")
+instance HasCField S4 "s4_b"
+    where type CFieldType S4 "s4_b" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s4_a" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_a = y_1,
                                          s4_b = getField @"s4_b" x_0,
                                          s4_c = getField @"s4_c" x_0},
                               getField @"s4_a" x_0)
-instance HasCField S4 "s4_c"
-    where type CFieldType S4 "s4_c" = Ptr CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
-    where getField = fromPtr (Proxy @"s4_c")
+instance (~) ty CInt => HasField "s4_a" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_a")
+instance HasCField S4 "s4_a"
+    where type CFieldType S4 "s4_a" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty (Ptr CInt) => HasField "s4_c" S4 ty
     where hasField = \x_0 -> (\y_1 -> S4{s4_c = y_1,
                                          s4_b = getField @"s4_b" x_0,
                                          s4_a = getField @"s4_a" x_0},
                               getField @"s4_c" x_0)
+instance (~) ty (Ptr CInt) => HasField "s4_c" (Ptr S4) (Ptr ty)
+    where getField = fromPtr (Proxy @"s4_c")
+instance HasCField S4 "s4_c"
+    where type CFieldType S4 "s4_c" = Ptr CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct S5@
 
     __defined at:__ @types\/structs\/simple_structs.h 26:16@
@@ -253,24 +253,24 @@ instance WriteRaw S5
                                        S5 s5_a_2
                                           s5_b_3 -> writeRaw (Proxy @"s5_a") ptr_0 s5_a_2 >> writeRaw (Proxy @"s5_b") ptr_0 s5_b_3
 deriving via (EquivStorable S5) instance Storable S5
-instance HasCField S5 "s5_a"
-    where type CFieldType S5 "s5_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"s5_a")
 instance (~) ty CChar => HasField "s5_a" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{s5_a = y_1,
                                          s5_b = getField @"s5_b" x_0},
                               getField @"s5_a" x_0)
-instance HasCField S5 "s5_b"
-    where type CFieldType S5 "s5_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
-    where getField = fromPtr (Proxy @"s5_b")
+instance (~) ty CChar => HasField "s5_a" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"s5_a")
+instance HasCField S5 "s5_a"
+    where type CFieldType S5 "s5_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s5_b" S5 ty
     where hasField = \x_0 -> (\y_1 -> S5{s5_b = y_1,
                                          s5_a = getField @"s5_a" x_0},
                               getField @"s5_b" x_0)
+instance (~) ty CInt => HasField "s5_b" (Ptr S5) (Ptr ty)
+    where getField = fromPtr (Proxy @"s5_b")
+instance HasCField S5 "s5_b"
+    where type CFieldType S5 "s5_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct S6@
 
     __defined at:__ @types\/structs\/simple_structs.h 31:8@
@@ -303,24 +303,24 @@ instance WriteRaw S6
                                        S6 s6_a_2
                                           s6_b_3 -> writeRaw (Proxy @"s6_a") ptr_0 s6_a_2 >> writeRaw (Proxy @"s6_b") ptr_0 s6_b_3
 deriving via (EquivStorable S6) instance Storable S6
-instance HasCField S6 "s6_a"
-    where type CFieldType S6 "s6_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"s6_a")
 instance (~) ty CChar => HasField "s6_a" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{s6_a = y_1,
                                          s6_b = getField @"s6_b" x_0},
                               getField @"s6_a" x_0)
-instance HasCField S6 "s6_b"
-    where type CFieldType S6 "s6_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
-    where getField = fromPtr (Proxy @"s6_b")
+instance (~) ty CChar => HasField "s6_a" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"s6_a")
+instance HasCField S6 "s6_a"
+    where type CFieldType S6 "s6_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s6_b" S6 ty
     where hasField = \x_0 -> (\y_1 -> S6{s6_b = y_1,
                                          s6_a = getField @"s6_a" x_0},
                               getField @"s6_b" x_0)
+instance (~) ty CInt => HasField "s6_b" (Ptr S6) (Ptr ty)
+    where getField = fromPtr (Proxy @"s6_b")
+instance HasCField S6 "s6_b"
+    where type CFieldType S6 "s6_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@S7a_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:9@
@@ -353,25 +353,25 @@ instance WriteRaw S7a_Aux
                                        S7a_Aux s7a_Aux_a_2
                                                s7a_Aux_b_3 -> writeRaw (Proxy @"s7a_Aux_a") ptr_0 s7a_Aux_a_2 >> writeRaw (Proxy @"s7a_Aux_b") ptr_0 s7a_Aux_b_3
 deriving via (EquivStorable S7a_Aux) instance Storable S7a_Aux
-instance HasCField S7a_Aux "s7a_Aux_a"
-    where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7a_Aux_a")
 instance (~) ty CChar => HasField "s7a_Aux_a" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{s7a_Aux_a = y_1,
                                               s7a_Aux_b = getField @"s7a_Aux_b" x_0},
                               getField @"s7a_Aux_a" x_0)
-instance HasCField S7a_Aux "s7a_Aux_b"
-    where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7a_Aux_b")
+instance (~) ty CChar =>
+         HasField "s7a_Aux_a" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7a_Aux_a")
+instance HasCField S7a_Aux "s7a_Aux_a"
+    where type CFieldType S7a_Aux "s7a_Aux_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s7a_Aux_b" S7a_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7a_Aux{s7a_Aux_b = y_1,
                                               s7a_Aux_a = getField @"s7a_Aux_a" x_0},
                               getField @"s7a_Aux_b" x_0)
+instance (~) ty CInt => HasField "s7a_Aux_b" (Ptr S7a_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7a_Aux_b")
+instance HasCField S7a_Aux "s7a_Aux_b"
+    where type CFieldType S7a_Aux "s7a_Aux_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7a@
 
     __defined at:__ @types\/structs\/simple_structs.h 34:36@
@@ -386,15 +386,15 @@ newtype S7a
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr S7a_Aux) => HasField "unwrapS7a" S7a ty
+    where hasField = \x_0 -> (\y_1 -> S7a{unwrapS7a = y_1},
+                              getField @"unwrapS7a" x_0)
 instance (~) ty (Ptr S7a_Aux) =>
          HasField "unwrapS7a" (Ptr S7a) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7a")
 instance HasCField S7a "unwrapS7a"
     where type CFieldType S7a "unwrapS7a" = Ptr S7a_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr S7a_Aux) => HasField "unwrapS7a" S7a ty
-    where hasField = \x_0 -> (\y_1 -> S7a{unwrapS7a = y_1},
-                              getField @"unwrapS7a" x_0)
 {-| __C declaration:__ @struct \@S7b_Aux@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:9@
@@ -427,25 +427,25 @@ instance WriteRaw S7b_Aux
                                        S7b_Aux s7b_Aux_a_2
                                                s7b_Aux_b_3 -> writeRaw (Proxy @"s7b_Aux_a") ptr_0 s7b_Aux_a_2 >> writeRaw (Proxy @"s7b_Aux_b") ptr_0 s7b_Aux_b_3
 deriving via (EquivStorable S7b_Aux) instance Storable S7b_Aux
-instance HasCField S7b_Aux "s7b_Aux_a"
-    where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
-          offset# = \_ -> \_ -> 0
-instance (~) ty CChar =>
-         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7b_Aux_a")
 instance (~) ty CChar => HasField "s7b_Aux_a" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{s7b_Aux_a = y_1,
                                               s7b_Aux_b = getField @"s7b_Aux_b" x_0},
                               getField @"s7b_Aux_a" x_0)
-instance HasCField S7b_Aux "s7b_Aux_b"
-    where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
-    where getField = fromPtr (Proxy @"s7b_Aux_b")
+instance (~) ty CChar =>
+         HasField "s7b_Aux_a" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7b_Aux_a")
+instance HasCField S7b_Aux "s7b_Aux_a"
+    where type CFieldType S7b_Aux "s7b_Aux_a" = CChar
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "s7b_Aux_b" S7b_Aux ty
     where hasField = \x_0 -> (\y_1 -> S7b_Aux{s7b_Aux_b = y_1,
                                               s7b_Aux_a = getField @"s7b_Aux_a" x_0},
                               getField @"s7b_Aux_b" x_0)
+instance (~) ty CInt => HasField "s7b_Aux_b" (Ptr S7b_Aux) (Ptr ty)
+    where getField = fromPtr (Proxy @"s7b_Aux_b")
+instance HasCField S7b_Aux "s7b_Aux_b"
+    where type CFieldType S7b_Aux "s7b_Aux_b" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @S7b@
 
     __defined at:__ @types\/structs\/simple_structs.h 35:38@
@@ -461,12 +461,12 @@ newtype S7b
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
+         HasField "unwrapS7b" S7b ty
+    where hasField = \x_0 -> (\y_1 -> S7b{unwrapS7b = y_1},
+                              getField @"unwrapS7b" x_0)
+instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
          HasField "unwrapS7b" (Ptr S7b) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapS7b")
 instance HasCField S7b "unwrapS7b"
     where type CFieldType S7b "unwrapS7b" = Ptr (Ptr (Ptr S7b_Aux))
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr (Ptr S7b_Aux))) =>
-         HasField "unwrapS7b" S7b ty
-    where hasField = \x_0 -> (\y_1 -> S7b{unwrapS7b = y_1},
-                              getField @"unwrapS7b" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/Example.hs
@@ -63,20 +63,20 @@ instance Marshal.WriteRaw Thing where
 
 deriving via Marshal.EquivStorable Thing instance RIP.Storable Thing
 
-instance HasCField.HasCField Thing "thing_x" where
-
-  type CFieldType Thing "thing_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "thing_x" (RIP.Ptr Thing) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"thing_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "thing_x" Thing ty where
 
   hasField =
     \x0 ->
       (\y1 ->
          Thing {thing_x = y1}, RIP.getField @"thing_x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "thing_x" (RIP.Ptr Thing) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"thing_x")
+
+instance HasCField.HasCField Thing "thing_x" where
+
+  type CFieldType Thing "thing_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/bindingspec.yaml
@@ -14,11 +14,12 @@ hstypes:
       fields:
       - thing_x
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize

--- a/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/structs/struct_arg/th.txt
@@ -120,14 +120,14 @@ instance WriteRaw Thing
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Thing thing_x_2 -> writeRaw (Proxy @"thing_x") ptr_0 thing_x_2
 deriving via (EquivStorable Thing) instance Storable Thing
-instance HasCField Thing "thing_x"
-    where type CFieldType Thing "thing_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "thing_x" (Ptr Thing) (Ptr ty)
-    where getField = fromPtr (Proxy @"thing_x")
 instance (~) ty CInt => HasField "thing_x" Thing ty
     where hasField = \x_0 -> (\y_1 -> Thing{thing_x = y_1},
                               getField @"thing_x" x_0)
+instance (~) ty CInt => HasField "thing_x" (Ptr Thing) (Ptr ty)
+    where getField = fromPtr (Proxy @"thing_x")
+instance HasCField Thing "thing_x"
+    where type CFieldType Thing "thing_x" = CInt
+          offset# = \_ -> \_ -> 0
 -- __unique:__ @test_typesstructsstruct_arg_Example_Safe_thing_fun_1@
 foreign import ccall safe "hs_bindgen_4ad25504590fdd2b" hs_bindgen_4ad25504590fdd2b_base ::
     Ptr Void

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/Example.hs
@@ -76,6 +76,14 @@ instance RIP.FromFunPtr T_Aux where
   fromFunPtr = hs_bindgen_281617c90fa9307a
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapT_Aux" (RIP.Ptr T_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -87,14 +95,6 @@ instance HasCField.HasCField T_Aux "unwrapT_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
 
 {-| __C declaration:__ @T@
 
@@ -109,6 +109,13 @@ newtype T = T
   deriving newtype (IsA.IsArray)
 
 instance ( ty ~ IA.IncompleteArray (RIP.FunPtr T_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ IA.IncompleteArray (RIP.FunPtr T_Aux)
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -119,13 +126,6 @@ instance HasCField.HasCField T "unwrapT" where
     IA.IncompleteArray (RIP.FunPtr T_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IA.IncompleteArray (RIP.FunPtr T_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
 
 {-| Auxiliary type used by 'U'
 
@@ -176,6 +176,14 @@ instance RIP.FromFunPtr U_Aux where
   fromFunPtr = hs_bindgen_abb428b050bb7646
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapU_Aux" U_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         U_Aux {unwrapU_Aux = y1}, RIP.getField @"unwrapU_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapU_Aux" (RIP.Ptr U_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -187,14 +195,6 @@ instance HasCField.HasCField U_Aux "unwrapU_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapU_Aux" U_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         U_Aux {unwrapU_Aux = y1}, RIP.getField @"unwrapU_Aux" x0)
 
 {-| __C declaration:__ @U@
 
@@ -215,6 +215,13 @@ newtype U = U
     )
 
 instance ( ty ~ CA.ConstantArray 3 (RIP.FunPtr U_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapU" U ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)
+
+instance ( ty ~ CA.ConstantArray 3 (RIP.FunPtr U_Aux)
          ) => RIP.HasField "unwrapU" (RIP.Ptr U) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapU")
@@ -225,10 +232,3 @@ instance HasCField.HasCField U "unwrapU" where
     CA.ConstantArray 3 (RIP.FunPtr U_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ CA.ConstantArray 3 (RIP.FunPtr U_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapU" U ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> U {unwrapU = y1}, RIP.getField @"unwrapU" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/bindingspec.yaml
@@ -17,11 +17,12 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - Show
 - hsname: U
@@ -31,11 +32,12 @@ hstypes:
       fields:
       - unwrapU
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - IsArray
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/array/th.txt
@@ -32,15 +32,15 @@ instance ToFunPtr T_Aux
     where toFunPtr = hs_bindgen_5927fedc3abfa99c
 instance FromFunPtr T_Aux
     where fromFunPtr = hs_bindgen_281617c90fa9307a
+instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
+    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
+                              getField @"unwrapT_Aux" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapT_Aux" (Ptr T_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT_Aux")
 instance HasCField T_Aux "unwrapT_Aux"
     where type CFieldType T_Aux "unwrapT_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
-    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
-                              getField @"unwrapT_Aux" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/array.h 1:16@
@@ -52,15 +52,15 @@ newtype T
     deriving stock (Eq, Generic, Show)
     deriving newtype IsArray
 instance (~) ty (IncompleteArray (FunPtr T_Aux)) =>
+         HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
+instance (~) ty (IncompleteArray (FunPtr T_Aux)) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = IncompleteArray (FunPtr T_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (IncompleteArray (FunPtr T_Aux)) =>
-         HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)
 {-| Auxiliary type used by 'U'
 
     __C declaration:__ @U@
@@ -94,15 +94,15 @@ instance ToFunPtr U_Aux
     where toFunPtr = hs_bindgen_a78147e446a66171
 instance FromFunPtr U_Aux
     where fromFunPtr = hs_bindgen_abb428b050bb7646
+instance (~) ty (CInt -> IO ()) => HasField "unwrapU_Aux" U_Aux ty
+    where hasField = \x_0 -> (\y_1 -> U_Aux{unwrapU_Aux = y_1},
+                              getField @"unwrapU_Aux" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapU_Aux" (Ptr U_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU_Aux")
 instance HasCField U_Aux "unwrapU_Aux"
     where type CFieldType U_Aux "unwrapU_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapU_Aux" U_Aux ty
-    where hasField = \x_0 -> (\y_1 -> U_Aux{unwrapU_Aux = y_1},
-                              getField @"unwrapU_Aux" x_0)
 {-| __C declaration:__ @U@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/array.h 2:16@
@@ -114,12 +114,12 @@ newtype U
     deriving stock (Eq, Generic, Show)
     deriving newtype (IsArray, ReadRaw, StaticSize, Storable, WriteRaw)
 instance (~) ty (ConstantArray 3 (FunPtr U_Aux)) =>
+         HasField "unwrapU" U ty
+    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
+                              getField @"unwrapU" x_0)
+instance (~) ty (ConstantArray 3 (FunPtr U_Aux)) =>
          HasField "unwrapU" (Ptr U) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapU")
 instance HasCField U "unwrapU"
     where type CFieldType U "unwrapU" = ConstantArray 3 (FunPtr U_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (ConstantArray 3 (FunPtr U_Aux)) =>
-         HasField "unwrapU" U ty
-    where hasField = \x_0 -> (\y_1 -> U{unwrapU = y_1},
-                              getField @"unwrapU" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/Example.hs
@@ -71,6 +71,14 @@ instance RIP.FromFunPtr T_Aux where
   fromFunPtr = hs_bindgen_281617c90fa9307a
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapT_Aux" (RIP.Ptr T_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -82,14 +90,6 @@ instance HasCField.HasCField T_Aux "unwrapT_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
 
 {-| __C declaration:__ @T@
 
@@ -104,6 +104,13 @@ newtype T = T
   deriving newtype (RIP.HasFFIType)
 
 instance ( ty ~ Block.Block T_Aux
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ Block.Block T_Aux
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -113,10 +120,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = Block.Block T_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ Block.Block T_Aux
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/bindingspec.yaml
@@ -14,8 +14,9 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/block/th.txt
@@ -32,15 +32,15 @@ instance ToFunPtr T_Aux
     where toFunPtr = hs_bindgen_5927fedc3abfa99c
 instance FromFunPtr T_Aux
     where fromFunPtr = hs_bindgen_281617c90fa9307a
+instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
+    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
+                              getField @"unwrapT_Aux" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapT_Aux" (Ptr T_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT_Aux")
 instance HasCField T_Aux "unwrapT_Aux"
     where type CFieldType T_Aux "unwrapT_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
-    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
-                              getField @"unwrapT_Aux" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/block.h 1:16@
@@ -51,12 +51,12 @@ newtype T
     = T {unwrapT :: (Block T_Aux)}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty (Block T_Aux) => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty (Block T_Aux) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = Block T_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (Block T_Aux) => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/Example.hs
@@ -67,6 +67,13 @@ instance RIP.FromFunPtr T where
   fromFunPtr = hs_bindgen_8f830eadb43a6fe4
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -76,10 +83,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/bindingspec.yaml
@@ -14,10 +14,11 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/direct/th.txt
@@ -30,12 +30,12 @@ instance ToFunPtr T
     where toFunPtr = hs_bindgen_b8534912f6256492
 instance FromFunPtr T
     where fromFunPtr = hs_bindgen_8f830eadb43a6fe4
+instance (~) ty (CInt -> IO ()) => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/Example.hs
@@ -83,6 +83,14 @@ instance RIP.FromFunPtr F1_Aux where
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
 instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapF1_Aux" F1_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F1_Aux {unwrapF1_Aux = y1}, RIP.getField @"unwrapF1_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -94,14 +102,6 @@ instance HasCField.HasCField F1_Aux "unwrapF1_Aux" where
     RIP.CInt -> RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapF1_Aux" F1_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F1_Aux {unwrapF1_Aux = y1}, RIP.getField @"unwrapF1_Aux" x0)
 
 {-| __C declaration:__ @f1@
 
@@ -122,6 +122,14 @@ newtype F1 = F1
     )
 
 instance ( ty ~ RIP.FunPtr F1_Aux
+         ) => RIP.CompatHasField.HasField "unwrapF1" F1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F1 {unwrapF1 = y1}, RIP.getField @"unwrapF1" x0)
+
+instance ( ty ~ RIP.FunPtr F1_Aux
          ) => RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF1")
@@ -131,14 +139,6 @@ instance HasCField.HasCField F1 "unwrapF1" where
   type CFieldType F1 "unwrapF1" = RIP.FunPtr F1_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr F1_Aux
-         ) => RIP.CompatHasField.HasField "unwrapF1" F1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F1 {unwrapF1 = y1}, RIP.getField @"unwrapF1" x0)
 
 {-| Auxiliary type used by 'F2'
 
@@ -189,6 +189,14 @@ instance RIP.FromFunPtr F2_Aux where
   fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 
 instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapF2_Aux" F2_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F2_Aux {unwrapF2_Aux = y1}, RIP.getField @"unwrapF2_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapF2_Aux" (RIP.Ptr F2_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -200,14 +208,6 @@ instance HasCField.HasCField F2_Aux "unwrapF2_Aux" where
     RIP.CInt -> RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapF2_Aux" F2_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F2_Aux {unwrapF2_Aux = y1}, RIP.getField @"unwrapF2_Aux" x0)
 
 {-| __C declaration:__ @f2@
 
@@ -228,6 +228,14 @@ newtype F2 = F2
     )
 
 instance ( ty ~ RIP.Ptr (RIP.FunPtr F2_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapF2" F2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F2 {unwrapF2 = y1}, RIP.getField @"unwrapF2" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.FunPtr F2_Aux)
          ) => RIP.HasField "unwrapF2" (RIP.Ptr F2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF2")
@@ -238,14 +246,6 @@ instance HasCField.HasCField F2 "unwrapF2" where
     RIP.Ptr (RIP.FunPtr F2_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F2_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapF2" F2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F2 {unwrapF2 = y1}, RIP.getField @"unwrapF2" x0)
 
 {-| Auxiliary type used by 'F3'
 
@@ -296,6 +296,14 @@ instance RIP.FromFunPtr F3_Aux where
   fromFunPtr = hs_bindgen_66460422a7197535
 
 instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapF3_Aux" F3_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F3_Aux {unwrapF3_Aux = y1}, RIP.getField @"unwrapF3_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapF3_Aux" (RIP.Ptr F3_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -307,14 +315,6 @@ instance HasCField.HasCField F3_Aux "unwrapF3_Aux" where
     RIP.CInt -> RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapF3_Aux" F3_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F3_Aux {unwrapF3_Aux = y1}, RIP.getField @"unwrapF3_Aux" x0)
 
 {-| __C declaration:__ @f3@
 
@@ -335,6 +335,14 @@ newtype F3 = F3
     )
 
 instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux))
+         ) => RIP.CompatHasField.HasField "unwrapF3" F3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F3 {unwrapF3 = y1}, RIP.getField @"unwrapF3" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux))
          ) => RIP.HasField "unwrapF3" (RIP.Ptr F3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF3")
@@ -345,14 +353,6 @@ instance HasCField.HasCField F3 "unwrapF3" where
     RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux))
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.Ptr (RIP.FunPtr F3_Aux))
-         ) => RIP.CompatHasField.HasField "unwrapF3" F3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F3 {unwrapF3 = y1}, RIP.getField @"unwrapF3" x0)
 
 {-| Auxiliary type used by 'F4'
 
@@ -403,6 +403,14 @@ instance RIP.FromFunPtr F4_Aux where
   fromFunPtr = hs_bindgen_40f9a8d432b9eb97
 
 instance ( ty ~ IO RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapF4_Aux" F4_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F4_Aux {unwrapF4_Aux = y1}, RIP.getField @"unwrapF4_Aux" x0)
+
+instance ( ty ~ IO RIP.CInt
          ) => RIP.HasField "unwrapF4_Aux" (RIP.Ptr F4_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -413,14 +421,6 @@ instance HasCField.HasCField F4_Aux "unwrapF4_Aux" where
   type CFieldType F4_Aux "unwrapF4_Aux" = IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapF4_Aux" F4_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F4_Aux {unwrapF4_Aux = y1}, RIP.getField @"unwrapF4_Aux" x0)
 
 {-| __C declaration:__ @f4@
 
@@ -441,6 +441,14 @@ newtype F4 = F4
     )
 
 instance ( ty ~ RIP.Ptr (RIP.FunPtr F4_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapF4" F4 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F4 {unwrapF4 = y1}, RIP.getField @"unwrapF4" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.FunPtr F4_Aux)
          ) => RIP.HasField "unwrapF4" (RIP.Ptr F4) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF4")
@@ -451,14 +459,6 @@ instance HasCField.HasCField F4 "unwrapF4" where
     RIP.Ptr (RIP.FunPtr F4_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F4_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapF4" F4 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F4 {unwrapF4 = y1}, RIP.getField @"unwrapF4" x0)
 
 {-| Auxiliary type used by 'F5'
 
@@ -509,6 +509,14 @@ instance RIP.FromFunPtr F5_Aux where
   fromFunPtr = hs_bindgen_586f6635c057975f
 
 instance ( ty ~ IO ()
+         ) => RIP.CompatHasField.HasField "unwrapF5_Aux" F5_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F5_Aux {unwrapF5_Aux = y1}, RIP.getField @"unwrapF5_Aux" x0)
+
+instance ( ty ~ IO ()
          ) => RIP.HasField "unwrapF5_Aux" (RIP.Ptr F5_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -519,14 +527,6 @@ instance HasCField.HasCField F5_Aux "unwrapF5_Aux" where
   type CFieldType F5_Aux "unwrapF5_Aux" = IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO ()
-         ) => RIP.CompatHasField.HasField "unwrapF5_Aux" F5_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F5_Aux {unwrapF5_Aux = y1}, RIP.getField @"unwrapF5_Aux" x0)
 
 {-| __C declaration:__ @f5@
 
@@ -547,6 +547,14 @@ newtype F5 = F5
     )
 
 instance ( ty ~ RIP.Ptr (RIP.FunPtr F5_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapF5" F5 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F5 {unwrapF5 = y1}, RIP.getField @"unwrapF5" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.FunPtr F5_Aux)
          ) => RIP.HasField "unwrapF5" (RIP.Ptr F5) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF5")
@@ -557,14 +565,6 @@ instance HasCField.HasCField F5 "unwrapF5" where
     RIP.Ptr (RIP.FunPtr F5_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F5_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapF5" F5 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F5 {unwrapF5 = y1}, RIP.getField @"unwrapF5" x0)
 
 {-| __C declaration:__ @MyInt@
 
@@ -595,6 +595,14 @@ newtype MyInt = MyInt
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyInt" (RIP.Ptr MyInt) (RIP.Ptr ty) where
 
   getField =
@@ -605,14 +613,6 @@ instance HasCField.HasCField MyInt "unwrapMyInt" where
   type CFieldType MyInt "unwrapMyInt" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyInt" MyInt ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         MyInt {unwrapMyInt = y1}, RIP.getField @"unwrapMyInt" x0)
 
 {-| Auxiliary type used by 'F6'
 
@@ -663,6 +663,14 @@ instance RIP.FromFunPtr F6_Aux where
   fromFunPtr = hs_bindgen_a887947b26e58f0c
 
 instance ( ty ~ (MyInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapF6_Aux" F6_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F6_Aux {unwrapF6_Aux = y1}, RIP.getField @"unwrapF6_Aux" x0)
+
+instance ( ty ~ (MyInt -> IO ())
          ) => RIP.HasField "unwrapF6_Aux" (RIP.Ptr F6_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -674,14 +682,6 @@ instance HasCField.HasCField F6_Aux "unwrapF6_Aux" where
     MyInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (MyInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapF6_Aux" F6_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F6_Aux {unwrapF6_Aux = y1}, RIP.getField @"unwrapF6_Aux" x0)
 
 {-| __C declaration:__ @f6@
 
@@ -702,6 +702,14 @@ newtype F6 = F6
     )
 
 instance ( ty ~ RIP.Ptr (RIP.FunPtr F6_Aux)
+         ) => RIP.CompatHasField.HasField "unwrapF6" F6 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F6 {unwrapF6 = y1}, RIP.getField @"unwrapF6" x0)
+
+instance ( ty ~ RIP.Ptr (RIP.FunPtr F6_Aux)
          ) => RIP.HasField "unwrapF6" (RIP.Ptr F6) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF6")
@@ -712,11 +720,3 @@ instance HasCField.HasCField F6 "unwrapF6" where
     RIP.Ptr (RIP.FunPtr F6_Aux)
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr (RIP.FunPtr F6_Aux)
-         ) => RIP.CompatHasField.HasField "unwrapF6" F6 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F6 {unwrapF6 = y1}, RIP.getField @"unwrapF6" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/bindingspec.yaml
@@ -32,12 +32,13 @@ hstypes:
       fields:
       - unwrapF1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -51,12 +52,13 @@ hstypes:
       fields:
       - unwrapF2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -70,12 +72,13 @@ hstypes:
       fields:
       - unwrapF3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -89,12 +92,13 @@ hstypes:
       fields:
       - unwrapF4
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -108,12 +112,13 @@ hstypes:
       fields:
       - unwrapF5
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -127,12 +132,13 @@ hstypes:
       fields:
       - unwrapF6
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -149,7 +155,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -157,6 +162,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/multi_level/th.txt
@@ -34,15 +34,15 @@ instance ToFunPtr F1_Aux
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
 instance (~) ty (CInt -> CInt -> IO ()) =>
+         HasField "unwrapF1_Aux" F1_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F1_Aux{unwrapF1_Aux = y_1},
+                              getField @"unwrapF1_Aux" x_0)
+instance (~) ty (CInt -> CInt -> IO ()) =>
          HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = CInt -> CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF1_Aux" F1_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F1_Aux{unwrapF1_Aux = y_1},
-                              getField @"unwrapF1_Aux" x_0)
 {-| __C declaration:__ @f1@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 7:16@
@@ -57,15 +57,15 @@ newtype F1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr F1_Aux) => HasField "unwrapF1" F1 ty
+    where hasField = \x_0 -> (\y_1 -> F1{unwrapF1 = y_1},
+                              getField @"unwrapF1" x_0)
 instance (~) ty (FunPtr F1_Aux) =>
          HasField "unwrapF1" (Ptr F1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr F1_Aux) => HasField "unwrapF1" F1 ty
-    where hasField = \x_0 -> (\y_1 -> F1{unwrapF1 = y_1},
-                              getField @"unwrapF1" x_0)
 {-| Auxiliary type used by 'F2'
 
     __C declaration:__ @f2@
@@ -101,15 +101,15 @@ instance ToFunPtr F2_Aux
 instance FromFunPtr F2_Aux
     where fromFunPtr = hs_bindgen_e15bcd26f1ed1df7
 instance (~) ty (CInt -> CInt -> IO ()) =>
+         HasField "unwrapF2_Aux" F2_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F2_Aux{unwrapF2_Aux = y_1},
+                              getField @"unwrapF2_Aux" x_0)
+instance (~) ty (CInt -> CInt -> IO ()) =>
          HasField "unwrapF2_Aux" (Ptr F2_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF2_Aux")
 instance HasCField F2_Aux "unwrapF2_Aux"
     where type CFieldType F2_Aux "unwrapF2_Aux" = CInt -> CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF2_Aux" F2_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F2_Aux{unwrapF2_Aux = y_1},
-                              getField @"unwrapF2_Aux" x_0)
 {-| __C declaration:__ @f2@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 10:17@
@@ -124,15 +124,15 @@ newtype F2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (FunPtr F2_Aux)) => HasField "unwrapF2" F2 ty
+    where hasField = \x_0 -> (\y_1 -> F2{unwrapF2 = y_1},
+                              getField @"unwrapF2" x_0)
 instance (~) ty (Ptr (FunPtr F2_Aux)) =>
          HasField "unwrapF2" (Ptr F2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF2")
 instance HasCField F2 "unwrapF2"
     where type CFieldType F2 "unwrapF2" = Ptr (FunPtr F2_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (FunPtr F2_Aux)) => HasField "unwrapF2" F2 ty
-    where hasField = \x_0 -> (\y_1 -> F2{unwrapF2 = y_1},
-                              getField @"unwrapF2" x_0)
 {-| Auxiliary type used by 'F3'
 
     __C declaration:__ @f3@
@@ -168,15 +168,15 @@ instance ToFunPtr F3_Aux
 instance FromFunPtr F3_Aux
     where fromFunPtr = hs_bindgen_66460422a7197535
 instance (~) ty (CInt -> CInt -> IO ()) =>
+         HasField "unwrapF3_Aux" F3_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F3_Aux{unwrapF3_Aux = y_1},
+                              getField @"unwrapF3_Aux" x_0)
+instance (~) ty (CInt -> CInt -> IO ()) =>
          HasField "unwrapF3_Aux" (Ptr F3_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF3_Aux")
 instance HasCField F3_Aux "unwrapF3_Aux"
     where type CFieldType F3_Aux "unwrapF3_Aux" = CInt -> CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> CInt -> IO ()) =>
-         HasField "unwrapF3_Aux" F3_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F3_Aux{unwrapF3_Aux = y_1},
-                              getField @"unwrapF3_Aux" x_0)
 {-| __C declaration:__ @f3@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 13:18@
@@ -192,15 +192,15 @@ newtype F3
                       Storable,
                       WriteRaw)
 instance (~) ty (Ptr (Ptr (FunPtr F3_Aux))) =>
+         HasField "unwrapF3" F3 ty
+    where hasField = \x_0 -> (\y_1 -> F3{unwrapF3 = y_1},
+                              getField @"unwrapF3" x_0)
+instance (~) ty (Ptr (Ptr (FunPtr F3_Aux))) =>
          HasField "unwrapF3" (Ptr F3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF3")
 instance HasCField F3 "unwrapF3"
     where type CFieldType F3 "unwrapF3" = Ptr (Ptr (FunPtr F3_Aux))
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (Ptr (FunPtr F3_Aux))) =>
-         HasField "unwrapF3" F3 ty
-    where hasField = \x_0 -> (\y_1 -> F3{unwrapF3 = y_1},
-                              getField @"unwrapF3" x_0)
 {-| Auxiliary type used by 'F4'
 
     __C declaration:__ @f4@
@@ -233,15 +233,15 @@ instance ToFunPtr F4_Aux
     where toFunPtr = hs_bindgen_83bcff023b3bc648
 instance FromFunPtr F4_Aux
     where fromFunPtr = hs_bindgen_40f9a8d432b9eb97
+instance (~) ty (IO CInt) => HasField "unwrapF4_Aux" F4_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F4_Aux{unwrapF4_Aux = y_1},
+                              getField @"unwrapF4_Aux" x_0)
 instance (~) ty (IO CInt) =>
          HasField "unwrapF4_Aux" (Ptr F4_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF4_Aux")
 instance HasCField F4_Aux "unwrapF4_Aux"
     where type CFieldType F4_Aux "unwrapF4_Aux" = IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO CInt) => HasField "unwrapF4_Aux" F4_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F4_Aux{unwrapF4_Aux = y_1},
-                              getField @"unwrapF4_Aux" x_0)
 {-| __C declaration:__ @f4@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 16:16@
@@ -256,15 +256,15 @@ newtype F4
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (FunPtr F4_Aux)) => HasField "unwrapF4" F4 ty
+    where hasField = \x_0 -> (\y_1 -> F4{unwrapF4 = y_1},
+                              getField @"unwrapF4" x_0)
 instance (~) ty (Ptr (FunPtr F4_Aux)) =>
          HasField "unwrapF4" (Ptr F4) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF4")
 instance HasCField F4 "unwrapF4"
     where type CFieldType F4 "unwrapF4" = Ptr (FunPtr F4_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (FunPtr F4_Aux)) => HasField "unwrapF4" F4 ty
-    where hasField = \x_0 -> (\y_1 -> F4{unwrapF4 = y_1},
-                              getField @"unwrapF4" x_0)
 {-| Auxiliary type used by 'F5'
 
     __C declaration:__ @f5@
@@ -297,15 +297,15 @@ instance ToFunPtr F5_Aux
     where toFunPtr = hs_bindgen_6891cbd81d6f42b9
 instance FromFunPtr F5_Aux
     where fromFunPtr = hs_bindgen_586f6635c057975f
+instance (~) ty (IO ()) => HasField "unwrapF5_Aux" F5_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F5_Aux{unwrapF5_Aux = y_1},
+                              getField @"unwrapF5_Aux" x_0)
 instance (~) ty (IO ()) =>
          HasField "unwrapF5_Aux" (Ptr F5_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF5_Aux")
 instance HasCField F5_Aux "unwrapF5_Aux"
     where type CFieldType F5_Aux "unwrapF5_Aux" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) => HasField "unwrapF5_Aux" F5_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F5_Aux{unwrapF5_Aux = y_1},
-                              getField @"unwrapF5_Aux" x_0)
 {-| __C declaration:__ @f5@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 19:17@
@@ -320,15 +320,15 @@ newtype F5
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (FunPtr F5_Aux)) => HasField "unwrapF5" F5 ty
+    where hasField = \x_0 -> (\y_1 -> F5{unwrapF5 = y_1},
+                              getField @"unwrapF5" x_0)
 instance (~) ty (Ptr (FunPtr F5_Aux)) =>
          HasField "unwrapF5" (Ptr F5) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF5")
 instance HasCField F5 "unwrapF5"
     where type CFieldType F5 "unwrapF5" = Ptr (FunPtr F5_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (FunPtr F5_Aux)) => HasField "unwrapF5" F5 ty
-    where hasField = \x_0 -> (\y_1 -> F5{unwrapF5 = y_1},
-                              getField @"unwrapF5" x_0)
 {-| __C declaration:__ @MyInt@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 22:13@
@@ -353,14 +353,14 @@ newtype MyInt
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
+    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
+                              getField @"unwrapMyInt" x_0)
 instance (~) ty CInt => HasField "unwrapMyInt" (Ptr MyInt) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyInt")
 instance HasCField MyInt "unwrapMyInt"
     where type CFieldType MyInt "unwrapMyInt" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyInt" MyInt ty
-    where hasField = \x_0 -> (\y_1 -> MyInt{unwrapMyInt = y_1},
-                              getField @"unwrapMyInt" x_0)
 {-| Auxiliary type used by 'F6'
 
     __C declaration:__ @f6@
@@ -395,15 +395,15 @@ instance ToFunPtr F6_Aux
 instance FromFunPtr F6_Aux
     where fromFunPtr = hs_bindgen_a887947b26e58f0c
 instance (~) ty (MyInt -> IO ()) =>
+         HasField "unwrapF6_Aux" F6_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F6_Aux{unwrapF6_Aux = y_1},
+                              getField @"unwrapF6_Aux" x_0)
+instance (~) ty (MyInt -> IO ()) =>
          HasField "unwrapF6_Aux" (Ptr F6_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF6_Aux")
 instance HasCField F6_Aux "unwrapF6_Aux"
     where type CFieldType F6_Aux "unwrapF6_Aux" = MyInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (MyInt -> IO ()) =>
-         HasField "unwrapF6_Aux" F6_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F6_Aux{unwrapF6_Aux = y_1},
-                              getField @"unwrapF6_Aux" x_0)
 {-| __C declaration:__ @f6@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/multi_level.h 23:17@
@@ -418,12 +418,12 @@ newtype F6
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr (FunPtr F6_Aux)) => HasField "unwrapF6" F6 ty
+    where hasField = \x_0 -> (\y_1 -> F6{unwrapF6 = y_1},
+                              getField @"unwrapF6" x_0)
 instance (~) ty (Ptr (FunPtr F6_Aux)) =>
          HasField "unwrapF6" (Ptr F6) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF6")
 instance HasCField F6 "unwrapF6"
     where type CFieldType F6 "unwrapF6" = Ptr (FunPtr F6_Aux)
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr (FunPtr F6_Aux)) => HasField "unwrapF6" F6 ty
-    where hasField = \x_0 -> (\y_1 -> F6{unwrapF6 = y_1},
-                              getField @"unwrapF6" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/Example.hs
@@ -71,6 +71,14 @@ instance RIP.FromFunPtr T_Aux where
   fromFunPtr = hs_bindgen_281617c90fa9307a
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapT_Aux" (RIP.Ptr T_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -82,14 +90,6 @@ instance HasCField.HasCField T_Aux "unwrapT_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
 
 {-| __C declaration:__ @T@
 
@@ -110,6 +110,13 @@ newtype T = T
     )
 
 instance ( ty ~ RIP.FunPtr T_Aux
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ RIP.FunPtr T_Aux
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -119,10 +126,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.FunPtr T_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr T_Aux
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/bindingspec.yaml
@@ -14,12 +14,13 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/pointer/th.txt
@@ -32,15 +32,15 @@ instance ToFunPtr T_Aux
     where toFunPtr = hs_bindgen_5927fedc3abfa99c
 instance FromFunPtr T_Aux
     where fromFunPtr = hs_bindgen_281617c90fa9307a
+instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
+    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
+                              getField @"unwrapT_Aux" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapT_Aux" (Ptr T_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT_Aux")
 instance HasCField T_Aux "unwrapT_Aux"
     where type CFieldType T_Aux "unwrapT_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
-    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
-                              getField @"unwrapT_Aux" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/pointer.h 1:16@
@@ -55,12 +55,12 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr T_Aux) => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty (FunPtr T_Aux) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = FunPtr T_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr T_Aux) => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/Example.hs
@@ -71,6 +71,14 @@ instance RIP.FromFunPtr T_Aux where
   fromFunPtr = hs_bindgen_281617c90fa9307a
 
 instance ( ty ~ (RIP.CInt -> IO ())
+         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
+
+instance ( ty ~ (RIP.CInt -> IO ())
          ) => RIP.HasField "unwrapT_Aux" (RIP.Ptr T_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -82,14 +90,6 @@ instance HasCField.HasCField T_Aux "unwrapT_Aux" where
     RIP.CInt -> IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO ())
-         ) => RIP.CompatHasField.HasField "unwrapT_Aux" T_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T_Aux {unwrapT_Aux = y1}, RIP.getField @"unwrapT_Aux" x0)
 
 {-| __C declaration:__ @T@
 
@@ -110,6 +110,13 @@ newtype T = T
     )
 
 instance ( ty ~ RIP.FunPtr T_Aux
+         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)
+
+instance ( ty ~ RIP.FunPtr T_Aux
          ) => RIP.HasField "unwrapT" (RIP.Ptr T) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapT")
@@ -119,10 +126,3 @@ instance HasCField.HasCField T "unwrapT" where
   type CFieldType T "unwrapT" = RIP.FunPtr T_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr T_Aux
-         ) => RIP.CompatHasField.HasField "unwrapT" T ty where
-
-  hasField =
-    \x0 ->
-      (\y1 -> T {unwrapT = y1}, RIP.getField @"unwrapT" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/bindingspec.yaml
@@ -14,12 +14,13 @@ hstypes:
       fields:
       - unwrapT
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/auxiliary/function-pointer/qual/th.txt
@@ -32,15 +32,15 @@ instance ToFunPtr T_Aux
     where toFunPtr = hs_bindgen_5927fedc3abfa99c
 instance FromFunPtr T_Aux
     where fromFunPtr = hs_bindgen_281617c90fa9307a
+instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
+    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
+                              getField @"unwrapT_Aux" x_0)
 instance (~) ty (CInt -> IO ()) =>
          HasField "unwrapT_Aux" (Ptr T_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT_Aux")
 instance HasCField T_Aux "unwrapT_Aux"
     where type CFieldType T_Aux "unwrapT_Aux" = CInt -> IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO ()) => HasField "unwrapT_Aux" T_Aux ty
-    where hasField = \x_0 -> (\y_1 -> T_Aux{unwrapT_Aux = y_1},
-                              getField @"unwrapT_Aux" x_0)
 {-| __C declaration:__ @T@
 
     __defined at:__ @types\/typedefs\/auxiliary\/function-pointer\/qual.h 1:23@
@@ -55,12 +55,12 @@ newtype T
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr T_Aux) => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
 instance (~) ty (FunPtr T_Aux) =>
          HasField "unwrapT" (Ptr T) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT")
 instance HasCField T "unwrapT"
     where type CFieldType T "unwrapT" = FunPtr T_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr T_Aux) => HasField "unwrapT" T ty
-    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
-                              getField @"unwrapT" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/Example.hs
@@ -59,6 +59,13 @@ newtype T1 = T1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapT1" (RIP.Ptr T1) (RIP.Ptr ty) where
 
@@ -69,13 +76,6 @@ instance HasCField.HasCField T1 "unwrapT1" where
   type CFieldType T1 "unwrapT1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapT1" T1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T1 {unwrapT1 = y1}, RIP.getField @"unwrapT1" x0)
 
 {-| __C declaration:__ @T2@
 
@@ -105,6 +105,13 @@ newtype T2 = T2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
+
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapT2" (RIP.Ptr T2) (RIP.Ptr ty) where
 
@@ -115,13 +122,6 @@ instance HasCField.HasCField T2 "unwrapT2" where
   type CFieldType T2 "unwrapT2" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapT2" T2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         T2 {unwrapT2 = y1}, RIP.getField @"unwrapT2" x0)
 
 {-| __C declaration:__ @macro M1@
 
@@ -151,6 +151,13 @@ newtype M1 = M1
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
+
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapM1" (RIP.Ptr M1) (RIP.Ptr ty) where
 
@@ -161,13 +168,6 @@ instance HasCField.HasCField M1 "unwrapM1" where
   type CFieldType M1 "unwrapM1" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapM1" M1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M1 {unwrapM1 = y1}, RIP.getField @"unwrapM1" x0)
 
 {-| __C declaration:__ @macro M2@
 
@@ -197,6 +197,13 @@ newtype M2 = M2
     , Marshal.WriteRaw
     )
 
+instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapM2" M2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M2 {unwrapM2 = y1}, RIP.getField @"unwrapM2" x0)
+
 instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unwrapM2" (RIP.Ptr M2) (RIP.Ptr ty) where
 
@@ -207,13 +214,6 @@ instance HasCField.HasCField M2 "unwrapM2" where
   type CFieldType M2 "unwrapM2" = RIP.CChar
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ RIP.CChar) => RIP.CompatHasField.HasField "unwrapM2" M2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M2 {unwrapM2 = y1}, RIP.getField @"unwrapM2" x0)
 
 {-| __C declaration:__ @macro M3@
 
@@ -234,6 +234,14 @@ newtype M3 = M3
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrapM3" (RIP.Ptr M3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapM3")
@@ -243,14 +251,6 @@ instance HasCField.HasCField M3 "unwrapM3" where
   type CFieldType M3 "unwrapM3" = RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapM3" M3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         M3 {unwrapM3 = y1}, RIP.getField @"unwrapM3" x0)
 
 {-| __C declaration:__ @struct ExampleStruct@
 
@@ -324,18 +324,6 @@ instance Marshal.WriteRaw ExampleStruct where
 
 deriving via Marshal.EquivStorable ExampleStruct instance RIP.Storable ExampleStruct
 
-instance HasCField.HasCField ExampleStruct "exampleStruct_t1" where
-
-  type CFieldType ExampleStruct "exampleStruct_t1" = T1
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ T1
-         ) => RIP.HasField "exampleStruct_t1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"exampleStruct_t1")
-
 instance ( ty ~ T1
          ) => RIP.CompatHasField.HasField "exampleStruct_t1" ExampleStruct ty where
 
@@ -350,17 +338,17 @@ instance ( ty ~ T1
       , RIP.getField @"exampleStruct_t1" x0
       )
 
-instance HasCField.HasCField ExampleStruct "exampleStruct_t2" where
-
-  type CFieldType ExampleStruct "exampleStruct_t2" = T2
-
-  offset# = \_ -> \_ -> 4
-
-instance ( ty ~ T2
-         ) => RIP.HasField "exampleStruct_t2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance ( ty ~ T1
+         ) => RIP.HasField "exampleStruct_t1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"exampleStruct_t2")
+    HasCField.fromPtr (RIP.Proxy @"exampleStruct_t1")
+
+instance HasCField.HasCField ExampleStruct "exampleStruct_t1" where
+
+  type CFieldType ExampleStruct "exampleStruct_t1" = T1
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ T2
          ) => RIP.CompatHasField.HasField "exampleStruct_t2" ExampleStruct ty where
@@ -376,17 +364,17 @@ instance ( ty ~ T2
       , RIP.getField @"exampleStruct_t2" x0
       )
 
-instance HasCField.HasCField ExampleStruct "exampleStruct_m1" where
-
-  type CFieldType ExampleStruct "exampleStruct_m1" = M1
-
-  offset# = \_ -> \_ -> 8
-
-instance ( ty ~ M1
-         ) => RIP.HasField "exampleStruct_m1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance ( ty ~ T2
+         ) => RIP.HasField "exampleStruct_t2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"exampleStruct_m1")
+    HasCField.fromPtr (RIP.Proxy @"exampleStruct_t2")
+
+instance HasCField.HasCField ExampleStruct "exampleStruct_t2" where
+
+  type CFieldType ExampleStruct "exampleStruct_t2" = T2
+
+  offset# = \_ -> \_ -> 4
 
 instance ( ty ~ M1
          ) => RIP.CompatHasField.HasField "exampleStruct_m1" ExampleStruct ty where
@@ -402,17 +390,17 @@ instance ( ty ~ M1
       , RIP.getField @"exampleStruct_m1" x0
       )
 
-instance HasCField.HasCField ExampleStruct "exampleStruct_m2" where
-
-  type CFieldType ExampleStruct "exampleStruct_m2" = M2
-
-  offset# = \_ -> \_ -> 12
-
-instance ( ty ~ M2
-         ) => RIP.HasField "exampleStruct_m2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+instance ( ty ~ M1
+         ) => RIP.HasField "exampleStruct_m1" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"exampleStruct_m2")
+    HasCField.fromPtr (RIP.Proxy @"exampleStruct_m1")
+
+instance HasCField.HasCField ExampleStruct "exampleStruct_m1" where
+
+  type CFieldType ExampleStruct "exampleStruct_m1" = M1
+
+  offset# = \_ -> \_ -> 8
 
 instance ( ty ~ M2
          ) => RIP.CompatHasField.HasField "exampleStruct_m2" ExampleStruct ty where
@@ -427,6 +415,18 @@ instance ( ty ~ M2
                         }
       , RIP.getField @"exampleStruct_m2" x0
       )
+
+instance ( ty ~ M2
+         ) => RIP.HasField "exampleStruct_m2" (RIP.Ptr ExampleStruct) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"exampleStruct_m2")
+
+instance HasCField.HasCField ExampleStruct "exampleStruct_m2" where
+
+  type CFieldType ExampleStruct "exampleStruct_m2" = M2
+
+  offset# = \_ -> \_ -> 12
 
 {-| __C declaration:__ @macro uint64_t@
 
@@ -457,6 +457,14 @@ newtype Uint64_t = Uint64_t
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapUint64_t" Uint64_t ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Uint64_t {unwrapUint64_t = y1}, RIP.getField @"unwrapUint64_t" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapUint64_t" (RIP.Ptr Uint64_t) (RIP.Ptr ty) where
 
   getField =
@@ -467,14 +475,6 @@ instance HasCField.HasCField Uint64_t "unwrapUint64_t" where
   type CFieldType Uint64_t "unwrapUint64_t" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapUint64_t" Uint64_t ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Uint64_t {unwrapUint64_t = y1}, RIP.getField @"unwrapUint64_t" x0)
 
 {-| __C declaration:__ @struct foo@
 
@@ -517,20 +517,20 @@ instance Marshal.WriteRaw Foo where
 
 deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
 
-instance HasCField.HasCField Foo "foo_a" where
-
-  type CFieldType Foo "foo_a" = RIP.Ptr Uint64_t
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr Uint64_t
-         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"foo_a")
-
 instance ( ty ~ RIP.Ptr Uint64_t
          ) => RIP.CompatHasField.HasField "foo_a" Foo ty where
 
   hasField =
     \x0 ->
       (\y1 -> Foo {foo_a = y1}, RIP.getField @"foo_a" x0)
+
+instance ( ty ~ RIP.Ptr Uint64_t
+         ) => RIP.HasField "foo_a" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"foo_a")
+
+instance HasCField.HasCField Foo "foo_a" where
+
+  type CFieldType Foo "foo_a" = RIP.Ptr Uint64_t
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/bindingspec.yaml
@@ -38,11 +38,12 @@ hstypes:
       - exampleStruct_m1
       - exampleStruct_m2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -55,11 +56,12 @@ hstypes:
       fields:
       - foo_a
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -75,7 +77,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -83,6 +84,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -105,7 +108,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -113,6 +115,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -132,12 +136,13 @@ hstypes:
       fields:
       - unwrapM3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -154,7 +159,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -162,6 +166,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -184,7 +190,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -192,6 +197,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -214,7 +221,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -222,6 +228,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedef_vs_macro/th.txt
@@ -23,14 +23,14 @@ newtype T1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapT1" T1 ty
+    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
+                              getField @"unwrapT1" x_0)
 instance (~) ty CInt => HasField "unwrapT1" (Ptr T1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT1")
 instance HasCField T1 "unwrapT1"
     where type CFieldType T1 "unwrapT1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapT1" T1 ty
-    where hasField = \x_0 -> (\y_1 -> T1{unwrapT1 = y_1},
-                              getField @"unwrapT1" x_0)
 {-| __C declaration:__ @T2@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 2:14@
@@ -55,14 +55,14 @@ newtype T2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapT2" T2 ty
+    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
+                              getField @"unwrapT2" x_0)
 instance (~) ty CChar => HasField "unwrapT2" (Ptr T2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapT2")
 instance HasCField T2 "unwrapT2"
     where type CFieldType T2 "unwrapT2" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapT2" T2 ty
-    where hasField = \x_0 -> (\y_1 -> T2{unwrapT2 = y_1},
-                              getField @"unwrapT2" x_0)
 {-| __C declaration:__ @macro M1@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 4:9@
@@ -87,14 +87,14 @@ newtype M1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapM1" M1 ty
+    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
+                              getField @"unwrapM1" x_0)
 instance (~) ty CInt => HasField "unwrapM1" (Ptr M1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM1")
 instance HasCField M1 "unwrapM1"
     where type CFieldType M1 "unwrapM1" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapM1" M1 ty
-    where hasField = \x_0 -> (\y_1 -> M1{unwrapM1 = y_1},
-                              getField @"unwrapM1" x_0)
 {-| __C declaration:__ @macro M2@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 5:9@
@@ -119,14 +119,14 @@ newtype M2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CChar => HasField "unwrapM2" M2 ty
+    where hasField = \x_0 -> (\y_1 -> M2{unwrapM2 = y_1},
+                              getField @"unwrapM2" x_0)
 instance (~) ty CChar => HasField "unwrapM2" (Ptr M2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM2")
 instance HasCField M2 "unwrapM2"
     where type CFieldType M2 "unwrapM2" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unwrapM2" M2 ty
-    where hasField = \x_0 -> (\y_1 -> M2{unwrapM2 = y_1},
-                              getField @"unwrapM2" x_0)
 {-| __C declaration:__ @macro M3@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 6:9@
@@ -141,14 +141,14 @@ newtype M3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr CInt) => HasField "unwrapM3" M3 ty
+    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
+                              getField @"unwrapM3" x_0)
 instance (~) ty (Ptr CInt) => HasField "unwrapM3" (Ptr M3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapM3")
 instance HasCField M3 "unwrapM3"
     where type CFieldType M3 "unwrapM3" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) => HasField "unwrapM3" M3 ty
-    where hasField = \x_0 -> (\y_1 -> M3{unwrapM3 = y_1},
-                              getField @"unwrapM3" x_0)
 {-| __C declaration:__ @struct ExampleStruct@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 8:8@
@@ -197,54 +197,54 @@ instance WriteRaw ExampleStruct
                                                      exampleStruct_m1_4
                                                      exampleStruct_m2_5 -> writeRaw (Proxy @"exampleStruct_t1") ptr_0 exampleStruct_t1_2 >> (writeRaw (Proxy @"exampleStruct_t2") ptr_0 exampleStruct_t2_3 >> (writeRaw (Proxy @"exampleStruct_m1") ptr_0 exampleStruct_m1_4 >> writeRaw (Proxy @"exampleStruct_m2") ptr_0 exampleStruct_m2_5))
 deriving via (EquivStorable ExampleStruct) instance Storable ExampleStruct
-instance HasCField ExampleStruct "exampleStruct_t1"
-    where type CFieldType ExampleStruct "exampleStruct_t1" = T1
-          offset# = \_ -> \_ -> 0
-instance (~) ty T1 =>
-         HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"exampleStruct_t1")
 instance (~) ty T1 => HasField "exampleStruct_t1" ExampleStruct ty
     where hasField = \x_0 -> (\y_1 -> ExampleStruct{exampleStruct_t1 = y_1,
                                                     exampleStruct_t2 = getField @"exampleStruct_t2" x_0,
                                                     exampleStruct_m1 = getField @"exampleStruct_m1" x_0,
                                                     exampleStruct_m2 = getField @"exampleStruct_m2" x_0},
                               getField @"exampleStruct_t1" x_0)
-instance HasCField ExampleStruct "exampleStruct_t2"
-    where type CFieldType ExampleStruct "exampleStruct_t2" = T2
-          offset# = \_ -> \_ -> 4
-instance (~) ty T2 =>
-         HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"exampleStruct_t2")
+instance (~) ty T1 =>
+         HasField "exampleStruct_t1" (Ptr ExampleStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"exampleStruct_t1")
+instance HasCField ExampleStruct "exampleStruct_t1"
+    where type CFieldType ExampleStruct "exampleStruct_t1" = T1
+          offset# = \_ -> \_ -> 0
 instance (~) ty T2 => HasField "exampleStruct_t2" ExampleStruct ty
     where hasField = \x_0 -> (\y_1 -> ExampleStruct{exampleStruct_t2 = y_1,
                                                     exampleStruct_t1 = getField @"exampleStruct_t1" x_0,
                                                     exampleStruct_m1 = getField @"exampleStruct_m1" x_0,
                                                     exampleStruct_m2 = getField @"exampleStruct_m2" x_0},
                               getField @"exampleStruct_t2" x_0)
-instance HasCField ExampleStruct "exampleStruct_m1"
-    where type CFieldType ExampleStruct "exampleStruct_m1" = M1
-          offset# = \_ -> \_ -> 8
-instance (~) ty M1 =>
-         HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"exampleStruct_m1")
+instance (~) ty T2 =>
+         HasField "exampleStruct_t2" (Ptr ExampleStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"exampleStruct_t2")
+instance HasCField ExampleStruct "exampleStruct_t2"
+    where type CFieldType ExampleStruct "exampleStruct_t2" = T2
+          offset# = \_ -> \_ -> 4
 instance (~) ty M1 => HasField "exampleStruct_m1" ExampleStruct ty
     where hasField = \x_0 -> (\y_1 -> ExampleStruct{exampleStruct_m1 = y_1,
                                                     exampleStruct_t1 = getField @"exampleStruct_t1" x_0,
                                                     exampleStruct_t2 = getField @"exampleStruct_t2" x_0,
                                                     exampleStruct_m2 = getField @"exampleStruct_m2" x_0},
                               getField @"exampleStruct_m1" x_0)
-instance HasCField ExampleStruct "exampleStruct_m2"
-    where type CFieldType ExampleStruct "exampleStruct_m2" = M2
-          offset# = \_ -> \_ -> 12
-instance (~) ty M2 =>
-         HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr ty)
-    where getField = fromPtr (Proxy @"exampleStruct_m2")
+instance (~) ty M1 =>
+         HasField "exampleStruct_m1" (Ptr ExampleStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"exampleStruct_m1")
+instance HasCField ExampleStruct "exampleStruct_m1"
+    where type CFieldType ExampleStruct "exampleStruct_m1" = M1
+          offset# = \_ -> \_ -> 8
 instance (~) ty M2 => HasField "exampleStruct_m2" ExampleStruct ty
     where hasField = \x_0 -> (\y_1 -> ExampleStruct{exampleStruct_m2 = y_1,
                                                     exampleStruct_t1 = getField @"exampleStruct_t1" x_0,
                                                     exampleStruct_t2 = getField @"exampleStruct_t2" x_0,
                                                     exampleStruct_m1 = getField @"exampleStruct_m1" x_0},
                               getField @"exampleStruct_m2" x_0)
+instance (~) ty M2 =>
+         HasField "exampleStruct_m2" (Ptr ExampleStruct) (Ptr ty)
+    where getField = fromPtr (Proxy @"exampleStruct_m2")
+instance HasCField ExampleStruct "exampleStruct_m2"
+    where type CFieldType ExampleStruct "exampleStruct_m2" = M2
+          offset# = \_ -> \_ -> 12
 {-| __C declaration:__ @macro uint64_t@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 15:9@
@@ -269,15 +269,15 @@ newtype Uint64_t
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapUint64_t" Uint64_t ty
+    where hasField = \x_0 -> (\y_1 -> Uint64_t{unwrapUint64_t = y_1},
+                              getField @"unwrapUint64_t" x_0)
 instance (~) ty CInt =>
          HasField "unwrapUint64_t" (Ptr Uint64_t) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapUint64_t")
 instance HasCField Uint64_t "unwrapUint64_t"
     where type CFieldType Uint64_t "unwrapUint64_t" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapUint64_t" Uint64_t ty
-    where hasField = \x_0 -> (\y_1 -> Uint64_t{unwrapUint64_t = y_1},
-                              getField @"unwrapUint64_t" x_0)
 {-| __C declaration:__ @struct foo@
 
     __defined at:__ @types\/typedefs\/typedef_vs_macro.h 17:8@
@@ -302,12 +302,12 @@ instance WriteRaw Foo
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        Foo foo_a_2 -> writeRaw (Proxy @"foo_a") ptr_0 foo_a_2
 deriving via (EquivStorable Foo) instance Storable Foo
-instance HasCField Foo "foo_a"
-    where type CFieldType Foo "foo_a" = Ptr Uint64_t
-          offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr Uint64_t) =>
-         HasField "foo_a" (Ptr Foo) (Ptr ty)
-    where getField = fromPtr (Proxy @"foo_a")
 instance (~) ty (Ptr Uint64_t) => HasField "foo_a" Foo ty
     where hasField = \x_0 -> (\y_1 -> Foo{foo_a = y_1},
                               getField @"foo_a" x_0)
+instance (~) ty (Ptr Uint64_t) =>
+         HasField "foo_a" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"foo_a")
+instance HasCField Foo "foo_a"
+    where type CFieldType Foo "foo_a" = Ptr Uint64_t
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/Example.hs
@@ -63,6 +63,14 @@ newtype Myint = Myint
     )
 
 instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapMyint" Myint ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Myint {unwrapMyint = y1}, RIP.getField @"unwrapMyint" x0)
+
+instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unwrapMyint" (RIP.Ptr Myint) (RIP.Ptr ty) where
 
   getField =
@@ -73,14 +81,6 @@ instance HasCField.HasCField Myint "unwrapMyint" where
   type CFieldType Myint "unwrapMyint" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapMyint" Myint ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Myint {unwrapMyint = y1}, RIP.getField @"unwrapMyint" x0)
 
 {-| __C declaration:__ @intptr@
 
@@ -101,6 +101,14 @@ newtype Intptr = Intptr
     )
 
 instance ( ty ~ RIP.Ptr RIP.CInt
+         ) => RIP.CompatHasField.HasField "unwrapIntptr" Intptr ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Intptr {unwrapIntptr = y1}, RIP.getField @"unwrapIntptr" x0)
+
+instance ( ty ~ RIP.Ptr RIP.CInt
          ) => RIP.HasField "unwrapIntptr" (RIP.Ptr Intptr) (RIP.Ptr ty) where
 
   getField =
@@ -112,14 +120,6 @@ instance HasCField.HasCField Intptr "unwrapIntptr" where
     RIP.Ptr RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.Ptr RIP.CInt
-         ) => RIP.CompatHasField.HasField "unwrapIntptr" Intptr ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Intptr {unwrapIntptr = y1}, RIP.getField @"unwrapIntptr" x0)
 
 {-| __C declaration:__ @int2int@
 
@@ -168,6 +168,14 @@ instance RIP.FromFunPtr Int2int where
   fromFunPtr = hs_bindgen_65378a8a3cf640ad
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapInt2int" Int2int ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Int2int {unwrapInt2int = y1}, RIP.getField @"unwrapInt2int" x0)
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapInt2int" (RIP.Ptr Int2int) (RIP.Ptr ty) where
 
   getField =
@@ -179,14 +187,6 @@ instance HasCField.HasCField Int2int "unwrapInt2int" where
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapInt2int" Int2int ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         Int2int {unwrapInt2int = y1}, RIP.getField @"unwrapInt2int" x0)
 
 {-| Auxiliary type used by 'FunctionPointer_Function'
 
@@ -237,6 +237,16 @@ instance RIP.FromFunPtr FunctionPointer_Function_Aux where
   fromFunPtr = hs_bindgen_4c3da8240a31e036
 
 instance ( ty ~ IO ()
+         ) => RIP.CompatHasField.HasField "unwrapFunctionPointer_Function_Aux" FunctionPointer_Function_Aux ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          FunctionPointer_Function_Aux {unwrapFunctionPointer_Function_Aux = y1}
+      , RIP.getField @"unwrapFunctionPointer_Function_Aux" x0
+      )
+
+instance ( ty ~ IO ()
          ) => RIP.HasField "unwrapFunctionPointer_Function_Aux" (RIP.Ptr FunctionPointer_Function_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -248,16 +258,6 @@ instance HasCField.HasCField FunctionPointer_Function_Aux "unwrapFunctionPointer
     IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO ()
-         ) => RIP.CompatHasField.HasField "unwrapFunctionPointer_Function_Aux" FunctionPointer_Function_Aux ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          FunctionPointer_Function_Aux {unwrapFunctionPointer_Function_Aux = y1}
-      , RIP.getField @"unwrapFunctionPointer_Function_Aux" x0
-      )
 
 {-| __C declaration:__ @FunctionPointer_Function@
 
@@ -278,6 +278,16 @@ newtype FunctionPointer_Function = FunctionPointer_Function
     )
 
 instance ( ty ~ RIP.FunPtr FunctionPointer_Function_Aux
+         ) => RIP.CompatHasField.HasField "unwrapFunctionPointer_Function" FunctionPointer_Function ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          FunctionPointer_Function {unwrapFunctionPointer_Function = y1}
+      , RIP.getField @"unwrapFunctionPointer_Function" x0
+      )
+
+instance ( ty ~ RIP.FunPtr FunctionPointer_Function_Aux
          ) => RIP.HasField "unwrapFunctionPointer_Function" (RIP.Ptr FunctionPointer_Function) (RIP.Ptr ty) where
 
   getField =
@@ -289,16 +299,6 @@ instance HasCField.HasCField FunctionPointer_Function "unwrapFunctionPointer_Fun
     RIP.FunPtr FunctionPointer_Function_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr FunctionPointer_Function_Aux
-         ) => RIP.CompatHasField.HasField "unwrapFunctionPointer_Function" FunctionPointer_Function ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          FunctionPointer_Function {unwrapFunctionPointer_Function = y1}
-      , RIP.getField @"unwrapFunctionPointer_Function" x0
-      )
 
 {-| __C declaration:__ @NonFunctionPointer_Function@
 
@@ -347,6 +347,16 @@ instance RIP.FromFunPtr NonFunctionPointer_Function where
   fromFunPtr = hs_bindgen_36c7108d046bcbc3
 
 instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
+         ) => RIP.CompatHasField.HasField "unwrapNonFunctionPointer_Function" NonFunctionPointer_Function ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          NonFunctionPointer_Function {unwrapNonFunctionPointer_Function = y1}
+      , RIP.getField @"unwrapNonFunctionPointer_Function" x0
+      )
+
+instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
          ) => RIP.HasField "unwrapNonFunctionPointer_Function" (RIP.Ptr NonFunctionPointer_Function) (RIP.Ptr ty) where
 
   getField =
@@ -358,16 +368,6 @@ instance HasCField.HasCField NonFunctionPointer_Function "unwrapNonFunctionPoint
     RIP.CInt -> IO RIP.CInt
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ (RIP.CInt -> IO RIP.CInt)
-         ) => RIP.CompatHasField.HasField "unwrapNonFunctionPointer_Function" NonFunctionPointer_Function ty where
-
-  hasField =
-    \x0 ->
-      ( \y1 ->
-          NonFunctionPointer_Function {unwrapNonFunctionPointer_Function = y1}
-      , RIP.getField @"unwrapNonFunctionPointer_Function" x0
-      )
 
 {-| Auxiliary type used by 'F1'
 
@@ -418,6 +418,14 @@ instance RIP.FromFunPtr F1_Aux where
   fromFunPtr = hs_bindgen_ddeb5206e8192425
 
 instance ( ty ~ IO ()
+         ) => RIP.CompatHasField.HasField "unwrapF1_Aux" F1_Aux ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F1_Aux {unwrapF1_Aux = y1}, RIP.getField @"unwrapF1_Aux" x0)
+
+instance ( ty ~ IO ()
          ) => RIP.HasField "unwrapF1_Aux" (RIP.Ptr F1_Aux) (RIP.Ptr ty) where
 
   getField =
@@ -428,14 +436,6 @@ instance HasCField.HasCField F1_Aux "unwrapF1_Aux" where
   type CFieldType F1_Aux "unwrapF1_Aux" = IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ IO ()
-         ) => RIP.CompatHasField.HasField "unwrapF1_Aux" F1_Aux ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F1_Aux {unwrapF1_Aux = y1}, RIP.getField @"unwrapF1_Aux" x0)
 
 {-| __C declaration:__ @f1@
 
@@ -456,6 +456,14 @@ newtype F1 = F1
     )
 
 instance ( ty ~ RIP.FunPtr F1_Aux
+         ) => RIP.CompatHasField.HasField "unwrapF1" F1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         F1 {unwrapF1 = y1}, RIP.getField @"unwrapF1" x0)
+
+instance ( ty ~ RIP.FunPtr F1_Aux
          ) => RIP.HasField "unwrapF1" (RIP.Ptr F1) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapF1")
@@ -465,14 +473,6 @@ instance HasCField.HasCField F1 "unwrapF1" where
   type CFieldType F1 "unwrapF1" = RIP.FunPtr F1_Aux
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr F1_Aux
-         ) => RIP.CompatHasField.HasField "unwrapF1" F1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         F1 {unwrapF1 = y1}, RIP.getField @"unwrapF1" x0)
 
 {-| __C declaration:__ @g1@
 
@@ -520,6 +520,13 @@ instance RIP.FromFunPtr G1 where
 
   fromFunPtr = hs_bindgen_8405c8e75aa78be5
 
+instance (ty ~ IO ()) => RIP.CompatHasField.HasField "unwrapG1" G1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         G1 {unwrapG1 = y1}, RIP.getField @"unwrapG1" x0)
+
 instance (ty ~ IO ()) => RIP.HasField "unwrapG1" (RIP.Ptr G1) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapG1")
@@ -529,13 +536,6 @@ instance HasCField.HasCField G1 "unwrapG1" where
   type CFieldType G1 "unwrapG1" = IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ IO ()) => RIP.CompatHasField.HasField "unwrapG1" G1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         G1 {unwrapG1 = y1}, RIP.getField @"unwrapG1" x0)
 
 {-| __C declaration:__ @g2@
 
@@ -556,6 +556,14 @@ newtype G2 = G2
     )
 
 instance ( ty ~ RIP.FunPtr G1
+         ) => RIP.CompatHasField.HasField "unwrapG2" G2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         G2 {unwrapG2 = y1}, RIP.getField @"unwrapG2" x0)
+
+instance ( ty ~ RIP.FunPtr G1
          ) => RIP.HasField "unwrapG2" (RIP.Ptr G2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapG2")
@@ -565,14 +573,6 @@ instance HasCField.HasCField G2 "unwrapG2" where
   type CFieldType G2 "unwrapG2" = RIP.FunPtr G1
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr G1
-         ) => RIP.CompatHasField.HasField "unwrapG2" G2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         G2 {unwrapG2 = y1}, RIP.getField @"unwrapG2" x0)
 
 {-| __C declaration:__ @h1@
 
@@ -620,6 +620,13 @@ instance RIP.FromFunPtr H1 where
 
   fromFunPtr = hs_bindgen_1a33688324e1924f
 
+instance (ty ~ IO ()) => RIP.CompatHasField.HasField "unwrapH1" H1 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         H1 {unwrapH1 = y1}, RIP.getField @"unwrapH1" x0)
+
 instance (ty ~ IO ()) => RIP.HasField "unwrapH1" (RIP.Ptr H1) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH1")
@@ -629,13 +636,6 @@ instance HasCField.HasCField H1 "unwrapH1" where
   type CFieldType H1 "unwrapH1" = IO ()
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ IO ()) => RIP.CompatHasField.HasField "unwrapH1" H1 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         H1 {unwrapH1 = y1}, RIP.getField @"unwrapH1" x0)
 
 {-| __C declaration:__ @h2@
 
@@ -649,6 +649,13 @@ newtype H2 = H2
   deriving stock (RIP.Generic)
   deriving newtype (RIP.HasFFIType)
 
+instance (ty ~ H1) => RIP.CompatHasField.HasField "unwrapH2" H2 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         H2 {unwrapH2 = y1}, RIP.getField @"unwrapH2" x0)
+
 instance (ty ~ H1) => RIP.HasField "unwrapH2" (RIP.Ptr H2) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH2")
@@ -658,13 +665,6 @@ instance HasCField.HasCField H2 "unwrapH2" where
   type CFieldType H2 "unwrapH2" = H1
 
   offset# = \_ -> \_ -> 0
-
-instance (ty ~ H1) => RIP.CompatHasField.HasField "unwrapH2" H2 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         H2 {unwrapH2 = y1}, RIP.getField @"unwrapH2" x0)
 
 {-| __C declaration:__ @h3@
 
@@ -685,6 +685,14 @@ newtype H3 = H3
     )
 
 instance ( ty ~ RIP.FunPtr H2
+         ) => RIP.CompatHasField.HasField "unwrapH3" H3 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         H3 {unwrapH3 = y1}, RIP.getField @"unwrapH3" x0)
+
+instance ( ty ~ RIP.FunPtr H2
          ) => RIP.HasField "unwrapH3" (RIP.Ptr H3) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unwrapH3")
@@ -694,11 +702,3 @@ instance HasCField.HasCField H3 "unwrapH3" where
   type CFieldType H3 "unwrapH3" = RIP.FunPtr H2
 
   offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.FunPtr H2
-         ) => RIP.CompatHasField.HasField "unwrapH3" H3 ty where
-
-  hasField =
-    \x0 ->
-      (\y1 ->
-         H3 {unwrapH3 = y1}, RIP.getField @"unwrapH3" x0)

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/bindingspec.yaml
@@ -44,12 +44,13 @@ hstypes:
       fields:
       - unwrapF1
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -63,12 +64,13 @@ hstypes:
       fields:
       - unwrapFunctionPointer_Function
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -82,12 +84,13 @@ hstypes:
       fields:
       - unwrapG1
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr
 - hsname: G2
   representation:
@@ -96,12 +99,13 @@ hstypes:
       fields:
       - unwrapG2
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -115,12 +119,13 @@ hstypes:
       fields:
       - unwrapH1
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr
 - hsname: H2
   representation:
@@ -129,11 +134,12 @@ hstypes:
       fields:
       - unwrapH2
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
 - hsname: H3
   representation:
     newtype:
@@ -141,12 +147,13 @@ hstypes:
       fields:
       - unwrapH3
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -160,12 +167,13 @@ hstypes:
       fields:
       - unwrapInt2int
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr
 - hsname: Intptr
   representation:
@@ -174,12 +182,13 @@ hstypes:
       fields:
       - unwrapIntptr
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Ord
   - ReadRaw
   - Show
@@ -196,7 +205,6 @@ hstypes:
   - Bitfield
   - Bits
   - Bounded
-  - CompatHasField
   - Enum
   - Eq
   - FiniteBits
@@ -204,6 +212,8 @@ hstypes:
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - Integral
   - Ix
   - Num
@@ -223,10 +233,11 @@ hstypes:
       fields:
       - unwrapNonFunctionPointer_Function
   instances:
-  - CompatHasField
   - FromFunPtr
   - Generic
   - HasCField
   - HasFFIType
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ToFunPtr

--- a/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/typedefs/typedefs/th.txt
@@ -23,14 +23,14 @@ newtype Myint
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty CInt => HasField "unwrapMyint" Myint ty
+    where hasField = \x_0 -> (\y_1 -> Myint{unwrapMyint = y_1},
+                              getField @"unwrapMyint" x_0)
 instance (~) ty CInt => HasField "unwrapMyint" (Ptr Myint) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapMyint")
 instance HasCField Myint "unwrapMyint"
     where type CFieldType Myint "unwrapMyint" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unwrapMyint" Myint ty
-    where hasField = \x_0 -> (\y_1 -> Myint{unwrapMyint = y_1},
-                              getField @"unwrapMyint" x_0)
 {-| __C declaration:__ @intptr@
 
     __defined at:__ @types\/typedefs\/typedefs.h 2:15@
@@ -45,15 +45,15 @@ newtype Intptr
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (Ptr CInt) => HasField "unwrapIntptr" Intptr ty
+    where hasField = \x_0 -> (\y_1 -> Intptr{unwrapIntptr = y_1},
+                              getField @"unwrapIntptr" x_0)
 instance (~) ty (Ptr CInt) =>
          HasField "unwrapIntptr" (Ptr Intptr) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapIntptr")
 instance HasCField Intptr "unwrapIntptr"
     where type CFieldType Intptr "unwrapIntptr" = Ptr CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (Ptr CInt) => HasField "unwrapIntptr" Intptr ty
-    where hasField = \x_0 -> (\y_1 -> Intptr{unwrapIntptr = y_1},
-                              getField @"unwrapIntptr" x_0)
 {-| __C declaration:__ @int2int@
 
     __defined at:__ @types\/typedefs\/typedefs.h 5:13@
@@ -86,15 +86,15 @@ instance ToFunPtr Int2int
 instance FromFunPtr Int2int
     where fromFunPtr = hs_bindgen_65378a8a3cf640ad
 instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapInt2int" Int2int ty
+    where hasField = \x_0 -> (\y_1 -> Int2int{unwrapInt2int = y_1},
+                              getField @"unwrapInt2int" x_0)
+instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapInt2int" (Ptr Int2int) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapInt2int")
 instance HasCField Int2int "unwrapInt2int"
     where type CFieldType Int2int "unwrapInt2int" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapInt2int" Int2int ty
-    where hasField = \x_0 -> (\y_1 -> Int2int{unwrapInt2int = y_1},
-                              getField @"unwrapInt2int" x_0)
 {-| Auxiliary type used by 'FunctionPointer_Function'
 
     __C declaration:__ @FunctionPointer_Function@
@@ -131,6 +131,12 @@ instance FromFunPtr FunctionPointer_Function_Aux
     where fromFunPtr = hs_bindgen_4c3da8240a31e036
 instance (~) ty (IO ()) =>
          HasField "unwrapFunctionPointer_Function_Aux"
+                  FunctionPointer_Function_Aux
+                  ty
+    where hasField = \x_0 -> (\y_1 -> FunctionPointer_Function_Aux{unwrapFunctionPointer_Function_Aux = y_1},
+                              getField @"unwrapFunctionPointer_Function_Aux" x_0)
+instance (~) ty (IO ()) =>
+         HasField "unwrapFunctionPointer_Function_Aux"
                   (Ptr FunctionPointer_Function_Aux)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function_Aux")
@@ -139,12 +145,6 @@ instance HasCField FunctionPointer_Function_Aux
     where type CFieldType FunctionPointer_Function_Aux
                           "unwrapFunctionPointer_Function_Aux" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) =>
-         HasField "unwrapFunctionPointer_Function_Aux"
-                  FunctionPointer_Function_Aux
-                  ty
-    where hasField = \x_0 -> (\y_1 -> FunctionPointer_Function_Aux{unwrapFunctionPointer_Function_Aux = y_1},
-                              getField @"unwrapFunctionPointer_Function_Aux" x_0)
 {-| __C declaration:__ @FunctionPointer_Function@
 
     __defined at:__ @types\/typedefs\/typedefs.h 8:16@
@@ -161,6 +161,12 @@ newtype FunctionPointer_Function
                       WriteRaw)
 instance (~) ty (FunPtr FunctionPointer_Function_Aux) =>
          HasField "unwrapFunctionPointer_Function"
+                  FunctionPointer_Function
+                  ty
+    where hasField = \x_0 -> (\y_1 -> FunctionPointer_Function{unwrapFunctionPointer_Function = y_1},
+                              getField @"unwrapFunctionPointer_Function" x_0)
+instance (~) ty (FunPtr FunctionPointer_Function_Aux) =>
+         HasField "unwrapFunctionPointer_Function"
                   (Ptr FunctionPointer_Function)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapFunctionPointer_Function")
@@ -169,12 +175,6 @@ instance HasCField FunctionPointer_Function
     where type CFieldType FunctionPointer_Function
                           "unwrapFunctionPointer_Function" = FunPtr FunctionPointer_Function_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr FunctionPointer_Function_Aux) =>
-         HasField "unwrapFunctionPointer_Function"
-                  FunctionPointer_Function
-                  ty
-    where hasField = \x_0 -> (\y_1 -> FunctionPointer_Function{unwrapFunctionPointer_Function = y_1},
-                              getField @"unwrapFunctionPointer_Function" x_0)
 {-| __C declaration:__ @NonFunctionPointer_Function@
 
     __defined at:__ @types\/typedefs\/typedefs.h 9:14@
@@ -211,6 +211,12 @@ instance FromFunPtr NonFunctionPointer_Function
     where fromFunPtr = hs_bindgen_36c7108d046bcbc3
 instance (~) ty (CInt -> IO CInt) =>
          HasField "unwrapNonFunctionPointer_Function"
+                  NonFunctionPointer_Function
+                  ty
+    where hasField = \x_0 -> (\y_1 -> NonFunctionPointer_Function{unwrapNonFunctionPointer_Function = y_1},
+                              getField @"unwrapNonFunctionPointer_Function" x_0)
+instance (~) ty (CInt -> IO CInt) =>
+         HasField "unwrapNonFunctionPointer_Function"
                   (Ptr NonFunctionPointer_Function)
                   (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapNonFunctionPointer_Function")
@@ -219,12 +225,6 @@ instance HasCField NonFunctionPointer_Function
     where type CFieldType NonFunctionPointer_Function
                           "unwrapNonFunctionPointer_Function" = CInt -> IO CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty (CInt -> IO CInt) =>
-         HasField "unwrapNonFunctionPointer_Function"
-                  NonFunctionPointer_Function
-                  ty
-    where hasField = \x_0 -> (\y_1 -> NonFunctionPointer_Function{unwrapNonFunctionPointer_Function = y_1},
-                              getField @"unwrapNonFunctionPointer_Function" x_0)
 {-| Auxiliary type used by 'F1'
 
     __C declaration:__ @f1@
@@ -257,15 +257,15 @@ instance ToFunPtr F1_Aux
     where toFunPtr = hs_bindgen_00d16e666202ed6c
 instance FromFunPtr F1_Aux
     where fromFunPtr = hs_bindgen_ddeb5206e8192425
+instance (~) ty (IO ()) => HasField "unwrapF1_Aux" F1_Aux ty
+    where hasField = \x_0 -> (\y_1 -> F1_Aux{unwrapF1_Aux = y_1},
+                              getField @"unwrapF1_Aux" x_0)
 instance (~) ty (IO ()) =>
          HasField "unwrapF1_Aux" (Ptr F1_Aux) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1_Aux")
 instance HasCField F1_Aux "unwrapF1_Aux"
     where type CFieldType F1_Aux "unwrapF1_Aux" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) => HasField "unwrapF1_Aux" F1_Aux ty
-    where hasField = \x_0 -> (\y_1 -> F1_Aux{unwrapF1_Aux = y_1},
-                              getField @"unwrapF1_Aux" x_0)
 {-| __C declaration:__ @f1@
 
     __defined at:__ @types\/typedefs\/typedefs.h 11:16@
@@ -280,15 +280,15 @@ newtype F1
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr F1_Aux) => HasField "unwrapF1" F1 ty
+    where hasField = \x_0 -> (\y_1 -> F1{unwrapF1 = y_1},
+                              getField @"unwrapF1" x_0)
 instance (~) ty (FunPtr F1_Aux) =>
          HasField "unwrapF1" (Ptr F1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapF1")
 instance HasCField F1 "unwrapF1"
     where type CFieldType F1 "unwrapF1" = FunPtr F1_Aux
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr F1_Aux) => HasField "unwrapF1" F1 ty
-    where hasField = \x_0 -> (\y_1 -> F1{unwrapF1 = y_1},
-                              getField @"unwrapF1" x_0)
 {-| __C declaration:__ @g1@
 
     __defined at:__ @types\/typedefs\/typedefs.h 13:14@
@@ -319,14 +319,14 @@ instance ToFunPtr G1
     where toFunPtr = hs_bindgen_fa5806570b682579
 instance FromFunPtr G1
     where fromFunPtr = hs_bindgen_8405c8e75aa78be5
+instance (~) ty (IO ()) => HasField "unwrapG1" G1 ty
+    where hasField = \x_0 -> (\y_1 -> G1{unwrapG1 = y_1},
+                              getField @"unwrapG1" x_0)
 instance (~) ty (IO ()) => HasField "unwrapG1" (Ptr G1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapG1")
 instance HasCField G1 "unwrapG1"
     where type CFieldType G1 "unwrapG1" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) => HasField "unwrapG1" G1 ty
-    where hasField = \x_0 -> (\y_1 -> G1{unwrapG1 = y_1},
-                              getField @"unwrapG1" x_0)
 {-| __C declaration:__ @g2@
 
     __defined at:__ @types\/typedefs\/typedefs.h 14:14@
@@ -341,15 +341,15 @@ newtype G2
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr G1) => HasField "unwrapG2" G2 ty
+    where hasField = \x_0 -> (\y_1 -> G2{unwrapG2 = y_1},
+                              getField @"unwrapG2" x_0)
 instance (~) ty (FunPtr G1) =>
          HasField "unwrapG2" (Ptr G2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapG2")
 instance HasCField G2 "unwrapG2"
     where type CFieldType G2 "unwrapG2" = FunPtr G1
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr G1) => HasField "unwrapG2" G2 ty
-    where hasField = \x_0 -> (\y_1 -> G2{unwrapG2 = y_1},
-                              getField @"unwrapG2" x_0)
 {-| __C declaration:__ @h1@
 
     __defined at:__ @types\/typedefs\/typedefs.h 16:14@
@@ -380,14 +380,14 @@ instance ToFunPtr H1
     where toFunPtr = hs_bindgen_ffae0d1234ed018f
 instance FromFunPtr H1
     where fromFunPtr = hs_bindgen_1a33688324e1924f
+instance (~) ty (IO ()) => HasField "unwrapH1" H1 ty
+    where hasField = \x_0 -> (\y_1 -> H1{unwrapH1 = y_1},
+                              getField @"unwrapH1" x_0)
 instance (~) ty (IO ()) => HasField "unwrapH1" (Ptr H1) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH1")
 instance HasCField H1 "unwrapH1"
     where type CFieldType H1 "unwrapH1" = IO ()
           offset# = \_ -> \_ -> 0
-instance (~) ty (IO ()) => HasField "unwrapH1" H1 ty
-    where hasField = \x_0 -> (\y_1 -> H1{unwrapH1 = y_1},
-                              getField @"unwrapH1" x_0)
 {-| __C declaration:__ @h2@
 
     __defined at:__ @types\/typedefs\/typedefs.h 17:12@
@@ -398,14 +398,14 @@ newtype H2
     = H2 {unwrapH2 :: H1}
     deriving stock Generic
     deriving newtype HasFFIType
+instance (~) ty H1 => HasField "unwrapH2" H2 ty
+    where hasField = \x_0 -> (\y_1 -> H2{unwrapH2 = y_1},
+                              getField @"unwrapH2" x_0)
 instance (~) ty H1 => HasField "unwrapH2" (Ptr H2) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH2")
 instance HasCField H2 "unwrapH2"
     where type CFieldType H2 "unwrapH2" = H1
           offset# = \_ -> \_ -> 0
-instance (~) ty H1 => HasField "unwrapH2" H2 ty
-    where hasField = \x_0 -> (\y_1 -> H2{unwrapH2 = y_1},
-                              getField @"unwrapH2" x_0)
 {-| __C declaration:__ @h3@
 
     __defined at:__ @types\/typedefs\/typedefs.h 18:14@
@@ -420,12 +420,12 @@ newtype H3
                       StaticSize,
                       Storable,
                       WriteRaw)
+instance (~) ty (FunPtr H2) => HasField "unwrapH3" H3 ty
+    where hasField = \x_0 -> (\y_1 -> H3{unwrapH3 = y_1},
+                              getField @"unwrapH3" x_0)
 instance (~) ty (FunPtr H2) =>
          HasField "unwrapH3" (Ptr H3) (Ptr ty)
     where getField = fromPtr (Proxy @"unwrapH3")
 instance HasCField H3 "unwrapH3"
     where type CFieldType H3 "unwrapH3" = FunPtr H2
           offset# = \_ -> \_ -> 0
-instance (~) ty (FunPtr H2) => HasField "unwrapH3" H3 ty
-    where hasField = \x_0 -> (\y_1 -> H3{unwrapH3 = y_1},
-                              getField @"unwrapH3" x_0)

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/Example.hs
@@ -102,20 +102,14 @@ set_unionA_b ::
   -> UnionA
 set_unionA_b = RIP.setUnionPayload
 
-instance HasCField.HasCField UnionA "unionA_a" where
-
-  type CFieldType UnionA "unionA_a" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "unionA_a" (RIP.Ptr UnionA) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unionA_a")
 
-instance HasCField.HasCField UnionA "unionA_b" where
+instance HasCField.HasCField UnionA "unionA_a" where
 
-  type CFieldType UnionA "unionA_b" = RIP.CChar
+  type CFieldType UnionA "unionA_a" = RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -123,6 +117,12 @@ instance ( ty ~ RIP.CChar
          ) => RIP.HasField "unionA_b" (RIP.Ptr UnionA) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"unionA_b")
+
+instance HasCField.HasCField UnionA "unionA_b" where
+
+  type CFieldType UnionA "unionA_b" = RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct exA@
 
@@ -165,11 +165,12 @@ instance Marshal.WriteRaw ExA where
 
 deriving via Marshal.EquivStorable ExA instance RIP.Storable ExA
 
-instance HasCField.HasCField ExA "exA_fieldA1" where
+instance (ty ~ UnionA) => RIP.CompatHasField.HasField "exA_fieldA1" ExA ty where
 
-  type CFieldType ExA "exA_fieldA1" = UnionA
-
-  offset# = \_ -> \_ -> 0
+  hasField =
+    \x0 ->
+      (\y1 ->
+         ExA {exA_fieldA1 = y1}, RIP.getField @"exA_fieldA1" x0)
 
 instance ( ty ~ UnionA
          ) => RIP.HasField "exA_fieldA1" (RIP.Ptr ExA) (RIP.Ptr ty) where
@@ -177,12 +178,11 @@ instance ( ty ~ UnionA
   getField =
     HasCField.fromPtr (RIP.Proxy @"exA_fieldA1")
 
-instance (ty ~ UnionA) => RIP.CompatHasField.HasField "exA_fieldA1" ExA ty where
+instance HasCField.HasCField ExA "exA_fieldA1" where
 
-  hasField =
-    \x0 ->
-      (\y1 ->
-         ExA {exA_fieldA1 = y1}, RIP.getField @"exA_fieldA1" x0)
+  type CFieldType ExA "exA_fieldA1" = UnionA
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @union \@exB_fieldB1@
 
@@ -253,23 +253,16 @@ set_exB_fieldB1_b ::
   -> ExB_fieldB1
 set_exB_fieldB1_b = RIP.setUnionPayload
 
-instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_a" where
-
-  type CFieldType ExB_fieldB1 "exB_fieldB1_a" =
-    RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ RIP.CInt
          ) => RIP.HasField "exB_fieldB1_a" (RIP.Ptr ExB_fieldB1) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1_a")
 
-instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_b" where
+instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_a" where
 
-  type CFieldType ExB_fieldB1 "exB_fieldB1_b" =
-    RIP.CChar
+  type CFieldType ExB_fieldB1 "exB_fieldB1_a" =
+    RIP.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -278,6 +271,13 @@ instance ( ty ~ RIP.CChar
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"exB_fieldB1_b")
+
+instance HasCField.HasCField ExB_fieldB1 "exB_fieldB1_b" where
+
+  type CFieldType ExB_fieldB1 "exB_fieldB1_b" =
+    RIP.CChar
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct exB@
 
@@ -320,18 +320,6 @@ instance Marshal.WriteRaw ExB where
 
 deriving via Marshal.EquivStorable ExB instance RIP.Storable ExB
 
-instance HasCField.HasCField ExB "exB_fieldB1" where
-
-  type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ ExB_fieldB1
-         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")
-
 instance ( ty ~ ExB_fieldB1
          ) => RIP.CompatHasField.HasField "exB_fieldB1" ExB ty where
 
@@ -339,3 +327,15 @@ instance ( ty ~ ExB_fieldB1
     \x0 ->
       (\y1 ->
          ExB {exB_fieldB1 = y1}, RIP.getField @"exB_fieldB1" x0)
+
+instance ( ty ~ ExB_fieldB1
+         ) => RIP.HasField "exB_fieldB1" (RIP.Ptr ExB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"exB_fieldB1")
+
+instance HasCField.HasCField ExB "exB_fieldB1" where
+
+  type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/bindingspec.yaml
@@ -23,10 +23,11 @@ hstypes:
       fields:
       - exA_fieldA1
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -38,10 +39,11 @@ hstypes:
       fields:
       - exB_fieldB1
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -55,7 +57,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -69,7 +71,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/nested_unions/th.txt
@@ -80,16 +80,16 @@ set_unionA_b :: CChar -> UnionA
 
 -}
 set_unionA_b = setUnionPayload
+instance (~) ty CInt => HasField "unionA_a" (Ptr UnionA) (Ptr ty)
+    where getField = fromPtr (Proxy @"unionA_a")
 instance HasCField UnionA "unionA_a"
     where type CFieldType UnionA "unionA_a" = CInt
           offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "unionA_a" (Ptr UnionA) (Ptr ty)
-    where getField = fromPtr (Proxy @"unionA_a")
+instance (~) ty CChar => HasField "unionA_b" (Ptr UnionA) (Ptr ty)
+    where getField = fromPtr (Proxy @"unionA_b")
 instance HasCField UnionA "unionA_b"
     where type CFieldType UnionA "unionA_b" = CChar
           offset# = \_ -> \_ -> 0
-instance (~) ty CChar => HasField "unionA_b" (Ptr UnionA) (Ptr ty)
-    where getField = fromPtr (Proxy @"unionA_b")
 {-| __C declaration:__ @struct exA@
 
     __defined at:__ @types\/unions\/nested_unions.h 1:8@
@@ -114,14 +114,14 @@ instance WriteRaw ExA
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        ExA exA_fieldA1_2 -> writeRaw (Proxy @"exA_fieldA1") ptr_0 exA_fieldA1_2
 deriving via (EquivStorable ExA) instance Storable ExA
-instance HasCField ExA "exA_fieldA1"
-    where type CFieldType ExA "exA_fieldA1" = UnionA
-          offset# = \_ -> \_ -> 0
-instance (~) ty UnionA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
-    where getField = fromPtr (Proxy @"exA_fieldA1")
 instance (~) ty UnionA => HasField "exA_fieldA1" ExA ty
     where hasField = \x_0 -> (\y_1 -> ExA{exA_fieldA1 = y_1},
                               getField @"exA_fieldA1" x_0)
+instance (~) ty UnionA => HasField "exA_fieldA1" (Ptr ExA) (Ptr ty)
+    where getField = fromPtr (Proxy @"exA_fieldA1")
+instance HasCField ExA "exA_fieldA1"
+    where type CFieldType ExA "exA_fieldA1" = UnionA
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @union \@exB_fieldB1@
 
     __defined at:__ @types\/unions\/nested_unions.h 9:9@
@@ -203,18 +203,18 @@ set_exB_fieldB1_b :: CChar -> ExB_fieldB1
 
 -}
 set_exB_fieldB1_b = setUnionPayload
-instance HasCField ExB_fieldB1 "exB_fieldB1_a"
-    where type CFieldType ExB_fieldB1 "exB_fieldB1_a" = CInt
-          offset# = \_ -> \_ -> 0
 instance (~) ty CInt =>
          HasField "exB_fieldB1_a" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1_a")
-instance HasCField ExB_fieldB1 "exB_fieldB1_b"
-    where type CFieldType ExB_fieldB1 "exB_fieldB1_b" = CChar
+instance HasCField ExB_fieldB1 "exB_fieldB1_a"
+    where type CFieldType ExB_fieldB1 "exB_fieldB1_a" = CInt
           offset# = \_ -> \_ -> 0
 instance (~) ty CChar =>
          HasField "exB_fieldB1_b" (Ptr ExB_fieldB1) (Ptr ty)
     where getField = fromPtr (Proxy @"exB_fieldB1_b")
+instance HasCField ExB_fieldB1 "exB_fieldB1_b"
+    where type CFieldType ExB_fieldB1 "exB_fieldB1_b" = CChar
+          offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct exB@
 
     __defined at:__ @types\/unions\/nested_unions.h 8:8@
@@ -239,12 +239,12 @@ instance WriteRaw ExB
     where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
                                        ExB exB_fieldB1_2 -> writeRaw (Proxy @"exB_fieldB1") ptr_0 exB_fieldB1_2
 deriving via (EquivStorable ExB) instance Storable ExB
-instance HasCField ExB "exB_fieldB1"
-    where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
-          offset# = \_ -> \_ -> 0
-instance (~) ty ExB_fieldB1 =>
-         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
-    where getField = fromPtr (Proxy @"exB_fieldB1")
 instance (~) ty ExB_fieldB1 => HasField "exB_fieldB1" ExB ty
     where hasField = \x_0 -> (\y_1 -> ExB{exB_fieldB1 = y_1},
                               getField @"exB_fieldB1" x_0)
+instance (~) ty ExB_fieldB1 =>
+         HasField "exB_fieldB1" (Ptr ExB) (Ptr ty)
+    where getField = fromPtr (Proxy @"exB_fieldB1")
+instance HasCField ExB "exB_fieldB1"
+    where type CFieldType ExB "exB_fieldB1" = ExB_fieldB1
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/unions/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/unions/Example.hs
@@ -92,17 +92,6 @@ instance Marshal.WriteRaw Dim2 where
 
 deriving via Marshal.EquivStorable Dim2 instance RIP.Storable Dim2
 
-instance HasCField.HasCField Dim2 "dim2_x" where
-
-  type CFieldType Dim2 "dim2_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim2_x" (RIP.Ptr Dim2) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"dim2_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim2_x" Dim2 ty where
 
   hasField =
@@ -112,16 +101,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim2_x" Dim2 ty where
       , RIP.getField @"dim2_x" x0
       )
 
-instance HasCField.HasCField Dim2 "dim2_y" where
-
-  type CFieldType Dim2 "dim2_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim2_y" (RIP.Ptr Dim2) (RIP.Ptr ty) where
+         ) => RIP.HasField "dim2_x" (RIP.Ptr Dim2) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"dim2_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"dim2_x")
+
+instance HasCField.HasCField Dim2 "dim2_x" where
+
+  type CFieldType Dim2 "dim2_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim2_y" Dim2 ty where
 
@@ -131,6 +120,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim2_y" Dim2 ty where
           Dim2 {dim2_y = y1, dim2_x = RIP.getField @"dim2_x" x0}
       , RIP.getField @"dim2_y" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "dim2_y" (RIP.Ptr Dim2) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"dim2_y")
+
+instance HasCField.HasCField Dim2 "dim2_y" where
+
+  type CFieldType Dim2 "dim2_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct Dim3@
 
@@ -191,17 +191,6 @@ instance Marshal.WriteRaw Dim3 where
 
 deriving via Marshal.EquivStorable Dim3 instance RIP.Storable Dim3
 
-instance HasCField.HasCField Dim3 "dim3_x" where
-
-  type CFieldType Dim3 "dim3_x" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_x" (RIP.Ptr Dim3) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"dim3_x")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_x" Dim3 ty where
 
   hasField =
@@ -214,16 +203,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_x" Dim3 ty where
       , RIP.getField @"dim3_x" x0
       )
 
-instance HasCField.HasCField Dim3 "dim3_y" where
-
-  type CFieldType Dim3 "dim3_y" = RIP.CInt
-
-  offset# = \_ -> \_ -> 4
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_y" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+         ) => RIP.HasField "dim3_x" (RIP.Ptr Dim3) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"dim3_y")
+  getField = HasCField.fromPtr (RIP.Proxy @"dim3_x")
+
+instance HasCField.HasCField Dim3 "dim3_x" where
+
+  type CFieldType Dim3 "dim3_x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_y" Dim3 ty where
 
@@ -237,16 +226,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_y" Dim3 ty where
       , RIP.getField @"dim3_y" x0
       )
 
-instance HasCField.HasCField Dim3 "dim3_z" where
-
-  type CFieldType Dim3 "dim3_z" = RIP.CInt
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim3_z" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+         ) => RIP.HasField "dim3_y" (RIP.Ptr Dim3) (RIP.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"dim3_z")
+  getField = HasCField.fromPtr (RIP.Proxy @"dim3_y")
+
+instance HasCField.HasCField Dim3 "dim3_y" where
+
+  type CFieldType Dim3 "dim3_y" = RIP.CInt
+
+  offset# = \_ -> \_ -> 4
 
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_z" Dim3 ty where
 
@@ -259,6 +248,17 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim3_z" Dim3 ty where
                }
       , RIP.getField @"dim3_z" x0
       )
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "dim3_z" (RIP.Ptr Dim3) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"dim3_z")
+
+instance HasCField.HasCField Dim3 "dim3_z" where
+
+  type CFieldType Dim3 "dim3_z" = RIP.CInt
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @union DimPayload@
 
@@ -329,21 +329,15 @@ set_dimPayload_dim3 ::
   -> DimPayload
 set_dimPayload_dim3 = RIP.setUnionPayload
 
-instance HasCField.HasCField DimPayload "dimPayload_dim2" where
-
-  type CFieldType DimPayload "dimPayload_dim2" = Dim2
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ Dim2
          ) => RIP.HasField "dimPayload_dim2" (RIP.Ptr DimPayload) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayload_dim2")
 
-instance HasCField.HasCField DimPayload "dimPayload_dim3" where
+instance HasCField.HasCField DimPayload "dimPayload_dim2" where
 
-  type CFieldType DimPayload "dimPayload_dim3" = Dim2
+  type CFieldType DimPayload "dimPayload_dim2" = Dim2
 
   offset# = \_ -> \_ -> 0
 
@@ -352,6 +346,12 @@ instance ( ty ~ Dim2
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayload_dim3")
+
+instance HasCField.HasCField DimPayload "dimPayload_dim3" where
+
+  type CFieldType DimPayload "dimPayload_dim3" = Dim2
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct Dim@
 
@@ -403,17 +403,6 @@ instance Marshal.WriteRaw Dim where
 
 deriving via Marshal.EquivStorable Dim instance RIP.Storable Dim
 
-instance HasCField.HasCField Dim "dim_tag" where
-
-  type CFieldType Dim "dim_tag" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dim_tag" (RIP.Ptr Dim) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"dim_tag")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim_tag" Dim ty where
 
   hasField =
@@ -423,17 +412,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dim_tag" Dim ty where
       , RIP.getField @"dim_tag" x0
       )
 
-instance HasCField.HasCField Dim "dim_payload" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "dim_tag" (RIP.Ptr Dim) (RIP.Ptr ty) where
 
-  type CFieldType Dim "dim_payload" = DimPayload
+  getField = HasCField.fromPtr (RIP.Proxy @"dim_tag")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField Dim "dim_tag" where
 
-instance ( ty ~ DimPayload
-         ) => RIP.HasField "dim_payload" (RIP.Ptr Dim) (RIP.Ptr ty) where
+  type CFieldType Dim "dim_tag" = RIP.CInt
 
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"dim_payload")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ DimPayload
          ) => RIP.CompatHasField.HasField "dim_payload" Dim ty where
@@ -444,6 +432,18 @@ instance ( ty ~ DimPayload
           Dim {dim_payload = y1, dim_tag = RIP.getField @"dim_tag" x0}
       , RIP.getField @"dim_payload" x0
       )
+
+instance ( ty ~ DimPayload
+         ) => RIP.HasField "dim_payload" (RIP.Ptr Dim) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"dim_payload")
+
+instance HasCField.HasCField Dim "dim_payload" where
+
+  type CFieldType Dim "dim_payload" = DimPayload
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @union DimPayloadB@
 
@@ -514,21 +514,15 @@ set_dimPayloadB_dim3 ::
   -> DimPayloadB
 set_dimPayloadB_dim3 = RIP.setUnionPayload
 
-instance HasCField.HasCField DimPayloadB "dimPayloadB_dim2" where
-
-  type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ Dim2
          ) => RIP.HasField "dimPayloadB_dim2" (RIP.Ptr DimPayloadB) (RIP.Ptr ty) where
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayloadB_dim2")
 
-instance HasCField.HasCField DimPayloadB "dimPayloadB_dim3" where
+instance HasCField.HasCField DimPayloadB "dimPayloadB_dim2" where
 
-  type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
+  type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
 
   offset# = \_ -> \_ -> 0
 
@@ -537,6 +531,12 @@ instance ( ty ~ Dim2
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"dimPayloadB_dim3")
+
+instance HasCField.HasCField DimPayloadB "dimPayloadB_dim3" where
+
+  type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
+
+  offset# = \_ -> \_ -> 0
 
 {-| __C declaration:__ @struct DimB@
 
@@ -588,17 +588,6 @@ instance Marshal.WriteRaw DimB where
 
 deriving via Marshal.EquivStorable DimB instance RIP.Storable DimB
 
-instance HasCField.HasCField DimB "dimB_tag" where
-
-  type CFieldType DimB "dimB_tag" = RIP.CInt
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "dimB_tag" (RIP.Ptr DimB) (RIP.Ptr ty) where
-
-  getField = HasCField.fromPtr (RIP.Proxy @"dimB_tag")
-
 instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dimB_tag" DimB ty where
 
   hasField =
@@ -608,17 +597,16 @@ instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "dimB_tag" DimB ty where
       , RIP.getField @"dimB_tag" x0
       )
 
-instance HasCField.HasCField DimB "dimB_payload" where
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "dimB_tag" (RIP.Ptr DimB) (RIP.Ptr ty) where
 
-  type CFieldType DimB "dimB_payload" = DimPayloadB
+  getField = HasCField.fromPtr (RIP.Proxy @"dimB_tag")
 
-  offset# = \_ -> \_ -> 4
+instance HasCField.HasCField DimB "dimB_tag" where
 
-instance ( ty ~ DimPayloadB
-         ) => RIP.HasField "dimB_payload" (RIP.Ptr DimB) (RIP.Ptr ty) where
+  type CFieldType DimB "dimB_tag" = RIP.CInt
 
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"dimB_payload")
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ DimPayloadB
          ) => RIP.CompatHasField.HasField "dimB_payload" DimB ty where
@@ -629,6 +617,18 @@ instance ( ty ~ DimPayloadB
           DimB {dimB_payload = y1, dimB_tag = RIP.getField @"dimB_tag" x0}
       , RIP.getField @"dimB_payload" x0
       )
+
+instance ( ty ~ DimPayloadB
+         ) => RIP.HasField "dimB_payload" (RIP.Ptr DimB) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"dimB_payload")
+
+instance HasCField.HasCField DimB "dimB_payload" where
+
+  type CFieldType DimB "dimB_payload" = DimPayloadB
+
+  offset# = \_ -> \_ -> 4
 
 {-| __C declaration:__ @struct \@AnonA_xy@
 
@@ -680,18 +680,6 @@ instance Marshal.WriteRaw AnonA_xy where
 
 deriving via Marshal.EquivStorable AnonA_xy instance RIP.Storable AnonA_xy
 
-instance HasCField.HasCField AnonA_xy "anonA_xy_x" where
-
-  type CFieldType AnonA_xy "anonA_xy_x" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_xy_x" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"anonA_xy_x")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "anonA_xy_x" AnonA_xy ty where
 
@@ -702,17 +690,17 @@ instance ( ty ~ RIP.CDouble
       , RIP.getField @"anonA_xy_x" x0
       )
 
-instance HasCField.HasCField AnonA_xy "anonA_xy_y" where
-
-  type CFieldType AnonA_xy "anonA_xy_y" = RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_xy_y" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
+         ) => RIP.HasField "anonA_xy_x" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"anonA_xy_y")
+    HasCField.fromPtr (RIP.Proxy @"anonA_xy_x")
+
+instance HasCField.HasCField AnonA_xy "anonA_xy_x" where
+
+  type CFieldType AnonA_xy "anonA_xy_x" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "anonA_xy_y" AnonA_xy ty where
@@ -723,6 +711,18 @@ instance ( ty ~ RIP.CDouble
           AnonA_xy {anonA_xy_y = y1, anonA_xy_x = RIP.getField @"anonA_xy_x" x0}
       , RIP.getField @"anonA_xy_y" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "anonA_xy_y" (RIP.Ptr AnonA_xy) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anonA_xy_y")
+
+instance HasCField.HasCField AnonA_xy "anonA_xy_y" where
+
+  type CFieldType AnonA_xy "anonA_xy_y" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @struct \@AnonA_polar@
 
@@ -774,19 +774,6 @@ instance Marshal.WriteRaw AnonA_polar where
 
 deriving via Marshal.EquivStorable AnonA_polar instance RIP.Storable AnonA_polar
 
-instance HasCField.HasCField AnonA_polar "anonA_polar_r" where
-
-  type CFieldType AnonA_polar "anonA_polar_r" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 0
-
-instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_polar_r" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
-
-  getField =
-    HasCField.fromPtr (RIP.Proxy @"anonA_polar_r")
-
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "anonA_polar_r" AnonA_polar ty where
 
@@ -797,18 +784,18 @@ instance ( ty ~ RIP.CDouble
       , RIP.getField @"anonA_polar_r" x0
       )
 
-instance HasCField.HasCField AnonA_polar "anonA_polar_p" where
-
-  type CFieldType AnonA_polar "anonA_polar_p" =
-    RIP.CDouble
-
-  offset# = \_ -> \_ -> 8
-
 instance ( ty ~ RIP.CDouble
-         ) => RIP.HasField "anonA_polar_p" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
+         ) => RIP.HasField "anonA_polar_r" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
 
   getField =
-    HasCField.fromPtr (RIP.Proxy @"anonA_polar_p")
+    HasCField.fromPtr (RIP.Proxy @"anonA_polar_r")
+
+instance HasCField.HasCField AnonA_polar "anonA_polar_r" where
+
+  type CFieldType AnonA_polar "anonA_polar_r" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
 
 instance ( ty ~ RIP.CDouble
          ) => RIP.CompatHasField.HasField "anonA_polar_p" AnonA_polar ty where
@@ -819,6 +806,19 @@ instance ( ty ~ RIP.CDouble
           AnonA_polar {anonA_polar_p = y1, anonA_polar_r = RIP.getField @"anonA_polar_r" x0}
       , RIP.getField @"anonA_polar_p" x0
       )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "anonA_polar_p" (RIP.Ptr AnonA_polar) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anonA_polar_p")
+
+instance HasCField.HasCField AnonA_polar "anonA_polar_p" where
+
+  type CFieldType AnonA_polar "anonA_polar_p" =
+    RIP.CDouble
+
+  offset# = \_ -> \_ -> 8
 
 {-| __C declaration:__ @union AnonA@
 
@@ -889,20 +889,14 @@ set_anonA_polar ::
   -> AnonA
 set_anonA_polar = RIP.setUnionPayload
 
-instance HasCField.HasCField AnonA "anonA_xy" where
-
-  type CFieldType AnonA "anonA_xy" = AnonA_xy
-
-  offset# = \_ -> \_ -> 0
-
 instance ( ty ~ AnonA_xy
          ) => RIP.HasField "anonA_xy" (RIP.Ptr AnonA) (RIP.Ptr ty) where
 
   getField = HasCField.fromPtr (RIP.Proxy @"anonA_xy")
 
-instance HasCField.HasCField AnonA "anonA_polar" where
+instance HasCField.HasCField AnonA "anonA_xy" where
 
-  type CFieldType AnonA "anonA_polar" = AnonA_polar
+  type CFieldType AnonA "anonA_xy" = AnonA_xy
 
   offset# = \_ -> \_ -> 0
 
@@ -911,3 +905,9 @@ instance ( ty ~ AnonA_polar
 
   getField =
     HasCField.fromPtr (RIP.Proxy @"anonA_polar")
+
+instance HasCField.HasCField AnonA "anonA_polar" where
+
+  type CFieldType AnonA "anonA_polar" = AnonA_polar
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/unions/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/unions/bindingspec.yaml
@@ -43,7 +43,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -56,11 +56,12 @@ hstypes:
       - anonA_polar_r
       - anonA_polar_p
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -74,11 +75,12 @@ hstypes:
       - anonA_xy_x
       - anonA_xy_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -92,10 +94,11 @@ hstypes:
       - dim_tag
       - dim_payload
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -108,11 +111,12 @@ hstypes:
       - dim2_x
       - dim2_y
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -127,11 +131,12 @@ hstypes:
       - dim3_y
       - dim3_z
   instances:
-  - CompatHasField
   - Eq
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - Show
   - StaticSize
@@ -145,10 +150,11 @@ hstypes:
       - dimB_tag
       - dimB_payload
   instances:
-  - CompatHasField
   - Generic
   - HasCField
   - HasField
+  - HasFieldCompat
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -162,7 +168,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable
@@ -176,7 +182,7 @@ hstypes:
   instances:
   - Generic
   - HasCField
-  - HasField
+  - HasFieldPtr
   - ReadRaw
   - StaticSize
   - Storable

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/unions/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/unions/th.txt
@@ -31,24 +31,24 @@ instance WriteRaw Dim2
                                        Dim2 dim2_x_2
                                             dim2_y_3 -> writeRaw (Proxy @"dim2_x") ptr_0 dim2_x_2 >> writeRaw (Proxy @"dim2_y") ptr_0 dim2_y_3
 deriving via (EquivStorable Dim2) instance Storable Dim2
-instance HasCField Dim2 "dim2_x"
-    where type CFieldType Dim2 "dim2_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim2_x" (Ptr Dim2) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim2_x")
 instance (~) ty CInt => HasField "dim2_x" Dim2 ty
     where hasField = \x_0 -> (\y_1 -> Dim2{dim2_x = y_1,
                                            dim2_y = getField @"dim2_y" x_0},
                               getField @"dim2_x" x_0)
-instance HasCField Dim2 "dim2_y"
-    where type CFieldType Dim2 "dim2_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "dim2_y" (Ptr Dim2) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim2_y")
+instance (~) ty CInt => HasField "dim2_x" (Ptr Dim2) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim2_x")
+instance HasCField Dim2 "dim2_x"
+    where type CFieldType Dim2 "dim2_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "dim2_y" Dim2 ty
     where hasField = \x_0 -> (\y_1 -> Dim2{dim2_y = y_1,
                                            dim2_x = getField @"dim2_x" x_0},
                               getField @"dim2_y" x_0)
+instance (~) ty CInt => HasField "dim2_y" (Ptr Dim2) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim2_y")
+instance HasCField Dim2 "dim2_y"
+    where type CFieldType Dim2 "dim2_y" = CInt
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct Dim3@
 
     __defined at:__ @types\/unions\/unions.h 6:8@
@@ -89,36 +89,36 @@ instance WriteRaw Dim3
                                             dim3_y_3
                                             dim3_z_4 -> writeRaw (Proxy @"dim3_x") ptr_0 dim3_x_2 >> (writeRaw (Proxy @"dim3_y") ptr_0 dim3_y_3 >> writeRaw (Proxy @"dim3_z") ptr_0 dim3_z_4)
 deriving via (EquivStorable Dim3) instance Storable Dim3
-instance HasCField Dim3 "dim3_x"
-    where type CFieldType Dim3 "dim3_x" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim3_x" (Ptr Dim3) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim3_x")
 instance (~) ty CInt => HasField "dim3_x" Dim3 ty
     where hasField = \x_0 -> (\y_1 -> Dim3{dim3_x = y_1,
                                            dim3_y = getField @"dim3_y" x_0,
                                            dim3_z = getField @"dim3_z" x_0},
                               getField @"dim3_x" x_0)
-instance HasCField Dim3 "dim3_y"
-    where type CFieldType Dim3 "dim3_y" = CInt
-          offset# = \_ -> \_ -> 4
-instance (~) ty CInt => HasField "dim3_y" (Ptr Dim3) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim3_y")
+instance (~) ty CInt => HasField "dim3_x" (Ptr Dim3) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim3_x")
+instance HasCField Dim3 "dim3_x"
+    where type CFieldType Dim3 "dim3_x" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty CInt => HasField "dim3_y" Dim3 ty
     where hasField = \x_0 -> (\y_1 -> Dim3{dim3_y = y_1,
                                            dim3_x = getField @"dim3_x" x_0,
                                            dim3_z = getField @"dim3_z" x_0},
                               getField @"dim3_y" x_0)
-instance HasCField Dim3 "dim3_z"
-    where type CFieldType Dim3 "dim3_z" = CInt
-          offset# = \_ -> \_ -> 8
-instance (~) ty CInt => HasField "dim3_z" (Ptr Dim3) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim3_z")
+instance (~) ty CInt => HasField "dim3_y" (Ptr Dim3) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim3_y")
+instance HasCField Dim3 "dim3_y"
+    where type CFieldType Dim3 "dim3_y" = CInt
+          offset# = \_ -> \_ -> 4
 instance (~) ty CInt => HasField "dim3_z" Dim3 ty
     where hasField = \x_0 -> (\y_1 -> Dim3{dim3_z = y_1,
                                            dim3_x = getField @"dim3_x" x_0,
                                            dim3_y = getField @"dim3_y" x_0},
                               getField @"dim3_z" x_0)
+instance (~) ty CInt => HasField "dim3_z" (Ptr Dim3) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim3_z")
+instance HasCField Dim3 "dim3_z"
+    where type CFieldType Dim3 "dim3_z" = CInt
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @union DimPayload@
 
     __defined at:__ @types\/unions\/unions.h 12:7@
@@ -200,18 +200,18 @@ set_dimPayload_dim3 :: Dim2 -> DimPayload
 
 -}
 set_dimPayload_dim3 = setUnionPayload
+instance (~) ty Dim2 =>
+         HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimPayload_dim2")
 instance HasCField DimPayload "dimPayload_dim2"
     where type CFieldType DimPayload "dimPayload_dim2" = Dim2
           offset# = \_ -> \_ -> 0
 instance (~) ty Dim2 =>
-         HasField "dimPayload_dim2" (Ptr DimPayload) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimPayload_dim2")
+         HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimPayload_dim3")
 instance HasCField DimPayload "dimPayload_dim3"
     where type CFieldType DimPayload "dimPayload_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayload_dim3" (Ptr DimPayload) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimPayload_dim3")
 {-| __C declaration:__ @struct Dim@
 
     __defined at:__ @types\/unions\/unions.h 17:8@
@@ -244,25 +244,25 @@ instance WriteRaw Dim
                                        Dim dim_tag_2
                                            dim_payload_3 -> writeRaw (Proxy @"dim_tag") ptr_0 dim_tag_2 >> writeRaw (Proxy @"dim_payload") ptr_0 dim_payload_3
 deriving via (EquivStorable Dim) instance Storable Dim
-instance HasCField Dim "dim_tag"
-    where type CFieldType Dim "dim_tag" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dim_tag" (Ptr Dim) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim_tag")
 instance (~) ty CInt => HasField "dim_tag" Dim ty
     where hasField = \x_0 -> (\y_1 -> Dim{dim_tag = y_1,
                                           dim_payload = getField @"dim_payload" x_0},
                               getField @"dim_tag" x_0)
-instance HasCField Dim "dim_payload"
-    where type CFieldType Dim "dim_payload" = DimPayload
-          offset# = \_ -> \_ -> 4
-instance (~) ty DimPayload =>
-         HasField "dim_payload" (Ptr Dim) (Ptr ty)
-    where getField = fromPtr (Proxy @"dim_payload")
+instance (~) ty CInt => HasField "dim_tag" (Ptr Dim) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim_tag")
+instance HasCField Dim "dim_tag"
+    where type CFieldType Dim "dim_tag" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty DimPayload => HasField "dim_payload" Dim ty
     where hasField = \x_0 -> (\y_1 -> Dim{dim_payload = y_1,
                                           dim_tag = getField @"dim_tag" x_0},
                               getField @"dim_payload" x_0)
+instance (~) ty DimPayload =>
+         HasField "dim_payload" (Ptr Dim) (Ptr ty)
+    where getField = fromPtr (Proxy @"dim_payload")
+instance HasCField Dim "dim_payload"
+    where type CFieldType Dim "dim_payload" = DimPayload
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @union DimPayloadB@
 
     __defined at:__ @types\/unions\/unions.h 23:15@
@@ -344,18 +344,18 @@ set_dimPayloadB_dim3 :: Dim2 -> DimPayloadB
 
 -}
 set_dimPayloadB_dim3 = setUnionPayload
+instance (~) ty Dim2 =>
+         HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimPayloadB_dim2")
 instance HasCField DimPayloadB "dimPayloadB_dim2"
     where type CFieldType DimPayloadB "dimPayloadB_dim2" = Dim2
           offset# = \_ -> \_ -> 0
 instance (~) ty Dim2 =>
-         HasField "dimPayloadB_dim2" (Ptr DimPayloadB) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimPayloadB_dim2")
+         HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimPayloadB_dim3")
 instance HasCField DimPayloadB "dimPayloadB_dim3"
     where type CFieldType DimPayloadB "dimPayloadB_dim3" = Dim2
           offset# = \_ -> \_ -> 0
-instance (~) ty Dim2 =>
-         HasField "dimPayloadB_dim3" (Ptr DimPayloadB) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimPayloadB_dim3")
 {-| __C declaration:__ @struct DimB@
 
     __defined at:__ @types\/unions\/unions.h 28:8@
@@ -388,25 +388,25 @@ instance WriteRaw DimB
                                        DimB dimB_tag_2
                                             dimB_payload_3 -> writeRaw (Proxy @"dimB_tag") ptr_0 dimB_tag_2 >> writeRaw (Proxy @"dimB_payload") ptr_0 dimB_payload_3
 deriving via (EquivStorable DimB) instance Storable DimB
-instance HasCField DimB "dimB_tag"
-    where type CFieldType DimB "dimB_tag" = CInt
-          offset# = \_ -> \_ -> 0
-instance (~) ty CInt => HasField "dimB_tag" (Ptr DimB) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimB_tag")
 instance (~) ty CInt => HasField "dimB_tag" DimB ty
     where hasField = \x_0 -> (\y_1 -> DimB{dimB_tag = y_1,
                                            dimB_payload = getField @"dimB_payload" x_0},
                               getField @"dimB_tag" x_0)
-instance HasCField DimB "dimB_payload"
-    where type CFieldType DimB "dimB_payload" = DimPayloadB
-          offset# = \_ -> \_ -> 4
-instance (~) ty DimPayloadB =>
-         HasField "dimB_payload" (Ptr DimB) (Ptr ty)
-    where getField = fromPtr (Proxy @"dimB_payload")
+instance (~) ty CInt => HasField "dimB_tag" (Ptr DimB) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimB_tag")
+instance HasCField DimB "dimB_tag"
+    where type CFieldType DimB "dimB_tag" = CInt
+          offset# = \_ -> \_ -> 0
 instance (~) ty DimPayloadB => HasField "dimB_payload" DimB ty
     where hasField = \x_0 -> (\y_1 -> DimB{dimB_payload = y_1,
                                            dimB_tag = getField @"dimB_tag" x_0},
                               getField @"dimB_payload" x_0)
+instance (~) ty DimPayloadB =>
+         HasField "dimB_payload" (Ptr DimB) (Ptr ty)
+    where getField = fromPtr (Proxy @"dimB_payload")
+instance HasCField DimB "dimB_payload"
+    where type CFieldType DimB "dimB_payload" = DimPayloadB
+          offset# = \_ -> \_ -> 4
 {-| __C declaration:__ @struct \@AnonA_xy@
 
     __defined at:__ @types\/unions\/unions.h 35:5@
@@ -439,26 +439,26 @@ instance WriteRaw AnonA_xy
                                        AnonA_xy anonA_xy_x_2
                                                 anonA_xy_y_3 -> writeRaw (Proxy @"anonA_xy_x") ptr_0 anonA_xy_x_2 >> writeRaw (Proxy @"anonA_xy_y") ptr_0 anonA_xy_y_3
 deriving via (EquivStorable AnonA_xy) instance Storable AnonA_xy
-instance HasCField AnonA_xy "anonA_xy_x"
-    where type CFieldType AnonA_xy "anonA_xy_x" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonA_xy_x")
 instance (~) ty CDouble => HasField "anonA_xy_x" AnonA_xy ty
     where hasField = \x_0 -> (\y_1 -> AnonA_xy{anonA_xy_x = y_1,
                                                anonA_xy_y = getField @"anonA_xy_y" x_0},
                               getField @"anonA_xy_x" x_0)
-instance HasCField AnonA_xy "anonA_xy_y"
-    where type CFieldType AnonA_xy "anonA_xy_y" = CDouble
-          offset# = \_ -> \_ -> 8
 instance (~) ty CDouble =>
-         HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonA_xy_y")
+         HasField "anonA_xy_x" (Ptr AnonA_xy) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonA_xy_x")
+instance HasCField AnonA_xy "anonA_xy_x"
+    where type CFieldType AnonA_xy "anonA_xy_x" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty CDouble => HasField "anonA_xy_y" AnonA_xy ty
     where hasField = \x_0 -> (\y_1 -> AnonA_xy{anonA_xy_y = y_1,
                                                anonA_xy_x = getField @"anonA_xy_x" x_0},
                               getField @"anonA_xy_y" x_0)
+instance (~) ty CDouble =>
+         HasField "anonA_xy_y" (Ptr AnonA_xy) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonA_xy_y")
+instance HasCField AnonA_xy "anonA_xy_y"
+    where type CFieldType AnonA_xy "anonA_xy_y" = CDouble
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @struct \@AnonA_polar@
 
     __defined at:__ @types\/unions\/unions.h 36:5@
@@ -491,26 +491,26 @@ instance WriteRaw AnonA_polar
                                        AnonA_polar anonA_polar_r_2
                                                    anonA_polar_p_3 -> writeRaw (Proxy @"anonA_polar_r") ptr_0 anonA_polar_r_2 >> writeRaw (Proxy @"anonA_polar_p") ptr_0 anonA_polar_p_3
 deriving via (EquivStorable AnonA_polar) instance Storable AnonA_polar
-instance HasCField AnonA_polar "anonA_polar_r"
-    where type CFieldType AnonA_polar "anonA_polar_r" = CDouble
-          offset# = \_ -> \_ -> 0
-instance (~) ty CDouble =>
-         HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonA_polar_r")
 instance (~) ty CDouble => HasField "anonA_polar_r" AnonA_polar ty
     where hasField = \x_0 -> (\y_1 -> AnonA_polar{anonA_polar_r = y_1,
                                                   anonA_polar_p = getField @"anonA_polar_p" x_0},
                               getField @"anonA_polar_r" x_0)
-instance HasCField AnonA_polar "anonA_polar_p"
-    where type CFieldType AnonA_polar "anonA_polar_p" = CDouble
-          offset# = \_ -> \_ -> 8
 instance (~) ty CDouble =>
-         HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr ty)
-    where getField = fromPtr (Proxy @"anonA_polar_p")
+         HasField "anonA_polar_r" (Ptr AnonA_polar) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonA_polar_r")
+instance HasCField AnonA_polar "anonA_polar_r"
+    where type CFieldType AnonA_polar "anonA_polar_r" = CDouble
+          offset# = \_ -> \_ -> 0
 instance (~) ty CDouble => HasField "anonA_polar_p" AnonA_polar ty
     where hasField = \x_0 -> (\y_1 -> AnonA_polar{anonA_polar_p = y_1,
                                                   anonA_polar_r = getField @"anonA_polar_r" x_0},
                               getField @"anonA_polar_p" x_0)
+instance (~) ty CDouble =>
+         HasField "anonA_polar_p" (Ptr AnonA_polar) (Ptr ty)
+    where getField = fromPtr (Proxy @"anonA_polar_p")
+instance HasCField AnonA_polar "anonA_polar_p"
+    where type CFieldType AnonA_polar "anonA_polar_p" = CDouble
+          offset# = \_ -> \_ -> 8
 {-| __C declaration:__ @union AnonA@
 
     __defined at:__ @types\/unions\/unions.h 34:7@
@@ -592,15 +592,15 @@ set_anonA_polar :: AnonA_polar -> AnonA
 
 -}
 set_anonA_polar = setUnionPayload
-instance HasCField AnonA "anonA_xy"
-    where type CFieldType AnonA "anonA_xy" = AnonA_xy
-          offset# = \_ -> \_ -> 0
 instance (~) ty AnonA_xy =>
          HasField "anonA_xy" (Ptr AnonA) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_xy")
-instance HasCField AnonA "anonA_polar"
-    where type CFieldType AnonA "anonA_polar" = AnonA_polar
+instance HasCField AnonA "anonA_xy"
+    where type CFieldType AnonA "anonA_xy" = AnonA_xy
           offset# = \_ -> \_ -> 0
 instance (~) ty AnonA_polar =>
          HasField "anonA_polar" (Ptr AnonA) (Ptr ty)
     where getField = fromPtr (Proxy @"anonA_polar")
+instance HasCField AnonA "anonA_polar"
+    where type CFieldType AnonA "anonA_polar" = AnonA_polar
+          offset# = \_ -> \_ -> 0

--- a/manual/low-level/usage/binding-specifications.md
+++ b/manual/low-level/usage/binding-specifications.md
@@ -152,7 +152,7 @@ hs-bindgen-cli preprocess \
     vector.h
 ```
 
-The generated `external/vector.yaml` binding specification contains the
+The generated `binding-specs/vector.yaml` binding specification contains the
 following content.
 
 ```yaml
@@ -183,6 +183,8 @@ hstypes:
       - Generic
       - HasCField
       - HasField
+      - HasFieldCompat
+      - HasFieldPtr
       - ReadRaw
       - Show
       - StaticSize


### PR DESCRIPTION
That is, we now use the name `HasFieldPtr` in external binding specs to specify that a type has `HasField` instances for the pointer manipulation API. The old `HasField` name is now only used to record that a type has the usual `HasField` instances for fields in record datatypes. Unions don't have the latter type of `HasField` instances (yet).

### PR checklist

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
- [x] Did you update the manual?
- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?
- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:
