### PR TITLE
`ValOrRef` -> `Dependency`: `NeedsShape`/`NeedsNameOnly`

### DIFF
--- a/dev/nomenclature.md
+++ b/dev/nomenclature.md
@@ -6,6 +6,10 @@ nomenclature:
 - In the `Select` pass, we either _select_ or _deselect_ a declaration.
 - Prescriptive binding specifications can _omit_ types; a declaration can be
   _extern_ due to an external binding specification.
+- Edges of the `DeclUse`/`UseDecl` graph are labelled with a `Dependency`: the
+  dependent either _needs the shape_ (`NeedsShape`) or _needs the name only_
+  (`NeedsNameOnly`) of the dependency. We avoid the old _by-value_/_by-reference_
+  framing.
 
 In particular,
 - we avoid the terms _exclude_, and _skip_.

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -33,13 +33,16 @@
   [PR #2091][pr-2091].
 * The `Macro.Lang` record fields and `Macro.HasTypes` associated data families
   have been renamed. Custom macro-language backend implementors must update
-  field names (`parseMacroBody` → `parse`, `parsedMacroDeps` → `parsedDeps`,
-  `typecheckMacroBodies` → `typecheck`, etc.), data family names
-  (`ParsedMacroBody l` → `Parsed l ann`, `TypecheckedMacroTypeBody l` →
-  `TypecheckedType l`, `TypecheckedMacroValueBody l` → `TypecheckedValue l`),
-  and supply the new `resolve` field. Error types are consolidated in
-  `HsBindgen.Macro.Error`; `MacroTypecheckResult` is renamed `TypecheckResult`
-  with shortened constructors.
+  field names (`parseMacroBody` → `parse`, `typecheckMacroBodies` → `typecheck`,
+  etc.), data family names (`ParsedMacroBody l` → `Parsed l ann`,
+  `TypecheckedMacroTypeBody l` → `TypecheckedType l`, `TypecheckedMacroValueBody
+  l` → `TypecheckedValue l`), and supply the new `resolve` field. The
+  `parsedDeps` and `typecheckedTypeDeps` fields have been removed: a macro's
+  dependencies are now resolved once (during `resolve`) and stored in the `deps`
+  field of the new `Resolved` type, alongside the `Unresolved` type produced by
+  `parse`. Error types are consolidated in `HsBindgen.Macro.Error`;
+  `MacroTypecheckResult` is renamed `TypecheckResult` with shortened
+  constructors.
 * Tagged types that would clash with the name of an enclosing typedef are now
   disambiguated with a `_struct`/`_union`/`_enum` suffix (mirroring the C
   keyword) instead of the previous `_Aux`. Clash detection now also covers
@@ -61,6 +64,16 @@
   addition to `DuplicateRecordFields`). No top-level field selector is emitted,
   so an unprefixed field name can no longer clash with a non-field declaration
   of the same name; fields are accessed via `HasField`/record-dot as before.
+* The `DeclUse`/`UseDecl` graph edge label `ValOrRef` (`ByValue`/`ByRef`) has
+  been renamed to `Dependency` (`NeedsShape`/`NeedsNameOnly`), reframing the
+  label as what the dependent needs to know about the dependency rather than a
+  misleading by-value/by-reference distinction. `Dependency` now lives in the
+  new `HsBindgen.Frontend.Analysis` module (previously `ValOrRef` lived in
+  `HsBindgen.IR.C.Type`). Dependency lists (e.g. as returned by `depsOfType` and
+  stored in the `deps` field of `Macro.Resolved`) now pair each dependency as
+  `(DeclId, Dependency)`, reversing the previous `(ValOrRef, DeclId)` order.
+  Macro-language backends must update accordingly. See
+  [#1751](https://github.com/well-typed/hs-bindgen/issues/1751).
 
 ### New features
 

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -165,6 +165,7 @@ library internal
     HsBindgen.Eff
     HsBindgen.Errors
     HsBindgen.Frontend
+    HsBindgen.Frontend.Analysis
     HsBindgen.Frontend.Analysis.AnonUsage
     HsBindgen.Frontend.Analysis.DeclIndex
     HsBindgen.Frontend.Analysis.DeclIndex.ResolveMacro

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -157,7 +157,7 @@ scanAllFunctionTypes = foldMap $ \decl ->
 -- | Check if a type is defined in the current module
 isDefinedInCurrentModule :: DeclIndex l -> C.Type Final -> Bool
 isDefinedInCurrentModule declIndex =
-    any (isInDeclIndex . snd) . C.depsOfType
+    any (isInDeclIndex . fst) . C.depsOfType
   where
     isInDeclIndex :: DeclIdPair -> Bool
     isInDeclIndex declId = isJust $ DeclIndex.lookup declId.cName declIndex

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -349,8 +349,7 @@ runFrontend tracer config boot = do
       (_, knownTypes, knownMacros) <- typecheckMacrosPass
       afterPrepareReparse <- prepareReparsePass
       cStd <- boot.cStandard
-      macroLang <- boot.macroLang
-      pure $ reparseMacroExpansions cStd (Map.map coercePass knownTypes) knownMacros macroLang afterPrepareReparse
+      pure $ reparseMacroExpansions cStd (Map.map coercePass knownTypes) knownMacros afterPrepareReparse
 
     resolveBindingSpecsPass <- cache "resolveBindingSpecs" $ do
       afterReparseMacroExpansions <- reparseMacroExpansionsPass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis.hs
@@ -1,0 +1,51 @@
+-- | Common vocabulary for the analysis done in the frontend
+--
+-- Intended for unqualified import.
+module HsBindgen.Frontend.Analysis (
+    -- * Dependencies
+    Dependency(..)
+  ) where
+
+{-------------------------------------------------------------------------------
+  Dependencies
+-------------------------------------------------------------------------------}
+
+-- | Does the dependent require the dependency's full definition or only a
+-- name-level reference?
+--
+-- That is, when generating a binding for @B@ which depends on @A@, what do we
+-- need to know about @A@?
+data Dependency =
+    -- | We need to know the full shape (i.e., its size and instances) of the
+    -- dependency.
+    --
+    -- For example, when generating a binding for @B@, we need to know the shape
+    -- of @A@:
+    --
+    -- @
+    -- typedef int A;
+    -- struct B {
+    --   A fieldA;
+    -- };
+    -- @
+    NeedsShape
+    -- | We only need to know the name of the dependency.
+    --
+    -- For example, since @fieldA@ is a /pointer/ to @A@, when generating a
+    -- binding for @B@, we only need to know the name of @A@:
+    --
+    -- @
+    -- typedef int A;
+    -- struct B {
+    --   A* fieldA;
+    -- };
+    -- @
+    --
+    -- A more subtle example using a function pointer:
+    --
+    -- @
+    -- typedef int A;
+    -- typedef void (*B) (A);
+    -- @
+  | NeedsNameOnly
+  deriving stock (Eq, Ord, Show)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -67,6 +67,7 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass.Msg (DelayedReparseMacroExpansionsMsg)
+import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports hiding (toList)
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass (IsPass)
@@ -597,10 +598,12 @@ registerDelayedParseMsg (declId, msg) (DeclIndex i) = DeclIndex $
   Support for macro failures
 -------------------------------------------------------------------------------}
 
