### PR TITLE
Add `enum` specification to C type specification, generate `COMPLETE` pragma when `closed`

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -135,6 +135,9 @@
   #2060][is-2060] and [PR #2091][pr-2091].
 * Generate `HsBindgen.Runtime.Union.IsUnion` instances for unions and newtypes
   around unions. See [issue #2060][is-2060] and [PR #2091][pr-2091].
+* Add `enum` specification to the C type specification of binding
+  specifications, enabling users to specify a C `enum` as `closed` so that we
+  generate a `COMPLETE` pragma for the declared patterns.
 
 ### Minor changes
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -98,6 +98,7 @@ library internal
     HsBindgen.Backend.Extensions
     HsBindgen.Backend.Global
     HsBindgen.Backend.Hs.AST
+    HsBindgen.Backend.Hs.AST.CompletePragma
     HsBindgen.Backend.Hs.AST.Strategy
     HsBindgen.Backend.Hs.CallConv
     HsBindgen.Backend.Hs.Haddock.Config

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Category/ApplyChoice.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Category/ApplyChoice.hs
@@ -32,6 +32,7 @@ applyTerms = \case
         Hs.DeclEmpty{}                    -> p
         Hs.DeclNewtype{}                  -> p
         Hs.DeclPatSyn{}                   -> p
+        Hs.DeclCompletePragma{}           -> p
         Hs.DeclDefineInstance{}           -> p
         Hs.DeclDeriveInstance{}           -> p
         fi@Hs.DeclForeignImport{}         -> fi

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Extensions.hs
@@ -68,6 +68,7 @@ requiredExtensions fieldNaming = \case
     DPatternSynonym{} -> mconcat [
         ext TH.PatternSynonyms
       ]
+    DCompletePragma{} -> mempty
   where
     ext :: TH.Extension -> Set TH.Extension
     ext = Set.singleton

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -88,12 +88,14 @@ module HsBindgen.Backend.Hs.AST (
   , makeElimStruct
     -- ** Pattern Synonyms
   , PatSyn(..)
+  , CompletePragma(..)
   ) where
 
 import Data.Type.Nat (SNat, SNatI, snat)
 import Data.Type.Nat qualified as Fin
 import DeBruijn (Add (..), Ctx, EmptyCtx, Idx (..), Wk (..))
 
+import HsBindgen.Backend.Hs.AST.CompletePragma
 import HsBindgen.Backend.Hs.AST.Strategy
 import HsBindgen.Backend.Hs.CallConv
 import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
@@ -253,6 +255,7 @@ data Decl l where
     DeclEmpty                :: EmptyData            -> Decl l
     DeclNewtype              :: Newtype              -> Decl l
     DeclPatSyn               :: PatSyn               -> Decl l
+    DeclCompletePragma       :: CompletePragma       -> Decl l
     DeclDefineInstance       :: DefineInstance       -> Decl l
     DeclDeriveInstance       :: DeriveInstance       -> Decl l
     DeclForeignImport        :: ForeignImportDecl    -> Decl l

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST/CompletePragma.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST/CompletePragma.hs
@@ -1,0 +1,20 @@
+module HsBindgen.Backend.Hs.AST.CompletePragma (
+    -- * Type
+    CompletePragma(..)
+  ) where
+
+import HsBindgen.Imports
+import HsBindgen.Language.Haskell qualified as Hs
+
+{-------------------------------------------------------------------------------
+  Type
+-------------------------------------------------------------------------------}
+
+-- | @COMPLETE@ pragma
+--
+-- This corresponds to a @COMPLETE@ pragma listing the specified pattern names.
+-- No type is specified.
+data CompletePragma = CompletePragma {
+      patterns :: [Hs.Name Hs.NsConstr]
+    }
+  deriving stock (Generic, Show)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -8,6 +8,7 @@ import Control.Monad.State qualified as State hiding (MonadState)
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
+import Data.Maybe qualified as Maybe
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import DeBruijn (Add (..), Idx (..), pattern I2)
@@ -364,6 +365,7 @@ enumDecs info enum spec = do
         ++ Hs.hasFieldCompatDecs nt
         ++ Hs.hasFieldPtrDecs nt
         ++ valueDecls
+        ++ completeDecl
       where
         -- Singleton field: 'InstanceCEnum' and its siblings rely on this
         -- struct having exactly one field (the underlying enum integer).
@@ -472,6 +474,19 @@ enumDecs info enum spec = do
                 }
             | constant <- enum.constants
             ]
+
+        completeDecl :: [Hs.Decl l]
+        completeDecl = Maybe.maybeToList $ do
+          cSpec     <- spec.cSpec
+          cEnumSpec <- cSpec.enum
+          guard $ cEnumSpec == BindingSpec.CEnumClosed
+          let pragma = Hs.CompletePragma{
+                  patterns = [
+                      Hs.assertNs (Proxy @Hs.NsConstr) constant.info.name.hsName
+                    | constant <- enum.constants
+                    ]
+                }
+          return $ Hs.DeclCompletePragma pragma
 
 {-------------------------------------------------------------------------------
   Typedef

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/Decl.hs
@@ -156,6 +156,17 @@ instance Pretty SDecl where
         , "pattern" <+> pretty patSyn.name <+> "=" <+> pretty patSyn.rhs
         ]
 
+    DCompletePragma completePragma ->
+      let patterns = map pretty completePragma.patterns
+          oneLine  = PP.hlist "{-# COMPLETE " " #-}" patterns
+      in  PP.ifFits oneLine oneLine $
+            PP.vcat . ("{-# COMPLETE" :) . (++ [PP.nest 2 "#-}"]) $
+              [ if idx == (0 :: Int)
+                  then PP.nest 6 pat
+                  else PP.nest 4 ("," <+> pat)
+              | (idx, pat) <- zip [0..] patterns
+              ]
+
 {-------------------------------------------------------------------------------
   PatEpxr pretty-printing
 -------------------------------------------------------------------------------}

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
@@ -303,6 +303,8 @@ resolveDeclImports = \case
         resolveTypeImports patSyn.typ
       , resolvePatExprImports patSyn.rhs
       ]
+    DCompletePragma _completePragma ->
+      mempty
 
 -- | Resolve nested deriving clauses (part of a datatype declaration)
 resolveNestedDeriv :: [(Hs.Strategy ClosedType, [Inst.TypeClass])] -> ImportAcc
@@ -436,6 +438,7 @@ resolveDeclExports = \case
     DForeignImport foreignImport -> exportVar foreignImport.name
     DBinding binding             -> exportVar binding.name
     DPatternSynonym patSyn       -> exportPattern patSyn.name
+    DCompletePragma _            -> []
     -- Instances are automatically exported by GHC
     DInst _                      -> []
     DDerivingInstance _          -> []

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation/Doxygen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation/Doxygen.hs
@@ -204,6 +204,7 @@ sdeclIsTopLevel = \case
     DForeignImport _    -> False
     DBinding _          -> False
     DPatternSynonym _   -> False
+    DCompletePragma _   -> False
     DInst _             -> False
     DDerivingInstance _ -> False
   where
@@ -228,6 +229,7 @@ sdeclOriginCName = \case
     DForeignImport _    -> Nothing
     DBinding _          -> Nothing
     DPatternSynonym _   -> Nothing
