### PR TITLE
Adapt `hs-bindgen` to the simplified macro interface

### DIFF
--- a/cabal.project.base
+++ b/cabal.project.base
@@ -10,14 +10,8 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/well-typed/c-expr
-    tag: c789b4ab20cc13696a96bf4e508a5af95d523ce0
-    subdir: c-expr-runtime
-
-source-repository-package
-    type: git
-    location: https://github.com/well-typed/c-expr
-    tag: c789b4ab20cc13696a96bf4e508a5af95d523ce0
-    subdir: c-expr-dsl
+    tag: e7dcc55a3799b4bac10a15fb764d6bbba546b787
+    subdir: c-expr-runtime c-expr-dsl
 
 source-repository-package
     type: git

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -7,7 +7,7 @@
 * The `SelectPredicate` type has been renamed to `SelectionPredicate`, and the
   `selectPredicate` field of `FrontendConfig` has been renamed to
   `selectionPredicate`. Update any code that references these names.
-* `hsBindgen` and `hsBindgenE` now take a `MacroLang l` as their first
+* `hsBindgen` and `hsBindgenE` now take a `Macro.Lang l` as their first
   argument; the `Artefact` type gained an `l` type parameter.  Callers should
   use the convenience wrappers `HsBindgen.IO.hsBindgen` (IO mode) or
   `HsBindgen.TH.withHsBindgen` (TH mode), which detect the C standard
