### PR TITLE
Parse not attempted is now "declaration unavailable"

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -186,10 +186,7 @@ usableToLoc = \case
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
 data Unusable =
-      -- Historically, there were more reasons for not attempting a parse,
-      -- that's why we store a non-empty list of reasons. We could remove this
-      -- indirection.
-      UnusableParseNotAttempted      SingleLoc (NonEmpty ParseNotAttempted)
+      UnusableParseUnavailable       SingleLoc
     | UnusableParseFailure           SingleLoc DelayedParseMsg
     | UnusableConflict               Conflict
     | UnusableMangleNamesFailure     SingleLoc MangleNamesError
@@ -202,8 +199,8 @@ data Unusable =
 
 instance PrettyForTrace Unusable where
   prettyForTrace = \case
-    UnusableParseNotAttempted{} ->
-      "Parse not attempted"
+    UnusableParseUnavailable{} ->
+      "Declaration unavailable"
     UnusableParseFailure{} ->
       "Parse failed"
     UnusableConflict{} ->
@@ -219,7 +216,7 @@ instance PrettyForTrace Unusable where
 
 unusableToLoc :: Unusable -> [SingleLoc]
 unusableToLoc = \case
-    UnusableParseNotAttempted loc _      -> [loc]
+    UnusableParseUnavailable loc         -> [loc]
     UnusableParseFailure loc _           -> [loc]
     UnusableConflict conflict            -> Conflict.toList conflict
     UnusableMangleNamesFailure loc _     -> [loc]
@@ -329,8 +326,8 @@ resolvedResultToEntry = \case
     parseResultToEntry result = case result.classification of
       ParseResultSuccess r ->
         UsableE $ UsableSuccess (parseSuccessToSuccess r)
-      ParseResultNotAttempted r ->
-        UnusableE $ UnusableParseNotAttempted result.loc $ r :| []
+      ParseResultUnavailable ->
+        UnusableE $ UnusableParseUnavailable result.loc
       ParseResultFailure r ->
         UnusableE $ UnusableParseFailure result.loc r
 
@@ -372,8 +369,10 @@ resolveMacros macroLang allDeclIds = map resolveParseResult
             , delayedParseMsgs = success.delayedParseMsgs
             }
           Left err -> Left err