-registerMacroTypecheckFailure
-  :: (C.DeclId, SingleLoc, MacroTypecheckError) -> DeclIndex l -> DeclIndex l
-registerMacroTypecheckFailure (declId, loc, err) (DeclIndex i) = DeclIndex $
-    Map.insert declId (UnusableE $ UnusableTypecheckMacrosError loc err) i
+registerMacroTypecheckFailure ::
+     DeclIndex l
+  -> (C.DeclInfo TypecheckMacros, MacroTypecheckError)
+  -> DeclIndex l
+registerMacroTypecheckFailure (DeclIndex i) (info, err)  = DeclIndex $
+    Map.insert info.id (UnusableE $ UnusableTypecheckMacrosError info.loc err) i
 
 {-------------------------------------------------------------------------------
   Support for @PrepareReparse@ pass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
@@ -17,6 +17,7 @@ import Clang.HighLevel.Types
 import Clang.Paths
 
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition
@@ -27,8 +28,6 @@ import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.Macro.Interface qualified as Macro
-import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Construction
@@ -36,11 +35,10 @@ import HsBindgen.Macro.Type qualified as Macro
 
 construct ::
      forall l. HasCallStack
-  => Macro.Lang l
-  -> IncludeGraph
+  => IncludeGraph
   -> DeclIndex l
   -> DeclUseGraph
-construct macroLang includeGraph declIndex = declUseGraph
+construct includeGraph declIndex = declUseGraph
   where
     -- The include graph informs us about the order of declarations which is
     -- key.
@@ -68,7 +66,7 @@ construct macroLang includeGraph declIndex = declUseGraph
     -- successfully parsed declarations, we do this in source order. This
     -- ensures that we preserve source order as much as possible in 'toDecls'
     -- (modulo dependencies).
-    verticesGraph :: Digraph C.ValOrRef C.DeclId
+    verticesGraph :: Digraph Dependency C.DeclId
     verticesGraph = foldl' (flip Digraph.insertVertex) Digraph.empty $
       map (.info.id) sortedSuccessfulDecls ++ Set.toList failedDeclIds
 
@@ -78,24 +76,24 @@ construct macroLang includeGraph declIndex = declUseGraph
     -- from the resolved (but not yet typechecked) macro body.
     insertDepsOfDeclParsedMacro ::
          C.Decl l ConstructTranslationUnit
-      -> Digraph C.ValOrRef C.DeclId
-      -> Digraph C.ValOrRef C.DeclId
+      -> Digraph Dependency C.DeclId
+      -> Digraph Dependency C.DeclId
     insertDepsOfDeclParsedMacro decl =
-      insertDeps decl.info.id (depsOfDeclParsedMacro macroLang decl.kind)
+      insertDeps decl.info.id (depsOfDeclParsedMacro decl.kind)
 
 insertDeps ::
      (HasCallStack)
   => C.DeclId
-  -> [(C.ValOrRef, C.DeclId)]
-  -> Digraph C.ValOrRef C.DeclId
-  -> Digraph C.ValOrRef C.DeclId
+  -> [(C.DeclId, Dependency)]
+  -> Digraph Dependency C.DeclId
+  -> Digraph Dependency C.DeclId
 insertDeps source = flip (foldl' aux)
   where
     aux ::
-         Digraph C.ValOrRef C.DeclId
-      -> (C.ValOrRef, C.DeclId)
-      -> Digraph C.ValOrRef C.DeclId
-    aux graph (edge, target) =
+         Digraph Dependency C.DeclId
+      -> (C.DeclId, Dependency)
+      -> Digraph Dependency C.DeclId
+    aux graph (target, edge) =
       case Digraph.insertEdgeIfVerticesExist target edge source graph of
         Digraph.InsertEdgeSuccess graph' -> graph'
         Digraph.InsertEdgeSourceVertexNotFound declId ->
@@ -105,13 +103,12 @@ insertDeps source = flip (foldl' aux)
 
 -- | Inserts dependency edges of provided declaration.
 insertDepsOfDecl ::
-     (Macro.HasTypes l, HasCallStack)
-  => Macro.Lang l
-  -> C.Decl l ReparseMacroExpansions
+     HasCallStack
+  => C.Decl l ReparseMacroExpansions
   -> DeclUseGraph
   -> DeclUseGraph
-insertDepsOfDecl macroLang decl declUseGraph = DeclUseGraph $
-    insertDeps (decl.info.id) (depsOfDecl macroLang decl.kind) declUseGraph.graph
+insertDepsOfDecl decl declUseGraph = DeclUseGraph $
+    insertDeps (decl.info.id) (depsOfDecl decl.kind) declUseGraph.graph
 
 {-------------------------------------------------------------------------------
   Deletion

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Definition.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Definition.hs
@@ -8,6 +8,7 @@ module HsBindgen.Frontend.Analysis.DeclUseGraph.Definition (
 import Data.Digraph (Digraph)
 import Data.Digraph qualified as Digraph
 
+import HsBindgen.Frontend.Analysis
 import HsBindgen.IR.C qualified as C
 
 {-------------------------------------------------------------------------------
@@ -18,11 +19,11 @@ import HsBindgen.IR.C qualified as C
 --
 -- This graph has edges from definition sites to use sites.
 data DeclUseGraph = DeclUseGraph {
-      graph :: Digraph C.ValOrRef C.DeclId
+      graph :: Digraph Dependency C.DeclId
     }
   deriving stock (Eq, Show)
 
-toDigraph :: DeclUseGraph -> Digraph C.ValOrRef C.DeclId
+toDigraph :: DeclUseGraph -> Digraph Dependency C.DeclId
 toDigraph declUseGraph = declUseGraph.graph
 
 {-------------------------------------------------------------------------------
@@ -32,7 +33,7 @@ toDigraph declUseGraph = declUseGraph.graph
 renderMermaid :: DeclUseGraph -> String
 renderMermaid declUseGraph = Digraph.renderMermaid opts declUseGraph.graph
   where
-    opts :: Digraph.VisOptions C.ValOrRef C.DeclId
+    opts :: Digraph.VisOptions Dependency C.DeclId
     opts = Digraph.VisOptions{
         visVertex = \v -> Digraph.VisVertex{
             label = Just (show v)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Query.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Query.hs
@@ -12,6 +12,7 @@ import Data.Digraph qualified as Digraph
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex)
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition
@@ -36,7 +37,7 @@ toDecls index declUseGraph =
     -- without a corresponding entry in the 'DeclIndex'.  For example, this can
     -- happen when we are using external binding specifications.
     mapMaybe (`DeclIndex.lookup` index) . Digraph.sort $
-      Digraph.filterEdges (== C.ByValue) declUseGraph.graph
+      Digraph.filterEdges (== NeedsShape) declUseGraph.graph
 
 {-------------------------------------------------------------------------------
   Transitive usage
@@ -50,11 +51,11 @@ getUseSitesTransitively declUseGraph declIds =
   Direct usage
 -------------------------------------------------------------------------------}
 
-getUseSites :: DeclUseGraph -> C.DeclId -> [(C.DeclId, C.ValOrRef)]
+getUseSites :: DeclUseGraph -> C.DeclId -> [(C.DeclId, Dependency)]
 getUseSites declUseGraph declId =
     aux $ Digraph.neighbors declId declUseGraph.graph
   where
-    aux :: Map C.DeclId (Set C.ValOrRef) -> [(C.DeclId, C.ValOrRef)]
+    aux :: Map C.DeclId (Set Dependency) -> [(C.DeclId, Dependency)]
     aux m = [
         (declId', edge)
       | (declId', edges) <- Map.toList m
@@ -64,9 +65,9 @@ getUseSites declUseGraph declId =
 getUseSitesNoSelfReferences ::
      DeclUseGraph
   -> C.DeclId
-  -> [(C.DeclId, C.ValOrRef)]
+  -> [(C.DeclId, Dependency)]
 getUseSitesNoSelfReferences graph declId =
   filter (not . isSelfReference) $ getUseSites graph declId
     where
-      isSelfReference :: (C.DeclId, C.ValOrRef) -> Bool
+      isSelfReference :: (C.DeclId, Dependency) -> Bool
       isSelfReference (declId', _usage) = declId == declId'

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -10,13 +10,12 @@ module HsBindgen.Frontend.Analysis.Deps (
 
 import GHC.Records
 
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
-import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Macro.Interface qualified as Macro
-import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Get all dependencies
@@ -25,9 +24,9 @@ import HsBindgen.Macro.Type qualified as Macro
 
 depsOfDeclWith ::
      forall l p. IsPass p
-  => (MacroBody p l -> [(C.ValOrRef, Id p)])
+  => (MacroBody p l -> [(Id p, Dependency)])
   -> C.DeclKind l p
-  -> [(C.ValOrRef, Id p)]
+  -> [(Id p, Dependency)]
 depsOfDeclWith depsOfMacro = \case
     (C.DeclStruct struct)      -> depsOfStruct struct
     (C.DeclUnion union)        -> depsOfUnion union
@@ -52,13 +51,9 @@ depsOfDeclParsedMacro ::
      ( IsPass p
      , MacroBody p ~ Macro.Resolved
      , Id p ~ C.DeclId )
-  => Macro.Lang l
-  -> C.DeclKind l p
-  -> [(C.ValOrRef, Id p)]
-depsOfDeclParsedMacro macroLang = depsOfDeclWith depsOfParsedMacro
-  where
-    depsOfParsedMacro :: Macro.Resolved l -> [(C.ValOrRef, C.DeclId)]
-    depsOfParsedMacro body = macroLang.parsedDeps body
+  => C.DeclKind l p
+  -> [(Id p, Dependency)]
+depsOfDeclParsedMacro = depsOfDeclWith (.deps)
 
 {-------------------------------------------------------------------------------
   Dependencies of declaration after @ReparseMacroExpansions@
@@ -74,65 +69,45 @@ depsOfDeclParsedMacro macroLang = depsOfDeclWith depsOfParsedMacro
 -- only refer to the /underlying types/ of the expanded macros.
 --
 depsOfDecl ::
-     Macro.HasTypes l
-  => Macro.Lang l
-  -> C.DeclKind l ReparseMacroExpansions
-  -> [(C.ValOrRef, C.DeclId)]
+     C.DeclKind l ReparseMacroExpansions
+  -> [(C.DeclId, Dependency)]
 depsOfDecl = depsOfDeclTcMacro
 
 depsOfDeclTcMacro ::
-     forall l. (Macro.HasTypes l)
-  => Macro.Lang l -> C.DeclKind l ReparseMacroExpansions -> [(C.ValOrRef, C.DeclId)]
-depsOfDeclTcMacro macroLang = depsOfDeclWith (typecheckedMacroDeps macroLang)
+     C.DeclKind l ReparseMacroExpansions
+  -> [(C.DeclId, Dependency)]
+depsOfDeclTcMacro = depsOfDeclWith typecheckedMacroDeps
 
 -- | Dependencies of typechecked macro declarations
 typecheckedMacroDeps ::
-     forall l. Macro.HasTypes l
-  => Macro.Lang l
-  -> TypecheckedMacro ReparseMacroExpansions l
-  -> [(C.ValOrRef, C.DeclId)]
-typecheckedMacroDeps macroLang = \case
-    MacroType  typ ->
-      macroLang.typecheckedTypeDeps $ fmap fromMacroTypeBodyVar typ.body
-    MacroValue val ->
-      typecheckedMacroValueDeps val.body
-  where
-    fromMacroTypeBodyVar :: MacroTypeBodyVar ReparseMacroExpansions -> C.DeclId
-    fromMacroTypeBodyVar = \case
-      MacroTypeExtBinding      x -> absurd x
-      MacroTypeBodyVar    declId -> declId
-
-    -- Collect value-level dependencies from a checked macro body. Local
-    -- arguments (lambda-bound IDs) are excluded.
-    --
-    -- On the value-level, all dependencies must be 'ByValue'.
-    typecheckedMacroValueDeps ::
-         Macro.TypecheckedValue l C.DeclId
-      -> [(C.ValOrRef, C.DeclId)]
-    typecheckedMacroValueDeps = map (C.ByValue,) . toList
+     TypecheckedMacro ReparseMacroExpansions l
+  -> [(C.DeclId, Dependency)]
+typecheckedMacroDeps = \case
+    MacroType  typ -> typ.deps
+    MacroValue val -> val.deps
 
 {-------------------------------------------------------------------------------
   Structs and unions
 -------------------------------------------------------------------------------}
 
-depsOfStruct :: IsPass p => C.Struct p -> [(C.ValOrRef, Id p)]
+depsOfStruct :: IsPass p => C.Struct p -> [(Id p, Dependency)]
 depsOfStruct struct = concat [
       concatMap depsOfField struct.fields
     , foldMap   depsOfField (C.flamStructField struct.flam)
     ]
 
-depsOfUnion :: IsPass p => C.Union p -> [(C.ValOrRef, Id p)]
+depsOfUnion :: IsPass p => C.Union p -> [(Id p, Dependency)]
 depsOfUnion union = concatMap depsOfField union.fields
 
 -- | Dependencies of struct or union field
 depsOfField :: forall a p.
      (HasField "typ" (a p) (C.Type p), IsPass p)
-  => a p -> [(C.ValOrRef, Id p)]
+  => a p -> [(Id p, Dependency)]
 depsOfField field = C.depsOfType field.typ
 
 {-------------------------------------------------------------------------------
   Typedefs
 -------------------------------------------------------------------------------}
 
-depsOfTypedef :: IsPass p => C.Typedef p -> [(C.ValOrRef, Id p)]
+depsOfTypedef :: IsPass p => C.Typedef p -> [(Id p, Dependency)]
 depsOfTypedef typedef = C.depsOfType typedef.typ

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Typedefs.hs
@@ -16,6 +16,7 @@ import Data.Map.Strict qualified as Map
 import Clang.HighLevel.Types
 
 import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph)
 import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass (ResolveBindingSpecs)
@@ -211,7 +212,7 @@ analyseTypedef declUseGraph typedefInfo typedef =
         , length useSites == 1
         ]
       where
-        useSites :: [(C.DeclId, C.ValOrRef)]
+        useSites :: [(C.DeclId, Dependency)]
         useSites = DeclUseGraph.getUseSitesNoSelfReferences declUseGraph payload.id
 
     suffixClashingPayload :: TaggedPayload -> TypedefAnalysis

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/UseDeclGraph.hs
@@ -20,6 +20,7 @@ import Data.Digraph (Digraph)
 import Data.Digraph qualified as Digraph
 import Data.Set qualified as Set
 
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition (DeclUseGraph)
 import HsBindgen.Frontend.Analysis.DeclUseGraph.Definition qualified as DeclUseGraph
 import HsBindgen.Imports
@@ -34,7 +35,7 @@ import HsBindgen.IR.C qualified as C
 -- Whenever declaration @A@ uses (depends on) declaration @B@, there is an edge
 -- from @A@ to @B@ in this graph.
 data UseDeclGraph = UseDeclGraph {
-      graph :: Digraph C.ValOrRef C.DeclId
+      graph :: Digraph Dependency C.DeclId
     }
   deriving stock (Show, Eq)
 
@@ -64,7 +65,7 @@ getStrictTransitiveDeps graph decls = getTransitiveDeps graph decls Set.\\ decls
 renderMermaid :: UseDeclGraph -> String
 renderMermaid useDeclGraph = Digraph.renderMermaid opts useDeclGraph.graph
   where
-    opts :: Digraph.VisOptions C.ValOrRef C.DeclId
+    opts :: Digraph.VisOptions Dependency C.DeclId
     opts = Digraph.VisOptions{
         visVertex = \v -> Digraph.VisVertex{
             label = Just (show v)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -9,7 +9,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit.hs
@@ -52,7 +52,7 @@ mkDeclMeta macroLang parseResults includeGraph = declMeta
     declIndex = DeclIndex.fromParseResults macroLang parseResults
 
     declUseGraph :: DeclUseGraph
-    declUseGraph = DeclUseGraph.construct macroLang includeGraph declIndex
+    declUseGraph = DeclUseGraph.construct includeGraph declIndex
 
     useDeclGraph :: UseDeclGraph
     useDeclGraph = UseDeclGraph.fromDeclUseGraph declUseGraph

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -7,7 +7,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
@@ -6,7 +6,7 @@ import HsBindgen.Frontend.Pass.AssignAnonIds.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
@@ -682,6 +682,7 @@ createMacroType hsName macroType = do
     names    <- createNewtypeNames strategy hsName
     pure TypecheckedMacroType{
         body = fmap coercePass macroType.body
+      , deps = macroType.deps
       , ann  = names
       }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
@@ -315,6 +315,7 @@ resolveMacroType macroType = do
     body' <- traverse resolveMacroTypeVar macroType.body
     pure TypecheckedMacroType{
         body = body'
+      , deps = macroType.deps
       , ann  = macroType.ann
       }
   where
@@ -331,7 +332,7 @@ resolveMacroValue ::
   -> ResolveE (TypecheckedMacroValue l MangleNames)
 resolveMacroValue macroValue = do
     body' <- traverse lookupVarPairR macroValue.body
-    pure $ TypecheckedMacroValue body'
+    pure $ TypecheckedMacroValue body' macroValue.deps
 
 instance Resolve C.Comment where
   resolve (C.Comment comment) = C.Comment <$> mapM resolve comment

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -30,7 +30,6 @@ import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.C qualified as C
 import HsBindgen.Macro.Interface qualified as Macro
-import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Top-level

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
@@ -270,8 +270,8 @@ isReferenced ::
   -> [C.Decl l Parse]
   -> Bool
 isReferenced decl fields decls =
-       decl.info.id `elem` map snd (concatMap depsOfField fields)
-    || decl.info.id `elem` map snd (concatMap depsOfStructOrUnion decls)
+       decl.info.id `elem` map fst (concatMap depsOfField fields)
+    || decl.info.id `elem` map fst (concatMap depsOfStructOrUnion decls)
   where
     depsOfStructOrUnion d = case d.kind of
         C.DeclStruct struct -> depsOfStruct struct

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -21,7 +21,7 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
   Definition

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -29,8 +29,6 @@ import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Interface qualified as Macro
-import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
   Top-level
@@ -39,16 +37,15 @@ import HsBindgen.Macro.Type qualified as Macro
 -- | Reparse declarations that have macro expansions in their type positions,
 -- using the known-types environment from 'typecheckMacros'.
 reparseMacroExpansions ::
-     forall l. Macro.HasTypes l
-  => ClangCStandard
+     forall l.
+     ClangCStandard
   -> Map LanC.CName (C.Type PrepareReparse)
      -- ^ Known non-macro names and their types (see 'ReparseEnv')
   -> Set LanC.CName
      -- ^ Known macro names (see 'ReparseEnv')
-  -> Macro.Lang l
   -> C.TranslationUnit l PrepareReparse
   -> C.TranslationUnit l ReparseMacroExpansions
-reparseMacroExpansions cStd knownNonMacroTypes knownMacros macroLang unit =
+reparseMacroExpansions cStd knownNonMacroTypes knownMacros unit =
     let (reparsedDecls, reparseState) =
           runM
             cStd
@@ -58,17 +55,16 @@ reparseMacroExpansions cStd knownNonMacroTypes knownMacros macroLang unit =
     in  C.TranslationUnit{
             decls        = reparsedDecls
           , includeGraph = unit.includeGraph
-          , meta         = updateMeta macroLang reparseState.reparseWarnings reparsedDecls unit.meta
+          , meta         = updateMeta reparseState.reparseWarnings reparsedDecls unit.meta
           }
 
 updateMeta ::
-     forall l. Macro.HasTypes l
-  => Macro.Lang l
-  -> [(C.DeclId, DelayedReparseMacroExpansionsMsg)]
+     forall l.
+     [(C.DeclId, DelayedReparseMacroExpansionsMsg)]
   -> [C.Decl l ReparseMacroExpansions]
   -> DeclMeta l
   -> DeclMeta l
-updateMeta macroLang msgs decls meta = DeclMeta{
+updateMeta msgs decls meta = DeclMeta{
       declIndex    = updatedDeclIndex
     , useDeclGraph = UseDeclGraph.fromDeclUseGraph updatedDeclUseGraph
     , declUseGraph = updatedDeclUseGraph
@@ -88,7 +84,7 @@ updateMeta macroLang msgs decls meta = DeclMeta{
     updatedDeclUseGraph :: DeclUseGraph
     updatedDeclUseGraph =
       Foldable.foldl'
-        (flip (updateDeps macroLang))
+        (flip updateDeps)
         meta.declUseGraph
         decls
 
@@ -108,13 +104,11 @@ updateMeta macroLang msgs decls meta = DeclMeta{
 -- that @foo@ depends on @B@. We have to cut the dependency to @A@ and
 -- replace it with the dependency to @B@.
 updateDeps ::
-     Macro.HasTypes l
-  => Macro.Lang l
-  -> C.Decl l ReparseMacroExpansions
+     C.Decl l ReparseMacroExpansions
   -> DeclUseGraph
   -> DeclUseGraph
-updateDeps macroLang decl graph =
-    DeclUseGraph.insertDepsOfDecl macroLang decl $
+updateDeps decl graph =
+    DeclUseGraph.insertDepsOfDecl decl $
       DeclUseGraph.deleteDeps (Set.singleton decl.info.id) graph
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -565,10 +565,11 @@ instance Resolve (Flip TypecheckedMacro l) l where
 
 instance Resolve (TypecheckedMacroType l) l where
   resolve ctx = \case
-      (TypecheckedMacroType body ann) -> do
+      (TypecheckedMacroType body deps ann) -> do
         body' <- traverse resolveVar body
         pure TypecheckedMacroType{
             body = body'
+          , deps = deps
           , ann  = ann
           }
     where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -10,7 +10,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros.hs
@@ -2,7 +2,6 @@ module HsBindgen.Frontend.Pass.TypecheckMacros (
     typecheckMacros
   ) where
 
-import Data.Either (partitionEithers)
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 
@@ -43,17 +42,15 @@ typecheckMacros ::
 typecheckMacros macroLang unit =
     let knownTypes =
           collectKnownTypes unit.decls
-        (tcRes, resolvedMacros) =
+        (typecheckedDecls, knownMacroTypes, failedMacros) =
           typecheckDecls macroLang unit.decls
-        (failedMacros, typecheckedDecls) =
-          partitionEithers tcRes
     in  ( reconstructAfterTypecheck unit failedMacros typecheckedDecls
         , Map.fromList [
               (n, v)
             | (declId, v) <- Map.toList knownTypes
             , Just n <- [C.renderNonAnonDeclId declId]
             ]
-        , resolvedMacros
+        , knownMacroTypes
         )
 
 reconstructAfterTypecheck ::
@@ -68,7 +65,7 @@ reconstructAfterTypecheck unit failedMacros decls =
       , meta         = unit.meta{
             declIndex =
               Foldable.foldl'
-                (flip DeclIndex.registerMacroTypecheckFailure)
+                DeclIndex.registerMacroTypecheckFailure
                 unit.meta.declIndex
                 failedMacros
           }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -7,6 +7,7 @@ module HsBindgen.Frontend.Pass.TypecheckMacros.IsPass (
   , MacroTypeBodyVar(..)
   ) where
 
+import HsBindgen.Frontend.Analysis (Dependency)
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass (ReparseInfo, Tokens)
 import HsBindgen.Imports
@@ -68,11 +69,13 @@ data TypecheckedMacro p l =
 -- | Checked type macro
 data TypecheckedMacroType l p = Macro.HasTypes l => TypecheckedMacroType{
       body :: Macro.TypecheckedType l (MacroTypeBodyVar p)
+    , deps :: [(C.DeclId, Dependency)]
     , ann  :: Ann "TypecheckedMacroType" p
     }
 
 data TypecheckedMacroValue l p = Macro.HasTypes l => TypecheckedMacroValue {
       body :: Macro.TypecheckedValue l (Id p)
+    , deps :: [(C.DeclId, Dependency)]
     }
 
 deriving stock instance IsPass p => Show (TypecheckedMacro      p l)
@@ -118,16 +121,18 @@ instance (
     , ExtBinding p ~ ExtBinding p'
     , Ann "TypecheckedMacroType" p ~ Ann "TypecheckedMacroType" p'
     ) => CoercePass (TypecheckedMacroType l) p p' where
-  coercePass (TypecheckedMacroType body ann) =
+  coercePass (TypecheckedMacroType body deps ann) =
     TypecheckedMacroType{
         body = fmap coercePass body
+      , deps = deps
       , ann  = ann
       }
 
 instance CoercePassId p p' => CoercePass (TypecheckedMacroValue l) p p' where
-  coercePass (TypecheckedMacroValue body) =
+  coercePass (TypecheckedMacroValue body deps) =
     TypecheckedMacroValue{
         body = fmap (coercePassId (Proxy @'(p, p'))) body
+      , deps = deps
       }
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Typecheck.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/Typecheck.hs
@@ -3,13 +3,12 @@ module HsBindgen.Frontend.Pass.TypecheckMacros.Typecheck (
   , typecheckDecls
   ) where
 
-import Data.Foldable qualified as Foldable
+import Data.Either
 import Data.Map qualified as Map
 import Data.Set qualified as Set
 
-import Clang.HighLevel.Types
-
-import HsBindgen.Errors (panicPure)
+import HsBindgen.Errors
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
@@ -22,127 +21,117 @@ import HsBindgen.Macro.Type qualified as Macro
 type In    = ConstructTranslationUnit
 type Out   = TypecheckMacros
 
-type FailedMacro = (C.DeclId, SingleLoc, MacroTypecheckError)
+type FailedMacro = (C.DeclInfo Out, MacroTypecheckError)
 
 {-------------------------------------------------------------------------------
-  Traversal 2: Typecheck macros
+  Typecheck macros
 -------------------------------------------------------------------------------}
 
 -- | Typecheck all macro declarations, threading non-macro declarations through
 -- unchanged.
 --
--- Returns the per-declaration results together with @resolvedMacroTypes@, the
--- mapping from macro names to their underlying C types (used by the reparse
--- environment).
+-- Returns the typechecked declarations, the set of names of type-like macros
+-- (used by the reparse environment), and the macros that failed to typecheck.
 typecheckDecls ::
      forall l. Macro.HasTypes l
   => Macro.Lang l
   -> [C.Decl l In]
-  -> ([Either FailedMacro (C.Decl l Out)], Set Text)
+  -> ([C.Decl l Out], Set Text, [FailedMacro])
 typecheckDecls macroLang decls =
-    merge typecheckedMacros decls
+    (successes, getKnownMacroTypes successes, failures)
   where
-    parsedMacros :: [Macro.Resolved l]
-    parsedMacros = mapMaybe getParsedMacro decls
+    tcResults :: Map Text (Macro.TypecheckResult l)
+    tcResults = macroLang.typecheck (mapMaybe getResolvedMacro decls)
 
-    typecheckedMacros :: Map Text (Macro.TypecheckResult l)
-    typecheckedMacros =
-      macroLang.typecheck parsedMacros
+    failures  :: [FailedMacro]
+    successes :: [C.Decl l Out]
+    (failures, successes) = partitionEithers (map (toOutcome tcResults) decls)
 
-{-------------------------------------------------------------------------------
-  Interleaving: thread typechecked macros back into declaration order
--------------------------------------------------------------------------------}
-
-getParsedMacro :: C.Decl l In -> Maybe (Macro.Resolved l)
-getParsedMacro decl = case decl.kind of
+getResolvedMacro :: C.Decl l In -> Maybe (Macro.Resolved l)
+getResolvedMacro decl = case decl.kind of
     C.DeclMacro macro -> Just macro
     _otherwise        -> Nothing
 
-data CoerceResult l =
-    NonMacro (C.Decl l Out)
-  | Macro    (C.DeclInfo Out)
+{-------------------------------------------------------------------------------
+  Process a single declaration
+-------------------------------------------------------------------------------}
 
-coerceDecl ::
-     C.Decl l In
-  -> CoerceResult l
-coerceDecl decl = case decl.kind of
-    C.DeclMacro            _ -> Macro info'
-    C.DeclTypedef          k -> nonMacro $ C.DeclTypedef          $ coercePass k
-    C.DeclStruct           k -> nonMacro $ C.DeclStruct           $ coercePass k
-    C.DeclUnion            k -> nonMacro $ C.DeclUnion            $ coercePass k
-    C.DeclEnum             k -> nonMacro $ C.DeclEnum             $ coercePass k
-    C.DeclAnonEnumConstant k -> nonMacro $ C.DeclAnonEnumConstant $ coercePass k
-    C.DeclOpaque mSize       -> nonMacro $ C.DeclOpaque mSize
-    C.DeclFunction         k -> nonMacro $ C.DeclFunction         $ coercePass k
-    C.DeclGlobal           k -> nonMacro $ C.DeclGlobal           $ coercePass k
+-- | The outcome of processing a single declaration: a macro that failed to
+-- typecheck (dropped from the output), or a declaration to keep (a non-macro,
+-- or a successfully typechecked macro).
+type Outcome l = Either FailedMacro (C.Decl l Out)
+
+-- | Coerce a non-macro declaration to the output pass, or assemble a macro from
+-- its typecheck result.
+toOutcome ::
+     forall l. Macro.HasTypes l
+  => Map Text (Macro.TypecheckResult l)
+  -> C.Decl l In
+  -> Outcome l
+toOutcome tcResults decl = case decl.kind of
+    C.DeclMacro            x -> assembleMacro tcResults info' decl.ann x
+    C.DeclTypedef          x -> nonMacro $ C.DeclTypedef          $ coercePass x
+    C.DeclStruct           x -> nonMacro $ C.DeclStruct           $ coercePass x
+    C.DeclUnion            x -> nonMacro $ C.DeclUnion            $ coercePass x
+    C.DeclEnum             x -> nonMacro $ C.DeclEnum             $ coercePass x
+    C.DeclAnonEnumConstant x -> nonMacro $ C.DeclAnonEnumConstant $ coercePass x
+    C.DeclOpaque           x -> nonMacro $ C.DeclOpaque             x
+    C.DeclFunction         x -> nonMacro $ C.DeclFunction         $ coercePass x
+    C.DeclGlobal           x -> nonMacro $ C.DeclGlobal           $ coercePass x
   where
     info' :: C.DeclInfo Out
     info' = coercePass decl.info
 
-    nonMacro :: C.DeclKind l Out -> CoerceResult l
-    nonMacro kind' = NonMacro (C.Decl info' kind' decl.ann)
+    nonMacro :: C.DeclKind l Out -> Outcome l
+    nonMacro kind' = Right $ C.Decl info' kind' decl.ann
 
--- | Merge typechecked macro results back into the original declarations
-merge ::
-     forall l. Macro.HasTypes l
-  => Map Text (Macro.TypecheckResult l)
-  -> [C.Decl l In]
-  -> ([Either FailedMacro (C.Decl l Out)], Set Text)
-merge checkedMacros =
-    first reverse . Foldable.foldl' step ([], Set.empty)
-  where
-    step ::
-         ([Either FailedMacro (C.Decl l Out)], Set Text)
-      -> C.Decl l In
-      -> ([Either FailedMacro (C.Decl l Out)], Set Text)
-    step (eDecls, resolvedMacroTypes) decl = case coerceDecl decl of
-      NonMacro decl' -> (Right decl' : eDecls, resolvedMacroTypes)
-      Macro    info' ->
-        let macroName = info'.id.name.text
-        in  case Map.lookup macroName checkedMacros of
-              Nothing ->
-                panicPure $ "merge: typechecked macro unavailable: "
-                          <> show macroName
-              Just checkedMacro ->
-                ( fromMacroTcResult info' checkedMacro : eDecls
-                , addKnownMacro
-                    macroName
-                    checkedMacro
-                    resolvedMacroTypes
-                )
-
-fromMacroTcResult ::
+-- | Assemble a macro declaration from its (pre-computed) batch typecheck result,
+-- reporting failure if typechecking did not succeed.
+assembleMacro ::
      Macro.HasTypes l
-  => C.DeclInfo Out
+  => Map Text (Macro.TypecheckResult l)
+  -> C.DeclInfo Out
+  -> Ann "Decl" Out
+  -> Macro.Resolved l
+  -> Outcome l
+assembleMacro tcResults info ann resolved =
+    case Map.lookup info.id.name.text tcResults of
+      Nothing ->
+        panicPure $
+          "assembleMacro: typechecked macro unavailable: "
+            <> show info.id.name.text
+      Just tcRes -> case fromTcResult resolved.deps tcRes of
+        Left  err  -> Left (info, err)
+        Right body -> Right (C.Decl info (C.DeclMacro body) ann)
+
+-- | Build the typechecked macro body from its typecheck result and (previously
+-- resolved) dependencies.
+fromTcResult ::
+     Macro.HasTypes l
+  => [(C.DeclId, Dependency)]
   -> Macro.TypecheckResult l
-  -> Either FailedMacro (C.Decl l Out)
-fromMacroTcResult info = \case
-    Macro.TypecheckType  x ->
-      Right $ toDecl $
-        MacroType $ TypecheckedMacroType (fmap MacroTypeBodyVar x) NoAnn
+  -> Either MacroTypecheckError (TypecheckedMacro TypecheckMacros l)
+fromTcResult deps = \case
+    Macro.TypecheckType x ->
+      Right $ MacroType $ TypecheckedMacroType (fmap MacroTypeBodyVar x) deps NoAnn
     Macro.TypecheckValue x ->
-      Right $ toDecl $
-        MacroValue $ TypecheckedMacroValue x
+      Right $ MacroValue $ TypecheckedMacroValue x deps
     Macro.TypecheckError err ->
-      Left (info.id, info.loc, err)
-  where
-    toDecl :: TypecheckedMacro Out l -> C.Decl l Out
-    toDecl checked = C.Decl{ info = info, kind = C.DeclMacro checked, ann = NoAnn }
+      Left err
 
 {-------------------------------------------------------------------------------
-  Build resolvedMacroTypes
+  Known macro types
 -------------------------------------------------------------------------------}
 
--- | Add a macro's underlying C type to the accumulator.
+-- | Names of the type-like macros among the given declarations.
 --
--- Special case: @#define bool _Bool@ from stdbool.h is normalised so that
--- @bool@ renders identically to @_Bool@ regardless of @language-c@ version.
-addKnownMacro ::
-     Text
-  -> Macro.TypecheckResult l
-  -> Set Text
-  -> Set Text
-addKnownMacro macroName tcRes knownMacros =
-    case tcRes of
-      Macro.TypecheckType _body -> Set.insert macroName knownMacros
-      _                         -> knownMacros
+-- The reparse environment uses these names to recognise macro-defined type
+-- names. Special case: @#define bool _Bool@ from stdbool.h is normalised so
+-- that @bool@ renders identically to @_Bool@ regardless of @language-c@
+-- version.
+getKnownMacroTypes :: [C.Decl l Out] -> Set Text
+getKnownMacroTypes decls = Set.fromList
+    [ decl.info.id.name.text
+    | decl <- decls
+    , C.DeclMacro (MacroType _) <- [decl.kind]
+    ]

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
@@ -43,7 +43,6 @@ module HsBindgen.IR.C.Type (
   , getCanonicalType
 
     -- * Queries
-  , ValOrRef(..)
   , depsOfType
   , depsOfTypeFunArg
   , hasUnsupportedType
@@ -65,6 +64,7 @@ import Data.Foldable qualified as Foldable
 import Data.Set qualified as Set
 
 import HsBindgen.Errors (panicPure)
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Imports
 import HsBindgen.IR.C.Naming qualified as C
 import HsBindgen.IR.Pass.Ann
@@ -571,16 +571,14 @@ getErasedType = normalize
   Queries
 -------------------------------------------------------------------------------}
 
-data ValOrRef = ByValue | ByRef
-  deriving stock (Eq, Ord, Show)
-
 -- | The declarations this type depends on (direct dependencies only)
 --
--- We also report whether this dependence is through a pointer or not.
+-- We also report what the dependent needs to know about each dependency (full
+-- shape vs. name only).
 depsOfType :: forall p.
      PassMacro p
   => Type p
-  -> [(ValOrRef, Id p)]
+  -> [(Id p, Dependency)]
 depsOfType = \case
     -- Primitive types
     TypePrim _    -> []
@@ -588,11 +586,11 @@ depsOfType = \case
     TypeVoid      -> []
 
     -- Interesting cases
-    TypeRef ref         -> [(ByValue, ref)]
-    TypeEnum ref        -> [(ByValue, ref.name)]
-    TypeMacro ref       -> [(ByValue, macroIdId (Proxy @p) ref.name)]
-    TypeTypedef ref     -> [(ByValue, ref.name)]
-    TypeUnsafePointer t -> first (const ByRef) <$> depsOfType t
+    TypeRef ref         -> [(ref                           , NeedsShape)]
+    TypeEnum ref        -> [(ref.name                      , NeedsShape)]
+    TypeMacro ref       -> [(macroIdId (Proxy @p) ref.name , NeedsShape)]
+    TypeTypedef ref     -> [(ref.name                      , NeedsShape)]
+    TypeUnsafePointer t -> second (const NeedsNameOnly) <$> depsOfType t
 
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1467>
     -- We could in /principle/ use extBindingId here to implement this case
@@ -600,7 +598,7 @@ depsOfType = \case
     -- whether a type is defined in the current module; 'extBindingId' currently
     -- omits the module, so this could result in potentially incorrect
     -- conclusions (if there happens to be a /another/ type of the same name).
-    -- TypeExtBinding extBinding -> [(ByValue, extBindingId (Proxy @p) extBinding)]
+    -- TypeExtBinding extBinding -> [(NeedsShape, extBindingId (Proxy @p) extBinding)]
     TypeExtBinding _extBinding -> []
 
     -- Recurse
@@ -613,7 +611,7 @@ depsOfType = \case
 depsOfTypeFunArg ::
      PassMacro p
   => TypeFunArgF Full p
-  -> [(ValOrRef, Id p)]
+  -> [(Id p, Dependency)]
 depsOfTypeFunArg arg = depsOfType arg.typ
 
 -- | Checks if a type is unsupported by Haskell's FFI

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Interface.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Interface.hs
@@ -1,10 +1,10 @@
 -- | Pluggable macro-language interface
 --
 -- This module defines the macro language 'Lang' record type, providing the
--- macro-language implementation (parsing, typechecking, translation). Values of
--- the macro language 'Lang' can be provided by separate packages. The default
--- value uses @c-expr-dsl@, and is defined in the user-facing @hs-bindgen@
--- library as 'HsBindgen.Macro.cExprLang'.
+-- macro-language implementation (parsing, name resolution, typechecking,
+-- translation). Values of the macro language 'Lang' can be provided by separate
+-- packages. The default value uses @c-expr-dsl@, and is defined in the
+-- user-facing @hs-bindgen@ library as 'HsBindgen.Macro.cExpr'.
 --
 -- Intended for qualified import.
 --
@@ -14,6 +14,9 @@
 module HsBindgen.Macro.Interface (
     -- * Record
     Lang(..)
+    -- * Name resolution
+  , Unresolved(..)
+  , Resolved(..)
     -- * Typecheck result
   , TypecheckResult(..)
   ) where
@@ -23,67 +26,79 @@ import Clang.HighLevel.Types
 import HsBindgen.Backend.Hs.Haddock.Documentation qualified as HsDoc
 import HsBindgen.Backend.Hs.Name qualified as Hs
 import HsBindgen.Backend.SHs.AST.Expr
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Hs qualified as Hs
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Macro.Error
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Type
 
 {-------------------------------------------------------------------------------
   Record
 -------------------------------------------------------------------------------}
 
--- | A macro language: provides parsing, typechecking and translation of C macro
--- bodies.
+-- | A macro language: provides parsing, name resolution, typechecking and
+-- translation of C macros.
 --
 -- The C standard (and any other configuration) is fixed when the macro 'Lang'
 -- is constructed; the interface itself is configuration-free.
+--
+-- Note how the macro language resembles the stages of compilers: parse,
+-- resolve, typecheck, translate.
 data Lang (l :: Star) = Lang {
     -- | Parse a single macro from @libclang@ tokens.
     parse ::
          [Token TokenSpelling]
-      -> Either MacroParseError (Macro.Unresolved l)
+      -> Either MacroParseError (Unresolved l)
 
   , resolve ::
          Set C.DeclId
          -- ^ Set of declaration IDs in scope.
-      -> Macro.Unresolved l
-      -> Either MacroResolutionError (Macro.Resolved l)
-
-    -- | Dependencies of a parsed (not yet typechecked) macro.
-    --
-    -- The caller supplies name resolvers; the implementation walks the macro
-    -- AST.
-  , parsedDeps ::
-         Macro.Resolved l
-      -> [(C.ValOrRef, C.DeclId)]
+      -> Unresolved l
+      -> Either MacroResolutionError (Resolved l)
 
     -- | Batch-typecheck a sequence of macros.
   , typecheck ::
-         [Macro.Resolved l]
+         [Resolved l]
       -> Map Text (TypecheckResult l)
 
-    -- | Get dependencies of a typechecked type-like macro body.
-  , typecheckedTypeDeps ::
-         Macro.TypecheckedType l C.DeclId
-      -> [(C.ValOrRef, C.DeclId)]
-
-    -- | Translate a checked type-like macro body to an 'HsType'.
+    -- | Translate a checked type-like macro to an 'HsType'.
     --
     -- The caller supplies a function to translate variables to 'HsType'.
   , translateType ::
-         Macro.TypecheckedType l Hs.Type
+         TypecheckedType l Hs.Type
       -> Hs.Type
 
     -- | Translate a checked value-macro to a 'Binding'.
   , translateValue ::
          Hs.Name Hs.NsVar
          -- ^ Exported binding name
-      -> Macro.TypecheckedValue l Hs.TermName
+      -> TypecheckedValue l Hs.TermName
       -> Maybe HsDoc.Comment
       -> Binding
   }
+
+{-------------------------------------------------------------------------------
+  Name resolution
+-------------------------------------------------------------------------------}
+
+newtype Unresolved l = Unresolved { unwrap :: Parsed l () }
+
+deriving stock instance (HasTypes l) => Eq   (Unresolved l)
+deriving stock instance (HasTypes l) => Show (Unresolved l)
+
+data Resolved l = Resolved {
+    -- | The macro, with references resolved to 'C.DeclId's.
+    macro :: Parsed l C.DeclId
+    -- | Dependencies of the macro, paired with what the dependent needs to know
+    -- about each dependency (full shape vs. name only).
+  , deps  :: [(C.DeclId, Dependency)]
+  }
+  deriving stock (Generic)
+
+deriving stock instance (HasTypes l) => Eq   (Resolved l)
+deriving stock instance (HasTypes l) => Show (Resolved l)
 
 {-------------------------------------------------------------------------------
   Typecheck result
@@ -91,13 +106,11 @@ data Lang (l :: Star) = Lang {
 
 -- | Result of typechecking a single macro.
 --
--- @l@ is the macro-language tag, @var@ is the variable type used to represent
--- macro dependencies.
+-- @l@ is the macro-language tag.
 data TypecheckResult l
-  = TypecheckType  (Macro.TypecheckedType  l C.DeclId)
-  | TypecheckValue (Macro.TypecheckedValue l C.DeclId)
+  = TypecheckType  (TypecheckedType l C.DeclId)
+  | TypecheckValue (TypecheckedValue l C.DeclId)
   | TypecheckError MacroTypecheckError
 
-deriving stock instance Macro.HasTypes l => Show (TypecheckResult l)
-deriving stock instance Macro.HasTypes l => Eq   (TypecheckResult l)
-
+deriving stock instance HasTypes l => Show (TypecheckResult l)
+deriving stock instance HasTypes l => Eq   (TypecheckResult l)

--- a/hs-bindgen/src-internal/HsBindgen/Macro/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Macro/Type.hs
@@ -13,19 +13,15 @@
 module HsBindgen.Macro.Type (
     -- * Typeclass
     HasTypes(..)
-    -- * Name resolution
-  , Unresolved(..)
-  , Resolved(..)
   ) where
 
 import HsBindgen.Imports
-import HsBindgen.IR.C.Naming qualified as C
 
 {-------------------------------------------------------------------------------
   Typeclass
 -------------------------------------------------------------------------------}
 
--- | Types for parsing and typechecking macro bodies
+-- | Types for parsing and typechecking macros
 --
 -- Initially, we store the 'ParsedMacro' in the AST. The 'ParsedMacro'
 -- is parameterized by an annotation:
@@ -57,27 +53,12 @@ class (
   , forall var. (Show var, Eq var) => Eq   (TypecheckedValue l var)
   ) => HasTypes (l :: Star) where
 
-  -- | Body of parsed (not yet typechecked) macro. Parameterized by the
+  -- | Parsed (not yet typechecked) macro. Parameterized by the
   --   annotation type.
   data Parsed l :: Star -> Star
 
-  -- | Body of typechecked type macro. Parameterized by the variable type.
+  -- | Typechecked type macro. Parameterized by the variable type.
   data TypecheckedType  l :: Star -> Star
 
-  -- | Body of typechecked value macro. Parameterized by the variable type.
+  -- | Typechecked value macro. Parameterized by the variable type.
   data TypecheckedValue l :: Star -> Star
-
-{-------------------------------------------------------------------------------
-  Name resolution
--------------------------------------------------------------------------------}
-
-newtype Unresolved l = Unresolved { unwrap :: Parsed l () }
-
-deriving stock instance (HasTypes l) => Eq   (Unresolved l)
-deriving stock instance (HasTypes l) => Show (Unresolved l)
-
-newtype Resolved l = Resolved { unwrap :: Parsed l C.DeclId }
-  deriving stock (Generic)
-
-deriving stock instance (HasTypes l) => Eq   (Resolved l)
-deriving stock instance (HasTypes l) => Show (Resolved l)

--- a/hs-bindgen/src/HsBindgen/Macro.hs
+++ b/hs-bindgen/src/HsBindgen/Macro.hs
@@ -35,9 +35,7 @@ cExpr :: ClangCStandard -> Macro.Lang CExpr
 cExpr cStd = Macro.Lang
   { parse               = parseMacro cStd
   , resolve             = resolveMacro
-  , parsedDeps          = parsedMacroDeps
   , typecheck           = typecheckMacros
-  , typecheckedTypeDeps = typecheckedMacroTypeDeps
   , translateType       = translateMacroType
   , translateValue      = translateMacroValue
   }

--- a/hs-bindgen/src/HsBindgen/Macro/Parse.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Parse.hs
@@ -1,19 +1,16 @@
 module HsBindgen.Macro.Parse (
     parseMacro
-  , parsedMacroDeps
   ) where
 
 import C.Expr.Parse qualified as CExpr
-import C.Expr.Syntax qualified as CExpr
 
 import Clang.CStandard
 import Clang.HighLevel.Types
 
-import HsBindgen.IR.C qualified as C
 import HsBindgen.Macro.CExpr (CExpr)
 import HsBindgen.Macro.CExpr qualified as Macro
 import HsBindgen.Macro.Error
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 
 parseMacro ::
      ClangCStandard
@@ -23,31 +20,3 @@ parseMacro cStd tokens =
     case CExpr.runParser (CExpr.parseMacro cStd) tokens of
       Right macro -> Right $ Macro.Unresolved $ Macro.ParsedCExpr macro
       Left  err   -> Left  $ MacroParseError err.parseError
-
-parsedMacroDeps ::
-     Macro.Resolved CExpr
-  -> [(C.ValOrRef, C.DeclId)]
-parsedMacroDeps resolvedMacro =
-    case resolvedMacro.unwrap.unwrap of
-      CExpr.Macro _ _ _ expr -> goExpr C.ByValue expr
-  where
-    goExpr ::
-         C.ValOrRef
-      -> CExpr.Expr ctx (CExpr.Ps C.DeclId)
-      -> [(C.ValOrRef, C.DeclId)]
-    goExpr depTy = \case
-      CExpr.Term term              -> goTerm depTy term
-      -- Pointer: switch the dependency type to 'ByRef'.
-      CExpr.TyApp CExpr.Pointer xs -> concatMap (goExpr C.ByRef) xs
-      CExpr.TyApp CExpr.Const   xs -> concatMap (goExpr depTy)   xs
-      CExpr.VaApp _ _ xs           -> concatMap (goExpr depTy)   xs
-
-    goTerm ::
-         C.ValOrRef
-      -> CExpr.Term ctx (CExpr.Ps C.DeclId)
-      -> [(C.ValOrRef, C.DeclId)]
-    goTerm depTy = \case
-      CExpr.Literal{}    -> []
-      CExpr.LocalParam{} -> []
-      CExpr.Var (CExpr.XVarPs declId) _nm args ->
-        (depTy, declId) : concatMap (goExpr depTy) args

--- a/hs-bindgen/src/HsBindgen/Macro/Resolution.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Resolution.hs
@@ -6,19 +6,24 @@ import Data.Set qualified as Set
 
 import C.Expr.Syntax qualified as CExpr
 
+import HsBindgen.Frontend.Analysis
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.Macro.CExpr (CExpr)
 import HsBindgen.Macro.CExpr qualified as Macro
 import HsBindgen.Macro.Error
-import HsBindgen.Macro.Type qualified as Macro
+import HsBindgen.Macro.Interface qualified as Macro
 
 resolveMacro ::
      Set C.DeclId
   -> Macro.Unresolved CExpr
   -> Either MacroResolutionError (Macro.Resolved CExpr)
-resolveMacro declIds (Macro.Unresolved (Macro.ParsedCExpr macro)) =
-    Macro.Resolved . Macro.ParsedCExpr <$> CExpr.annotateMacro resolve macro
+resolveMacro declIds (Macro.Unresolved (Macro.ParsedCExpr macro)) = do
+    resolvedMacro <- Macro.ParsedCExpr <$> CExpr.annotateMacro resolve macro
+    pure Macro.Resolved{
+        macro = resolvedMacro
+      , deps  = getDependencies resolvedMacro
+      }
   where
     resolve :: CExpr.Name -> () -> Either MacroResolutionError C.DeclId
     resolve name _ = case name of
@@ -81,3 +86,29 @@ resolveMacro declIds (Macro.Unresolved (Macro.ParsedCExpr macro)) =
       where
         taggedId :: C.DeclId
         taggedId = C.DeclId (C.DeclName nm $ C.NameKindTagged tag) False
+
+getDependencies :: Macro.Parsed CExpr C.DeclId -> [(C.DeclId, Dependency)]
+getDependencies resolvedMacro =
+    case resolvedMacro.unwrap of
+      CExpr.Macro _ _ _ expr -> goExpr NeedsShape expr
+  where
+    goExpr ::
+         Dependency
+      -> CExpr.Expr ctx (CExpr.Ps C.DeclId)
+      -> [(C.DeclId, Dependency)]
+    goExpr depTy = \case
+      CExpr.Term term              -> goTerm depTy term
+      -- Pointer: switch the dependency to 'NeedsNameOnly'.
+      CExpr.TyApp CExpr.Pointer xs -> concatMap (goExpr NeedsNameOnly) xs
+      CExpr.TyApp CExpr.Const   xs -> concatMap (goExpr depTy)   xs
+      CExpr.VaApp _ _ xs           -> concatMap (goExpr depTy)   xs
+
+    goTerm ::
+         Dependency
+      -> CExpr.Term ctx (CExpr.Ps C.DeclId)
+      -> [(C.DeclId, Dependency)]
+    goTerm depTy = \case
+      CExpr.Literal{}    -> []
+      CExpr.LocalParam{} -> []
+      CExpr.Var (CExpr.XVarPs declId) _nm args ->
+        (declId, depTy) : concatMap (goExpr depTy) args

--- a/hs-bindgen/src/HsBindgen/Macro/Typecheck.hs
+++ b/hs-bindgen/src/HsBindgen/Macro/Typecheck.hs
@@ -1,6 +1,5 @@
 module HsBindgen.Macro.Typecheck (
     typecheckMacros
-  , typecheckedMacroTypeDeps
   ) where
 
 import Data.Map qualified as Map
@@ -8,7 +7,6 @@ import Data.Text qualified as Text
 
 import C.Expr.Syntax qualified as CExpr
 import C.Expr.Typecheck qualified as CExpr
-import C.Expr.Typecheck.Interface.Type qualified as T
 import C.Expr.Typecheck.Type qualified as CExpr
 
 import HsBindgen.Imports
@@ -17,7 +15,6 @@ import HsBindgen.Macro.CExpr (CExpr)
 import HsBindgen.Macro.CExpr qualified as Macro
 import HsBindgen.Macro.Error
 import HsBindgen.Macro.Interface qualified as Macro
-import HsBindgen.Macro.Type qualified as Macro
 
 typeOfAnn :: C.DeclId -> Maybe CExpr.QuantTy
 typeOfAnn declId = case declId.name.kind of
@@ -29,7 +26,7 @@ typecheckMacros ::
   -> Map Text (Macro.TypecheckResult CExpr)
 typecheckMacros bodies =
     Map.mapKeysMonotonic (.getIdentifier) $ fmap convertResult $
-      CExpr.tcMacros typeOfAnn (map (.unwrap.unwrap) bodies)
+      CExpr.tcMacros typeOfAnn (map (.macro.unwrap) bodies)
   where
     convertResult ::
          CExpr.MacroTcResult C.DeclId
@@ -42,19 +39,3 @@ typecheckMacros bodies =
       CExpr.MacroTcError err ->
         Macro.TypecheckError $
             MacroTypecheckError (Text.unpack (CExpr.pprMacroTcError err))
-
-typecheckedMacroTypeDeps ::
-     Macro.TypecheckedType CExpr C.DeclId
-  -> [(C.ValOrRef, C.DeclId)]
-typecheckedMacroTypeDeps (Macro.TypecheckedTypeCExpr tcExpr) =
-    -- 'T.Expr' is a unary type-application tree, so it carries at most one variable.
-    case go C.ByValue tcExpr.macroTypeBody of
-      Nothing -> []
-      Just x  -> [x]
-  where
-    go :: C.ValOrRef -> T.Expr C.DeclId -> Maybe (C.ValOrRef, C.DeclId)
-    go depTy = \case
-      T.TypeLit{}       -> Nothing
-      T.App T.Pointer e -> go C.ByRef e
-      T.App T.Const   e -> go depTy e
-      T.Var v           -> Just (depTy, v)


### PR DESCRIPTION
`ByValue`/`ByRef` naming was a misnomer: a function-pointer arg `typedef void (*F)(A)` yielded `F --by-reference--> A`, but F passes nothing by reference; it only needs A's name. Reframe the label as what the dependent needs to know (full shape vs. name only).

Also flip dependency-list element order from `(ValOrRef, DeclId)` to `(DeclId, Dependency)`, matching the natural reading "this decl needs X".

Closes #1751.

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] Did you update the manual?

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