@@ -31,16 +31,26 @@
 * Remove the old style of union getters and setters. Use the new `get` and `set`
   functions from `hs-bindgen-runtime` instead. See [issue #2060][is-2060] and
   [PR #2091][pr-2091].
+* The `Macro.Lang` record fields and `Macro.HasTypes` associated data families
+  have been renamed. Custom macro-language backend implementors must update
+  field names (`parseMacroBody` → `parse`, `parsedMacroDeps` → `parsedDeps`,
+  `typecheckMacroBodies` → `typecheck`, etc.), data family names
+  (`ParsedMacroBody l` → `Parsed l ann`, `TypecheckedMacroTypeBody l` →
+  `TypecheckedType l`, `TypecheckedMacroValueBody l` → `TypecheckedValue l`),
+  and supply the new `resolve` field. Error types are consolidated in
+  `HsBindgen.Macro.Error`; `MacroTypecheckResult` is renamed `TypecheckResult`
+  with shortened constructors.
 
 ### New features
 
-* The macro-language implementation is now pluggable. The `HasMacroTypes`
-  type class and the `MacroLang` record (in the internal library) define the
+* Variable names in macro bodies are resolved against all known declarations.
+* The macro-language implementation is now pluggable. The `Macro.HasTypes` type
+  class and the `Macro.Lang` record (in the internal library) define the
   interface that a macro-language backend must implement. The default backend
   (`CExpr`, backed by `c-expr-dsl`) is exposed from the new `HsBindgen.Macro`
-  module in the public library as `cExprLang :: ClangCStandard -> MacroLang
-  CExpr`, which also contains all translation logic from typechecked macro
-  expressions to Haskell AST nodes.
+  module in the public library as `cExpr :: ClangCStandard -> Macro.Lang CExpr`,
+  which also contains all translation logic from typechecked macro expressions
+  to Haskell AST nodes.
 * New `HsBindgen.IO` module exposes `hsBindgen`, a convenience entry point that
   auto-detects the effective C standard and delegates to the internal
   `hsBindgen`, and `hsBindgenMacroLang` for supplying a custom macro-language

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -63,7 +63,7 @@ hsBindgen ::
   -> [C.UncheckedHashIncludeArg]
   -> Artefact CExpr a
   -> IO a
-hsBindgen = hsBindgenMacroLang (pure . cExprLang)
+hsBindgen = hsBindgenMacroLang (pure . cExpr)
 
 {-------------------------------------------------------------------------------
   Global options

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -166,6 +166,7 @@ library internal
     HsBindgen.Frontend
     HsBindgen.Frontend.Analysis.AnonUsage
     HsBindgen.Frontend.Analysis.DeclIndex
+    HsBindgen.Frontend.Analysis.DeclIndex.ResolveMacro
     HsBindgen.Frontend.Analysis.DeclUseGraph
     HsBindgen.Frontend.Analysis.DeclUseGraph.Construction
     HsBindgen.Frontend.Analysis.DeclUseGraph.Definition
@@ -268,6 +269,8 @@ library internal
     HsBindgen.IR.Translation
     HsBindgen.Language.C
     HsBindgen.Language.Haskell
+    HsBindgen.Macro.Error
+    HsBindgen.Macro.Flip
     HsBindgen.Macro.Interface
     HsBindgen.Macro.Type
     HsBindgen.NameHint
@@ -346,6 +349,7 @@ library
     HsBindgen.Macro.CExpr
     HsBindgen.Macro.Global
     HsBindgen.Macro.Parse
+    HsBindgen.Macro.Resolution
     HsBindgen.Macro.Translation.Type
     HsBindgen.Macro.Translation.Value
     HsBindgen.Macro.Typecheck
@@ -369,7 +373,6 @@ library
     , debruijn
     , fin
     , libclang-bindings
-    , mtl
     , template-haskell
     , text
     , vec

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -81,8 +81,8 @@ import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
 
@@ -93,8 +93,8 @@ import Doxygen.Parser (Doxygen, lookupGroupInfo, lookupGroupMembership)
 -- For a list of build artefacts, see the description and constructors of
 -- 'Artefact'.
 hsBindgenMacroLang ::
-     HasMacroTypes l
-  => (ClangCStandard -> IO (MacroLang l))
+     Macro.HasTypes l
+  => (ClangCStandard -> IO (Macro.Lang l))
   -> TracerConfig Level     TraceMsg
   -> TracerConfig SafeLevel SafeTraceMsg
   -> BindgenConfig
@@ -120,8 +120,8 @@ hsBindgenMacroLang mkMacroLang tu ts b i a = do
 
 -- | Like 'hsBindgen' but does not exit with failure when an error has occurred.
 hsBindgenEMacroLang ::
-     forall a l. HasMacroTypes l
-  => (ClangCStandard -> IO (MacroLang l))
+     forall a l. Macro.HasTypes l
+  => (ClangCStandard -> IO (Macro.Lang l))
   -> TracerConfig Level     TraceMsg
   -> TracerConfig SafeLevel SafeTraceMsg
   -> BindgenConfig

--- a/hs-bindgen/src-internal/HsBindgen/Backend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend.hs
@@ -22,7 +22,7 @@ import HsBindgen.Frontend.Pass.Final
 import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
 
 -- | The backend translates the parsed C declarations in to Haskell
@@ -30,7 +30,7 @@ import HsBindgen.Util.Tracer
 --
 -- The backend is pure and should not emit warnings or errors.
 runBackend ::
-     forall l. HasMacroTypes l
+     forall l. Macro.HasTypes l
   => Tracer BackendMsg
   -> BindgenConfig
   -> BootArtefact l

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -53,8 +53,8 @@ import HsBindgen.IR.Pass
 import HsBindgen.IR.Translation
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.NameHint
 
 import Doxygen.Parser.Types qualified as Doxy
@@ -64,8 +64,8 @@ import Doxygen.Parser.Types qualified as Doxy
 -------------------------------------------------------------------------------}
 
 generateDeclarations ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> UniqueId
   -> HaddockConfig
   -> BaseModuleName
@@ -96,8 +96,8 @@ data WithCategory a = WithCategory {
   } deriving (Show)
 
 generateDeclarations' ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> HsM.Env
   -> DeclIndex l
   -> [C.Decl l Final]
@@ -168,8 +168,8 @@ isDefinedInCurrentModule declIndex =
 -- TODO <https://github.com/well-typed/hs-bindgen/issues/1758>
 -- Take the 'PrescriptiveDeclSpec' into account.
 generateDecs ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> C.Decl l Final
   -> HsM (HsM.Action [WithCategory (Hs.Decl l)])
 generateDecs macroLang (C.Decl info kind spec) =
@@ -678,8 +678,8 @@ typedefFunTypeIndirectionDecs origInfo (args, res, reconstruct) names origSpec =
 -------------------------------------------------------------------------------}
 
 macroDecs ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> C.DeclInfo Final
   -> TypecheckedMacro Final l
   -> PrescriptiveDeclSpec
@@ -690,8 +690,8 @@ macroDecs macroLang info checkedMacro spec =
       MacroValue val -> macroVarDecs info val
 
 macroDecsTypedef ::
-     forall l. (HasMacroTypes l, HasCallStack)
-  => MacroLang l
+     forall l. (Macro.HasTypes l, HasCallStack)
+  => Macro.Lang l
   -> C.DeclInfo Final
   -> TypecheckedMacroType l Final
   -> PrescriptiveDeclSpec
@@ -715,7 +715,7 @@ macroDecsTypedef macroLang info macroType spec = do
         newtypeField :: Hs.Field
         newtypeField = Hs.Field{
             name    = macroType.names.field
-          , typ     = macroLang.translateMacroType (fmap macroVarToHsType macroType.body)
+          , typ     = macroLang.translateType (fmap macroVarToHsType macroType.body)
           , origin  = Origin.GeneratedField
           , comment = Nothing
           }

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -33,8 +33,8 @@ import HsBindgen.IR.Hs qualified as Hs
 import HsBindgen.IR.Pass
 import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.NameHint
 
 {-------------------------------------------------------------------------------
@@ -42,8 +42,8 @@ import HsBindgen.NameHint
 -------------------------------------------------------------------------------}
 
 translateDecls ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> ByCategory_ [Hs.Decl l]
   -> ByCategory_ ([CWrapper], [SDecl])
 translateDecls macroLang = fmap go
@@ -65,7 +65,7 @@ getCWrappers decls = mapMaybe getCWrapper decls
           _otherCallConv         -> Nothing
       _otherDecl -> Nothing
 
-translateDecl :: HasMacroTypes l => MacroLang l -> Hs.Decl l -> SDecl
+translateDecl :: Macro.HasTypes l => Macro.Lang l -> Hs.Decl l -> SDecl
 translateDecl macroLang = \case
   Hs.DeclTypSyn               x -> translateDeclTypSyn            x
   Hs.DeclData                 x -> translateDeclData              x
@@ -211,10 +211,10 @@ translateDeriveInstance deriv = DDerivingInstance DerivingInstance {
     , comment  = deriv.comment
     }
 
-translateMacroValue' :: HasMacroTypes l => MacroLang l -> Hs.MacroValue l -> SDecl
+translateMacroValue' :: Macro.HasTypes l => Macro.Lang l -> Hs.MacroValue l -> SDecl
 translateMacroValue' macroLang macro = DBinding $
     withCLiteralComment $
-    macroLang.translateMacroValue
+    macroLang.translateValue
       macro.name
       (fmap macroIdToHsName macro.expr.body)
       macro.comment

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -29,7 +29,7 @@ import HsBindgen.Config.Internal
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.C (Sizeofs)
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.Interface qualified as Macro
 import HsBindgen.Util.Tracer
 
 -- | Boot phase.
@@ -41,7 +41,7 @@ import HsBindgen.Util.Tracer
 -- - Load external and prescriptive binding specifications.
 runBoot ::
      Tracer BootMsg
-  -> (ClangCStandard -> IO (MacroLang l))
+  -> (ClangCStandard -> IO (Macro.Lang l))
   -> BindgenConfig
   -> [C.UncheckedHashIncludeArg]
   -> IO (BootArtefact l)
@@ -188,7 +188,7 @@ data BootArtefact l = BootArtefact {
     , cStandard               :: Cached ClangCStandard
     , clangExe                :: Cached (Maybe ClangExe)
     , clangArgs               :: Cached ClangArgs
-    , macroLang               :: Cached (MacroLang l)
+    , macroLang               :: Cached (Macro.Lang l)
     , hashIncludeArgs         :: Cached [C.HashIncludeArg]
     , externalBindingSpecs    :: Cached MergedBindingSpecs
     , prescriptiveBindingSpec :: Cached PrescriptiveBindingSpec

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -62,7 +62,7 @@ import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
 
 import Doxygen.Parser (Doxygen, DoxygenException (..), Result (..),
@@ -253,7 +253,7 @@ import Doxygen.Parser (Doxygen, DoxygenException (..), Result (..),
 --   that the unusable declaration /and all of its dependencies/ will not be
 --   selected.
 runFrontend ::
-     forall l. (HasMacroTypes l, HasCallStack)
+     forall l. (Macro.HasTypes l, HasCallStack)
   => Tracer FrontendMsg
   -> FrontendConfig
   -> BootArtefact l

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -52,31 +52,43 @@ import Data.Foldable qualified as Foldable
 import Data.Map.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Data.Set qualified as Set
+import Optics.Core (traverseOf)
 
 import Clang.HighLevel.Types
 import Clang.Paths
 
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis.DeclIndex.ResolveMacro
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict (Conflict)
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
+import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.EnrichComments.IsPass
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.Result
-import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg)
+import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg
 import HsBindgen.Imports hiding (toList)
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass (IsPass)
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
+
+type In  = EnrichComments
+type Out = ConstructTranslationUnit
 
 {-------------------------------------------------------------------------------
   Definition
 -------------------------------------------------------------------------------}
 
--- | Index of all declarations
+-- | The declaration index, parameterized by the pass at which the indexed
+-- declarations are represented.
+--
+-- The public 'DeclIndex' fixes this to 'ConstructTranslationUnit' (macros
+-- resolved). The polymorphic form is used internally to build the index at
+-- 'EnrichComments' before resolving macros (see 'fromParseResults').
 --
 -- The declaration index indexes C types (not Haskell types); as such, it
 -- contains declarations in the source code, and never contains external
@@ -146,7 +158,7 @@ data DeclIndex l = DeclIndex {
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
 data Usable l =
-      UsableSuccess (Success l EnrichComments)
+      UsableSuccess (Success l Out)
       -- TODO <https://github.com/well-typed/hs-bindgen/issues/1577>
       -- This should have a SingleLoc.
     | UsableExternal
@@ -174,11 +186,12 @@ data Unusable =
       -- Historically, there were more reasons for not attempting a parse,
       -- that's why we store a non-empty list of reasons. We could remove this
       -- indirection.
-      UnusableParseNotAttempted    SingleLoc (NonEmpty ParseNotAttempted)
-    | UnusableParseFailure         SingleLoc DelayedParseMsg
-    | UnusableConflict             Conflict
-    | UnusableMangleNamesFailure   SingleLoc MangleNamesError
-    | UnusableTypecheckMacrosError SingleLoc MacroTypecheckError
+      UnusableParseNotAttempted      SingleLoc (NonEmpty ParseNotAttempted)
+    | UnusableParseFailure           SingleLoc DelayedParseMsg
+    | UnusableConflict               Conflict
+    | UnusableMangleNamesFailure     SingleLoc MangleNamesError
+    | UnusableTypecheckMacrosError   SingleLoc MacroTypecheckError
+    | UnusableMacroResolutionFailure SingleLoc MacroResolutionError
 
       -- | Omitted by prescriptive binding specifications
     | UnusableOmitted            SingleLoc
@@ -196,17 +209,20 @@ instance PrettyForTrace Unusable where
       "Name mangler failure"
     UnusableTypecheckMacrosError{} ->
       "Macro type-checking failed"
+    UnusableMacroResolutionFailure{} ->
+      "Macro name resolution failed"
     UnusableOmitted{} ->
       "Omitted by prescriptive binding specification"
 
 unusableToLoc :: Unusable -> [SingleLoc]
 unusableToLoc = \case
-    UnusableParseNotAttempted loc _    -> [loc]
-    UnusableParseFailure loc _         -> [loc]
-    UnusableConflict conflict          -> Conflict.toList conflict
-    UnusableMangleNamesFailure loc _   -> [loc]
-    UnusableTypecheckMacrosError loc _ -> [loc]
-    UnusableOmitted loc                -> [loc]
+    UnusableParseNotAttempted loc _      -> [loc]
+    UnusableParseFailure loc _           -> [loc]
+    UnusableConflict conflict            -> Conflict.toList conflict
+    UnusableMangleNamesFailure loc _     -> [loc]
+    UnusableTypecheckMacrosError loc _   -> [loc]
+    UnusableMacroResolutionFailure loc _ -> [loc]
+    UnusableOmitted loc                  -> [loc]
 
 data Success l p = Success {
     decl                      :: C.Decl l p
@@ -216,7 +232,7 @@ data Success l p = Success {
   deriving stock (Generic)
 
 deriving stock instance ( IsPass p
-                        , HasMacroTypes l
+                        , Macro.HasTypes l
                         ) => Show (Success l p)
 
 data Squashed = Squashed {
@@ -257,29 +273,132 @@ entryToAvailability = \case
 empty :: DeclIndex l
 empty = DeclIndex Map.empty
 
+-- | Construct the declaration index, resolving macro names.
+--
+-- Macro resolution needs the set of all declaration IDs, which is only known
+-- once the whole index has been built. We therefore build the index in two
+-- stages: first 'buildIndex' constructs the index at 'EnrichComments' (so that
+-- conflict detection can compare macro bodies, and so that we detect conflicts
+-- even with macros that we cannot resolve), then 'resolveMacros' resolves each
+-- successful declaration into the final index fixed to the
+-- 'ConstructTranslationUnit' pass.
+fromParseResults ::
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
+  -> [ParseResult l In]
+  -> DeclIndex l
+fromParseResults macroLang parseResults =
+    buildIndex $ resolveMacros macroLang declIds parseResults
+  where
+    declIds :: Set C.DeclId
+    declIds = getDeclIds parseResults
+
+    getDeclIds :: [ParseResult l In] -> Set C.DeclId
+    getDeclIds = Set.fromList . map (.id)
+
+{-------------------------------------------------------------------------------
+  Macro resolution
+-------------------------------------------------------------------------------}
+
+-- | Result of resolving macro names in a single parse result.
+data ResolvedResult l =
+    -- | Macro names were resolved successfully (or the declaration was not a
+    -- macro, or was not a parse success to begin with).
+    Resolved (ParseResult l Out)
+    -- | Macro names could not be resolved.
+  | Unresolved C.DeclId SingleLoc MacroResolutionError
+
+resolvedResultId :: ResolvedResult l -> C.DeclId
+resolvedResultId = \case
+    Resolved result       -> result.id
+    Unresolved declId _ _ -> declId
+
+resolvedResultLoc :: ResolvedResult l -> SingleLoc
+resolvedResultLoc = \case
+    Resolved result    -> result.loc
+    Unresolved _ loc _ -> loc
+
+resolvedResultToEntry :: ResolvedResult l -> Entry l
+resolvedResultToEntry = \case
+    Resolved result      -> parseResultToEntry result
+    Unresolved _ loc err -> UnusableE $ UnusableMacroResolutionFailure loc err
+  where
+    parseResultToEntry :: ParseResult l Out -> Entry l
+    parseResultToEntry result = case result.classification of
+      ParseResultSuccess r ->
+        UsableE $ UsableSuccess (parseSuccessToSuccess r)
+      ParseResultNotAttempted r ->
+        UnusableE $ UnusableParseNotAttempted result.loc $ r :| []
+      ParseResultFailure r ->
+        UnusableE $ UnusableParseFailure result.loc r
+
+    parseSuccessToSuccess :: ParseSuccess l Out -> Success l Out
+    parseSuccessToSuccess success = Success {
+          decl = success.decl
+        , delayedParseMsgs = success.delayedParseMsgs
+        , delayedPrepareReparseMsgs = []
+        }
+
+-- | Resolve macro names in every successful declaration.
+--
+-- A declaration whose macro names cannot be resolved becomes 'Unresolved', which
+-- 'buildIndex' turns into an 'UnusableMacroResolutionFailure' entry.
+resolveMacros ::
+     forall l.
+     Macro.Lang l
+  -> Set C.DeclId
+  -> [ParseResult l In]
+  -> [ResolvedResult l]
+resolveMacros macroLang allDeclIds = map resolveParseResult
+  where
+    resolveParseResult :: ParseResult l In -> ResolvedResult l
+    resolveParseResult result =
+      case traverseOf #classification resolveParseClassification result of
+        Right resolved -> Resolved resolved
+        Left  err      -> Unresolved result.id result.loc err
+
+    resolveParseClassification ::
+         ParseClassification l In
+      -> Either MacroResolutionError (ParseClassification l Out)
+    resolveParseClassification = \case
+      ParseResultSuccess success ->
+        case resolveMacroWith macroLang allDeclIds success.decl of
+          Right resolvedDecl -> Right $
+            ParseResultSuccess ParseSuccess{
+              decl             = resolvedDecl
+            , delayedParseMsgs = success.delayedParseMsgs
+            }
+          Left err -> Left err
+      ParseResultNotAttempted x -> Right $ ParseResultNotAttempted x
+      ParseResultFailure      x -> Right $ ParseResultFailure      x
+
+{-------------------------------------------------------------------------------
+  Build from resolved macros
+-------------------------------------------------------------------------------}
+
 -- This function checks for conflicts between ordinary declarations and macro
 -- declarations, which must be done specially because they are in separate
 -- namespaces. This is done here because we need to detect conflicts even with
 -- macros that we cannot typecheck, which are thrown out in the
 -- @TypecheckMacros@ pass.
-fromParseResults ::
-     forall l. HasMacroTypes l
-  => [ParseResult l EnrichComments]
-  -> DeclIndex l
-fromParseResults results = flip execState empty $ mapM_ aux results
+buildIndex :: forall l. Macro.HasTypes l => [ResolvedResult l] -> DeclIndex l
+buildIndex results = flip execState empty $ mapM_ aux results
   where
-    aux :: ParseResult l EnrichComments -> State (DeclIndex l) ()
+    aux :: ResolvedResult l -> State (DeclIndex l) ()
     aux new = modify' $ \index -> DeclIndex $
-      let mConflict :: Maybe (IsConflict l)
+      let declId :: C.DeclId
+          declId = resolvedResultId new
+
+          mConflict :: Maybe (IsConflict l)
           mConflict = Foldable.asum [
               do
-                old <- Map.lookup new.id index.map
-                pure $ checkIsConflict new (new.id, old)
-            , case new.id.name.kind of
+                old <- Map.lookup declId index.map
+                pure $ checkIsConflict new (declId, old)
+            , case declId.name.kind of
                 C.NameKindOrdinary -> do
                   let altDeclId = C.DeclId{
                           name   = C.DeclName{
-                              text = new.id.name.text
+                              text = declId.name.text
                             , kind = C.NameKindMacro
                             }
                         , isAnon = False
@@ -289,7 +408,7 @@ fromParseResults results = flip execState empty $ mapM_ aux results
                 C.NameKindMacro    -> do
                   let altDeclId = C.DeclId{
                           name   = C.DeclName{
-                              text = new.id.name.text
+                              text = declId.name.text
                             , kind = C.NameKindOrdinary
                             }
                         , isAnon = False
@@ -300,9 +419,9 @@ fromParseResults results = flip execState empty $ mapM_ aux results
             ]
       in  case mConflict of
             Nothing ->
-              Map.insert new.id (parseResultToEntry new) index.map
+              Map.insert declId (resolvedResultToEntry new) index.map
             Just (Redefinition success) ->
-              Map.insert new.id (UsableE $ UsableSuccess success) index.map
+              Map.insert declId (UsableE $ UsableSuccess success) index.map
             Just (SingleConflict ids conflict) ->
               Map.union
                 ( Map.fromList
@@ -312,37 +431,21 @@ fromParseResults results = flip execState empty $ mapM_ aux results
                 )
                 index.map
 
-    parseResultToEntry :: ParseResult l EnrichComments -> Entry l
-    parseResultToEntry result = case result.classification of
-      ParseResultSuccess r ->
-        UsableE $ UsableSuccess (parseSuccessToSuccess r)
-      ParseResultNotAttempted r ->
-        UnusableE $ UnusableParseNotAttempted result.loc $ r :| []
-      ParseResultFailure r ->
-        UnusableE $ UnusableParseFailure result.loc r
-
-    parseSuccessToSuccess :: ParseSuccess l EnrichComments -> Success l EnrichComments
-    parseSuccessToSuccess success = Success {
-          decl = success.decl
-        , delayedParseMsgs = success.delayedParseMsgs
-        , delayedPrepareReparseMsgs = []
-        }
-
 {-------------------------------------------------------------------------------
   Conflicts
 -------------------------------------------------------------------------------}
 
 data IsConflict l =
-    Redefinition (Success l EnrichComments)
+    Redefinition (Success l ConstructTranslationUnit)
   | SingleConflict (Set C.DeclId) Conflict
 
 checkIsConflict ::
-     HasMacroTypes l
-  => ParseResult l EnrichComments
+     Macro.HasTypes l
+  => ResolvedResult l
   -> (C.DeclId, Entry l)
   -> IsConflict l
-checkIsConflict new (oldId, old) =
-    case (new.classification, old) of
+checkIsConflict new (oldId, old) = case new of
+    Resolved new' -> case (new'.classification, old) of
       (ParseResultSuccess newSuccess, UsableE (UsableSuccess oldSuccess))
         | newSuccess.decl.kind == oldSuccess.decl.kind ->
           -- TODO <https://github.com/well-typed/hs-bindgen/issues/2099?
@@ -360,20 +463,27 @@ checkIsConflict new (oldId, old) =
                  delayedParseMsgs          = delayedParseMsgs
                , delayedPrepareReparseMsgs = delayedPrepareReparseMsgs
                }
-      _otherwise ->
-        let conflict :: Conflict
-            conflict = case old of
-              UnusableE (UnusableConflict c) ->
-                Conflict.insert c new.loc
-              _otherwise ->
-                Conflict.fromList $ new.loc : entryToLoc old
-        in SingleConflict (Set.fromList [new.id, oldId]) conflict
+      _otherwise -> singleConflict
+    _otherwise -> singleConflict
+  where
+    singleConflict =
+      let newLoc = resolvedResultLoc new
+          conflict :: Conflict
+          conflict = case old of
+            UnusableE (UnusableConflict c) ->
+              Conflict.insert c newLoc
+            _otherwise ->
+              Conflict.fromList $ newLoc : entryToLoc old
+      in SingleConflict (Set.fromList [resolvedResultId new, oldId]) conflict
 
 {-------------------------------------------------------------------------------
   Filter
 -------------------------------------------------------------------------------}
 
-filter :: (C.DeclId -> Entry l -> Bool) -> DeclIndex l -> DeclIndex l
+filter ::
+     (C.DeclId -> Entry l -> Bool)
+  -> DeclIndex l
+  -> DeclIndex l
 filter p (DeclIndex entries) = DeclIndex (Map.filterWithKey p entries)
 
 restrictKeys :: DeclIndex l -> Set C.DeclId -> DeclIndex l
@@ -387,14 +497,14 @@ withoutKeys index xs = DeclIndex $ Map.withoutKeys index.map xs
 -------------------------------------------------------------------------------}
 
 -- | Lookup parse success.
-lookup :: C.DeclId -> DeclIndex l -> Maybe (C.Decl l EnrichComments)
+lookup :: C.DeclId -> DeclIndex l -> Maybe (C.Decl l Out)
 lookup declId (DeclIndex i) = case Map.lookup declId i of
   Nothing                          -> Nothing
   Just (UsableE (UsableSuccess x)) -> Just $ x.decl
   _                                -> Nothing
 
 -- | Get all parse successes.
-getDecls :: DeclIndex l -> [C.Decl l EnrichComments]
+getDecls :: DeclIndex l -> [C.Decl l Out]
 getDecls index = mapMaybe toDecl $ Map.elems index.map
   where
     toDecl = \case
@@ -451,7 +561,9 @@ getSquashed ::
   -> Map C.DeclId (SourcePath, Hs.Name Hs.NsTypeConstr)
 getSquashed index targets = Map.mapMaybe onlySquashedTargetingSet index.map
   where
-    onlySquashedTargetingSet :: Entry l -> Maybe (SourcePath, Hs.Name Hs.NsTypeConstr)
+    onlySquashedTargetingSet ::
+         Entry l
+      -> Maybe (SourcePath, Hs.Name Hs.NsTypeConstr)
     onlySquashedTargetingSet = \case
       UsableE (UsableSquashed e) ->
         case (e.targetNameHs, Set.member e.targetNameC targets) of

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex/ResolveMacro.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex/ResolveMacro.hs
@@ -1,0 +1,48 @@
+module HsBindgen.Frontend.Analysis.DeclIndex.ResolveMacro (
+    resolveMacroWith
+  ) where
+
+
+import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
+import HsBindgen.Frontend.Pass.EnrichComments.IsPass
+import HsBindgen.Imports
+import HsBindgen.IR.C qualified as C
+import HsBindgen.IR.Pass
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Interface qualified as Macro
+
+type In  = EnrichComments
+type Out = ConstructTranslationUnit
+
+resolveMacroWith ::
+     Macro.Lang l
+  -> Set C.DeclId
+  -> C.Decl l In
+  -> Either MacroResolutionError (C.Decl l Out)
+resolveMacroWith macroLang allDeclIds decl = case decl.kind of
+    C.DeclStruct           x -> Right $ aux $ C.DeclStruct           $ coercePass x
+    C.DeclUnion            x -> Right $ aux $ C.DeclUnion            $ coercePass x
+    C.DeclTypedef          x -> Right $ aux $ C.DeclTypedef          $ coercePass x
+    C.DeclEnum             x -> Right $ aux $ C.DeclEnum             $ coercePass x
+    C.DeclAnonEnumConstant x -> Right $ aux $ C.DeclAnonEnumConstant $ coercePass x
+    C.DeclOpaque           x -> Right $ aux $ C.DeclOpaque           $ x
+    C.DeclMacro            x -> resolveMacro macroLang allDeclIds info' decl.ann x
+    C.DeclFunction         x -> Right $ aux $ C.DeclFunction         $ coercePass x
+    C.DeclGlobal           x -> Right $ aux $ C.DeclGlobal           $ coercePass x
+  where
+    info' :: C.DeclInfo Out
+    info' = coercePass decl.info
+
+    aux :: C.DeclKind l Out -> C.Decl l Out
+    aux x = C.Decl info' x decl.ann
+
+resolveMacro ::
+     Macro.Lang l
+  -> Set C.DeclId
+  -> C.DeclInfo Out
+  -> Ann "Decl" Out
+  -> MacroBody In l
+  -> Either MacroResolutionError (C.Decl l Out)
+resolveMacro macroLang allDeclIds info' ann unresolvedMacro = do
+    resolvedMacro <- macroLang.resolve allDeclIds unresolvedMacro
+    pure $ C.Decl info' (C.DeclMacro resolvedMacro) ann

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph.hs
@@ -9,7 +9,7 @@ module HsBindgen.Frontend.Analysis.DeclUseGraph (
     DeclUseGraph -- opaque
   , toDigraph
     -- * Construction
-  , fromDecls
+  , construct
   , insertDepsOfDecl
     -- * Deletion
   , deleteDeps

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
@@ -1,6 +1,6 @@
 module HsBindgen.Frontend.Analysis.DeclUseGraph.Construction (
     -- * Construction
-    fromDecls
+    construct
   , insertDepsOfDecl
     -- * Deletion
   , deleteDeps
@@ -23,58 +23,65 @@ import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition
 import HsBindgen.Frontend.Analysis.Deps
 import HsBindgen.Frontend.Analysis.IncludeGraph (IncludeGraph)
 import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
-import HsBindgen.Frontend.Pass.EnrichComments.IsPass
+import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Zip.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Construction
 -------------------------------------------------------------------------------}
 
-fromDecls ::
+construct ::
      forall l. HasCallStack
-  => MacroLang l
+  => Macro.Lang l
   -> IncludeGraph
   -> DeclIndex l
   -> DeclUseGraph
-fromDecls macroLang includeGraph declIndex = DeclUseGraph $
-    foldl'
-      (flip insertDepsOfDeclParsedMacro)
-      verticesGraph
-      sortedSuccessfulDecls
+construct macroLang includeGraph declIndex = declUseGraph
   where
-    successfulDecls, sortedSuccessfulDecls :: [C.Decl l EnrichComments]
+    -- The include graph informs us about the order of declarations which is
+    -- key.
+    orderMap :: Map SourcePath Int
+    orderMap = IncludeGraph.toOrderMap includeGraph
+    -- The declaration index contains declarations that we cannot use. Macros
+    -- have already been resolved while constructing the declaration index.
+    successfulDecls, sortedSuccessfulDecls :: [C.Decl l ConstructTranslationUnit]
     successfulDecls       = DeclIndex.getDecls declIndex
     sortedSuccessfulDecls = List.sortOn (annSortKey orderMap) successfulDecls
 
-    orderMap :: Map SourcePath Int
-    orderMap = IncludeGraph.toOrderMap includeGraph
-
     allDeclIds, successfulDeclIds, failedDeclIds :: Set C.DeclId
     allDeclIds        = DeclIndex.keysSet declIndex
-    successfulDeclIds = Set.fromList $ map (.info.id) successfulDecls
-    failedDeclIds = allDeclIds Set.\\ successfulDeclIds
+    successfulDeclIds = Set.fromList $ map (.info.id) sortedSuccessfulDecls
+    failedDeclIds     = allDeclIds Set.\\ successfulDeclIds
 
-    -- We first insert all declarations, so that they are assigned vertices.
-    -- For successfully parsed declarations, we do this in source order.  This
+    declUseGraph :: DeclUseGraph
+    declUseGraph = DeclUseGraph $
+      foldl'
+        (flip insertDepsOfDeclParsedMacro)
+        verticesGraph
+        sortedSuccessfulDecls
+
+    -- We first insert all declarations, so that they are assigned vertices. For
+    -- successfully parsed declarations, we do this in source order. This
     -- ensures that we preserve source order as much as possible in 'toDecls'
     -- (modulo dependencies).
     verticesGraph :: Digraph C.ValOrRef C.DeclId
     verticesGraph = foldl' (flip Digraph.insertVertex) Digraph.empty $
       map (.info.id) sortedSuccessfulDecls ++ Set.toList failedDeclIds
 
-    -- We cannot use plain 'depsOfDecl' here because we have not typechecked
-    -- macros yet.  Instead, we must provide a "resolver" for bare names (see
-    -- below).
+    -- We cannot use plain 'depsOfDecl' here because, at this pass, macros have
+    -- been resolved (in the declaration index) but not yet typechecked. We
+    -- therefore use 'depsOfDeclParsedMacro', which derives the dependencies
+    -- from the resolved (but not yet typechecked) macro body.
     insertDepsOfDeclParsedMacro ::
-         C.Decl l EnrichComments
+         C.Decl l ConstructTranslationUnit
       -> Digraph C.ValOrRef C.DeclId
       -> Digraph C.ValOrRef C.DeclId
     insertDepsOfDeclParsedMacro decl =
-      insertDeps decl.info.id (depsOfDeclParsedMacro macroLang allDeclIds decl.kind)
+      insertDeps decl.info.id (depsOfDeclParsedMacro macroLang decl.kind)
 
 insertDeps ::
      (HasCallStack)
@@ -98,8 +105,8 @@ insertDeps source = flip (foldl' aux)
 
 -- | Inserts dependency edges of provided declaration.
 insertDepsOfDecl ::
-     (HasMacroTypes l, HasCallStack)
-  => MacroLang l
+     (Macro.HasTypes l, HasCallStack)
+  => Macro.Lang l
   -> C.Decl l Zip
   -> DeclUseGraph
   -> DeclUseGraph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Query.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Query.hs
@@ -15,7 +15,7 @@ import Data.Set qualified as Set
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition
-import HsBindgen.Frontend.Pass.EnrichComments.IsPass
+import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 
@@ -30,7 +30,7 @@ import HsBindgen.IR.C qualified as C
 --
 -- For each declaration we provide one example of how that declaration is used
 -- (if one exists).
-toDecls :: DeclIndex l -> DeclUseGraph -> [C.Decl l EnrichComments]
+toDecls :: DeclIndex l -> DeclUseGraph -> [C.Decl l ConstructTranslationUnit]
 toDecls index declUseGraph =
     -- NOTE: There might be dependencies in the 'DeclUseGraph' on declarations
     -- without a corresponding entry in the 'DeclIndex'.  For example, this can

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -15,8 +15,8 @@ import HsBindgen.Frontend.Pass.Zip.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Get all dependencies
@@ -50,16 +50,15 @@ depsOfDeclWith depsOfMacro = \case
 depsOfDeclParsedMacro ::
      forall l p.
      ( IsPass p
-     , MacroBody p ~ ParsedMacroBody
+     , MacroBody p ~ Macro.Resolved
      , Id p ~ C.DeclId )
-  => MacroLang l
-  -> Set C.DeclId
+  => Macro.Lang l
   -> C.DeclKind l p
   -> [(C.ValOrRef, Id p)]
-depsOfDeclParsedMacro macroLang allDeclIds = depsOfDeclWith depsOfParsedMacro
+depsOfDeclParsedMacro macroLang = depsOfDeclWith depsOfParsedMacro
   where
-    depsOfParsedMacro :: ParsedMacroBody l -> [(C.ValOrRef, C.DeclId)]
-    depsOfParsedMacro body = macroLang.parsedMacroDeps allDeclIds body
+    depsOfParsedMacro :: Macro.Resolved l -> [(C.ValOrRef, C.DeclId)]
+    depsOfParsedMacro body = macroLang.parsedDeps body
 
 {-------------------------------------------------------------------------------
   Dependencies of declaration after @ReparseMacroExpansions@ and 'Zip'
@@ -79,26 +78,26 @@ depsOfDeclParsedMacro macroLang allDeclIds = depsOfDeclWith depsOfParsedMacro
 -- We use 'depsOfDecl' after reconciling the pre- and post-reparse ASTs in the
 -- 'Zip' pass, updating the dependency graphs.
 depsOfDecl ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> C.DeclKind l Zip
   -> [(C.ValOrRef, C.DeclId)]
 depsOfDecl = depsOfDeclTcMacro
 
 depsOfDeclTcMacro ::
-     forall l. (HasMacroTypes l)
-  => MacroLang l -> C.DeclKind l Zip -> [(C.ValOrRef, C.DeclId)]
+     forall l. (Macro.HasTypes l)
+  => Macro.Lang l -> C.DeclKind l Zip -> [(C.ValOrRef, C.DeclId)]
 depsOfDeclTcMacro macroLang = depsOfDeclWith (typecheckedMacroDeps macroLang)
 
 -- | Dependencies of typechecked macro declarations
 typecheckedMacroDeps ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> TypecheckedMacro Zip l
   -> [(C.ValOrRef, C.DeclId)]
 typecheckedMacroDeps macroLang = \case
     MacroType  typ ->
-      macroLang.typecheckedMacroTypeDeps $ fmap fromMacroTypeBodyVar typ.body
+      macroLang.typecheckedTypeDeps $ fmap fromMacroTypeBodyVar typ.body
     MacroValue val ->
       typecheckedMacroValueDeps val.body
   where
@@ -112,7 +111,7 @@ typecheckedMacroDeps macroLang = \case
     --
     -- On the value-level, all dependencies must be 'ByValue'.
     typecheckedMacroValueDeps ::
-         TypecheckedMacroValueBody l C.DeclId
+         Macro.TypecheckedValue l C.DeclId
       -> [(C.ValOrRef, C.DeclId)]
     typecheckedMacroValueDeps = map (C.ByValue,) . toList
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -9,7 +9,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -35,7 +35,7 @@ instance PassId AssignAnonIds
 instance PassScopedName AssignAnonIds
 
 instance PassMacro AssignAnonIds where
-  type MacroBody AssignAnonIds = ParsedMacroBody
+  type MacroBody AssignAnonIds = Macro.Unresolved
 
 instance PassExtBinding AssignAnonIds
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
@@ -14,9 +14,8 @@ import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.EnrichComments.IsPass
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.TranslationUnit qualified as C
-import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Construction
@@ -25,16 +24,15 @@ import HsBindgen.Macro.Type
 type PreviousPass = EnrichComments
 
 constructTranslationUnit ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> [ParseResult l PreviousPass]
   -> IncludeGraph
   -> C.TranslationUnit l ConstructTranslationUnit
 constructTranslationUnit macroLang parseResults includeGraph = C.TranslationUnit{
-      decls        = map coercePass $
-                           DeclUseGraph.toDecls
-                             declMeta.declIndex
-                             declMeta.declUseGraph
+      decls        = DeclUseGraph.toDecls
+                       declMeta.declIndex
+                       declMeta.declUseGraph
     , includeGraph = includeGraph
     , meta         = declMeta
     }
@@ -43,22 +41,25 @@ constructTranslationUnit macroLang parseResults includeGraph = C.TranslationUnit
     declMeta = mkDeclMeta macroLang parseResults includeGraph
 
 mkDeclMeta ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> [ParseResult l PreviousPass]
   -> IncludeGraph
   -> DeclMeta l
-mkDeclMeta macroLang parseResults includeGraph = DeclMeta{
+mkDeclMeta macroLang parseResults includeGraph = declMeta
+  where
+    declIndex :: DeclIndex l
+    declIndex = DeclIndex.fromParseResults macroLang parseResults
+
+    declUseGraph :: DeclUseGraph
+    declUseGraph = DeclUseGraph.construct macroLang includeGraph declIndex
+
+    useDeclGraph :: UseDeclGraph
+    useDeclGraph = UseDeclGraph.fromDeclUseGraph declUseGraph
+
+    declMeta :: DeclMeta l
+    declMeta = DeclMeta{
       declIndex    = declIndex
     , declUseGraph = declUseGraph
     , useDeclGraph = useDeclGraph
     }
-  where
-    declIndex :: DeclIndex l
-    declIndex = DeclIndex.fromParseResults parseResults
-
-    declUseGraph :: DeclUseGraph
-    declUseGraph = DeclUseGraph.fromDecls macroLang includeGraph declIndex
-
-    useDeclGraph :: UseDeclGraph
-    useDeclGraph = UseDeclGraph.fromDeclUseGraph declUseGraph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -7,7 +7,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition
@@ -33,7 +33,7 @@ instance PassId ConstructTranslationUnit
 instance PassScopedName ConstructTranslationUnit
 
 instance PassMacro ConstructTranslationUnit where
-  type MacroBody ConstructTranslationUnit = ParsedMacroBody
+  type MacroBody ConstructTranslationUnit = Macro.Resolved
 
 instance PassExtBinding ConstructTranslationUnit
 
@@ -49,7 +49,6 @@ instance PassMsg ConstructTranslationUnit
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassMacroBody          EnrichComments ConstructTranslationUnit
 instance CoercePassId                 EnrichComments ConstructTranslationUnit
 instance CoercePassMacroId            EnrichComments ConstructTranslationUnit
 instance CoercePassMacroUnderlying    EnrichComments ConstructTranslationUnit

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
@@ -6,7 +6,7 @@ import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition
@@ -31,7 +31,7 @@ instance PassId EnrichComments
 instance PassScopedName EnrichComments
 
 instance PassMacro EnrichComments where
-  type MacroBody EnrichComments = ParsedMacroBody
+  type MacroBody EnrichComments = Macro.Unresolved
 
 instance PassExtBinding EnrichComments
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -36,7 +36,8 @@ import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer (WithCallStack, withCallStack)
 
 import Doxygen.Parser.Types qualified as Doxy
@@ -52,7 +53,7 @@ import Doxygen.Parser.Types qualified as Doxy
 -------------------------------------------------------------------------------}
 
 mangleNames ::
-     forall l. (HasCallStack, HasMacroTypes l)
+     forall l. (HasCallStack, Macro.HasTypes l)
   => FieldNamingStrategy
   -> C.TranslationUnit l ResolveBindingSpecs
   -> (C.TranslationUnit l MangleNames, [AnnMsg MangleNames])
@@ -466,7 +467,7 @@ data MangleDeclResult l =
     | MdrSquashed MangleNamesSquash
     | MdrMangled (C.Decl l MangleNames)
 
-mangleDecl :: HasMacroTypes l => C.Decl l ResolveBindingSpecs -> M (MangleDeclResult l)
+mangleDecl :: Macro.HasTypes l => C.Decl l ResolveBindingSpecs -> M (MangleDeclResult l)
 mangleDecl decl = do
     mConclusion <- checkTypedefAnalysis decl.info.id
     case mConclusion of
@@ -683,7 +684,7 @@ mangleEnclosingRef = \case
     C.UnusableEnclosingRef e ->
       pure $ C.UnusableEnclosingRef e
 
-instance HasMacroTypes l => MangleWithDeclName (C.DeclKind l) where
+instance Macro.HasTypes l => MangleWithDeclName (C.DeclKind l) where
   mangleWithDeclName hsName = \case
       C.DeclStruct   x         -> C.DeclStruct           <$> mangleWithDeclName hsName x
       C.DeclUnion    x         -> C.DeclUnion            <$> mangleWithDeclName hsName x
@@ -947,12 +948,12 @@ instance Mangle C.Global where
         , ann = global.ann
         }
 
-instance HasMacroTypes l => MangleWithDeclName (Flip TypecheckedMacro l) where
+instance Macro.HasTypes l => MangleWithDeclName (Flip TypecheckedMacro l) where
   mangleWithDeclName hsName (Flip m) = Flip <$> case m of
       MacroType  typ -> MacroType  <$> mangleWithDeclName hsName typ
       MacroValue val -> MacroValue <$> mangle val
 
-instance HasMacroTypes l => MangleWithDeclName (TypecheckedMacroType l) where
+instance Macro.HasTypes l => MangleWithDeclName (TypecheckedMacroType l) where
   mangleWithDeclName hsName macroType = do
       strategy       <- asks (.fieldNamingStrategy)
       macroTypeNames <- mkMacroTypeNames strategy hsName
@@ -969,7 +970,7 @@ instance HasMacroTypes l => MangleWithDeclName (TypecheckedMacroType l) where
         MacroTypeExtBinding ext -> pure $ MacroTypeExtBinding ext
         MacroTypeBodyVar declId -> MacroTypeBodyVar <$> lookupTypePair declId
 
-instance HasMacroTypes l => Mangle (TypecheckedMacroValue l) where
+instance Macro.HasTypes l => Mangle (TypecheckedMacroValue l) where
   mangle macroValue = do
       body' <- traverse lookupVarPair macroValue.body
       pure $ TypecheckedMacroValue body'

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
@@ -20,7 +20,7 @@ import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
   Construction
@@ -28,7 +28,7 @@ import HsBindgen.Macro.Interface
 
 parseDecls ::
      forall l.
-     MacroLang l
+     Macro.Lang l
   -> ParseDecl.Env
   -> IO ([ParseResult l Parse], [MacroDefinition])
 parseDecls macroLang parseEnv = do

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -29,8 +29,8 @@ import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.C qualified as C
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -42,7 +42,7 @@ import HsBindgen.Macro.Type
 -- goes wrong with a nested declaration, we want to skip the entire outer
 -- declaration.
 topLevelDecl ::
-     MacroLang l
+     Macro.Lang l
   -> Fold ParseDecl (CXSourceLocation, [ParseResult l Parse])
 topLevelDecl macroLang =
     foldWithHandler handleParseExceptions (parseDeclTopLevel macroLang)
@@ -65,7 +65,7 @@ type Parser l = CXCursor -> ParseDecl (Next ParseDecl [ParseResult l Parse])
 
 -- | Parse declarations with available parse context
 parseDeclNested ::
-     MacroLang l
+     Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> Parser l
@@ -74,7 +74,7 @@ parseDeclNested macroLang enclosing ctx =
 
 -- | Parse a top level declaration (parse context not yet available)
 parseDeclTopLevel ::
-     MacroLang l
+     Macro.Lang l
   -> CXCursor
   -> ParseDecl (Next ParseDecl (CXSourceLocation, [ParseResult l Parse]))
 parseDeclTopLevel macroLang curr = do
@@ -94,7 +94,7 @@ parseDeclTopLevel macroLang curr = do
 -- | Auxiliary function; use 'parseDeclNested' or 'parseDeclTopLevel'
 parseDecl' ::
      (HasCallStack)
-  => MacroLang l
+  => Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> Maybe ParseCtx
   -> Parser l
@@ -209,7 +209,7 @@ parseDeclWith enclosing ctx parser curr = do
 -- | Macros
 macroDefinition ::
      forall l. HasCallStack
-  => MacroLang l
+  => Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> C.DeclInfo Parse -> Parser l
@@ -255,7 +255,7 @@ macroDefinition macroLang _enclosing ctx info = \curr -> do
 -- Visibility attributes are ignored on structs, since as far as we can tell
 -- they do not affect the Haskell bindings.
 structDecl ::
-     MacroLang l
+     Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> C.DeclInfo Parse
@@ -346,7 +346,7 @@ structDecl macroLang enclosing ctx info = \curr -> do
 -- Visibility attributes are ignored on unions, since as far as we can tell they
 -- do not affect the Haskell bindings.
 unionDecl ::
-     MacroLang l
+     Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> C.DeclInfo Parse
@@ -583,7 +583,7 @@ enumConstantDecl sign = \curr -> do
 
 functionDecl ::
      forall l.
-     MacroLang l
+     Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> C.DeclInfo Parse
@@ -734,7 +734,7 @@ functionDecl macroLang enclosing ctx info =
 -- | Global variable declaration
 varDecl ::
      forall l.
-     MacroLang l
+     Macro.Lang l
   -> [C.EnclosingRef Parse]
   -> ParseCtx
   -> C.DeclInfo Parse
@@ -1110,14 +1110,14 @@ partitionAnonDecls =
 -- No type environment is needed for this step; type resolution and
 -- expression typechecking happen later in 'TypecheckMacros'.
 parseMacroTokens ::
-     MacroLang l
+     Macro.Lang l
   -> C.PrelimDeclId
   -> [Token TokenSpelling]
-  -> Either DelayedParseMsg (ParsedMacroBody l)
+  -> Either DelayedParseMsg (Macro.Unresolved l)
 parseMacroTokens macroLang name = \case
     []      -> Left $ ParseMacroEmpty name []
     [token] -> Left $ ParseMacroEmpty name [token]
-    tokens  -> first ParseMacroErrorParse $ macroLang.parseMacroBody tokens
+    tokens  -> first ParseMacroErrorParse $ macroLang.parse tokens
 
 -- | Whether a global variable has @extern@ storage class
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Members.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Members.hs
@@ -26,7 +26,7 @@ import HsBindgen.Frontend.Pass.Parse.Msg (DelayedParseMsg (ParseImplicitFieldFai
 import HsBindgen.Frontend.Pass.Parse.Result (ParseResult,
                                              getParseResultEitherDecl)
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 -- NOTE: this is a copy of 'HsBindgen.Frontend.Pass.Parse.Decl.Parser' for
 -- internal use to prevent cyclic module dependencies
@@ -43,7 +43,7 @@ data ParseMembersResult field l = ParseMembersResult {
     , fieldMembers :: Either DelayedParseMsg [field Parse]
     }
 
-deriving stock instance (Show (field Parse), HasMacroTypes l)
+deriving stock instance (Show (field Parse), Macro.HasTypes l)
   => Show (ParseMembersResult field l)
 
 -- | Parse the members of a struct

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -22,7 +22,7 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition
@@ -53,7 +53,7 @@ instance PassId Parse where
 instance PassScopedName Parse
 
 instance PassMacro Parse where
-  type MacroBody Parse = ParsedMacroBody
+  type MacroBody Parse = Macro.Unresolved
 
 instance PassExtBinding Parse
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -23,7 +23,7 @@ import HsBindgen.Frontend.LanguageC.Error qualified as LanC
 import HsBindgen.Frontend.Pass.Zip.Error
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.Error
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -128,7 +128,7 @@ data DelayedParseMsg =
   | ParseMacroEmpty C.PrelimDeclId [Token TokenSpelling]
 
     -- | We could not parse the macro (macro def sites)
-  | ParseMacroErrorParse MacroLangParseError
+  | ParseMacroErrorParse MacroParseError
 
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/2022>
     --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
@@ -21,7 +21,7 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -41,7 +41,7 @@ data ParseResult l p = ParseResult{
     deriving (Generic)
 
 deriving stock instance ( IsPass p
-                        , HasMacroTypes l
+                        , Macro.HasTypes l
                         ) => Show (ParseResult l p)
 
 data ParseClassification l p =
@@ -51,7 +51,7 @@ data ParseClassification l p =
   deriving stock (Generic)
 
 deriving stock instance ( IsPass p
-                        , HasMacroTypes l
+                        , Macro.HasTypes l
                         ) => Show (ParseClassification l p)
 
 instance PrettyForTrace (ParseClassification l p) where
@@ -68,7 +68,7 @@ data ParseSuccess l p = ParseSuccess {
   deriving stock (Generic)
 
 deriving stock instance ( IsPass p
-                        , HasMacroTypes l
+                        , Macro.HasTypes l
                         ) => Show (ParseSuccess l p)
 
 -- | Why did we not attempt to parse a declaration?

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Simplifier.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Simplifier.hs
@@ -30,7 +30,7 @@ import HsBindgen.Frontend.Pass.PrepareReparse.Printer.Util qualified as P
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
 
 {-------------------------------------------------------------------------------
   Top-level

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Update.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Update.hs
@@ -40,7 +40,7 @@ import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports (Map, mapMaybe)
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
 import HsBindgen.Util.Tracer (WithCallStack, withCallStack)
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -31,7 +31,8 @@ import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Monad (mapMaybeM)
 import HsBindgen.Util.Tracer (withCallStack)
 
@@ -136,7 +137,7 @@ data MEnv l = MEnv {
     , declIndex    :: DeclIndex l
     }
 
-deriving stock instance HasMacroTypes l => Show (MEnv l)
+deriving stock instance Macro.HasTypes l => Show (MEnv l)
 
 {-------------------------------------------------------------------------------
   Internal: monad state

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -28,7 +28,7 @@ import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.Conflict qualified as Conflict
-import HsBindgen.Frontend.Pass.EnrichComments.IsPass (EnrichComments)
+import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Frontend.TranslationUnit qualified as C
@@ -289,7 +289,11 @@ getSelectMsgs
   declIndex
   = concatMap (uncurry aux) $ DeclIndex.toList declIndex
   where
-    aux :: HasCallStack => C.DeclId -> Entry l -> [AnnMsg Select]
+    aux ::
+         HasCallStack
+      => C.DeclId
+      -> Entry l
+      -> [AnnMsg Select]
     aux =
       getSelectMsgsDeclId
         getTransitiveSelectability
@@ -395,7 +399,7 @@ getSelectMsgsDeclId
 mkSuccessMessages ::
      HasCallStack
   => C.DeclId
-  -> Success l EnrichComments
+  -> Success l ConstructTranslationUnit
   -> [AnnMsg Select]
 mkSuccessMessages declId success = concat [
       fmap (mkAnnMsg . SelectDelayedParseMsg)
@@ -415,7 +419,11 @@ mkSuccessMessages declId success = concat [
 getDelayedMsgsSelectionRoots :: HasCallStack => DeclIndex l -> [AnnMsg Select]
 getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => C.DeclId -> Entry l -> [AnnMsg Select]
+    aux ::
+         HasCallStack
+      => C.DeclId
+      -> Entry l
+      -> [AnnMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success -> mkSuccessMessages declId success
@@ -436,22 +444,31 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
               }
           | x <- NonEmpty.toList xs
           ]
-        UnusableParseFailure loc x -> List.singleton $ withCallStack C.WithLocationInfo{
-            loc = C.declIdLocationInfo declId [loc]
-          , msg = SelectParseFailure x
-          }
-        UnusableConflict x -> List.singleton $ withCallStack C.WithLocationInfo{
-            loc = C.declIdLocationInfo declId (Conflict.toList x)
-          , msg = SelectConflict
-          }
-        UnusableMangleNamesFailure loc x -> List.singleton $ withCallStack C.WithLocationInfo{
-            loc = C.declIdLocationInfo declId [loc]
-          , msg = SelectMangleNamesFailure x
-          }
-        UnusableTypecheckMacrosError loc err -> List.singleton$ withCallStack C.WithLocationInfo{
-            loc = C.declIdLocationInfo declId [loc]
-          , msg = SelectMacroTypecheckFailure err
-          }
+        UnusableParseFailure loc x ->
+          List.singleton $ withCallStack C.WithLocationInfo{
+              loc = C.declIdLocationInfo declId [loc]
+            , msg = SelectParseFailure x
+            }
+        UnusableConflict x ->
+          List.singleton $ withCallStack C.WithLocationInfo{
+              loc = C.declIdLocationInfo declId (Conflict.toList x)
+            , msg = SelectConflict
+            }
+        UnusableMangleNamesFailure loc x ->
+          List.singleton $ withCallStack C.WithLocationInfo{
+              loc = C.declIdLocationInfo declId [loc]
+            , msg = SelectMangleNamesFailure x
+            }
+        UnusableTypecheckMacrosError loc err ->
+          List.singleton$ withCallStack C.WithLocationInfo{
+              loc = C.declIdLocationInfo declId [loc]
+            , msg = SelectMacroTypecheckFailure err
+            }
+        UnusableMacroResolutionFailure loc err ->
+          List.singleton $ withCallStack C.WithLocationInfo{
+              loc = C.declIdLocationInfo declId [loc]
+            , msg = SelectMacroResolutionFailure err
+            }
         UnusableOmitted{} ->
           []
 
@@ -461,7 +478,11 @@ getDelayedMsgsAdditionalSelectedTransDeps ::
   -> [AnnMsg Select]
 getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => C.DeclId -> Entry l -> [AnnMsg Select]
+    aux ::
+         HasCallStack
+      => C.DeclId
+      -> Entry l
+      -> [AnnMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success -> mkSuccessMessages declId success
@@ -484,7 +505,11 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
 getDelayedMsgsNotSelected :: HasCallStack => DeclIndex l -> [AnnMsg Select]
 getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
   where
-    aux :: HasCallStack => C.DeclId -> Entry l -> [AnnMsg Select]
+    aux ::
+         HasCallStack
+      => C.DeclId
+      -> Entry l
+      -> [AnnMsg Select]
     aux declId = \case
       UsableE e -> case e of
         UsableSuccess success ->
@@ -508,6 +533,13 @@ getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
             List.singleton $ withCallStack C.WithLocationInfo{
                 loc = C.declIdLocationInfo declId [loc]
               , msg = SelectMacroTypecheckFailure err
+              }
+          _otherLvl -> []
+        UnusableMacroResolutionFailure loc err -> case getDefaultLogLevel err of
+          Bug ->
+            List.singleton $ withCallStack C.WithLocationInfo{
+                loc = C.declIdLocationInfo declId [loc]
+              , msg = SelectMacroResolutionFailure err
               }
           _otherLvl -> []
         UnusableOmitted{} -> []
@@ -607,6 +639,8 @@ selectDeclIndex declUseGraph p declIndex =
           UnusableMangleNamesFailure loc _ ->
             Just ([loc], C.Available)
           UnusableTypecheckMacrosError loc _ ->
+            Just ([loc], C.Available)
+          UnusableMacroResolutionFailure loc _ ->
             Just ([loc], C.Available)
           UnusableOmitted{} ->
             Nothing

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -30,7 +30,7 @@ import HsBindgen.Frontend.Predicate
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.IR.Translation
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.Error
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -176,6 +176,9 @@ data SelectMsg =
     -- | Delayed handle macros message for macros the user wants to select
     -- directly, but we have failed to parse.
   | SelectMacroTypecheckFailure MacroTypecheckError
+    -- | Delayed macro name-resolution failure for macros the user wants to
+    -- select directly.
+  | SelectMacroResolutionFailure MacroResolutionError
     -- | Delayed @PrepareReparse@ message
   | SelectDelayedPrepareReparseMsg DelayedPrepareReparseMsg
     -- | Inform the user that no declarations matched the selection predicate.
@@ -209,6 +212,8 @@ instance PrettyForTrace SelectMsg where
         ]
       SelectMacroTypecheckFailure x ->
         couldNotSelect $ prettyForTrace x
+      SelectMacroResolutionFailure x ->
+        couldNotSelect $ prettyForTrace x
       SelectDelayedPrepareReparseMsg x ->
         PP.hang "During prepare-reparse:" 2 (prettyForTrace x)
       SelectNoDeclarationsMatched ->
@@ -240,6 +245,7 @@ instance IsTrace Level SelectMsg where
     SelectMangleNamesFailure{}       -> Warning
     SelectMangleNamesSquashed{}      -> Notice
     SelectMacroTypecheckFailure x    -> getDefaultLogLevel x
+    SelectMacroResolutionFailure x   -> getDefaultLogLevel x
     SelectDelayedPrepareReparseMsg x -> getDefaultLogLevel x
     SelectNoDeclarationsMatched      -> Warning
   getSource  = const HsBindgen
@@ -254,6 +260,7 @@ instance IsTrace Level SelectMsg where
     SelectMangleNamesFailure{}       -> "select-mangle-names-failure"
     SelectMangleNamesSquashed{}      -> "select-mangle-names-squashed"
     SelectMacroTypecheckFailure x    -> "select-" <> getTraceId x
+    SelectMacroResolutionFailure x   -> "select-" <> getTraceId x
     SelectDelayedPrepareReparseMsg x -> "select-" <> getTraceId x
     SelectNoDeclarationsMatched      -> "select"
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -10,7 +10,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -43,7 +43,7 @@ instance PassId SimplifyAST where
 instance PassScopedName SimplifyAST
 
 instance PassMacro SimplifyAST where
-  type MacroBody SimplifyAST = ParsedMacroBody
+  type MacroBody SimplifyAST = Macro.Unresolved
 
 instance PassExtBinding SimplifyAST
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
@@ -18,8 +18,8 @@ import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 type In  = ConstructTranslationUnit
 type Out = TypecheckMacros
@@ -35,8 +35,8 @@ type Out = TypecheckMacros
 --
 -- Register macro typecheck failures in @DeclMeta@.
 typecheckMacros ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> C.TranslationUnit l In
   -> ( C.TranslationUnit l Out
      , Map LanC.CName (C.Type ReparseMacroExpansions)
@@ -46,7 +46,7 @@ typecheckMacros macroLang unit =
     let knownTypes =
           collectKnownTypes unit.decls
         (tcRes, resolvedMacros) =
-          typecheckDecls macroLang knownTypes unit.decls
+          typecheckDecls macroLang unit.decls
         (failedMacros, typecheckedDecls) =
           partitionEithers tcRes
     in  ( reconstructAfterTypecheck unit failedMacros typecheckedDecls

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -12,7 +12,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass (ReparseInfo, Tokens)
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition
@@ -66,13 +66,13 @@ data TypecheckedMacro p l =
   | MacroValue (TypecheckedMacroValue l p)
 
 -- | Checked type macro
-data TypecheckedMacroType l p = HasMacroTypes l => TypecheckedMacroType{
-      body :: TypecheckedMacroTypeBody l (MacroTypeBodyVar p)
+data TypecheckedMacroType l p = Macro.HasTypes l => TypecheckedMacroType{
+      body :: Macro.TypecheckedType l (MacroTypeBodyVar p)
     , ann  :: Ann "TypecheckedMacroType" p
     }
 
-data TypecheckedMacroValue l p = HasMacroTypes l => TypecheckedMacroValue {
-      body :: TypecheckedMacroValueBody l (Id p)
+data TypecheckedMacroValue l p = Macro.HasTypes l => TypecheckedMacroValue {
+      body :: Macro.TypecheckedValue l (Id p)
     }
 
 deriving stock instance IsPass p => Show (TypecheckedMacro      p l)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Typecheck.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Typecheck.hs
@@ -15,12 +15,12 @@ import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 type In    = ConstructTranslationUnit
 type Out   = TypecheckMacros
-type CType = C.Type Out
 
 type FailedMacro = (C.DeclId, SingleLoc, MacroTypecheckError)
 
@@ -34,33 +34,26 @@ type FailedMacro = (C.DeclId, SingleLoc, MacroTypecheckError)
 -- Returns the per-declaration results together with @resolvedMacroTypes@, the
 -- mapping from macro names to their underlying C types (used by the reparse
 -- environment).
---
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1952>
---
--- We should only resolve the declaration IDs of macro dependencies once. Now
--- we resolve them twice: when we get the dependencies of parsed macros, and
--- when we typecheck macros.
 typecheckDecls ::
-     forall l. HasMacroTypes l
-  => MacroLang l
-  -> Map C.DeclId CType
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> [C.Decl l In]
   -> ([Either FailedMacro (C.Decl l Out)], Set Text)
-typecheckDecls macroLang knownTypes decls =
+typecheckDecls macroLang decls =
     merge typecheckedMacros decls
   where
-    parsedMacros :: [ParsedMacroBody l]
+    parsedMacros :: [Macro.Resolved l]
     parsedMacros = mapMaybe getParsedMacro decls
 
-    typecheckedMacros :: Map Text (MacroTypecheckResult l)
+    typecheckedMacros :: Map Text (Macro.TypecheckResult l)
     typecheckedMacros =
-      macroLang.typecheckMacroBodies (Map.keysSet knownTypes) parsedMacros
+      macroLang.typecheck parsedMacros
 
 {-------------------------------------------------------------------------------
   Interleaving: thread typechecked macros back into declaration order
 -------------------------------------------------------------------------------}
 
-getParsedMacro :: C.Decl l In -> Maybe (ParsedMacroBody l)
+getParsedMacro :: C.Decl l In -> Maybe (Macro.Resolved l)
 getParsedMacro decl = case decl.kind of
     C.DeclMacro macro -> Just macro
     _otherwise        -> Nothing
@@ -91,8 +84,8 @@ coerceDecl decl = case decl.kind of
 
 -- | Merge typechecked macro results back into the original declarations
 merge ::
-     forall l. HasMacroTypes l
-  => Map Text (MacroTypecheckResult l)
+     forall l. Macro.HasTypes l
+  => Map Text (Macro.TypecheckResult l)
   -> [C.Decl l In]
   -> ([Either FailedMacro (C.Decl l Out)], Set Text)
 merge checkedMacros =
@@ -119,18 +112,18 @@ merge checkedMacros =
                 )
 
 fromMacroTcResult ::
-     HasMacroTypes l
+     Macro.HasTypes l
   => C.DeclInfo Out
-  -> MacroTypecheckResult l
+  -> Macro.TypecheckResult l
   -> Either FailedMacro (C.Decl l Out)
 fromMacroTcResult info = \case
-    MacroTypecheckType  x ->
+    Macro.TypecheckType  x ->
       Right $ toDecl $
         MacroType $ TypecheckedMacroType (fmap MacroTypeBodyVar x) NoAnn
-    MacroTypecheckValue x ->
+    Macro.TypecheckValue x ->
       Right $ toDecl $
         MacroValue $ TypecheckedMacroValue x
-    MacroTypecheckError err ->
+    Macro.TypecheckError err ->
       Left (info.id, info.loc, err)
   where
     toDecl :: TypecheckedMacro Out l -> C.Decl l Out
@@ -146,10 +139,10 @@ fromMacroTcResult info = \case
 -- @bool@ renders identically to @_Bool@ regardless of @language-c@ version.
 addKnownMacro ::
      Text
-  -> MacroTypecheckResult l
+  -> Macro.TypecheckResult l
   -> Set Text
   -> Set Text
 addKnownMacro macroName tcRes knownMacros =
     case tcRes of
-      MacroTypecheckType _body -> Set.insert macroName knownMacros
-      _                        -> knownMacros
+      Macro.TypecheckType _body -> Set.insert macroName knownMacros
+      _                         -> knownMacros

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Zip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Zip.hs
@@ -22,13 +22,14 @@ import HsBindgen.Frontend.Pass.Zip.Zip
 import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
 -- | Zip reparsed declarations with their original definitions
 zip ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> C.TranslationUnit l ReparseMacroExpansions
   -> C.TranslationUnit l Zip
 zip macroLang unit =
@@ -40,8 +41,8 @@ zip macroLang unit =
          }
 
 updateMeta ::
-     forall l. HasMacroTypes l
-  => MacroLang l
+     forall l. Macro.HasTypes l
+  => Macro.Lang l
   -> [(C.DeclId, [DelayedParseMsg])]
   -> [C.Decl l Zip]
   -> DeclMeta l
@@ -87,8 +88,8 @@ updateMeta macroLang failures successes meta = DeclMeta{
 -- that @foo@ depends on @B@. We have to cut the dependency to @A@ and
 -- replace it with the dependency to @B@.
 updateDeps ::
-     HasMacroTypes l
-  => MacroLang l
+     Macro.HasTypes l
+  => Macro.Lang l
   -> C.Decl l Zip
   -> DeclUseGraph
   -> DeclUseGraph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Zip/Zip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Zip/Zip.hs
@@ -17,7 +17,7 @@ import HsBindgen.Frontend.Pass.Zip.IsPass
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.C qualified as C
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Flip
 
 type In  = PrepareReparse
 type Out = ReparseMacroExpansions

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/TranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/TranslationUnit.hs
@@ -12,7 +12,7 @@ import HsBindgen.Frontend.DeclMeta
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 -- | Information we collect from a C translation unit.
 --
@@ -57,7 +57,7 @@ data TranslationUnit l p = TranslationUnit{
   deriving stock (Generic)
 
 deriving stock instance ( IsPass p
-                        , HasMacroTypes l
+                        , Macro.HasTypes l
                         ) => Show (TranslationUnit l p)
 
 instance (

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
@@ -47,7 +47,7 @@ import HsBindgen.IR.C.Naming qualified as C
 import HsBindgen.IR.C.Type qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.C (PrimType)
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 import Doxygen.Parser.Types qualified as Doxy
 
@@ -409,10 +409,10 @@ deriving stock instance IsPass p => Show (Typedef          p)
 deriving stock instance IsPass p => Show (Union            p)
 deriving stock instance IsPass p => Show (UnionField       p)
 
-deriving stock instance (HasMacroTypes l, IsPass p) => Eq (DeclKind l p)
+deriving stock instance (Macro.HasTypes l, IsPass p) => Eq (DeclKind l p)
 
-deriving stock instance (HasMacroTypes l, IsPass p) => Show (Decl     l p)
-deriving stock instance (HasMacroTypes l, IsPass p) => Show (DeclKind l p)
+deriving stock instance (Macro.HasTypes l, IsPass p) => Show (Decl     l p)
+deriving stock instance (Macro.HasTypes l, IsPass p) => Show (DeclKind l p)
 
 {-------------------------------------------------------------------------------
   CoercePass instances

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/LocationInfo.hs
@@ -36,7 +36,7 @@ data WithLocationInfo a = WithLocationInfo{
       loc :: LocationInfo
     , msg :: a
     }
-  deriving stock (Eq, Ord, Show)
+  deriving stock (Eq, Ord, Show, Functor)
 
 instance IsTrace lvl a => IsTrace lvl (WithLocationInfo a) where
   getDefaultLogLevel x = getDefaultLogLevel x.msg

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass/Macro.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass/Macro.hs
@@ -18,7 +18,7 @@ module HsBindgen.IR.Pass.Macro (
 import HsBindgen.Imports
 import HsBindgen.IR.Pass.Definition
 import HsBindgen.IR.Pass.Id
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Associated type families
@@ -32,7 +32,7 @@ class (
     , Ord  (MacroUnderlying p)  -- For using as map key
     , Show (MacroId         p)  -- For debugging
     , Show (MacroUnderlying p)  -- For debugging
-    , forall l. HasMacroTypes l => ValidMacroBody p l
+    , forall l. Macro.HasTypes l => ValidMacroBody p l
     ) => PassMacro (p :: Pass) where
 
   -- | Declaration identifier for macro types

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Error.hs
@@ -1,0 +1,47 @@
+module HsBindgen.Macro.Error (
+    MacroParseError(..)
+  , MacroResolutionError(..)
+  , MacroTypecheckError(..)
+  ) where
+
+import GHC.Generics
+import Text.SimplePrettyPrint qualified as PP
+
+import HsBindgen.Util.Tracer
+
+-- | An opaque parse error from the macro-language backend.
+newtype MacroParseError = MacroParseError { macroParseError :: String }
+  deriving stock (Eq, Show, Generic)
+
+newtype MacroResolutionError = MacroResolutionError {
+      macroResolutionError :: String
+    }
+  deriving stock (Eq, Show, Generic)
+
+instance PrettyForTrace MacroResolutionError where
+  prettyForTrace (MacroResolutionError msg) =
+    PP.hang "Could not resolve variables in macro:" 2 (PP.string msg)
+
+instance IsTrace Level MacroResolutionError where
+  getDefaultLogLevel = const Warning
+  getSource          = const HsBindgen
+  getTraceId         = const "macro-resolution"
+
+-- | An opaque typecheck error from the macro-language backend.
+newtype MacroTypecheckError = MacroTypecheckError {
+      macroTypecheckError :: String
+    }
+  deriving stock (Eq, Show, Generic)
+
+instance PrettyForTrace MacroTypecheckError where
+  prettyForTrace = \case
+      MacroTypecheckError err -> PP.hsep [
+          "Failed to typecheck macro:"
+        , PP.string err
+        ]
+
+instance IsTrace Level MacroTypecheckError where
+  getDefaultLogLevel = \case
+    MacroTypecheckError{} -> Info
+  getSource          = const HsBindgen
+  getTraceId         = const "macro-typecheck"

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Flip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Flip.hs
@@ -1,0 +1,19 @@
+-- | 'Flip' is useful when working with 'HsBindgen.Macro.Type.HasTypes'
+module HsBindgen.Macro.Flip (
+    Flip(..)
+  , flipF
+  , flipM
+  ) where
+
+newtype Flip f a l = Flip { unflip :: f l a }
+  deriving stock (Eq, Show)
+
+flipF :: (Flip f n a -> Flip f n b) -> f a n -> f b n
+flipF f x =
+  let (Flip x') = f (Flip x)
+  in  x'
+
+flipM :: Monad m => (Flip f n a -> m (Flip f n b)) -> f a n -> m (f b n)
+flipM f x = do
+  (Flip x') <- f (Flip x)
+  pure x'

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Interface.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Interface.hs
@@ -1,22 +1,22 @@
 -- | Pluggable macro-language interface
 --
--- This module defines the 'MacroLang' record type, providing the macro-language
--- implementation (parsing, typechecking, translation). Values of 'MacroLang'
--- can be provided by separate packages. The default value uses @c-expr-dsl@,
--- and is defined in the user-facing @hs-bindgen@ library as
--- 'HsBindgen.Macro.cExprLang'.
+-- This module defines the macro language 'Lang' record type, providing the
+-- macro-language implementation (parsing, typechecking, translation). Values of
+-- the macro language 'Lang' can be provided by separate packages. The default
+-- value uses @c-expr-dsl@, and is defined in the user-facing @hs-bindgen@
+-- library as 'HsBindgen.Macro.cExprLang'.
+--
+-- Intended for qualified import.
+--
+-- @
+-- import HsBindgen.Macro.Interface qualified as Macro
+-- @
 module HsBindgen.Macro.Interface (
     -- * Record
-    MacroLang(..)
+    Lang(..)
     -- * Typecheck result
-  , MacroTypecheckResult(..)
-    -- * Errors
-  , MacroTypecheckError(..)
-  , MacroLangParseError(..)
-  , MacroLangTypecheckError(..)
+  , TypecheckResult(..)
   ) where
-
-import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
 
@@ -27,8 +27,8 @@ import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Hs qualified as Hs
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Type
-import HsBindgen.Util.Tracer
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Record
@@ -37,48 +37,50 @@ import HsBindgen.Util.Tracer
 -- | A macro language: provides parsing, typechecking and translation of C macro
 -- bodies.
 --
--- The C standard (and any other configuration) is fixed when the 'MacroLang'
+-- The C standard (and any other configuration) is fixed when the macro 'Lang'
 -- is constructed; the interface itself is configuration-free.
-data MacroLang (l :: Star) = MacroLang {
+data Lang (l :: Star) = Lang {
     -- | Parse a single macro from @libclang@ tokens.
-    parseMacroBody ::
+    parse ::
          [Token TokenSpelling]
-      -> Either MacroLangParseError (ParsedMacroBody l)
+      -> Either MacroParseError (Macro.Unresolved l)
+
+  , resolve ::
+         Set C.DeclId
+         -- ^ Set of declaration IDs in scope.
+      -> Macro.Unresolved l
+      -> Either MacroResolutionError (Macro.Resolved l)
 
     -- | Dependencies of a parsed (not yet typechecked) macro.
     --
     -- The caller supplies name resolvers; the implementation walks the macro
     -- AST.
-  , parsedMacroDeps ::
-         Set C.DeclId
-         -- ^ Declarations in scope
-      -> ParsedMacroBody l
+  , parsedDeps ::
+         Macro.Resolved l
       -> [(C.ValOrRef, C.DeclId)]
 
     -- | Batch-typecheck a sequence of macros.
-  , typecheckMacroBodies ::
-         Set C.DeclId
-         -- ^ Declarations in scope
-      -> [ParsedMacroBody l]
-      -> Map Text (MacroTypecheckResult l)
+  , typecheck ::
+         [Macro.Resolved l]
+      -> Map Text (TypecheckResult l)
 
     -- | Get dependencies of a typechecked type-like macro body.
-  , typecheckedMacroTypeDeps ::
-         TypecheckedMacroTypeBody l C.DeclId
+  , typecheckedTypeDeps ::
+         Macro.TypecheckedType l C.DeclId
       -> [(C.ValOrRef, C.DeclId)]
 
     -- | Translate a checked type-like macro body to an 'HsType'.
     --
     -- The caller supplies a function to translate variables to 'HsType'.
-  , translateMacroType ::
-         TypecheckedMacroTypeBody l Hs.Type
+  , translateType ::
+         Macro.TypecheckedType l Hs.Type
       -> Hs.Type
 
     -- | Translate a checked value-macro to a 'Binding'.
-  , translateMacroValue ::
+  , translateValue ::
          Hs.Name Hs.NsVar
          -- ^ Exported binding name
-      -> TypecheckedMacroValueBody l Hs.TermName
+      -> Macro.TypecheckedValue l Hs.TermName
       -> Maybe HsDoc.Comment
       -> Binding
   }
@@ -91,45 +93,11 @@ data MacroLang (l :: Star) = MacroLang {
 --
 -- @l@ is the macro-language tag, @var@ is the variable type used to represent
 -- macro dependencies.
-data MacroTypecheckResult l
-  = MacroTypecheckType  (TypecheckedMacroTypeBody  l C.DeclId)
-  | MacroTypecheckValue (TypecheckedMacroValueBody l C.DeclId)
-  | MacroTypecheckError MacroTypecheckError
+data TypecheckResult l
+  = TypecheckType  (Macro.TypecheckedType  l C.DeclId)
+  | TypecheckValue (Macro.TypecheckedValue l C.DeclId)
+  | TypecheckError MacroTypecheckError
 
-deriving stock instance HasMacroTypes l => Show (MacroTypecheckResult l)
-deriving stock instance HasMacroTypes l => Eq   (MacroTypecheckResult l)
+deriving stock instance Macro.HasTypes l => Show (TypecheckResult l)
+deriving stock instance Macro.HasTypes l => Eq   (TypecheckResult l)
 
-{-------------------------------------------------------------------------------
-  Errors
--------------------------------------------------------------------------------}
-
-data MacroTypecheckError =
-    MacroTypecheckTypecheckError       MacroLangTypecheckError
-  | MacroTypecheckUnresolvedTaggedType C.DeclId
-  deriving stock (Show, Eq)
-
-instance PrettyForTrace MacroTypecheckError where
-  prettyForTrace = \case
-      MacroTypecheckTypecheckError err -> PP.hsep [
-          "Failed to typecheck macro:"
-        , PP.string err.macroTypecheckError
-        ]
-      MacroTypecheckUnresolvedTaggedType declId -> PP.hsep [
-          "Macro type references unknown tagged type:"
-        , prettyForTrace declId
-        ]
-
-instance IsTrace Level MacroTypecheckError where
-  getDefaultLogLevel = \case
-    MacroTypecheckTypecheckError{}       -> Info
-    MacroTypecheckUnresolvedTaggedType{} -> Warning
-  getSource          = const HsBindgen
-  getTraceId         = const "macro-typecheck"
-
--- | An opaque parse error from the macro-language backend.
-newtype MacroLangParseError = MacroLangParseError { macroParseError :: String }
-  deriving stock (Eq, Show, Generic)
-
--- | An opaque typecheck error from the macro-language backend.
-newtype MacroLangTypecheckError = MacroLangTypecheckError { macroTypecheckError :: String }
-  deriving stock (Eq, Show, Generic)

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Type.hs
@@ -1,61 +1,83 @@
 -- | Pluggable macro-language types
 --
--- This module defines the 'HasMacroTypes' typeclass, defining types for parsing
--- and typechecking macros. Instances of 'HasMacroTypes' can be provided by
+-- This module defines the macro 'HasTypes' typeclass, defining types for
+-- parsing and typechecking macros. Instances of 'HasTypes' can be provided by
 -- separate packages. The default instance uses @c-expr-dsl@, and is defined in
 -- the user-facing @hs-bindgen@ library.
+--
+-- Intended for qualified import.
+--
+-- @
+-- import HsBindgen.Macro.Type qualified as Macro
+-- @
 module HsBindgen.Macro.Type (
     -- * Typeclass
-    HasMacroTypes(..)
-    -- * Macro language type parameter
-  , Flip(..)
-  , flipF
-  , flipM
+    HasTypes(..)
+    -- * Name resolution
+  , Unresolved(..)
+  , Resolved(..)
   ) where
 
 import HsBindgen.Imports
+import HsBindgen.IR.C.Naming qualified as C
 
 {-------------------------------------------------------------------------------
   Typeclass
 -------------------------------------------------------------------------------}
 
 -- | Types for parsing and typechecking macro bodies
+--
+-- Initially, we store the 'ParsedMacro' in the AST. The 'ParsedMacro'
+-- is parameterized by an annotation:
+--
+-- 1. After parse, the annotation is @()@ (see 'Macro.Unresolved').
+--
+-- 2. After name resolution, the annotation is the 'C.DeclId' (see
+--    'Macro.Resolved').
+--
+-- After we typecheck the macros, we store the 'TypecheckedMacroType' or
+-- 'TypecheckedMacroValue' in the AST. These are parameterized by a variable:
+--
+-- 1. After typechecking that variable is instantiated to 'DeclId' (which is the
+--    annotation of the 'ParsedMacro' prior to typechecking).
+--
+-- 2. After name mangling, the variable becomes a 'C.DeclIdPair'.
 class (
-    Show (ParsedMacroBody l)
-  , Eq   (ParsedMacroBody l)
-  , Functor     (TypecheckedMacroTypeBody  l)
-  , Foldable    (TypecheckedMacroTypeBody  l)
-  , Traversable (TypecheckedMacroTypeBody  l)
-  , forall var. (Show var, Eq var) => Show (TypecheckedMacroTypeBody  l var)
-  , forall var. (Show var, Eq var) => Eq   (TypecheckedMacroTypeBody  l var)
-  , Functor     (TypecheckedMacroValueBody l)
-  , Foldable    (TypecheckedMacroValueBody l)
-  , Traversable (TypecheckedMacroValueBody l)
-  , forall var. (Show var, Eq var) => Show (TypecheckedMacroValueBody l var)
-  , forall var. (Show var, Eq var) => Eq   (TypecheckedMacroValueBody l var)
-  ) => HasMacroTypes (l :: Star) where
+    forall ann. (Show ann) => Show (Parsed l ann)
+  , forall ann. (Eq   ann) => Eq   (Parsed l ann)
+  , Functor     (TypecheckedType  l)
+  , Foldable    (TypecheckedType  l)
+  , Traversable (TypecheckedType  l)
+  , forall var. (Show var, Eq var) => Show (TypecheckedType  l var)
+  , forall var. (Show var, Eq var) => Eq   (TypecheckedType  l var)
+  , Functor     (TypecheckedValue l)
+  , Foldable    (TypecheckedValue l)
+  , Traversable (TypecheckedValue l)
+  , forall var. (Show var, Eq var) => Show (TypecheckedValue l var)
+  , forall var. (Show var, Eq var) => Eq   (TypecheckedValue l var)
+  ) => HasTypes (l :: Star) where
 
-  -- | Body of parsed (not yet typechecked) macro.
-  data ParsedMacroBody l :: Star
+  -- | Body of parsed (not yet typechecked) macro. Parameterized by the
+  --   annotation type.
+  data Parsed l :: Star -> Star
 
   -- | Body of typechecked type macro. Parameterized by the variable type.
-  data TypecheckedMacroTypeBody  l :: Star -> Star
+  data TypecheckedType  l :: Star -> Star
 
   -- | Body of typechecked value macro. Parameterized by the variable type.
-  data TypecheckedMacroValueBody l :: Star -> Star
+  data TypecheckedValue l :: Star -> Star
 
 {-------------------------------------------------------------------------------
-  Macro language type parameter
+  Name resolution
 -------------------------------------------------------------------------------}
 
-newtype Flip f a l = Flip { unflip :: f l a }
+newtype Unresolved l = Unresolved { unwrap :: Parsed l () }
 
-flipF :: (Flip f n a -> Flip f n b) -> f a n -> f b n
-flipF f x =
-  let (Flip x') = f (Flip x)
-  in  x'
+deriving stock instance (HasTypes l) => Eq   (Unresolved l)
+deriving stock instance (HasTypes l) => Show (Unresolved l)
 
-flipM :: Monad m => (Flip f n a -> m (Flip f n b)) -> f a n -> m (f b n)
-flipM f x = do
-  (Flip x') <- f (Flip x)
-  pure x'
+newtype Resolved l = Resolved { unwrap :: Parsed l C.DeclId }
+  deriving stock (Generic)
+
+deriving stock instance (HasTypes l) => Eq   (Resolved l)
+deriving stock instance (HasTypes l) => Show (Resolved l)

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -33,8 +33,8 @@ import HsBindgen.Guasi
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.Interface
-import HsBindgen.Macro.Type (HasMacroTypes)
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.TraceMsg
 import HsBindgen.Util.TH
 import HsBindgen.Util.Tracer
@@ -71,9 +71,9 @@ toFilePath _    (Dir x) = x
 -- >   hashInclude "foo.h"
 -- >   hashInclude "bar.h"
 withHsBindgenMacroLang ::
-     forall l. HasMacroTypes l
-  => (ClangCStandard -> IO (MacroLang l))
-     --  ^ The callback returning the 'MacroLang' to use.
+     forall l. Macro.HasTypes l
+  => (ClangCStandard -> IO (Macro.Lang l))
+     --  ^ The callback returning the macro 'Macro.Lang' to use.
   -> Config
   -> ConfigTH
   -> BindgenM

--- a/hs-bindgen/src/HsBindgen/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/Macro.hs
@@ -1,33 +1,44 @@
+-- | The macro instance of @hs-bindgen@ is based on @c-expr-dsl@.
+--
+-- Intended for qualified import.
+--
+-- @
+-- import HsBindgen.Macro (CExpr)
+-- import HsBindgen.Macro qualified as Macro
+-- @
 module HsBindgen.Macro (
     -- * Type
     CExpr
-  , HasMacroTypes(..)
+  , Macro.HasTypes(..)
     -- * Macro language
-  , cExprLang
-  , MacroLang(..)
+  , cExpr
+  , Macro.Lang(..)
   ) where
 
 import Clang.CStandard
 
 import HsBindgen.Macro.CExpr
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.Interface qualified as Macro
 import HsBindgen.Macro.Parse
+import HsBindgen.Macro.Resolution
 import HsBindgen.Macro.Translation.Type
 import HsBindgen.Macro.Translation.Value
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 import HsBindgen.Macro.Typecheck
 
 -- | Default macro language implementation backed by @c-expr-dsl@.
 --
--- The C standard is fixed at construction time; the resulting 'MacroLang' is
--- configuration-free.
-cExprLang :: ClangCStandard -> MacroLang CExpr
-cExprLang cStd = MacroLang
-  { parseMacroBody           = parseMacroBody cStd
-  , parsedMacroDeps          = parsedMacroDeps
-  , typecheckMacroBodies     = typecheckMacroBodies
-  , typecheckedMacroTypeDeps = typecheckedMacroTypeDeps
-  , translateMacroType       = translateMacroType
-  , translateMacroValue      = translateMacroValue
+-- The C standard is fixed at construction time; the resulting macro
+-- 'Macro.Lang' is configuration-free.
+
+cExpr :: ClangCStandard -> Macro.Lang CExpr
+cExpr cStd = Macro.Lang
+  { parse               = parseMacro cStd
+  , resolve             = resolveMacro
+  , parsedDeps          = parsedMacroDeps
+  , typecheck           = typecheckMacros
+  , typecheckedTypeDeps = typecheckedMacroTypeDeps
+  , translateType       = translateMacroType
+  , translateValue      = translateMacroValue
   }
 

--- a/hs-bindgen/src/HsBindgen/Macro/CExpr.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/CExpr.hs
@@ -1,9 +1,16 @@
+-- | Macro types specific to @c-expr-dsl@.
+--
+-- Intended for qualified import
+--
+-- @
+-- import HsBindgen.Macro.CExpr (CExpr)
+-- import HsBindgen.Macro.CExpr qualified as Macro
+-- @
 module HsBindgen.Macro.CExpr (
     CExpr
-  , ParsedMacroBody(..)
-  , TypecheckedMacroTypeBody(..)
-  , TypecheckedMacroValueBody(..)
-
+  , Macro.Parsed(..)
+  , Macro.TypecheckedType(..)
+  , Macro.TypecheckedValue(..)
     -- Internal
   , convertTagKind
   ) where
@@ -12,35 +19,41 @@ import C.Expr.Syntax qualified as CExpr
 import C.Expr.Typecheck qualified as CExpr
 
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Type
+import HsBindgen.Macro.Type qualified as Macro
 
 -- | Tag for the default C macro language, backed by @c-expr-dsl@.
 data CExpr
 
-instance HasMacroTypes CExpr where
-  newtype ParsedMacroBody CExpr =
-    ParsedMacroBodyCExpr CExpr.Macro
-  newtype TypecheckedMacroTypeBody CExpr var =
-    TypecheckedMacroTypeBodyCExpr (CExpr.TypecheckedMacroTypeExpr var)
-  newtype TypecheckedMacroValueBody CExpr var =
-    TypecheckedMacroValueBodyCExpr (CExpr.TypecheckedMacroValueExpr var)
+instance Macro.HasTypes CExpr where
+  newtype Parsed CExpr ann =
+    ParsedCExpr{
+        unwrap :: CExpr.Macro ann
+      }
+  newtype TypecheckedType CExpr var =
+    TypecheckedTypeCExpr{
+        unwrap :: CExpr.TypecheckedMacroTypeExpr var
+      }
+  newtype TypecheckedValue CExpr var =
+    TypecheckedValueCExpr{
+        unwrap :: CExpr.TypecheckedMacroValueExpr var
+      }
 
-deriving stock instance Show (ParsedMacroBody CExpr)
-deriving stock instance Eq   (ParsedMacroBody CExpr)
+deriving stock instance (Show ann) => Show (Macro.Parsed CExpr ann)
+deriving stock instance (Eq   ann) => Eq   (Macro.Parsed CExpr ann)
 
-deriving stock instance (Show var) => Show (TypecheckedMacroTypeBody CExpr var)
-deriving stock instance (Eq var)   => Eq   (TypecheckedMacroTypeBody CExpr var)
+deriving stock instance (Show var) => Show (Macro.TypecheckedType CExpr var)
+deriving stock instance (Eq var)   => Eq   (Macro.TypecheckedType CExpr var)
 
-deriving stock instance Functor     (TypecheckedMacroTypeBody CExpr)
-deriving stock instance Foldable    (TypecheckedMacroTypeBody CExpr)
-deriving stock instance Traversable (TypecheckedMacroTypeBody CExpr)
+deriving stock instance Functor     (Macro.TypecheckedType CExpr)
+deriving stock instance Foldable    (Macro.TypecheckedType CExpr)
+deriving stock instance Traversable (Macro.TypecheckedType CExpr)
 
-deriving stock instance (Show var) => Show (TypecheckedMacroValueBody CExpr var)
-deriving stock instance (Eq var)   => Eq   (TypecheckedMacroValueBody CExpr var)
+deriving stock instance (Show var) => Show (Macro.TypecheckedValue CExpr var)
+deriving stock instance (Eq var)   => Eq   (Macro.TypecheckedValue CExpr var)
 
-deriving stock instance Functor     (TypecheckedMacroValueBody CExpr)
-deriving stock instance Foldable    (TypecheckedMacroValueBody CExpr)
-deriving stock instance Traversable (TypecheckedMacroValueBody CExpr)
+deriving stock instance Functor     (Macro.TypecheckedValue CExpr)
+deriving stock instance Foldable    (Macro.TypecheckedValue CExpr)
+deriving stock instance Traversable (Macro.TypecheckedValue CExpr)
 
 {-------------------------------------------------------------------------------
   Internal helpers

--- a/hs-bindgen/src/HsBindgen/Macro/Parse.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Parse.hs
@@ -1,9 +1,7 @@
 module HsBindgen.Macro.Parse (
-    parseMacroBody
+    parseMacro
   , parsedMacroDeps
   ) where
-
-import Data.Set qualified as Set
 
 import C.Expr.Parse qualified as CExpr
 import C.Expr.Syntax qualified as CExpr
@@ -11,29 +9,32 @@ import C.Expr.Syntax qualified as CExpr
 import Clang.CStandard
 import Clang.HighLevel.Types
 
-import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.CExpr
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.CExpr (CExpr)
+import HsBindgen.Macro.CExpr qualified as Macro
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Type qualified as Macro
 
-parseMacroBody ::
+parseMacro ::
      ClangCStandard
   -> [Token TokenSpelling]
-  -> Either MacroLangParseError (ParsedMacroBody CExpr)
-parseMacroBody cStd tokens =
+  -> Either MacroParseError (Macro.Unresolved CExpr)
+parseMacro cStd tokens =
     case CExpr.runParser (CExpr.parseMacro cStd) tokens of
-      Right macro -> Right (ParsedMacroBodyCExpr macro)
-      Left  err   -> Left  (MacroLangParseError err.parseError)
+      Right macro -> Right $ Macro.Unresolved $ Macro.ParsedCExpr macro
+      Left  err   -> Left  $ MacroParseError err.parseError
 
 parsedMacroDeps ::
-     Set C.DeclId
-  -> ParsedMacroBody CExpr
+     Macro.Resolved CExpr
   -> [(C.ValOrRef, C.DeclId)]
-parsedMacroDeps declIds (ParsedMacroBodyCExpr macro) =
-    case macro of
+parsedMacroDeps resolvedMacro =
+    case resolvedMacro.unwrap.unwrap of
       CExpr.Macro _ _ _ expr -> goExpr C.ByValue expr
   where
-    goExpr :: C.ValOrRef -> CExpr.Expr ctx CExpr.Ps -> [(C.ValOrRef, C.DeclId)]
+    goExpr ::
+         C.ValOrRef
+      -> CExpr.Expr ctx (CExpr.Ps C.DeclId)
+      -> [(C.ValOrRef, C.DeclId)]
     goExpr depTy = \case
       CExpr.Term term              -> goTerm depTy term
       -- Pointer: switch the dependency type to 'ByRef'.
@@ -41,55 +42,12 @@ parsedMacroDeps declIds (ParsedMacroBodyCExpr macro) =
       CExpr.TyApp CExpr.Const   xs -> concatMap (goExpr depTy)   xs
       CExpr.VaApp _ _ xs           -> concatMap (goExpr depTy)   xs
 
-    goTerm :: C.ValOrRef -> CExpr.Term ctx CExpr.Ps -> [(C.ValOrRef, C.DeclId)]
+    goTerm ::
+         C.ValOrRef
+      -> CExpr.Term ctx (CExpr.Ps C.DeclId)
+      -> [(C.ValOrRef, C.DeclId)]
     goTerm depTy = \case
-      CExpr.Literal lit  -> goLit depTy lit
+      CExpr.Literal{}    -> []
       CExpr.LocalParam{} -> []
-      CExpr.Var _ nm args
-        | Just x <- resolveBare nm.getName ->
-            (depTy, x) : concatMap (goExpr depTy) args
-        | otherwise ->
-            concatMap (goExpr depTy) args
-
-    goLit :: C.ValOrRef -> CExpr.Literal -> [(C.ValOrRef, C.DeclId)]
-    goLit depTy = \case
-      CExpr.TypeTagged tag nm
-        | Just a <- resolveTagged (convertTagKind tag) nm.getName -> [(depTy, a)]
-        | otherwise -> []
-      CExpr.TypeLit{}  -> []
-      CExpr.ValueLit{} -> []
-
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1952>
-    --
-    -- We should only resolve the declaration IDs of macro dependencies once.
-    -- Now we resolve them twice: when we get the dependencies of parsed macros,
-    -- and when we typecheck macros.
-
-    -- | Resolves a bare name found in a parsed macro body
-    --
-    -- Result:
-    --
-    -- - @'Just' 'CNameKind'@: This bare name refers to another declaration that is in
-    --   the 'DeclIndex'. For example, a macro, or a @typedef@.
-    --
-    -- - @'Nothing'@: This bare name is not in the set of known declarations. It
-    --   may simply be non-existent, or refer to a built-in type or a system
-    --   @typedef@ not present in the 'DeclIndex'. In this case, we /do not
-    --   generate/ a dependency.
-    resolveBare :: Text -> Maybe C.DeclId
-    resolveBare nm
-      | macroId   `Set.member` declIds = Just macroId
-      | typedefId `Set.member` declIds = Just typedefId
-      | otherwise                         = Nothing
-      where
-        macroId, typedefId :: C.DeclId
-        macroId   = C.DeclId (C.DeclName nm C.NameKindMacro)    False
-        typedefId = C.DeclId (C.DeclName nm C.NameKindOrdinary) False
-
-    resolveTagged :: C.TagKind -> Text -> Maybe C.DeclId
-    resolveTagged tag nm
-      | taggedId `Set.member` declIds = Just taggedId
-      | otherwise                     = Nothing
-      where
-        taggedId :: C.DeclId
-        taggedId = C.DeclId (C.DeclName nm $ C.NameKindTagged tag) False
+      CExpr.Var (CExpr.XVarPs declId) _nm args ->
+        (depTy, declId) : concatMap (goExpr depTy) args

--- a/hs-bindgen/src/HsBindgen/Macro/Resolution.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Resolution.hs
@@ -1,0 +1,83 @@
+module HsBindgen.Macro.Resolution (
+    resolveMacro
+  ) where
+
+import Data.Set qualified as Set
+
+import C.Expr.Syntax qualified as CExpr
+
+import HsBindgen.Imports
+import HsBindgen.IR.C qualified as C
+import HsBindgen.Macro.CExpr (CExpr)
+import HsBindgen.Macro.CExpr qualified as Macro
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Type qualified as Macro
+
+resolveMacro ::
+     Set C.DeclId
+  -> Macro.Unresolved CExpr
+  -> Either MacroResolutionError (Macro.Resolved CExpr)
+resolveMacro declIds (Macro.Unresolved (Macro.ParsedCExpr macro)) =
+    Macro.Resolved . Macro.ParsedCExpr <$> CExpr.annotateMacro resolve macro
+  where
+    resolve :: CExpr.Name -> () -> Either MacroResolutionError C.DeclId
+    resolve name _ = case name of
+      CExpr.NameOrdinary nm ->
+        resolveBare nm.getIdentifier
+      CExpr.NameTagged nm tag ->
+        resolveTagged nm.getIdentifier (Macro.convertTagKind tag)
+
+    -- | Resolves a bare name found in a parsed macro body
+    --
+    -- Result:
+    --
+    -- - @'Just' 'CNameKind'@: This bare name refers to another declaration that is in
+    --   the 'DeclIndex'. For example, a macro, or a @typedef@.
+    --
+    -- - @'Nothing'@: This bare name is not in the set of known declarations. It
+    --   may simply be non-existent, or refer to a built-in type or a system
+    --   @typedef@ not present in the 'DeclIndex'. In this case, we /do not
+    --   generate/ a dependency.
+    resolveBare :: Text -> Either MacroResolutionError C.DeclId
+    resolveBare nm = case (isMacro, isTypedef) of
+        -- TODO <https://github.com/well-typed/hs-bindgen/issues/2097>
+        --
+        -- This is separate from user-selection or resolution of conflicts in
+        -- the Select pass [issue-1553], but instead we'd need to know which
+        -- definition C chooses to resolve to.
+        --
+        -- Crucially, this depends on the order of declarations (i.e., sequence
+        -- order); and we currently do not have this order available. Once our
+        -- lower limit on LLVM is 20.1, we can ensure sequence order and resolve
+        -- to the name as C does.
+        --
+        -- [issue-1553] https://github.com/well-typed/hs-bindgen/issues/1553
+        (True,  True)  -> Left $
+          MacroResolutionError $
+            "conflict detected: " <> show nm <> " is both a type and a macro"
+        (True,  False) -> Right macroId
+        (False, True)  -> Right typedefId
+        (False, False) -> Left $
+          MacroResolutionError $
+            "bare identifier " <> show nm <> " not found"
+      where
+        macroId, typedefId :: C.DeclId
+        macroId   = C.DeclId (C.DeclName nm C.NameKindMacro)    False
+        typedefId = C.DeclId (C.DeclName nm C.NameKindOrdinary) False
+        isMacro   = macroId   `Set.member` declIds
+        isTypedef = typedefId `Set.member` declIds
+
+    resolveTagged :: Text -> C.TagKind -> Either MacroResolutionError C.DeclId
+    resolveTagged nm tag
+      | taggedId `Set.member` declIds = Right taggedId
+      | otherwise =
+        Left $
+          MacroResolutionError $
+            "tagged identifier "
+            <> show (C.tagKindPrefix tag)
+            <> " "
+            <> show nm
+            <> " not found"
+      where
+        taggedId :: C.DeclId
+        taggedId = C.DeclId (C.DeclName nm $ C.NameKindTagged tag) False

--- a/hs-bindgen/src/HsBindgen/Macro/Translation/Common.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Translation/Common.hs
@@ -1,3 +1,0 @@
-module HsBindgen.Macro.Translation.Common (
-
-  ) where

--- a/hs-bindgen/src/HsBindgen/Macro/Translation/Type.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Translation/Type.hs
@@ -9,12 +9,13 @@ import C.Expr.Typecheck.Interface.Type qualified as T
 import HsBindgen.Backend.Hs.Translation.Type qualified as Type
 import HsBindgen.IR.Hs qualified as Hs
 import HsBindgen.Language.C qualified as C
-import HsBindgen.Macro.CExpr
+import HsBindgen.Macro.CExpr (CExpr)
+import HsBindgen.Macro.CExpr qualified as Macro
 
 translateMacroType ::
-     TypecheckedMacroTypeBody CExpr Hs.Type
+     Macro.TypecheckedType CExpr Hs.Type
   -> Hs.Type
-translateMacroType (TypecheckedMacroTypeBodyCExpr tcExpr) = go tcExpr.macroTypeBody
+translateMacroType (Macro.TypecheckedTypeCExpr tcExpr) = go tcExpr.macroTypeBody
   where
     go :: T.Expr Hs.Type -> Hs.Type
     go = \case

--- a/hs-bindgen/src/HsBindgen/Macro/Translation/Value.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Translation/Value.hs
@@ -23,16 +23,17 @@ import HsBindgen.Config.MangleCandidate
 import HsBindgen.Errors
 import HsBindgen.Imports
 import HsBindgen.Language.Haskell qualified as Hs
-import HsBindgen.Macro.CExpr
+import HsBindgen.Macro.CExpr (CExpr)
+import HsBindgen.Macro.CExpr qualified as Macro
 import HsBindgen.Macro.Global
 import HsBindgen.NameHint
 
 translateMacroValue ::
      Hs.Name Hs.NsVar
-  -> TypecheckedMacroValueBody CExpr Hs.TermName
+  -> Macro.TypecheckedValue CExpr Hs.TermName
   -> Maybe HsDoc.Comment
   -> Binding
-translateMacroValue name (TypecheckedMacroValueBodyCExpr expr) comment =
+translateMacroValue name (Macro.TypecheckedValueCExpr expr) comment =
     Binding
       { name       = Hs.ExportedName name
       , parameters = []
@@ -203,11 +204,11 @@ translateBody ::
      CExpr.TypecheckedMacroValueExpr Hs.TermName
   -> ClosedExpr
 translateBody (CExpr.TypecheckedMacroValueExpr params body _) =
-    lambdaN (Vec.reverse (nameToHint <$> params)) (mexpr body)
+    lambdaN (Vec.reverse (identifierToHint <$> params)) (mexpr body)
 
-nameToHint :: CExpr.Name -> NameHint
-nameToHint nm =
-    toHint $ mangleCandidateDefaultFallback fallback nm.getName
+identifierToHint :: CExpr.Identifier -> NameHint
+identifierToHint nm =
+    toHint $ mangleCandidateDefaultFallback fallback nm.getIdentifier
   where
     fallback :: Hs.Name Hs.NsVar
     fallback = Hs.UnsafeName "x"

--- a/hs-bindgen/src/HsBindgen/Macro/Typecheck.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Typecheck.hs
@@ -1,93 +1,52 @@
 module HsBindgen.Macro.Typecheck (
-    typecheckMacroBodies
+    typecheckMacros
   , typecheckedMacroTypeDeps
   ) where
 
-import Control.Monad.Except (Except, MonadError (..))
 import Data.Map qualified as Map
-import Data.Set qualified as Set
 import Data.Text qualified as Text
 
 import C.Expr.Syntax qualified as CExpr
 import C.Expr.Typecheck qualified as CExpr
 import C.Expr.Typecheck.Interface.Type qualified as T
+import C.Expr.Typecheck.Type qualified as CExpr
 
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.CExpr
-import HsBindgen.Macro.Interface
+import HsBindgen.Macro.CExpr (CExpr)
+import HsBindgen.Macro.CExpr qualified as Macro
+import HsBindgen.Macro.Error
+import HsBindgen.Macro.Interface qualified as Macro
+import HsBindgen.Macro.Type qualified as Macro
 
-typecheckMacroBodies ::
-     Set C.DeclId
-  -> [ParsedMacroBody CExpr]
-  -> Map Text (MacroTypecheckResult CExpr)
-typecheckMacroBodies declsInScope bodies =
-    Map.mapKeysMonotonic (.getName) $ fmap convertResult $
-      CExpr.tcMacros
-        typedefs
-        injectTypeName
-        injectValueName
-        injectNonAnonTaggedTypeName
-        [m | ParsedMacroBodyCExpr m <- bodies]
+typeOfAnn :: C.DeclId -> Maybe CExpr.QuantTy
+typeOfAnn declId = case declId.name.kind of
+    C.NameKindOrdinary -> Just CExpr.simpleType
+    _otherwise         -> Nothing
+
+typecheckMacros ::
+     [Macro.Resolved CExpr]
+  -> Map Text (Macro.TypecheckResult CExpr)
+typecheckMacros bodies =
+    Map.mapKeysMonotonic (.getIdentifier) $ fmap convertResult $
+      CExpr.tcMacros typeOfAnn (map (.unwrap.unwrap) bodies)
   where
-    typedefs :: Set CExpr.Name
-    typedefs = Set.fromList $ [ (CExpr.Name declId.name.text)
-                              | declId <- Set.toList declsInScope
-                              , declId.name.kind == C.NameKindOrdinary ]
-
     convertResult ::
-         CExpr.MacroTcResult MacroTypecheckError C.DeclId
-      -> MacroTypecheckResult CExpr
+         CExpr.MacroTcResult C.DeclId
+      -> Macro.TypecheckResult CExpr
     convertResult = \case
       CExpr.MacroTcTypeExpr x ->
-        MacroTypecheckType  (TypecheckedMacroTypeBodyCExpr  x)
+        Macro.TypecheckType  (Macro.TypecheckedTypeCExpr  x)
       CExpr.MacroTcValueExpr x ->
-        MacroTypecheckValue (TypecheckedMacroValueBodyCExpr x)
-      CExpr.MacroTcInjectError e ->
-        MacroTypecheckError e
+        Macro.TypecheckValue (Macro.TypecheckedValueCExpr x)
       CExpr.MacroTcError err ->
-        MacroTypecheckError $
-          MacroTypecheckTypecheckError $
-            MacroLangTypecheckError (Text.unpack (CExpr.pprMacroTcError err))
-
-    injectTypeName ::
-         CExpr.CTypeSource
-      -> CExpr.Name
-      -> C.DeclId
-    injectTypeName = \case
-        CExpr.FromTypedef ->
-          \n -> C.DeclId (C.DeclName n.getName C.NameKindOrdinary) False
-        CExpr.FromMacroType ->
-          \n -> C.DeclId (C.DeclName n.getName C.NameKindMacro) False
-
-    injectValueName :: CExpr.Name -> C.DeclId
-    injectValueName (CExpr.Name n) =
-        let dn = C.DeclName{text = n , kind = C.NameKindMacro}
-        in  C.DeclId dn False
-
-    injectNonAnonTaggedTypeName ::
-         CExpr.TagKind
-      -> CExpr.Name
-      -> Except MacroTypecheckError C.DeclId
-    injectNonAnonTaggedTypeName k n =
-        if Set.member declId declsInScope then
-          pure declId
-        else
-          throwError  $ MacroTypecheckUnresolvedTaggedType declId
-      where
-        declId :: C.DeclId
-        declId = C.DeclId{
-            name = C.DeclName{
-              text = n.getName
-            , kind = C.NameKindTagged (convertTagKind k)
-            }
-          , isAnon = False
-          }
+        Macro.TypecheckError $
+            MacroTypecheckError (Text.unpack (CExpr.pprMacroTcError err))
 
 typecheckedMacroTypeDeps ::
-     TypecheckedMacroTypeBody CExpr C.DeclId
+     Macro.TypecheckedType CExpr C.DeclId
   -> [(C.ValOrRef, C.DeclId)]
-typecheckedMacroTypeDeps (TypecheckedMacroTypeBodyCExpr tcExpr) =
+typecheckedMacroTypeDeps (Macro.TypecheckedTypeCExpr tcExpr) =
     -- 'T.Expr' is a unary type-application tree, so it carries at most one variable.
     case go C.ByValue tcExpr.macroTypeBody of
       Nothing -> []

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -90,4 +90,4 @@ withHsBindgen ::
   -> Config.ConfigTH
   -> TH.BindgenM
   -> TH.Q [TH.Dec]
-withHsBindgen = TH.withHsBindgenMacroLang (pure . cExprLang)
+withHsBindgen = TH.withHsBindgenMacroLang (pure . cExpr)

--- a/hs-bindgen/test-artefacts/headers/golden/macros/macro_type_unresolved_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/macro_type_unresolved_tagged.h
@@ -1,6 +1,6 @@
 // Struct whose parse fails because of an unsupported field type (long double).
-// As a result it is absent from the declaration environment, so the macro
-// below triggers 'TypecheckMacrosErrorUnresolvedTaggedType'.
+// As a result it is absent from the declaration environment, so the macros
+// below trigger name resolution errors.
 struct Unparsable {
   long double x;
 };

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCase.hs
@@ -304,7 +304,7 @@ runTestHsBindgen report getTestResources test artefacts = do
         bindgenConfig  = BindgenConfig bootConfig frontendConfig backendConfig
     withTestTraceConfig report test $ \traceConfigUnsafe -> do
       hsBindgenEMacroLang
-        (pure . cExprLang)
+        (pure . cExpr)
         traceConfigUnsafe
         quietTracerConfig
         bindgenConfig

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -6,7 +6,6 @@ import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Interface
 import HsBindgen.TraceMsg
 
 import Test.Common.HsBindgen.Trace.Patterns
@@ -65,11 +64,13 @@ test_macros_macro_type_unresolved_tagged =
         Just $ Expected (name, "select-parse-failure")
       MatchSelect name@"macro PTR_UNPARSABLE" (TransitiveDependenciesMissing{}) ->
         Just $ Expected (name, "select-transitive-dependencies-missing")
-      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMacroTypecheckFailure MacroTypecheckUnresolvedTaggedType{}) ->
+      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMangleNamesFailure{}) ->
+        Just $ Expected (name, "select-mangle-names-failure")
+      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
-      MatchSelect name@"macro PTR_DOES_NOT_EXIST" (SelectMacroTypecheckFailure MacroTypecheckUnresolvedTaggedType{}) ->
+      MatchSelect name@"macro PTR_DOES_NOT_EXIST" (SelectMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
-      MatchSelect name@"macro DOES_NOT_EXIST" (SelectMacroTypecheckFailure MacroTypecheckUnresolvedTaggedType{}) ->
+      MatchSelect name@"macro DOES_NOT_EXIST" (SelectMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
       _otherwise ->
         Nothing
@@ -78,7 +79,7 @@ test_macros_macro_type_unresolved_tagged =
     declsWithMsgs = [
         ("struct Unparsable",        "select-parse-failure")
       , ("macro PTR_UNPARSABLE",     "select-transitive-dependencies-missing")
-      , ("macro PTR_UNPARSABLE",     "macro-unresolved-tagged-type")
+      , ("macro PTR_UNPARSABLE",     "select-mangle-names-failure")
       , ("macro PTR_DOES_NOT_EXIST", "macro-unresolved-tagged-type")
       , ("macro DOES_NOT_EXIST",     "macro-unresolved-tagged-type")
       ]

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
@@ -346,15 +346,24 @@ test_programAnalysis_selection_fail_variant_3 =
 test_programAnalysis_selection_foo :: TestCase
 test_programAnalysis_selection_foo =
     testTraceMulti "program-analysis/selection_foo" declsWithMsgs $ \case
-      MatchSelect name SelectParseFailure{} ->
-        Just $ Expected name
-      MatchSelect name (MatchTransMissing [_]) ->
-        Just $ Expected name
+      MatchSelect _name (MatchTransMissing [_]) ->
+        Just $ Expected ("macro A", "foo_t not selected")
+
+      -- We get a transient name mangler failure here because @foo_t@ is
+      -- unsupported, and so, it is not mangled.
+      MatchSelect _name SelectMangleNamesFailure{} ->
+        Just $ Expected ("macro A", "foo_t not mangled")
+      MatchSelect _name SelectParseFailure{} ->
+        Just $ Expected ("f", "unsupported underlying type")
       _otherwise ->
         Nothing
   where
-    declsWithMsgs :: [C.DeclName]
-    declsWithMsgs = ["macro A", "f"]
+    declsWithMsgs :: [(C.DeclName, String)]
+    declsWithMsgs = [
+        ("macro A", "foo_t not selected")
+      , ("macro A", "foo_t not mangled")
+      , ("f", "unsupported underlying type")
+      ]
 
 test_programAnalysis_selection_matches_c_names_1 :: TestCase
 test_programAnalysis_selection_matches_c_names_1 =

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
@@ -123,7 +123,7 @@ execFrontend getTestResources cStdStr incDirs header k =
           config         = BindgenConfig bootConfig frontendConfig backendConfig
           bootTracer     = contramap TraceBoot tracer
           frontendTracer = contramap TraceFrontend tracer
-      bootArtefact     <- runBoot bootTracer (pure . cExprLang) config [header]
+      bootArtefact     <- runBoot bootTracer (pure . cExpr) config [header]
       frontendArtefact <- runFrontend frontendTracer frontendConfig bootArtefact
       k frontendArtefact
   where


### PR DESCRIPTION
- Resolve variable names in macros when constructing the translation unit
- Do not use name injection functions

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