-      ParseResultNotAttempted x -> Right $ ParseResultNotAttempted x
-      ParseResultFailure      x -> Right $ ParseResultFailure      x
+      ParseResultUnavailable ->
+        Right $ ParseResultUnavailable
+      ParseResultFailure x ->
+        Right $ ParseResultFailure x
 
 {-------------------------------------------------------------------------------
   Build from resolved macros

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -50,8 +50,8 @@ updateParseResult chosenNames result =
       ParseResultSuccess success -> do
         auxSuccess success <$>
           updateDefSite chosenNames success.decl.info.id
-      ParseResultNotAttempted notAttempted ->
-        auxNotAttempted notAttempted <$>
+      ParseResultUnavailable ->
+        auxUnavailable <$>
           updateDefSite chosenNames result.id
       ParseResultFailure failure ->
         auxFailure failure <$>
@@ -87,14 +87,13 @@ updateParseResult chosenNames result =
             <$> updateDeclInfo declId' success.decl.info
             <*> updateUseSites         success.decl.kind
 
-    auxNotAttempted ::
-         ParseNotAttempted
-      -> C.DeclId
+    auxUnavailable ::
+         C.DeclId
       -> ParseResult l AssignAnonIds
-    auxNotAttempted notAttempted declId' = ParseResult{
+    auxUnavailable declId' = ParseResult{
           id             = declId'
         , loc            = result.loc
-        , classification = ParseResultNotAttempted notAttempted
+        , classification = ParseResultUnavailable
         }
 
     auxFailure ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -201,7 +201,7 @@ parseDeclWith enclosing ctx parser curr = do
     parseExplicitDecl info = \_curr ->
       if | C.Unavailable <- info.availability ->
              foldContinueWith [
-                 parseDoNotAttempt info DeclarationUnavailable
+                 parseUnavailable info
                ]
          | otherwise ->
              parser enclosing ctx info curr

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
@@ -3,11 +3,10 @@ module HsBindgen.Frontend.Pass.Parse.Result (
     ParseResult(..)
   , ParseClassification(..)
   , ParseSuccess(..)
-  , ParseNotAttempted(..)
     -- * Convenience constructors
   , parseSucceed
   , parseSucceedWith
-  , parseDoNotAttempt
+  , parseUnavailable
     -- * Query
   , getParseResultMaybeDecl
   , getParseResultEitherDecl
@@ -46,7 +45,9 @@ deriving stock instance ( IsPass p
 
 data ParseClassification l p =
     ParseResultSuccess      (ParseSuccess l p)
-  | ParseResultNotAttempted ParseNotAttempted
+    -- | We unexpectedly did not parse a declaration because it is reported
+    -- "unavailable".
+  | ParseResultUnavailable
   | ParseResultFailure      DelayedParseMsg
   deriving stock (Generic)
 
@@ -56,10 +57,13 @@ deriving stock instance ( IsPass p
 
 instance PrettyForTrace (ParseClassification l p) where
   prettyForTrace = \case
-    ParseResultSuccess      x -> prettyForTrace x
-    ParseResultNotAttempted x -> prettyForTrace x
-    ParseResultFailure msg    -> PP.hang "Parse failure:" 2 $
-      prettyForTrace msg
+    ParseResultSuccess x ->
+      prettyForTrace x
+    ParseResultUnavailable ->
+      PP.hang "Parse not attempted: " 2
+        "Declaration is 'unavailable' on this platform"
+    ParseResultFailure msg ->
+      PP.hang "Parse failure:" 2 $ prettyForTrace msg
 
 data ParseSuccess l p = ParseSuccess {
       decl             :: C.Decl l p
@@ -67,16 +71,10 @@ data ParseSuccess l p = ParseSuccess {
     }
   deriving stock (Generic)
 
-deriving stock instance ( IsPass p
-                        , Macro.HasTypes l
-                        ) => Show (ParseSuccess l p)
-
--- | Why did we not attempt to parse a declaration?
-data ParseNotAttempted =
-    -- | We unexpectedly did not attempt to parse a declaration because it is
-    -- reported "unavailable".
-    DeclarationUnavailable
-  deriving stock (Show, Eq, Ord)
+deriving stock instance (
+    IsPass p
+  , Macro.HasTypes l
+  ) => Show (ParseSuccess l p)
 
 {-------------------------------------------------------------------------------
   Pretty-printing
@@ -98,10 +96,6 @@ instance PrettyForTrace (ParseSuccess l p) where
           PP.vcat $
           map prettyForTrace success.delayedParseMsgs
 
-instance PrettyForTrace ParseNotAttempted where
-  prettyForTrace = PP.hang "Parse not attempted: " 2 . \case
-    DeclarationUnavailable   -> "Declaration is 'unavailable' on this platform"
-
 {-------------------------------------------------------------------------------
   Convenience constructors
 -------------------------------------------------------------------------------}
@@ -121,12 +115,12 @@ parseSucceedWith msgs decl = ParseResult{
        }
     }
 
--- | Assemble a "parse not attempted" with a reason
-parseDoNotAttempt :: C.DeclInfo p -> ParseNotAttempted -> ParseResult l p
-parseDoNotAttempt info reason = ParseResult{
+-- | Assemble a parse result for an unavailable declaration
+parseUnavailable :: C.DeclInfo p -> ParseResult l p
+parseUnavailable info = ParseResult{
       id              = info.id
     , loc             = info.loc
-    , classification = ParseResultNotAttempted reason
+    , classification = ParseResultUnavailable
     }
 
 {-------------------------------------------------------------------------------
@@ -163,9 +157,9 @@ instance (
     , Ann "TranslationUnit" p ~ Ann "TranslationUnit" p'
     ) => CoercePass (ParseClassification l) p p' where
   coercePass = \case
-    ParseResultSuccess s      -> ParseResultSuccess (coercePass s)
-    ParseResultNotAttempted x -> ParseResultNotAttempted x
-    ParseResultFailure x      -> ParseResultFailure x
+    ParseResultSuccess s   -> ParseResultSuccess (coercePass s)
+    ParseResultUnavailable -> ParseResultUnavailable
+    ParseResultFailure x   -> ParseResultFailure x
 
 instance (
       CoercePass (C.Decl l) p p'

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -4,7 +4,6 @@ module HsBindgen.Frontend.Pass.Select (
 
 import Data.List (sortBy)
 import Data.List qualified as List
-import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
 import Data.Maybe (maybeToList)
 import Data.Ord (comparing)
@@ -164,14 +163,14 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
             getMostNaturalUnselectable l r = case (l,r) of
               (UnselectableNotSelected, Unselectable u         ) ->
                 case u of
-                  UnusableParseNotAttempted{} -> r
-                  UnusableOmitted{}           -> r
-                  _otherReason                -> l
+                  UnusableParseUnavailable{} -> r
+                  UnusableOmitted{}          -> r
+                  _otherReason               -> l
               (Unselectable u         , UnselectableNotSelected) ->
                 case u of
-                  UnusableParseNotAttempted{} -> l
-                  UnusableOmitted{}           -> l
-                  _otherReason                -> r
+                  UnusableParseUnavailable{} -> l
+                  UnusableOmitted{}          -> l
+                  _otherReason               -> r
               (_, _) -> l
 
         selectDecl :: Decl l -> Maybe (Decl l)
@@ -436,19 +435,16 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
         -- Parse messages are unavailable for squashed entries. We are OK with
         -- this; instead we have issued a notice that the @typedef@ was squashed.
         UsableSquashed x ->
-          [ withCallStack C.WithLocationInfo{
+          List.singleton $ withCallStack C.WithLocationInfo{
                 loc = C.declIdLocationInfo declId [x.typedefLoc]
               , msg = SelectMangleNamesSquashed x
               }
-          ]
       UnusableE e -> case e of
-        UnusableParseNotAttempted loc xs ->
-          [ withCallStack C.WithLocationInfo{
+        UnusableParseUnavailable loc ->
+          List.singleton $ withCallStack C.WithLocationInfo{
                 loc = C.declIdLocationInfo declId [loc]
-              , msg = SelectParseNotAttempted x
+              , msg = SelectParseUnavailable
               }
-          | x <- NonEmpty.toList xs
-          ]
         UnusableParseFailure loc x ->
           List.singleton $ withCallStack C.WithLocationInfo{
               loc = C.declIdLocationInfo declId [loc]
@@ -523,7 +519,7 @@ getDelayedMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
         UsableExternal -> []
         UsableSquashed{} -> []
       UnusableE e -> case e of
-        UnusableParseNotAttempted{} -> []
+        UnusableParseUnavailable{} -> []
         UnusableParseFailure loc x -> case getDefaultLogLevel x of
           Bug ->
             List.singleton $ withCallStack C.WithLocationInfo{
@@ -635,7 +631,7 @@ selectDeclIndex declUseGraph p declIndex =
           UsableSquashed x ->
             Just ([x.typedefLoc], C.Available)
         UnusableE e -> case e of
-          UnusableParseNotAttempted loc _ ->
+          UnusableParseUnavailable loc ->
             Just ([loc], C.Available)
           UnusableParseFailure loc _ ->
             Just ([loc], C.Available)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -164,9 +164,8 @@ data SelectMsg =
   | SelectDeprecated SelectReason
     -- | Delayed parse message.
   | SelectDelayedParseMsg DelayedParseMsg
-    -- | Delayed parse message for declarations the user wants to select
-    -- directly, but we have not attempted to parse.
-  | SelectParseNotAttempted ParseNotAttempted
+    -- | Delayed parse message for declarations that are "unavailable".
+  | SelectParseUnavailable
     -- | Delayed parse message for declarations the user wants to select
     -- directly, but we have failed to parse.
   | SelectParseFailure DelayedParseMsg
@@ -202,8 +201,8 @@ instance PrettyForTrace SelectMsg where
         withSelectReason r "Selected a deprecated declaration"
       SelectDelayedParseMsg x ->
         during x $ prettyForTrace x
-      SelectParseNotAttempted x ->
-        couldNotSelect $ prettyForTrace x
+      SelectParseUnavailable ->
+        couldNotSelect $ prettyForTrace ParseResultUnavailable
       SelectParseFailure x ->
         couldNotSelect $ prettyForTrace x
       SelectConflict ->
@@ -248,7 +247,7 @@ instance IsTrace Level SelectMsg where
     TransitiveDependenciesMissing{}          -> Warning
     SelectDeprecated{}                       -> Notice
     SelectDelayedParseMsg x                  -> getDefaultLogLevel x
-    SelectParseNotAttempted{}                -> Warning
+    SelectParseUnavailable                   -> Warning
     SelectParseFailure x                     -> getDefaultLogLevel x
     SelectConflict{}                         -> Warning
     SelectMangleNamesFailure x               -> case x of
@@ -266,7 +265,7 @@ instance IsTrace Level SelectMsg where
     TransitiveDependenciesMissing{}          -> "select"
     SelectDeprecated{}                       -> "select"
     SelectDelayedParseMsg x                  -> "select-" <> getTraceId x
-    SelectParseNotAttempted{}                -> "select-parse"
+    SelectParseUnavailable                   -> "select-parse"
     SelectParseFailure x                     -> "select-" <> getTraceId x
     SelectConflict{}                         -> "select"
     SelectMangleNamesFailure{}               -> "select-mangle-names-failure"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST.hs
@@ -85,8 +85,8 @@ simplifyAST usage parseResults = (results, msgs)
                     }]
                  , []
                  )
-        ParseResultNotAttempted notAttempted ->
-          ([ParseResult result.id result.loc (ParseResultNotAttempted notAttempted)], [])
+        ParseResultUnavailable ->
+          ([ParseResult result.id result.loc ParseResultUnavailable], [])
         ParseResultFailure failure ->
           ([ParseResult result.id result.loc (ParseResultFailure failure)], [])
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
@@ -3,7 +3,6 @@ module Test.HsBindgen.Golden.Functions (testCases) where
 
 import HsBindgen.Backend.Category
 import HsBindgen.Config.Internal
-import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
@@ -74,7 +73,7 @@ test_functions_fun_attributes =
               Just $ Expected name
             MatchSelect name SelectDeprecated{} ->
               Just $ Expected name
-            MatchSelect name (SelectParseNotAttempted DeclarationUnavailable) ->
+            MatchSelect name SelectParseUnavailable ->
               Just $ Expected name
             _otherwise ->
               Nothing


### PR DESCRIPTION
This change was long overdue; "parse not attempted" was a remnant from times with parse predicates.

Fixes #2100.