+    DCompletePragma _   -> Nothing
     DInst _             -> Nothing
     DDerivingInstance _ -> Nothing
   where
@@ -248,6 +250,7 @@ sdeclExportedName = \case
     DForeignImport foreignImport -> termText foreignImport.name
     DBinding binding             -> termText binding.name
     DPatternSynonym patSyn       -> Just patSyn.name.text
+    DCompletePragma _            -> Nothing
     DInst _                      -> Nothing
     DDerivingInstance _          -> Nothing
   where

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/AST.hs
@@ -37,6 +37,7 @@ module HsBindgen.Backend.SHs.AST (
   ) where
 
 import HsBindgen.Backend.Global
+import HsBindgen.Backend.Hs.AST.CompletePragma qualified as Hs
 import HsBindgen.Backend.Hs.AST.Strategy qualified as Hs
 import HsBindgen.Backend.Hs.CallConv
 import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
@@ -74,6 +75,7 @@ data SDecl =
   | DForeignImport ForeignImport
   | DBinding Binding
   | DPatternSynonym PatternSynonym
+  | DCompletePragma Hs.CompletePragma
   deriving stock (Show)
 
 data TypeSynonym = TypeSynonym{

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -79,6 +79,7 @@ translateDecl macroLang = \case
   Hs.DeclForeignImportDynamic x -> translateForeignImportDynamic  x
   Hs.DeclFunction             x -> translateFunctionDecl          x
   Hs.DeclPatSyn               x -> translatePatSyn                x
+  Hs.DeclCompletePragma       x -> translateCompletePragma        x
   Hs.DeclVar                  x -> translateDeclVar               x
 
 translateDeclTypSyn :: Hs.TypSyn -> SDecl
@@ -319,6 +320,9 @@ translatePatSyn patSyn = DPatternSynonym PatternSynonym{
     , origin  = patSyn.origin
     , comment = patSyn.comment
     }
+
+translateCompletePragma :: Hs.CompletePragma -> SDecl
+translateCompletePragma = DCompletePragma
 
 {-------------------------------------------------------------------------------
   Types

--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -7,6 +7,7 @@ module HsBindgen.Backend.TH.Translation (
 
 import Control.Monad (liftM2)
 import Data.ByteString qualified as BS
+import Data.List qualified as List
 import Data.Set qualified as Set
 import Data.Text qualified as Text
 import DeBruijn (Add (..), EmptyCtx, Env (..), lookupEnv)
@@ -353,6 +354,10 @@ mkDecl fns = \case
           ]
         putLocalDocM patSyn.name patSyn.comment
         pure decls
+
+      DCompletePragma completePragma ->
+        List.singleton
+          <$> TH.pragCompleteD (map mkHsName completePragma.patterns) Nothing
     where
       simpleDecl :: TH.Name -> SExpr EmptyCtx -> q TH.Dec
       simpleDecl x f = TH.valD (TH.varP x) (TH.normalB $ mkExpr EmptyEnv f) []

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -36,6 +36,7 @@ module HsBindgen.BindingSpec (
     -- ** Types
   , Common.Omittable(..)
   , BindingSpec.CTypeSpec(..)
+  , BindingSpec.CEnumSpec(..)
   , BindingSpec.HsTypeSpec(..)
   , BindingSpec.HsTypeRep(..)
   , BindingSpec.HsRecordRep(..)

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -106,7 +106,10 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
           ] ++
           [ let headers   = getMainHeaders' sourcePath
                 cTypeSpec :: CTypeSpec
-                cTypeSpec = CTypeSpec $ Just hsName
+                cTypeSpec = CTypeSpec{
+                    hsName = Just hsName
+                  , enum   = Nothing
+                  }
             in  (cDeclId, [(headers, Require cTypeSpec)])
           | (cDeclId, (sourcePath, hsName)) <- squashedTypes
           ]
@@ -165,6 +168,7 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
     auxTypSyn typSyn =
       let cTypeSpec = BindingSpec.CTypeSpec {
               hsName = Just typSyn.name
+            , enum   = Nothing
             }
           hsTypeSpec = BindingSpec.HsTypeSpec {
               hsRep     = Just BindingSpec.HsTypeRepTypeAlias
@@ -184,6 +188,7 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
       Just originDecl ->
         let cTypeSpec = BindingSpec.CTypeSpec {
                 hsName = Just hsStruct.name
+              , enum   = Nothing
               }
             hsRecordRep = BindingSpec.HsRecordRep {
                 constructor = Just hsStruct.constr
@@ -212,6 +217,7 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
       let originDecl   = edata.origin
           cTypeSpec = BindingSpec.CTypeSpec {
               hsName = Just edata.name
+            , enum   = Nothing
             }
           hsTypeSpec = BindingSpec.HsTypeSpec {
               hsRep     = Just BindingSpec.HsTypeRepEmptyData
@@ -230,6 +236,13 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
       let originDecl   = hsNewtype.origin
           cTypeSpec    = BindingSpec.CTypeSpec {
               hsName = Just hsNewtype.name
+            , enum   =
+                case originDecl.spec.cSpec of
+                  Just spec -> spec.enum
+                  Nothing   ->
+                    case originDecl.kind of
+                      HsOrigin.Enum{} -> Just BindingSpec.CEnumOpen
+                      _otherwise      -> Nothing
             }
           hsNewtypeRep = BindingSpec.HsNewtypeRep {
               constructor = Just hsNewtype.constr

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -136,6 +136,7 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
           HsOrigin.Aux{} -> id
           _otherwise     -> insertType $ auxNewtype ntype
       Hs.DeclPatSyn{}               -> id
+      Hs.DeclCompletePragma{}       -> id
       Hs.DeclDefineInstance{}       -> id
       Hs.DeclDeriveInstance{}       -> id
       Hs.DeclForeignImport{}        -> id

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/Stdlib.hs
@@ -263,6 +263,7 @@ mkType t hsId hsTypeRep insts headers' =
     cTypeSpec :: BindingSpec.CTypeSpec
     cTypeSpec = BindingSpec.CTypeSpec {
         hsName = Just typeConstrName
+      , enum   = Nothing -- No C @enum@ types in @stdlib@
       }
 
     hsTypeSpec :: BindingSpec.HsTypeSpec

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/V1.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Private/V1.hs
@@ -23,6 +23,7 @@ module HsBindgen.BindingSpec.Private.V1 (
   , UnresolvedBindingSpec
   , ResolvedBindingSpec
   , CTypeSpec(..)
+  , CEnumSpec(..)
   , HsTypeSpec(..)
   , HsTypeRep(..)
   , HsRecordRep(..)
@@ -150,8 +151,20 @@ type ResolvedBindingSpec = BindingSpec (C.HashIncludeArg, SourcePath)
 -- | Binding specification for a C type
 data CTypeSpec = CTypeSpec {
       hsName :: Maybe (Hs.Name Hs.NsTypeConstr)
+    , enum   :: Maybe CEnumSpec -- ^ Specified for C @enum@ types
     }
   deriving stock (Show, Eq, Ord, Generic)
+
+--------------------------------------------------------------------------------
+
+-- | C @enum@ specification
+data CEnumSpec =
+    CEnumOpen   -- ^ C @enum@ may have values other than those declared
+  | CEnumClosed -- ^ C @enum@ may only have declared vlaues
+  deriving stock (Bounded, Enum, Eq, Generic, Ord, Show)
+
+instance Default CEnumSpec where
+  def = CEnumOpen
 
 --------------------------------------------------------------------------------
 
@@ -369,18 +382,20 @@ encodeYaml' = Data.Yaml.Pretty.encodePretty yamlConfig
       "cname"                 -> 11
       -- ACTypeSpec:3, AHsTypeSpec:1, AConstraintSpec:3
       "hsname"                -> 12
-      -- ACTypeSpec:4, AHsTypeSpec:2
-      "representation"        -> 13
+      -- ACTypeSpec:4
+      "enum"                  -> 13
+      -- AHsTypeSpec:2
+      "representation"        -> 14
       -- AHsTypeSpec:3
-      "instances"             -> 14
+      "instances"             -> 15
       -- AHsTypeRep:1
-      "record"                -> 15
+      "record"                -> 16
       -- AHsTypeRep:2
-      "newtype"               -> 16
+      "newtype"               -> 17
       -- HsRecordRep:1, HsNewtypeRep:1
-      "constructor"           -> 17
+      "constructor"           -> 18
       -- HsRecordRep:2, HsNewtypeRep:2
-      "fields"                -> 18
+      "fields"                -> 19
       key -> panicPure $ "Unknown key: " ++ show key
 
 {-------------------------------------------------------------------------------
@@ -630,6 +645,7 @@ data instance ARep V1 CTypeSpec = ACTypeSpec {
       headers :: [FilePath]
     , cName   :: Text
     , hsName  :: Maybe (Hs.Name Hs.NsTypeConstr)
+    , enum    :: Maybe CEnumSpec
     }
   deriving stock (Show)
 
@@ -638,10 +654,12 @@ instance Aeson.FromJSON (ARep V1 CTypeSpec) where
     aCTypeSpecHeaders <- o .:  "headers" >>= listFromJSON
     aCTypeSpecCName   <- o .:  "cname"
     aCTypeSpecHsName  <- o .:? "hsname"
+    aCTypeSpecEnum    <- o .:? "enum"
     return ACTypeSpec{
         headers = aCTypeSpecHeaders
       , cName   = aCTypeSpecCName
       , hsName  = fromARep' <$> aCTypeSpecHsName
+      , enum    = fromARep' <$> aCTypeSpecEnum
       }
 
 instance Aeson.ToJSON (ARep V1 CTypeSpec) where
@@ -649,6 +667,7 @@ instance Aeson.ToJSON (ARep V1 CTypeSpec) where
       Just ("headers" .= listToJSON arep.headers)
     , Just ("cname"   .= arep.cName)
     , ("hsname" .=) . toARep' <$> arep.hsName
+    , ("enum"   .=) . toARep' <$> arep.enum
     ]
 
 instance ARepKV V1 CTypeSpec where
@@ -664,6 +683,7 @@ instance ARepKV V1 CTypeSpec where
         }
     , CTypeSpec{
           hsName = arep.hsName
+        , enum   = arep.enum
         }
     )
 
@@ -671,6 +691,7 @@ instance ARepKV V1 CTypeSpec where
       headers = k.headers
     , cName   = k.cName
     , hsName  = v.hsName
+    , enum    = v.enum
     }
 
 deriving stock instance Show (ARepK V1 CTypeSpec)
@@ -778,7 +799,8 @@ toAOCTypeSpecs compareCDeclId cTypeMap = map snd $ List.sortBy aux [
         Require spec -> ARequire ACTypeSpec{
             headers = map (.path) (Set.toAscList headers)
           , cName   = C.renderDeclId cDeclId
-          , hsName = spec.hsName
+          , hsName  = spec.hsName
+          , enum    = spec.enum
           }
         Omit -> AOmit AKCTypeSpec{
             headers = map (.path) (Set.toAscList headers)
@@ -799,6 +821,34 @@ toAOCTypeSpecs compareCDeclId cTypeMap = map snd $ List.sortBy aux [
     headersOf = \case
       ARequire x -> x.headers
       AOmit    x -> x.headers
+
+--------------------------------------------------------------------------------
+
+newtype instance ARep V1 CEnumSpec = ACEnumSpec CEnumSpec
+  deriving stock (Show)
+
+instance ARepIso V1 CEnumSpec
+
+instance Aeson.FromJSON (ARep V1 CEnumSpec) where
+  parseJSON = Aeson.withText "CEnumSpec" $ \t ->
+    case Map.lookup t cEnumSpecFromText of
+      Just cEnumSpec -> return (ACEnumSpec cEnumSpec)
+      Nothing        -> Aeson.parseFail $
+        "unknown C enum specification: " ++ Text.unpack t
+
+instance Aeson.ToJSON (ARep V1 CEnumSpec) where
+  toJSON (ACEnumSpec cEnumSpec) = Aeson.String (cEnumSpecToText cEnumSpec)
+
+cEnumSpecToText :: CEnumSpec -> Text
+cEnumSpecToText = \case
+    CEnumOpen   -> "open"
+    CEnumClosed -> "closed"
+
+cEnumSpecFromText :: Map Text CEnumSpec
+cEnumSpecFromText = Map.fromList [
+      (cEnumSpecToText cEnumSpec, cEnumSpec)
+    | cEnumSpec <- [minBound..]
+    ]
 
 --------------------------------------------------------------------------------
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -7,6 +7,8 @@ import Control.Monad.Reader (MonadReader, ReaderT, runReaderT)
 import Control.Monad.Reader qualified as Reader
 import Control.Monad.State (MonadState, State, runState)
 import Control.Monad.State qualified as State
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Maybe (MaybeT (..))
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
@@ -248,8 +250,8 @@ resolveTop decl = Reader.ask >>= \env -> do
 -- it.
 --
 -- Type specifications that do not match declarations may themselves be mutated.
-applyPrescriptive ::
-     forall l. HasCallStack
+applyPrescriptive :: forall l.
+     HasCallStack
   => C.Decl l PreviousPass
   -> BindingSpec.CTypeSpec
   -> Maybe BindingSpec.HsTypeSpec
@@ -259,25 +261,41 @@ applyPrescriptive ::
            , (Maybe BindingSpec.CTypeSpec, Maybe BindingSpec.HsTypeSpec)
            )
        )
-applyPrescriptive decl cTypeSpec = \case
-    Nothing         -> return $ Just (decl, (Just cTypeSpec, Nothing))
-    Just hsTypeSpec -> do
-      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1447>
-      -- We should validate instances only set for supported kinds
-      -- (instances themselves are to be resolved in a separate pass)
-      (decl', hsRep) <- case hsTypeSpec.hsRep of
-        Nothing    -> return (decl, Nothing)
-        Just hsRep -> case hsRep of
-          BindingSpec.HsTypeRepRecord    recordRep  -> auxRecord recordRep
-          BindingSpec.HsTypeRepNewtype   newtypeRep -> auxNewtype newtypeRep
-          BindingSpec.HsTypeRepEmptyData            -> auxEmptyData
-          BindingSpec.HsTypeRepTypeAlias            -> auxTypeAlias
-      let hsTypeSpec' = hsTypeSpec{ BindingSpec.hsRep = hsRep }
-      return $ Just (decl', (Just cTypeSpec, Just hsTypeSpec'))
+applyPrescriptive decl cTypeSpec mHsTypeSpec = runMaybeT $ do
+    mCTypeSpec'           <- applyCTypeSpec
+    (decl', mHsTypeSpec') <- applyHsTypeSpec
+    return (decl', (mCTypeSpec', mHsTypeSpec'))
   where
+    applyCTypeSpec :: MaybeT (M l) (Maybe BindingSpec.CTypeSpec)
+    applyCTypeSpec = do
+      case (decl.kind, cTypeSpec.enum) of
+        (C.DeclEnum{}, _)       -> return ()
+        (_,            Nothing) -> return ()
+        (_,            Just{})  -> lift . State.modify' $
+          insertTrace
+            (withCallStack $ ResolveBindingSpecsEnumTypeMismatch decl.info.id)
+      return (Just cTypeSpec)
+
+    applyHsTypeSpec ::
+      MaybeT (M l) (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeSpec)
+    applyHsTypeSpec = case mHsTypeSpec of
+      Nothing         -> return (decl, Nothing)
+      Just hsTypeSpec -> do
+        -- TODO <https://github.com/well-typed/hs-bindgen/issues/1447>
+        -- We should validate instances only set for supported kinds
+        -- (instances themselves are to be resolved in a separate pass)
+        (decl', hsRep') <- case hsTypeSpec.hsRep of
+          Nothing    -> return (decl, Nothing)
+          Just hsRep -> case hsRep of
+            BindingSpec.HsTypeRepRecord    recordRep  -> auxRecord recordRep
+            BindingSpec.HsTypeRepNewtype   newtypeRep -> auxNewtype newtypeRep
+            BindingSpec.HsTypeRepEmptyData            -> auxEmptyData
+            BindingSpec.HsTypeRepTypeAlias            -> auxTypeAlias
+        return (decl', Just hsTypeSpec{ BindingSpec.hsRep = hsRep' })
+
     auxRecord ::
          BindingSpec.HsRecordRep
-      -> M l (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
+      -> MaybeT (M l) (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
     auxRecord recordRep =
       -- TODO <https://github.com/well-typed/hs-bindgen/issues/1447>
       -- We should validate the record type and number of fields.
@@ -285,15 +303,16 @@ applyPrescriptive decl cTypeSpec = \case
 
     auxNewtype ::
          BindingSpec.HsNewtypeRep
-      -> M l (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
+      -> MaybeT (M l) (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
     auxNewtype newtypeRep =
       -- TODO <https://github.com/well-typed/hs-bindgen/issues/1447>
       -- We should validate enum, typedef, or macro type
       return (decl, Just (BindingSpec.HsTypeRepNewtype newtypeRep))
 
-    auxEmptyData :: M l (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
+    auxEmptyData ::
+      MaybeT (M l) (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
     auxEmptyData = do
-      declIndex <- Reader.asks (.declIndex)
+      declIndex <- lift $ Reader.asks (.declIndex)
       -- A complete C type keeps its size and alignment, so that a 'StaticSize'
       -- instance can be generated for the empty data type.  Structs, unions, and
       -- enums carry the layout directly; a typedef is followed to its underlying
@@ -312,7 +331,7 @@ applyPrescriptive decl cTypeSpec = \case
             _otherwise        -> (False, Nothing)
       if isValid
         then do
-          State.modify' $
+          lift . State.modify' $
               insertTrace (withCallStack $ ResolveBindingSpecsPreEmptyData decl.info.id)
             . insertOpaquedType decl.info.id
           -- Cannot use record update because 'C.kind' is ambiguous
@@ -323,11 +342,12 @@ applyPrescriptive decl cTypeSpec = \case
                 }
           return (decl', Just BindingSpec.HsTypeRepEmptyData)
         else do
-          State.modify' $
+          lift . State.modify' $
             insertTrace (withCallStack $ ResolveBindingSpecsPreEmptyDataInvalid decl.info.id)
           return (decl, Nothing)
 
-    auxTypeAlias :: M l (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
+    auxTypeAlias ::
+      MaybeT (M l) (C.Decl l PreviousPass, Maybe BindingSpec.HsTypeRep)
     auxTypeAlias =
       -- TODO <https://github.com/well-typed/hs-bindgen/issues/1447>
       -- We should validate types.

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -86,6 +86,7 @@ data PrescriptiveDeclSpec = PrescriptiveDeclSpec {
 
 data ResolveBindingSpecsMsg =
     ResolveBindingSpecsModuleMismatch       Hs.ModuleName Hs.ModuleName
+  | ResolveBindingSpecsEnumTypeMismatch     C.DeclId
   | ResolveBindingSpecsExtHsRefNoIdentifier C.DeclId
   | ResolveBindingSpecsNoHsTypeSpec         C.DeclId
   | ResolveBindingSpecsOmittedType          C.DeclId
@@ -105,6 +106,9 @@ instance PrettyForTrace ResolveBindingSpecsMsg where
           <+> prettyForTrace pSpecHsModuleName
           <+> "cannot be used to generate"
           <+> prettyForTrace hsModuleName
+      ResolveBindingSpecsEnumTypeMismatch cDeclId ->
+        "C enum specification for non-enum type:"
+          <+> prettyForTrace cDeclId
       ResolveBindingSpecsExtHsRefNoIdentifier cDeclId ->
         "Haskell identifier not specified in binding specification:"
           <+> prettyForTrace cDeclId
@@ -141,6 +145,7 @@ instance PrettyForTrace ResolveBindingSpecsMsg where
 instance IsTrace Level ResolveBindingSpecsMsg where
   getDefaultLogLevel = \case
     ResolveBindingSpecsModuleMismatch{}       -> Warning
+    ResolveBindingSpecsEnumTypeMismatch{}     -> Warning
     ResolveBindingSpecsExtHsRefNoIdentifier{} -> Warning
     ResolveBindingSpecsNoHsTypeSpec{}         -> Warning
     ResolveBindingSpecsOmittedType{}          -> Info

--- a/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/attributes/visibility/types/bindingspec.yaml
@@ -141,48 +141,63 @@ ctypes:
 - headers: attributes/visibility/types.h
   cname: enum E5
   hsname: E5
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E6
   hsname: E6
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E7
   hsname: E7
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E8
   hsname: E8
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E9
   hsname: E9
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E10
   hsname: E10
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E11
   hsname: E11
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E12
   hsname: E12
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E13
   hsname: E13
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E14
   hsname: E14
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E15
   hsname: E15
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E16
   hsname: E16
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E17
   hsname: E17
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E18
   hsname: E18
+  enum: open
 - headers: attributes/visibility/types.h
   cname: enum E19
   hsname: E19
+  enum: open
 hstypes:
 - hsname: E0
   representation: emptydata

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/Example.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Foo(..)
+    , pattern Example.Bar
+    , pattern Example.Baz
+    )
+  where
+
+import qualified HsBindgen.Runtime.CEnum as CEnum
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @enum foo@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 1:6@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+newtype Foo = Foo
+  { unwrapFoo :: RIP.CUInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord)
+  deriving newtype (RIP.HasFFIType)
+
+instance Marshal.StaticSize Foo where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Foo where
+
+  readRaw =
+    \ptr0 ->
+          pure Foo
+      <*> Marshal.readRawByteOff ptr0 (0 :: Int)
+
+instance Marshal.WriteRaw Foo where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Foo unwrapFoo2 ->
+            Marshal.writeRawByteOff ptr0 (0 :: Int) unwrapFoo2
+
+deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
+
+deriving via RIP.CUInt instance RIP.Prim Foo
+
+instance CEnum.CEnum Foo where
+
+  type CEnumZ Foo = RIP.CUInt
+
+  toCEnum = Foo
+
+  fromCEnum = RIP.getField @"unwrapFoo"
+
+  declaredValues =
+    \_ ->
+      CEnum.declaredValuesFromList [(0, RIP.singleton "Bar"), (1, RIP.singleton "Baz")]
+
+  showsUndeclared = CEnum.showsWrappedUndeclared "Foo"
+
+  readPrecUndeclared =
+    CEnum.readPrecWrappedUndeclared "Foo"
+
+  isDeclared = CEnum.seqIsDeclared
+
+  mkDeclared = CEnum.seqMkDeclared
+
+instance CEnum.SequentialCEnum Foo where
+
+  minDeclaredValue = Bar
+
+  maxDeclaredValue = Baz
+
+instance Show Foo where
+
+  showsPrec = CEnum.shows
+
+instance Read Foo where
+
+  readPrec = CEnum.readPrec
+
+  readList = RIP.readListDefault
+
+  readListPrec = RIP.readListPrecDefault
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
+
+instance HasCField.HasCField Foo "unwrapFoo" where
+
+  type CFieldType Foo "unwrapFoo" = RIP.CUInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 2:3@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+pattern Bar :: Foo
+pattern Bar = Foo 0
+
+{-| __C declaration:__ @baz@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 3:3@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+pattern Baz :: Foo
+pattern Baz = Foo 1
+
+{-# COMPLETE Bar, Baz #-}

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/bindingspec.yaml
@@ -1,0 +1,34 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: binding-specs/enum/closed.h
+  cname: enum foo
+  hsname: Foo
+  enum: closed
+hstypes:
+- hsname: Foo
+  representation:
+    newtype:
+      constructor: Foo
+      fields:
+      - unwrapFoo
+  instances:
+  - CEnum
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - SequentialCEnum
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/closed/th.txt
@@ -1,0 +1,66 @@
+-- addDependentFile test-artefacts/headers/golden/binding-specs/enum/closed.h
+{-| __C declaration:__ @enum foo@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 1:6@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+newtype Foo
+    = Foo {unwrapFoo :: CUInt}
+    deriving stock (Eq, Generic, Ord)
+    deriving newtype HasFFIType
+instance StaticSize Foo
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Foo
+    where readRaw = \ptr_0 -> pure Foo <*> readRawByteOff ptr_0 (0 :: Int)
+instance WriteRaw Foo
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Foo unwrapFoo_2 -> writeRawByteOff ptr_0 (0 :: Int) unwrapFoo_2
+deriving via (EquivStorable Foo) instance Storable Foo
+deriving via CUInt instance Prim Foo
+instance CEnum Foo
+    where type CEnumZ Foo = CUInt
+          toCEnum = Foo
+          fromCEnum = getField @"unwrapFoo"
+          declaredValues = \_ -> declaredValuesFromList [(0,
+                                                          singleton "Bar"),
+                                                         (1, singleton "Baz")]
+          showsUndeclared = showsWrappedUndeclared "Foo"
+          readPrecUndeclared = readPrecWrappedUndeclared "Foo"
+          isDeclared = seqIsDeclared
+          mkDeclared = seqMkDeclared
+instance SequentialCEnum Foo
+    where minDeclaredValue = Bar
+          maxDeclaredValue = Baz
+instance Show Foo
+    where showsPrec = shows
+instance Read Foo
+    where readPrec = readPrec
+          readList = readListDefault
+          readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapFoo" Foo ty
+    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
+                              getField @"unwrapFoo" x_0)
+instance (~) ty CUInt => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapFoo")
+instance HasCField Foo "unwrapFoo"
+    where type CFieldType Foo "unwrapFoo" = CUInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 2:3@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+pattern Bar :: Foo
+pattern Bar = Foo 0
+{-| __C declaration:__ @baz@
+
+    __defined at:__ @binding-specs\/enum\/closed.h 3:3@
+
+    __exported by:__ @binding-specs\/enum\/closed.h@
+-}
+pattern Baz :: Foo
+pattern Baz = Foo 1
+{-# COMPLETE Bar, Baz #-}

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/Example.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Pt(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @struct pt@
+
+    __defined at:__ @binding-specs\/enum\/mismatch.h 1:8@
+
+    __exported by:__ @binding-specs\/enum\/mismatch.h@
+-}
+data Pt = Pt
+  { pt_x :: RIP.CDouble
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @binding-specs\/enum\/mismatch.h 1:20@
+
+         __exported by:__ @binding-specs\/enum\/mismatch.h@
+    -}
+  , pt_y :: RIP.CDouble
+    {- ^ __C declaration:__ @y@
+
+         __defined at:__ @binding-specs\/enum\/mismatch.h 1:23@
+
+         __exported by:__ @binding-specs\/enum\/mismatch.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize Pt where
+
+  staticSizeOf = \_ -> (16 :: Int)
+
+  staticAlignment = \_ -> (8 :: Int)
+
+instance Marshal.ReadRaw Pt where
+
+  readRaw =
+    \ptr0 ->
+          pure Pt
+      <*> HasCField.readRaw (RIP.Proxy @"pt_x") ptr0
+      <*> HasCField.readRaw (RIP.Proxy @"pt_y") ptr0
+
+instance Marshal.WriteRaw Pt where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Pt pt_x2 pt_y3 ->
+               HasCField.writeRaw (RIP.Proxy @"pt_x") ptr0 pt_x2
+            >> HasCField.writeRaw (RIP.Proxy @"pt_y") ptr0 pt_y3
+
+deriving via Marshal.EquivStorable Pt instance RIP.Storable Pt
+
+instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_x" Pt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Pt {pt_x = y1, pt_y = RIP.getField @"pt_y" x0}
+      , RIP.getField @"pt_x" x0
+      )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "pt_x" (RIP.Ptr Pt) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"pt_x")
+
+instance HasCField.HasCField Pt "pt_x" where
+
+  type CFieldType Pt "pt_x" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 0
+
+instance (ty ~ RIP.CDouble) => RIP.CompatHasField.HasField "pt_y" Pt ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Pt {pt_y = y1, pt_x = RIP.getField @"pt_x" x0}
+      , RIP.getField @"pt_y" x0
+      )
+
+instance ( ty ~ RIP.CDouble
+         ) => RIP.HasField "pt_y" (RIP.Ptr Pt) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"pt_y")
+
+instance HasCField.HasCField Pt "pt_y" where
+
+  type CFieldType Pt "pt_y" = RIP.CDouble
+
+  offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/bindingspec.yaml
@@ -1,0 +1,28 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: binding-specs/enum/mismatch.h
+  cname: struct pt
+  hsname: Pt
+hstypes:
+- hsname: Pt
+  representation:
+    record:
+      constructor: Pt
+      fields:
+      - pt_x
+      - pt_y
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/mismatch/th.txt
@@ -1,0 +1,51 @@
+-- addDependentFile test-artefacts/headers/golden/binding-specs/enum/mismatch.h
+{-| __C declaration:__ @struct pt@
+
+    __defined at:__ @binding-specs\/enum\/mismatch.h 1:8@
+
+    __exported by:__ @binding-specs\/enum\/mismatch.h@
+-}
+data Pt
+    = Pt {pt_x :: CDouble
+          {- ^ __C declaration:__ @x@
+
+               __defined at:__ @binding-specs\/enum\/mismatch.h 1:20@
+
+               __exported by:__ @binding-specs\/enum\/mismatch.h@
+          -},
+          pt_y :: CDouble
+          {- ^ __C declaration:__ @y@
+
+               __defined at:__ @binding-specs\/enum\/mismatch.h 1:23@
+
+               __exported by:__ @binding-specs\/enum\/mismatch.h@
+          -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Pt
+    where staticSizeOf = \_ -> 16 :: Int
+          staticAlignment = \_ -> 8 :: Int
+instance ReadRaw Pt
+    where readRaw = \ptr_0 -> (pure Pt <*> readRaw (Proxy @"pt_x") ptr_0) <*> readRaw (Proxy @"pt_y") ptr_0
+instance WriteRaw Pt
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Pt pt_x_2
+                                          pt_y_3 -> writeRaw (Proxy @"pt_x") ptr_0 pt_x_2 >> writeRaw (Proxy @"pt_y") ptr_0 pt_y_3
+deriving via (EquivStorable Pt) instance Storable Pt
+instance (~) ty CDouble => HasField "pt_x" Pt ty
+    where hasField = \x_0 -> (\y_1 -> Pt{pt_x = y_1,
+                                         pt_y = getField @"pt_y" x_0},
+                              getField @"pt_x" x_0)
+instance (~) ty CDouble => HasField "pt_x" (Ptr Pt) (Ptr ty)
+    where getField = fromPtr (Proxy @"pt_x")
+instance HasCField Pt "pt_x"
+    where type CFieldType Pt "pt_x" = CDouble
+          offset# = \_ -> \_ -> 0
+instance (~) ty CDouble => HasField "pt_y" Pt ty
+    where hasField = \x_0 -> (\y_1 -> Pt{pt_y = y_1,
+                                         pt_x = getField @"pt_x" x_0},
+                              getField @"pt_y" x_0)
+instance (~) ty CDouble => HasField "pt_y" (Ptr Pt) (Ptr ty)
+    where getField = fromPtr (Proxy @"pt_y")
+instance HasCField Pt "pt_y"
+    where type CFieldType Pt "pt_y" = CDouble
+          offset# = \_ -> \_ -> 8

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/Example.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Foo(..)
+    , pattern Example.Bar
+    , pattern Example.Baz
+    )
+  where
+
+import qualified HsBindgen.Runtime.CEnum as CEnum
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @enum foo@
+
+    __defined at:__ @binding-specs\/enum\/open.h 1:6@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+newtype Foo = Foo
+  { unwrapFoo :: RIP.CUInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord)
+  deriving newtype (RIP.HasFFIType)
+
+instance Marshal.StaticSize Foo where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw Foo where
+
+  readRaw =
+    \ptr0 ->
+          pure Foo
+      <*> Marshal.readRawByteOff ptr0 (0 :: Int)
+
+instance Marshal.WriteRaw Foo where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Foo unwrapFoo2 ->
+            Marshal.writeRawByteOff ptr0 (0 :: Int) unwrapFoo2
+
+deriving via Marshal.EquivStorable Foo instance RIP.Storable Foo
+
+deriving via RIP.CUInt instance RIP.Prim Foo
+
+instance CEnum.CEnum Foo where
+
+  type CEnumZ Foo = RIP.CUInt
+
+  toCEnum = Foo
+
+  fromCEnum = RIP.getField @"unwrapFoo"
+
+  declaredValues =
+    \_ ->
+      CEnum.declaredValuesFromList [(0, RIP.singleton "Bar"), (1, RIP.singleton "Baz")]
+
+  showsUndeclared = CEnum.showsWrappedUndeclared "Foo"
+
+  readPrecUndeclared =
+    CEnum.readPrecWrappedUndeclared "Foo"
+
+  isDeclared = CEnum.seqIsDeclared
+
+  mkDeclared = CEnum.seqMkDeclared
+
+instance CEnum.SequentialCEnum Foo where
+
+  minDeclaredValue = Bar
+
+  maxDeclaredValue = Baz
+
+instance Show Foo where
+
+  showsPrec = CEnum.shows
+
+instance Read Foo where
+
+  readPrec = CEnum.readPrec
+
+  readList = RIP.readListDefault
+
+  readListPrec = RIP.readListPrecDefault
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.CompatHasField.HasField "unwrapFoo" Foo ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         Foo {unwrapFoo = y1}, RIP.getField @"unwrapFoo" x0)
+
+instance ( ty ~ RIP.CUInt
+         ) => RIP.HasField "unwrapFoo" (RIP.Ptr Foo) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapFoo")
+
+instance HasCField.HasCField Foo "unwrapFoo" where
+
+  type CFieldType Foo "unwrapFoo" = RIP.CUInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @binding-specs\/enum\/open.h 2:3@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+pattern Bar :: Foo
+pattern Bar = Foo 0
+
+{-| __C declaration:__ @baz@
+
+    __defined at:__ @binding-specs\/enum\/open.h 3:3@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+pattern Baz :: Foo
+pattern Baz = Foo 1

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/bindingspec.yaml
@@ -1,0 +1,34 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: binding-specs/enum/open.h
+  cname: enum foo
+  hsname: Foo
+  enum: open
+hstypes:
+- hsname: Foo
+  representation:
+    newtype:
+      constructor: Foo
+      fields:
+      - unwrapFoo
+  instances:
+  - CEnum
+  - Eq
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - SequentialCEnum
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/enum/open/th.txt
@@ -1,0 +1,65 @@
+-- addDependentFile test-artefacts/headers/golden/binding-specs/enum/open.h
+{-| __C declaration:__ @enum foo@
+
+    __defined at:__ @binding-specs\/enum\/open.h 1:6@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+newtype Foo
+    = Foo {unwrapFoo :: CUInt}
+    deriving stock (Eq, Generic, Ord)
+    deriving newtype HasFFIType
+instance StaticSize Foo
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw Foo
+    where readRaw = \ptr_0 -> pure Foo <*> readRawByteOff ptr_0 (0 :: Int)
+instance WriteRaw Foo
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Foo unwrapFoo_2 -> writeRawByteOff ptr_0 (0 :: Int) unwrapFoo_2
+deriving via (EquivStorable Foo) instance Storable Foo
+deriving via CUInt instance Prim Foo
+instance CEnum Foo
+    where type CEnumZ Foo = CUInt
+          toCEnum = Foo
+          fromCEnum = getField @"unwrapFoo"
+          declaredValues = \_ -> declaredValuesFromList [(0,
+                                                          singleton "Bar"),
+                                                         (1, singleton "Baz")]
+          showsUndeclared = showsWrappedUndeclared "Foo"
+          readPrecUndeclared = readPrecWrappedUndeclared "Foo"
+          isDeclared = seqIsDeclared
+          mkDeclared = seqMkDeclared
+instance SequentialCEnum Foo
+    where minDeclaredValue = Bar
+          maxDeclaredValue = Baz
+instance Show Foo
+    where showsPrec = shows
+instance Read Foo
+    where readPrec = readPrec
+          readList = readListDefault
+          readListPrec = readListPrecDefault
+instance (~) ty CUInt => HasField "unwrapFoo" Foo ty
+    where hasField = \x_0 -> (\y_1 -> Foo{unwrapFoo = y_1},
+                              getField @"unwrapFoo" x_0)
+instance (~) ty CUInt => HasField "unwrapFoo" (Ptr Foo) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapFoo")
+instance HasCField Foo "unwrapFoo"
+    where type CFieldType Foo "unwrapFoo" = CUInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @bar@
+
+    __defined at:__ @binding-specs\/enum\/open.h 2:3@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+pattern Bar :: Foo
+pattern Bar = Foo 0
+{-| __C declaration:__ @baz@
+
+    __defined at:__ @binding-specs\/enum\/open.h 3:3@
+
+    __exported by:__ @binding-specs\/enum\/open.h@
+-}
+pattern Baz :: Foo
+pattern Baz = Foo 1

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/macro/enum/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: binding-specs/fun_arg/macro/enum.h
   cname: enum MyEnum
   hsname: MyEnum
+  enum: open
 - headers: binding-specs/fun_arg/macro/enum.h
   cname: macro A
   hsname: A

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/fun_arg/typedef/enum/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: binding-specs/fun_arg/typedef/enum.h
   cname: enum MyEnum
   hsname: MyEnum
+  enum: open
 - headers: binding-specs/fun_arg/typedef/enum.h
   cname: A
   hsname: A

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/c2hsc/bindingspec.yaml
@@ -27,6 +27,7 @@ ctypes:
 - headers: comprehensive/c2hsc.h
   cname: enum Bar_10_
   hsname: Bar_10
+  enum: open
 - headers: comprehensive/c2hsc.h
   cname: Bar_10
   hsname: Bar_10
@@ -36,6 +37,7 @@ ctypes:
 - headers: comprehensive/c2hsc.h
   cname: enum e
   hsname: E
+  enum: open
 - headers: comprehensive/c2hsc.h
   cname: union u
   hsname: U

--- a/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/comprehensive/smoke/bindingspec.yaml
@@ -27,15 +27,18 @@ ctypes:
 - headers: comprehensive/smoke.h
   cname: enum baz2_t
   hsname: Baz2_t
+  enum: open
 - headers: comprehensive/smoke.h
   cname: baz2_t
   hsname: Baz2_t
 - headers: comprehensive/smoke.h
   cname: enum baz3_t
   hsname: Baz3_t
+  enum: open
 - headers: comprehensive/smoke.h
   cname: enum baz4_t
   hsname: Baz4_t
+  enum: open
 - headers: comprehensive/smoke.h
   cname: baz4_t
   hsname: Baz4_t

--- a/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/documentation/doxygen_docs/bindingspec.yaml
@@ -15,6 +15,7 @@ ctypes:
 - headers: documentation/doxygen_docs.h
   cname: enum color_enum
   hsname: Color_enum
+  enum: open
 - headers: documentation/doxygen_docs.h
   cname: event_callback_t
   hsname: Event_callback_t
@@ -27,6 +28,7 @@ ctypes:
 - headers: documentation/doxygen_docs.h
   cname: enum status_code_t
   hsname: Status_code_t
+  enum: open
 - headers: documentation/doxygen_docs.h
   cname: status_code_t
   hsname: Status_code_t

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/distilled_lib_1/bindingspec.yaml
@@ -12,6 +12,7 @@ ctypes:
 - headers: edge-cases/distilled_lib_1.h
   cname: enum another_typedef_enum_e
   hsname: Another_typedef_enum_e
+  enum: open
 - headers: edge-cases/distilled_lib_1.h
   cname: another_typedef_enum_e
   hsname: Another_typedef_enum_e
@@ -30,6 +31,7 @@ ctypes:
 - headers: edge-cases/distilled_lib_1.h
   cname: enum a_typedef_enum_e
   hsname: A_typedef_enum_e
+  enum: open
 - headers: edge-cases/distilled_lib_1.h
   cname: a_typedef_enum_e
   hsname: A_typedef_enum_e

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/enum_as_array_size/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: edge-cases/enum_as_array_size.h
   cname: enum test
   hsname: Test
+  enum: open
 hstypes:
 - hsname: Test
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/edge-cases/uses_utf8/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: edge-cases/uses_utf8.h
   cname: enum MyEnum
   hsname: MyEnum
+  enum: open
 hstypes:
 - hsname: MyEnum
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/functions/callbacks/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/callbacks/bindingspec.yaml
@@ -39,6 +39,7 @@ ctypes:
 - headers: functions/callbacks.h
   cname: enum @Processor_mode
   hsname: Processor_mode
+  enum: open
 - headers: functions/callbacks.h
   cname: foo
   hsname: Foo

--- a/hs-bindgen/test-artefacts/fixtures/globals/untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/globals/untagged/bindingspec.yaml
@@ -12,12 +12,15 @@ ctypes:
 - headers: globals/untagged.h
   cname: enum @anonEnum
   hsname: AnonEnum
+  enum: open
 - headers: globals/untagged.h
   cname: enum @anonEnumCoords
   hsname: AnonEnumCoords
+  enum: open
 - headers: globals/untagged.h
   cname: enum @A
   hsname: A
+  enum: open
 - headers: globals/untagged.h
   cname: union @B
   hsname: B

--- a/hs-bindgen/test-artefacts/fixtures/macros/reparse/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/reparse/bindingspec.yaml
@@ -15,6 +15,7 @@ ctypes:
 - headers: macros/reparse.h
   cname: enum some_enum
   hsname: Some_enum
+  enum: open
 - headers: macros/reparse.h
   cname: arr_typedef1
   hsname: Arr_typedef1

--- a/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/program-analysis/program_slicing_selection/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: program-analysis/program_slicing_selection.h
   cname: enum FileOperationStatus
   hsname: FileOperationStatus
+  enum: open
 - headers: program-analysis/program_slicing_selection.h
   cname: struct FileOperationRecord
   hsname: FileOperationRecord

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_cpp_syntax/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: types/enums/enum_cpp_syntax.h
   cname: enum foo_enum
   hsname: Foo_enum
+  enum: open
 - headers: types/enums/enum_cpp_syntax.h
   cname: foo_enum
   hsname: Foo_enum

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enum_unsigned_values/bindingspec.yaml
@@ -6,6 +6,7 @@ ctypes:
 - headers: types/enums/enum_unsigned_values.h
   cname: enum uint8_enum
   hsname: Uint8_enum
+  enum: open
 - headers: types/enums/enum_unsigned_values.h
   cname: uint8_enum
   hsname: Uint8_enum

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/enums/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/enums/bindingspec.yaml
@@ -6,39 +6,48 @@ ctypes:
 - headers: types/enums/enums.h
   cname: enum first
   hsname: First
+  enum: open
 - headers: types/enums/enums.h
   cname: enum second
   hsname: Second
+  enum: open
 - headers: types/enums/enums.h
   cname: enum same
   hsname: Same
+  enum: open
 - headers: types/enums/enums.h
   cname: enum nonseq
   hsname: Nonseq
+  enum: open
 - headers: types/enums/enums.h
   cname: enum packed
   hsname: Packed
+  enum: open
 - headers: types/enums/enums.h
   cname: enum enumA
   hsname: EnumA
+  enum: open
 - headers: types/enums/enums.h
   cname: enumA
   hsname: EnumA
 - headers: types/enums/enums.h
   cname: enum enumB
   hsname: EnumB
+  enum: open
 - headers: types/enums/enums.h
   cname: enumB
   hsname: EnumB
 - headers: types/enums/enums.h
   cname: enum enumC
   hsname: EnumC
+  enum: open
 - headers: types/enums/enums.h
   cname: enumC
   hsname: EnumC
 - headers: types/enums/enums.h
   cname: enum enumD
   hsname: EnumD_t
+  enum: open
 - headers: types/enums/enums.h
   cname: enumD_t
   hsname: EnumD_t

--- a/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/enums/nested_enums/bindingspec.yaml
@@ -9,12 +9,14 @@ ctypes:
 - headers: types/enums/nested_enums.h
   cname: enum enumA
   hsname: EnumA
+  enum: open
 - headers: types/enums/nested_enums.h
   cname: struct exB
   hsname: ExB
 - headers: types/enums/nested_enums.h
   cname: enum @exB_fieldB1
   hsname: ExB_fieldB1
+  enum: open
 hstypes:
 - hsname: EnumA
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/qualifiers/const_typedefs/bindingspec.yaml
@@ -15,6 +15,7 @@ ctypes:
 - headers: types/qualifiers/const_typedefs.h
   cname: enum E
   hsname: E
+  enum: open
 - headers: types/qualifiers/const_typedefs.h
   cname: TI
   hsname: TI

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/closed.h
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/closed.h
@@ -1,0 +1,4 @@
+enum foo {
+  bar,
+  baz
+};

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/closed_p.yaml
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/closed_p.yaml
@@ -1,0 +1,10 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+
+hsmodule: Example
+
+ctypes:
+  - headers: binding-specs/enum/closed.h
+    cname: enum foo
+    enum: closed

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/mismatch.h
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/mismatch.h
@@ -1,0 +1,1 @@
+struct pt { double x, y; };

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/mismatch_p.yaml
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/mismatch_p.yaml
@@ -1,0 +1,10 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+
+hsmodule: Example
+
+ctypes:
+  - headers: binding-specs/enum/mismatch.h
+    cname: struct pt
+    enum: closed

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/open.h
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/open.h
@@ -1,0 +1,4 @@
+enum foo {
+  bar,
+  baz
+};

--- a/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/open_p.yaml
+++ b/hs-bindgen/test-artefacts/headers/golden/binding-specs/enum/open_p.yaml
@@ -1,0 +1,10 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+
+hsmodule: Example
+
+ctypes:
+  - headers: binding-specs/enum/open.h
+    cname: enum foo
+    enum: open

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/BindingSpecs.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/BindingSpecs.hs
@@ -7,6 +7,7 @@ import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
+import HsBindgen.IR.C qualified as C
 import HsBindgen.TraceMsg
 
 import Test.Common.HsBindgen.Trace.Predicate
@@ -28,6 +29,10 @@ testCases = [
     , test_bindingSpecs_name_squash_struct
     , test_bindingSpecs_name_squash_typedef
     , test_bindingSpecs_name_type
+      -- * C @enum@ specification
+    , test_bindingSpecs_enum_closed
+    , test_bindingSpecs_enum_open
+    , test_bindingSpecs_enum_mismatch
       -- * Representation: emptydata
     , test_bindingSpecs_rep_emptydata_staticsize
       -- * Function arguments with typedefs
@@ -124,6 +129,38 @@ test_bindingSpecs_name_type =
     defaultTest "binding-specs/name/type"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/name/type_p.yaml"
+
+{-------------------------------------------------------------------------------
+  C @enum@ specification
+-------------------------------------------------------------------------------}
+
+test_bindingSpecs_enum_closed :: TestCase
+test_bindingSpecs_enum_closed =
+    defaultTest "binding-specs/enum/closed"
+      & #specPrescriptive .~
+          Just "test-artefacts/headers/golden/binding-specs/enum/closed_p.yaml"
+
+test_bindingSpecs_enum_open :: TestCase
+test_bindingSpecs_enum_open =
+    defaultTest "binding-specs/enum/open"
+      & #specPrescriptive .~
+          Just "test-artefacts/headers/golden/binding-specs/enum/open_p.yaml"
+
+test_bindingSpecs_enum_mismatch :: TestCase
+test_bindingSpecs_enum_mismatch =
+    testTraceSimple "binding-specs/enum/mismatch" auxTrace
+      & #specPrescriptive .~
+          Just "test-artefacts/headers/golden/binding-specs/enum/mismatch_p.yaml"
+  where
+    auxTrace :: TraceMsg -> Maybe (TraceExpectation ())
+    auxTrace traceMsg = do
+      declId <- case traceMsg of
+        TraceFrontend
+          (FrontendResolveBindingSpecs
+            (ResolveBindingSpecsEnumTypeMismatch declId)) -> Just declId
+        _otherwise -> Nothing
+      guard $ C.renderDeclId declId == "struct pt"
+      return $ Expected ()
 
 {-------------------------------------------------------------------------------
   Representation: emptydata

--- a/manual/low-level/translation/enums.md
+++ b/manual/low-level/translation/enums.md
@@ -29,7 +29,17 @@ pattern C = Index 2
 ```
 
 These patterns are not declared `COMPLETE`, because C `enum`s merely declare
-values, they do not restrict the range.
+values, they do not restrict the range.  In cases when you know that the
+declared values are the only valid values, you can use a prescriptive binding
+specification to specify that a C `enum` is closed, in which case the patterns
+are declared `COMPLETE`.
+
+```yaml
+ctypes:
+  - headers: example.h
+    cname: index
+    enum: closed
+```
 
 ### User-defined ranges
 

--- a/manual/low-level/usage/binding-specifications.md
+++ b/manual/low-level/usage/binding-specifications.md
@@ -791,6 +791,33 @@ ctypes:
       cname: struct foo
 ```
 
+C `enum`s do not *really* define new types; they merely give names to some
+values of the parent type.  However, in some applications *users* may know that
+the values declared for a specific `enum` are the only ones possible.  Key
+`enum` allows users to explicitly distinguish these cases:
+
+* `open` specifies that a C `enum` may have values others than those declared.
+  This is the default.
+
+    ```yaml
+    - headers: acme.h
+      cname: enum foo
+      enum: open
+    ```
+
+* `closed` specifies that the declared values are the only valid values of a C
+  `enum`.  In this case, `hs-bindgen` generates a `COMPLETE` pragma for the
+  declared patterns.
+
+    ```yaml
+    - headers: acme.h
+      cname: enum bar
+      enum: closed
+    ```
+
+It is invalid to specify `enum` for a non-`enum` type.  In this case, a warning
+is emitted and the `enum` specification is ignored.
+
 #### `hstypes`
 
 Description


### PR DESCRIPTION
This PR implements the following:

* New binding specification syntax:

    ```yaml
    ctypes:
      - headers: acme.h
        cname: enum foo
        hsname: Foo
        enum: closed
    ```

* Binding specification generation always specifies `enum` for `enum` types and never specifies `enum` for non-`enum` types.

* When an `enum` is declared `closed`, we now generate a `COMPLETE` pragma for the declared patterns.

* The `ResolveBindingSpecifications` pass emits a *warning* if there is an `enum` specification for a non-`enum` type.

* Golden tests are added for `open`, `closed`, and mismatch cases.

The manual and CHANGELOG are updated.