### PR TITLE
Replace `UnionField` and `StructField` with `Field` in the C AST

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Origin.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Origin.hs
@@ -78,6 +78,6 @@ newtype PatSyn =
 
 data Field =
     GeneratedField  -- ^ Field without a direct counterpart in C
-  | StructField (C.StructField Final)
+  | StructField (C.Field Final)
   deriving stock (Generic, Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -133,10 +133,8 @@ generateDeclarations' macroLang env declIndex decs =
 scanAllFunctionTypes :: [C.Decl l Final] -> Set ([C.TypeFunArg Final], C.Type Final)
 scanAllFunctionTypes = foldMap $ \decl ->
     case decl.kind of
-      C.DeclStruct struct ->
-        foldMap (C.getAllFunTypes . (.typ)) struct.fields
-      C.DeclUnion union   ->
-        foldMap (C.getAllFunTypes . (.typ)) union.fields
+      C.DeclStruct struct -> foldMap scanField struct.fields
+      C.DeclUnion union   -> foldMap scanField union.fields
       C.DeclTypedef typedef
         -- Exclude function type indirections, because they are already handled
         -- by 'typedefFuntypeIndirectionDecs'
@@ -153,6 +151,11 @@ scanAllFunctionTypes = foldMap $ \decl ->
       C.DeclFunction fn ->
         foldMap C.getAllFunTypes (fn.res : map (.argTyp.typ) fn.args)
       C.DeclGlobal g -> C.getAllFunTypes g.typ
+  where
+    scanField :: C.Field Final -> Set ([C.TypeFunArg Final], C.Type Final)
+    scanField = C.elimField scanExplicitField scanImplicitField
+    scanExplicitField field = C.getAllFunTypes field.typ
+    scanImplicitField field = C.getAllFunTypes field.typ
 
 -- | Check if a type is defined in the current module
 isDefinedInCurrentModule :: DeclIndex l -> C.Type Final -> Bool

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -66,7 +66,7 @@ getDeclsRegular spec info struct = do
 
 getDeclsFlam ::
      HasCallStack
-  => C.StructField Final
+  => C.ExplicitField Final
   -> Hs.Name Hs.NsTypeConstr -- ^ Auxiliary type-constructor name
   -> PrescriptiveDeclSpec
   -> C.DeclInfo Final
@@ -120,7 +120,7 @@ getDeclsFlam flam auxName spec info struct = do
 getInstances ::
      Map Inst.TypeClass Inst.SupportedStrategies
   -> Hs.Name Hs.NsTypeConstr
-  -> [C.StructField Final]
+  -> [C.Field Final]
   -> Hs.InstanceMap
   -> Set Inst.TypeClass
 getInstances supInsts structName fields instanceMap =
@@ -146,10 +146,10 @@ getDecls supInsts hCfg spec structName info struct insts =
     , marshalDecls ++ optDecls ++ fieldDecls
     )
   where
-    fieldName :: C.StructField Final -> Hs.Name Hs.NsVar
+    fieldName :: C.Field Final -> Hs.Name Hs.NsVar
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) . (.info.name.hsName)
 
-    getHsField :: C.StructField Final -> Hs.Field
+    getHsField :: C.Field Final -> Hs.Field
     getHsField field =
         Hs.Field {
             name    = fieldName field
@@ -158,13 +158,13 @@ getDecls supInsts hCfg spec structName info struct insts =
           , comment = mkHaddocksFieldInfo hCfg info field.info
           }
 
-    fieldHint :: C.StructField Final -> NameHint
+    fieldHint :: C.Field Final -> NameHint
     fieldHint = toNameHint . fieldName
 
     -- Build @\ptr s -> case s of Constr f0 f1 ... -> do { f f0; f f1; ... }@,
     -- shared between 'writeRaw' and 'poke'.
     elimFieldsLambda ::
-         (forall ctx. Idx ctx -> C.StructField Final -> Idx ctx -> a ctx)
+         (forall ctx. Idx ctx -> C.Field Final -> Idx ctx -> a ctx)
       -> Hs.Lambda (Hs.Lambda (Hs.ElimStruct (Hs.Seq a))) EmptyCtx
     elimFieldsLambda mkField =
         Hs.Lambda (NameHint "ptr") $ Hs.Lambda (NameHint "s") $
@@ -259,7 +259,7 @@ getDecls supInsts hCfg spec structName info struct insts =
 
     fieldDecls :: [Hs.Decl l]
     fieldDecls = flip concatMap struct.fields $ \field ->
-        hasFieldCompatDecs structName struct hsStruct field ++
+        hasFieldCompatDecs hsStruct field ++
         hasFieldPtrDecs hsStruct field
 
     knownInsts :: Set Inst.TypeClass
@@ -279,7 +279,6 @@ getDecls supInsts hCfg spec structName info struct insts =
   HasField
 -------------------------------------------------------------------------------}
 
-
 -- | Class instances for 'GHC.Records.Compat.HasField' instances for a struct
 -- field
 --
@@ -298,22 +297,20 @@ getDecls supInsts hCfg spec structName info struct insts =
 -- > instance GHC.Records.Compat.HasField "myStruct_y" MyStruct CChar
 --
 hasFieldCompatDecs ::
-     Hs.Name Hs.NsTypeConstr
-  -> C.Struct Final
-  -> Hs.Struct
-  -> C.StructField Final
+     Hs.Struct
+  -> C.Field Final
   -> [Hs.Decl l]
-hasFieldCompatDecs structName cStruct hsStruct field = [
+hasFieldCompatDecs struct field = [
       Hs.DeclDefineInstance $
         Hs.DefineInstance {
             comment      = Nothing
           , instanceDecl = Hs.InstanceHasFieldCompat hasFieldCompatDecl
           }
-    | Inst.HasFieldCompat `elem` hsStruct.instances
+    | Inst.HasFieldCompat `elem` struct.instances
     ]
   where
     parentType :: Hs.Type
-    parentType = Hs.TypRef structName Nothing
+    parentType = Hs.TypRef struct.name Nothing
 
     fieldName :: Hs.Name Hs.NsVar
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) field.info.name.hsName
@@ -328,14 +325,14 @@ hasFieldCompatDecs structName cStruct hsStruct field = [
         , fieldType  = fieldType
         , impl = Hs.HasFieldCompatImplRecord $ Hs.HFCImplRecord {
               otherFields = otherFields
-            , constr = hsStruct.constr
+            , constr = struct.constr
             }
         }
       where
         -- All fields that are /not/ the field we are creating an instance for
         -- should stay unmodified
-        otherFields = flip mapMaybe cStruct.fields $ \field' ->
-            let fieldName' = Hs.assertNs (Proxy @Hs.NsVar) field'.info.name.hsName in
+        otherFields = flip mapMaybe struct.fields $ \field' ->
+            let fieldName' = field'.name in
             if fieldName == fieldName' then Nothing else Just fieldName'
 
 -- | Class instances for 'GHC.Records.HasField' for a struct field the pointer
@@ -366,7 +363,7 @@ hasFieldCompatDecs structName cStruct hsStruct field = [
 --
 hasFieldPtrDecs ::
      Hs.Struct
-  -> C.StructField Final
+  -> C.Field Final
   -> [Hs.Decl l]
 hasFieldPtrDecs struct field = concat [
       [ Hs.DeclDefineInstance $
@@ -431,21 +428,21 @@ hasFieldPtrDecs struct field = concat [
   Field I\/O
 -------------------------------------------------------------------------------}
 
-peekField :: Idx ctx -> C.StructField Final -> Hs.PeekCField ctx
+peekField :: Idx ctx -> C.Field Final -> Hs.PeekCField ctx
 peekField ptr field = case field.width of
     Nothing -> Hs.PeekCField    (Hs.StrLit name) ptr
     Just _w -> Hs.PeekCBitfield (Hs.StrLit name) ptr
   where
     name = Text.unpack field.info.name.hsName.text
 
-pokeField :: Idx ctx -> C.StructField Final -> Idx ctx -> Hs.PokeCField ctx
+pokeField :: Idx ctx -> C.Field Final -> Idx ctx -> Hs.PokeCField ctx
 pokeField ptr field x = case field.width of
     Nothing  -> Hs.PokeCField    (Hs.StrLit name) ptr x
     Just _w  -> Hs.PokeCBitfield (Hs.StrLit name) ptr x
   where
     name = Text.unpack field.info.name.hsName.text
 
-readRawField :: Idx ctx -> C.StructField Final -> Hs.ReadRawCField ctx
+readRawField :: Idx ctx -> C.Field Final -> Hs.ReadRawCField ctx
 readRawField ptr field = case field.width of
     Nothing -> Hs.ReadRawCField    (Hs.StrLit name) ptr
     Just _w -> Hs.ReadRawCBitfield (Hs.StrLit name) ptr
@@ -454,7 +451,7 @@ readRawField ptr field = case field.width of
 
 writeRawField ::
      Idx ctx
-  -> C.StructField Final
+  -> C.Field Final
   -> Idx ctx
   -> Hs.WriteRawCField ctx
 writeRawField ptr field x = case field.width of

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
@@ -182,7 +182,7 @@ hasFieldDecs ::
   -> HsM.Env
   -> C.DeclInfo Final
   -> Hs.Newtype
-  -> C.UnionField Final
+  -> C.Field Final
   -> [Hs.Decl l]
 hasFieldDecs st env info nt field =
     if Inst.Storable `Set.member` fInsts
@@ -264,14 +264,14 @@ hasFieldDecs st env info nt field =
 -- 'HsBindgen.Runtime.HasCBitfield.HasCBitfield' instance instead of a
 -- 'HsBindgen.Runtime.HasCField.HasCField' instance.
 --
-hasFieldPtrDecs :: Hs.Newtype -> C.UnionField Final -> [Hs.Decl l]
-hasFieldPtrDecs nt field = concat [
+hasFieldPtrDecs :: Hs.Newtype -> C.Field Final -> [Hs.Decl l]
+hasFieldPtrDecs union field = concat [
       [ Hs.DeclDefineInstance $
           Hs.DefineInstance {
               comment      = Nothing
             , instanceDecl = Hs.InstanceHasFieldPtr hasFieldPtrDecl
             }
-      | Inst.HasFieldPtr `elem` nt.instances
+      | Inst.HasFieldPtr `elem` union.instances
       ]
     , [ Hs.DeclDefineInstance $
           Hs.DefineInstance {
@@ -282,19 +282,19 @@ hasFieldPtrDecs nt field = concat [
                   Just w  -> Hs.InstanceHasCBitfield $ hasCBitfieldDecl w
             }
       | case unionFieldWidth field of
-          Nothing -> Inst.HasCField `elem` nt.instances
-          Just{} -> Inst.HasCBitfield `elem` nt.instances
+          Nothing -> Inst.HasCField `elem` union.instances
+          Just{} -> Inst.HasCBitfield `elem` union.instances
       ]
     ]
   where
     -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
     -- Should be changed to @C.unionFieldWidth f@ when bit-fields in unions are
     -- supported.
-    unionFieldWidth :: C.UnionField Final -> Maybe Int
+    unionFieldWidth :: C.Field Final -> Maybe Int
     unionFieldWidth _f = Nothing
 
     parentType :: Hs.Type
-    parentType = Hs.TypRef nt.name Nothing
+    parentType = Hs.TypRef union.name Nothing
 
     fieldName :: Hs.Name Hs.NsVar
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) field.info.name.hsName

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/AnonUsage.hs
@@ -181,19 +181,31 @@ analyseDecl decl =
 
 analyseStruct :: C.DeclInfo Parse -> C.Struct Parse -> [(C.AnonId, Context)]
 analyseStruct info struct = concat [
-      concatMap aux struct.fields
-    , foldMap   aux (C.flamStructField struct.flam)
+      concatMap aux     struct.fields
+    , foldMap   auxFlam (C.flamStructField struct.flam)
     ]
   where
-    aux :: C.StructField Parse -> [(C.AnonId, Context)]
-    aux f = analyseType (Field info f.info) f.typ
+    aux :: C.Field Parse -> [(C.AnonId, Context)]
+    aux f = analyseField (Field info f.info) f
+
+    auxFlam :: C.ExplicitField Parse -> [(C.AnonId, Context)]
+    auxFlam f = analyseExplicitField (Field info f.info) f
 
 analyseUnion :: C.DeclInfo Parse -> C.Union Parse -> [(C.AnonId, Context)]
 analyseUnion info union =
     concatMap aux union.fields
   where
-    aux :: C.UnionField Parse -> [(C.AnonId, Context)]
-    aux f = analyseType (Field info f.info) f.typ
+    aux :: C.Field Parse -> [(C.AnonId, Context)]
+    aux f = analyseField (Field info f.info) f
+
+analyseField :: Context -> C.Field Parse -> [(C.AnonId, Context)]
+analyseField ctx = C.elimField (analyseExplicitField ctx) (analyseImplicitField ctx)
+
+analyseExplicitField :: Context -> C.ExplicitField Parse -> [(C.AnonId, Context)]
+analyseExplicitField ctx field = analyseType ctx field.typ
+
+analyseImplicitField :: Context -> C.ImplicitField Parse -> [(C.AnonId, Context)]
+analyseImplicitField ctx field = analyseType ctx field.typ
 
 analyseTypedef :: C.DeclInfo Parse -> C.Typedef Parse -> [(C.AnonId, Context)]
 analyseTypedef info typedef = analyseType (TypedefDirect info) typedef.typ

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -4,11 +4,10 @@ module HsBindgen.Frontend.Analysis.Deps (
   , depsOfStruct
   , depsOfUnion
   , depsOfField
+  , depsOfExplicitField
     -- * Parsed macros
   , depsOfDeclParsedMacro
   ) where
-
-import GHC.Records
 
 import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
@@ -93,17 +92,30 @@ typecheckedMacroDeps = \case
 depsOfStruct :: IsPass p => C.Struct p -> [(Id p, Dependency)]
 depsOfStruct struct = concat [
       concatMap depsOfField struct.fields
-    , foldMap   depsOfField (C.flamStructField struct.flam)
+    , foldMap   depsOfExplicitField (C.flamStructField struct.flam)
     ]
 
 depsOfUnion :: IsPass p => C.Union p -> [(Id p, Dependency)]
 depsOfUnion union = concatMap depsOfField union.fields
 
 -- | Dependencies of struct or union field
-depsOfField :: forall a p.
-     (HasField "typ" (a p) (C.Type p), IsPass p)
-  => a p -> [(Id p, Dependency)]
-depsOfField field = C.depsOfType field.typ
+depsOfField ::
+     forall p. IsPass p
+  => C.Field p
+  -> [(Id p, Dependency)]
+depsOfField = C.elimField depsOfExplicitField depsOfImplicitField
+
+depsOfExplicitField ::
+     forall p. IsPass p
+  => C.ExplicitField p
+  -> [(Id p, Dependency)]
+depsOfExplicitField field = C.depsOfType field.typ
+
+depsOfImplicitField ::
+     forall p. IsPass p
+  => C.ImplicitField p
+  -> [(Id p, Dependency)]
+depsOfImplicitField field = C.depsOfType field.typ
 
 {-------------------------------------------------------------------------------
   Typedefs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
@@ -71,21 +71,11 @@ processDeclKind kind =
 processStruct :: C.Struct MangleNames -> C.Struct AdjustTypes
 processStruct struct =
     C.Struct {
-        fields    = map processStructField struct.fields
-      , flam      = C.mapFlamField processStructField struct.flam
+        fields    = map processField struct.fields
+      , flam      = C.mapFlamField processExplicitField struct.flam
       , sizeof    = struct.sizeof
       , alignment = struct.alignment
       , ann       = struct.ann
-      }
-
-processStructField :: C.StructField MangleNames -> C.StructField AdjustTypes
-processStructField field =
-    C.StructField {
-        info   = coercePass field.info
-      , typ    = processType field.typ
-      , offset = field.offset
-      , width  = field.width
-      , ann    = field.ann
       }
 
 processUnion :: C.Union MangleNames -> C.Union AdjustTypes
@@ -93,17 +83,38 @@ processUnion union =
     C.Union {
         sizeof    = union.sizeof
       , alignment = union.alignment
-      , fields    = map processUnionField union.fields
+      , fields    = map processField union.fields
       , ann       = union.ann
       }
 
-processUnionField :: C.UnionField MangleNames -> C.UnionField AdjustTypes
-processUnionField field =
-    C.UnionField {
-        info = coercePass field.info
-      , typ  = processType field.typ
-      , ann  = field.ann
+processField :: C.Field MangleNames -> C.Field AdjustTypes
+processField = \case
+    C.FieldExplicit field -> C.FieldExplicit $ processExplicitField field
+    C.FieldImplicit field -> C.FieldImplicit $ processImplicitField field
+
+processExplicitField :: C.ExplicitField MangleNames -> C.ExplicitField AdjustTypes
+processExplicitField field =
+    C.ExplicitField {
+        info   = coercePass field.info
+      , typ    = processType field.typ
+      , offset = field.offset
+      , width  = field.width
+      , ann    = field.ann
       }
+
+processImplicitField :: C.ImplicitField MangleNames -> C.ImplicitField AdjustTypes
+processImplicitField field =
+    C.ImplicitField {
+        info   = coercePass field.info
+      , typRef = processAnonRef field.typRef
+      , offset = field.offset
+      , ann    = field.ann
+      }
+
+processAnonRef :: C.AnonRef MangleNames -> C.AnonRef AdjustTypes
+processAnonRef = \case
+    C.AnonRef ref -> C.AnonRef ref
+    C.AnonExtBinding ext -> C.AnonExtBinding $ processExtBindingRef ext
 
 processTypedef :: C.Typedef MangleNames -> C.Typedef AdjustTypes
 processTypedef typedef =
@@ -222,7 +233,10 @@ processType = \case
     C.TypeQual qual ty ->
       C.TypeQual qual $ processType ty
     C.TypeExtBinding ref ->
-      C.TypeExtBinding $ C.Ref {
+      C.TypeExtBinding $ processExtBindingRef ref
+
+processExtBindingRef :: C.ExtBindingRef MangleNames -> C.ExtBindingRef AdjustTypes
+processExtBindingRef ref = C.Ref {
           name       = ref.name
         , underlying = processType ref.underlying
         }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -193,62 +193,77 @@ instance UpdateUseSites C.Struct where
         <*> C.traverseFlamField updateUseSites struct.flam
     where
       reconstruct ::
-           [C.StructField AssignAnonIds]
+           [C.Field AssignAnonIds]
         -> C.Flam AssignAnonIds
         -> C.Struct AssignAnonIds
-      reconstruct structFields' structFlam' = C.Struct {
-            fields    = structFields'
-          , flam      = structFlam'
+      reconstruct fields' flam' = C.Struct {
+            fields    = fields'
+          , flam      = flam'
           , sizeof    = struct.sizeof
           , alignment = struct.alignment
           , ann       = NoAnn
-          }
-
-instance UpdateUseSites C.StructField where
-  updateUseSites field =
-      reconstruct
-        <$> updateUseSites field.typ
-        <*> updateUseSites field.info
-    where
-      reconstruct ::
-           C.Type AssignAnonIds
-        -> C.FieldInfo AssignAnonIds
-        -> C.StructField AssignAnonIds
-      reconstruct structFieldType' structFieldInfo' = C.StructField {
-            typ    = structFieldType'
-          , info   = structFieldInfo'
-          , offset = field.offset
-          , width  = field.width
-          , ann    = fst field.ann
           }
 
 instance UpdateUseSites C.Union where
   updateUseSites union =
       reconstruct <$> mapM updateUseSites union.fields
     where
-      reconstruct :: [C.UnionField AssignAnonIds] -> C.Union AssignAnonIds
-      reconstruct unionFields' = C.Union {
-            fields    = unionFields'
+      reconstruct :: [C.Field AssignAnonIds] -> C.Union AssignAnonIds
+      reconstruct fields' = C.Union {
+            fields    = fields'
           , sizeof    = union.sizeof
           , alignment = union.alignment
           , ann       = NoAnn
           }
 
-instance UpdateUseSites C.UnionField where
+instance UpdateUseSites C.Field where
+  updateUseSites = C.mapMField updateUseSites updateUseSites
+
+instance UpdateUseSites C.FieldInfo where
+  updateUseSites info = pure C.FieldInfo{
+        comment = ()
+      , name    = info.name
+      , loc     = info.loc
+      }
+
+instance UpdateUseSites C.ExplicitField where
   updateUseSites field =
       reconstruct
-        <$> updateUseSites field.typ
-        <*> updateUseSites field.info
+        <$> updateUseSites field.info
+        <*> updateUseSites field.typ
     where
       reconstruct ::
-           C.Type AssignAnonIds
-        -> C.FieldInfo AssignAnonIds
-        -> C.UnionField AssignAnonIds
-      reconstruct unionFieldType' unionFieldInfo' = C.UnionField {
-          typ  = unionFieldType'
-        , info = unionFieldInfo'
-        , ann  = fst field.ann
-        }
+           C.FieldInfo AssignAnonIds
+        -> C.Type AssignAnonIds
+        -> C.ExplicitField AssignAnonIds
+      reconstruct info' typ' = C.ExplicitField {
+            info   = info'
+          , typ    = typ'
+          , offset = field.offset
+          , width  = field.width
+          , ann    = field.ann
+          }
+
+instance UpdateUseSites C.ImplicitField where
+  updateUseSites field =
+      reconstruct
+        <$> updateUseSites field.info
+        <*> updateUseSites field.typRef
+    where
+      reconstruct ::
+           C.FieldInfo AssignAnonIds
+        -> C.AnonRef AssignAnonIds
+        -> C.ImplicitField AssignAnonIds
+      reconstruct info' typRef' = C.ImplicitField {
+            info   = info'
+          , typRef = typRef'
+          , offset = field.offset
+          , ann    = NoAnn
+          }
+
+instance UpdateUseSites C.AnonRef where
+  updateUseSites = \case
+      C.AnonRef ref -> C.AnonRef <$> updateDeclId ref
 
 instance UpdateUseSites C.Typedef where
   updateUseSites typedef =
@@ -367,13 +382,6 @@ updateDeclId prelimDeclId = WrapM $ do
 {-------------------------------------------------------------------------------
   Comments
 -------------------------------------------------------------------------------}
-
-instance UpdateUseSites C.FieldInfo where
-  updateUseSites info = pure C.FieldInfo{
-        comment = ()
-      , name    = info.name
-      , loc     = info.loc
-      }
 
 instance UpdateUseSites C.EnumConstant where
   updateUseSites constant =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds/IsPass.hs
@@ -21,12 +21,11 @@ data AssignAnonIds a
 
 -- We preserve the annotations from the @Parse@ pass
 type family AnnAssignAnonIds ix where
-  AnnAssignAnonIds "Function"    = ReparseInfo Tokens
-  AnnAssignAnonIds "Global"      = ReparseInfo Tokens
-  AnnAssignAnonIds "StructField" = ReparseInfo Tokens
-  AnnAssignAnonIds "Typedef"     = ReparseInfo Tokens
-  AnnAssignAnonIds "UnionField"  = ReparseInfo Tokens
-  AnnAssignAnonIds _             = NoAnn
+  AnnAssignAnonIds "ExplicitField" = ReparseInfo Tokens
+  AnnAssignAnonIds "Function"      = ReparseInfo Tokens
+  AnnAssignAnonIds "Global"        = ReparseInfo Tokens
+  AnnAssignAnonIds "Typedef"       = ReparseInfo Tokens
+  AnnAssignAnonIds _               = NoAnn
 
 instance IsPass AssignAnonIds
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -19,12 +19,11 @@ type ConstructTranslationUnit :: Pass
 data ConstructTranslationUnit a
 
 type family AnnConstructTranslationUnit (ix :: Symbol) :: Star where
-  AnnConstructTranslationUnit "Function"    = ReparseInfo Tokens
-  AnnConstructTranslationUnit "Global"      = ReparseInfo Tokens
-  AnnConstructTranslationUnit "StructField" = ReparseInfo Tokens
-  AnnConstructTranslationUnit "Typedef"     = ReparseInfo Tokens
-  AnnConstructTranslationUnit "UnionField"  = ReparseInfo Tokens
-  AnnConstructTranslationUnit _             = NoAnn
+  AnnConstructTranslationUnit "ExplicitField" = ReparseInfo Tokens
+  AnnConstructTranslationUnit "Function"      = ReparseInfo Tokens
+  AnnConstructTranslationUnit "Global"        = ReparseInfo Tokens
+  AnnConstructTranslationUnit "Typedef"       = ReparseInfo Tokens
+  AnnConstructTranslationUnit _               = NoAnn
 
 instance IsPass ConstructTranslationUnit
 
@@ -53,11 +52,10 @@ instance CoercePassId                 EnrichComments ConstructTranslationUnit
 instance CoercePassMacroId            EnrichComments ConstructTranslationUnit
 instance CoercePassMacroUnderlying    EnrichComments ConstructTranslationUnit
 
+instance CoercePassAnn "ExplicitField" EnrichComments ConstructTranslationUnit
 instance CoercePassAnn "Function"      EnrichComments ConstructTranslationUnit
 instance CoercePassAnn "Global"        EnrichComments ConstructTranslationUnit
-instance CoercePassAnn "StructField"   EnrichComments ConstructTranslationUnit
 instance CoercePassAnn "TypeFunArg"    EnrichComments ConstructTranslationUnit
 instance CoercePassAnn "Typedef"       EnrichComments ConstructTranslationUnit
-instance CoercePassAnn "UnionField"    EnrichComments ConstructTranslationUnit
 instance CoercePassCommentDecl         EnrichComments ConstructTranslationUnit where
   coercePassCommentDecl _ = fmap coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments.hs
@@ -191,28 +191,32 @@ enrichDeclKind doxy name = \case
 
 enrichStruct :: Doxygen -> Text -> C.Struct EnrichComments -> C.Struct EnrichComments
 enrichStruct doxy name struct = struct
-    & #fields %~ map (enrichStructField doxy name)
-    & #flam   %~ C.mapFlamField (enrichStructField doxy name)
+    & #fields %~ map (enrichField doxy name)
+    & #flam   %~ C.mapFlamField (enrichExplicitField doxy name)
 
 enrichUnion :: Doxygen -> Text -> C.Union EnrichComments -> C.Union EnrichComments
 enrichUnion doxy name union = union
-    & #fields %~ map (enrichUnionField doxy name)
+    & #fields %~ map (enrichField doxy name)
 
 enrichEnum :: Doxygen -> Text -> C.Enum EnrichComments -> C.Enum EnrichComments
 enrichEnum doxy name enum = enum
     & #constants %~ map (enrichEnumConstant doxy name)
 
-enrichStructField ::
-     Doxygen -> Text -> C.StructField EnrichComments -> C.StructField EnrichComments
-enrichStructField doxy name sf =
-    maybe sf (\c -> sf & #info % #comment .~ Just c) $ do
-      lookupFieldComment doxy (KeyField name sf.info.name.text)
+enrichField ::
+     Doxygen -> Text -> C.Field EnrichComments -> C.Field EnrichComments
+enrichField doxy name = C.mapField (enrichExplicitField doxy name) (enrichImplicitField doxy name)
 
-enrichUnionField ::
-     Doxygen -> Text -> C.UnionField EnrichComments -> C.UnionField EnrichComments
-enrichUnionField doxy name uf =
-    maybe uf (\c -> uf & #info % #comment .~ Just c) $ do
-      lookupFieldComment doxy (KeyField name uf.info.name.text)
+enrichExplicitField ::
+     Doxygen -> Text -> C.ExplicitField EnrichComments -> C.ExplicitField EnrichComments
+enrichExplicitField doxy name field =
+    maybe field (\c -> field & #info % #comment .~ Just c) $ do
+      lookupFieldComment doxy (KeyField name field.info.name.text)
+
+enrichImplicitField ::
+     Doxygen -> Text -> C.ImplicitField EnrichComments -> C.ImplicitField EnrichComments
+enrichImplicitField doxy name field =
+    maybe field (\c -> field & #info % #comment .~ Just c) $ do
+        lookupFieldComment doxy (KeyField name field.info.name.text)
 
 enrichEnumConstant ::
      Doxygen -> Text -> C.EnumConstant EnrichComments -> C.EnumConstant EnrichComments

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
@@ -17,12 +17,11 @@ data EnrichComments a
 
 -- We preserve the annotations from the @Parse@ pass (same as @AssignAnonIds@)
 type family AnnEnrichComments ix where
-  AnnEnrichComments "Function"    = ReparseInfo Tokens
-  AnnEnrichComments "Global"      = ReparseInfo Tokens
-  AnnEnrichComments "StructField" = ReparseInfo Tokens
-  AnnEnrichComments "Typedef"     = ReparseInfo Tokens
-  AnnEnrichComments "UnionField"  = ReparseInfo Tokens
-  AnnEnrichComments _             = NoAnn
+  AnnEnrichComments "ExplicitField" = ReparseInfo Tokens
+  AnnEnrichComments "Function"      = ReparseInfo Tokens
+  AnnEnrichComments "Global"        = ReparseInfo Tokens
+  AnnEnrichComments "Typedef"       = ReparseInfo Tokens
+  AnnEnrichComments _               = NoAnn
 
 instance IsPass EnrichComments
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
@@ -61,12 +61,12 @@ data CreateNames a
 
 type family AnnCreateNames ix where
   AnnCreateNames "Decl"                 = PrescriptiveDeclSpec
-  AnnCreateNames "Struct"               = StructNames
-  AnnCreateNames "Flam"                 = FlamNames
-  AnnCreateNames "Union"                = NewtypeNames
   AnnCreateNames "Enum"                 = NewtypeNames
+  AnnCreateNames "Flam"                 = FlamNames
+  AnnCreateNames "Struct"               = StructNames
   AnnCreateNames "Typedef"              = TypedefNames
   AnnCreateNames "TypecheckedMacroType" = NewtypeNames
+  AnnCreateNames "Union"                = NewtypeNames
   AnnCreateNames _                      = NoAnn
 
 instance IsPass CreateNames
@@ -438,7 +438,7 @@ createStructNames name = do
 createFlam :: Text -> C.Flam ResolveBindingSpecs -> CreateE (C.Flam CreateNames)
 createFlam _      C.NoFlam        = pure C.NoFlam
 createFlam hsName (C.Flam field _) = do
-    field'  <- createStructField hsName field
+    field'  <- createExplicitField hsName field
     auxName <- mkName (Proxy @Hs.NsTypeConstr) (hsName <> "_Aux")
     pure $ C.Flam field' FlamNames{ aux = auxName }
 
@@ -523,7 +523,7 @@ createArgumentName argName = do
 createStruct ::
      Text -> C.Struct ResolveBindingSpecs -> CreateE (C.Struct CreateNames)
 createStruct hsName struct = do
-    fields <- mapM (createStructField hsName) struct.fields
+    fields <- mapM (createField hsName) struct.fields
     flam   <- createFlam hsName struct.flam
     names  <- createStructNames hsName
     pure C.Struct{
@@ -534,13 +534,32 @@ createStruct hsName struct = do
       , alignment = struct.alignment
       }
 
-createStructField ::
+createUnion ::
+     Text -> C.Union ResolveBindingSpecs -> CreateE (C.Union CreateNames)
+createUnion hsName union = do
+    strategy <- asks (.fieldNamingStrategy)
+    names    <- createNewtypeNames strategy hsName
+    fields   <- mapM (createField hsName) union.fields
+    pure C.Union{
+        fields    = fields
+      , ann       = names
+      , sizeof    = union.sizeof
+      , alignment = union.alignment
+      }
+
+createField ::
      Text
-  -> C.StructField ResolveBindingSpecs
-  -> CreateE (C.StructField CreateNames)
-createStructField hsName field = do
+  -> C.Field ResolveBindingSpecs
+  -> CreateE (C.Field CreateNames)
+createField hsName = C.mapMField (createExplicitField hsName) (createImplicitField hsName)
+
+createExplicitField ::
+     Text
+  -> C.ExplicitField ResolveBindingSpecs
+  -> CreateE (C.ExplicitField CreateNames)
+createExplicitField hsName field = do
     name' <- createFieldName hsName field.info.name
-    pure C.StructField{
+    pure C.ExplicitField{
         info   = C.FieldInfo{
                      loc     = field.info.loc
                    , name    = name'
@@ -552,34 +571,30 @@ createStructField hsName field = do
       , ann    = field.ann
       }
 
-createUnion ::
-     Text -> C.Union ResolveBindingSpecs -> CreateE (C.Union CreateNames)
-createUnion hsName union = do
-    strategy <- asks (.fieldNamingStrategy)
-    names    <- createNewtypeNames strategy hsName
-    fields   <- mapM (createUnionField hsName) union.fields
-    pure C.Union{
-        fields    = fields
-      , ann       = names
-      , sizeof    = union.sizeof
-      , alignment = union.alignment
-      }
-
-createUnionField ::
+createImplicitField ::
      Text
-  -> C.UnionField ResolveBindingSpecs
-  -> CreateE (C.UnionField CreateNames)
-createUnionField hsName field = do
-    name'    <- createFieldName hsName field.info.name
-    pure C.UnionField{
+  -> C.ImplicitField ResolveBindingSpecs
+  -> CreateE (C.ImplicitField CreateNames)
+createImplicitField hsName field = do
+    name'   <- createFieldName hsName field.info.name
+    typRef' <- createAnonRef field.typRef
+    pure C.ImplicitField{
         info = C.FieldInfo{
                    loc     = field.info.loc
                  , name    = name'
                  , comment = fmap coercePass field.info.comment
                  }
-      , typ  = coercePass field.typ
+      , typRef = typRef'
+      , offset = field.offset
       , ann  = NoAnn
       }
+
+createAnonRef ::
+     C.AnonRef ResolveBindingSpecs
+  -> CreateE (C.AnonRef CreateNames)
+createAnonRef = \case
+    C.AnonRef ref -> pure $ C.AnonRef ref
+    C.AnonExtBinding ext -> pure $ C.AnonExtBinding $ C.coercePassExtBindingRef ext
 
 createEnum :: Text -> C.Enum ResolveBindingSpecs -> CreateE (C.Enum CreateNames)
 createEnum hsName enum = do

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/DetectClashes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/DetectClashes.hs
@@ -85,11 +85,11 @@ derivedNames strategy owner loc = \case
          (Constructor, GlobalScope, loc, Hs.demoteNs struct.ann.constr)
        : [ (AuxType, GlobalScope, loc, Hs.demoteNs flamNames.aux)
          | C.Flam _ flamNames <- [struct.flam] ]
-      ++ concatMap structFieldNames
-           (struct.fields ++ maybeToList (C.flamStructField struct.flam))
+      ++ concatMap fieldNames struct.fields
+      ++ foldMap explicitFieldNames (C.flamStructField struct.flam)
     C.DeclUnion union ->
          newtypeNames union.ann
-      ++ concatMap unionFieldNames union.fields
+      ++ concatMap fieldNames union.fields
     C.DeclEnum enum ->
          newtypeNames enum.ann
       ++ map enumConstantName enum.constants
@@ -111,12 +111,14 @@ derivedNames strategy owner loc = \case
       AddFieldPrefixes  -> GlobalScope
       OmitFieldPrefixes -> DeclScope owner
 
-    structFieldNames :: C.StructField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
-    structFieldNames field = [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
+    fieldNames :: C.Field CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    fieldNames = C.elimField explicitFieldNames implicitFieldNames
 
-    unionFieldNames :: C.UnionField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
-    unionFieldNames field =
-        [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
+    explicitFieldNames :: C.ExplicitField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    explicitFieldNames field = [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
+
+    implicitFieldNames :: C.ImplicitField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    implicitFieldNames field = [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
 
     enumConstantName :: C.EnumConstant CreateNames -> (NameRole, Scope, SingleLoc, Hs.SomeName)
     enumConstantName constant = (Constructor, GlobalScope, loc, constant.info.name.hsName)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
@@ -191,11 +191,26 @@ instance Resolve C.Struct where
       , alignment = struct.alignment
       }
 
-instance Resolve C.StructField where
+instance Resolve C.Union where
+  resolve union = do
+    fields <- mapM resolve union.fields
+    pure C.Union{
+        fields    = fields
+      , ann       = union.ann
+      , sizeof    = union.sizeof
+      , alignment = union.alignment
+      }
+
+instance Resolve C.Field where
+  resolve = \case
+      C.FieldExplicit field -> C.FieldExplicit <$> resolve field
+      C.FieldImplicit field -> C.FieldImplicit <$> resolve field
+
+instance Resolve C.ExplicitField where
   resolve field = do
     typ'     <- resolve field.typ
     comment' <- traverse resolve field.info.comment
-    pure C.StructField{
+    pure C.ExplicitField{
         info   = C.FieldInfo{
                      loc     = field.info.loc
                    , name    = field.info.name
@@ -207,29 +222,25 @@ instance Resolve C.StructField where
       , ann    = field.ann
       }
 
-instance Resolve C.Union where
-  resolve union = do
-    fields <- mapM resolve union.fields
-    pure C.Union{
-        fields    = fields
-      , ann       = union.ann
-      , sizeof    = union.sizeof
-      , alignment = union.alignment
+instance Resolve C.ImplicitField where
+  resolve field = do
+    typRef'     <- resolve field.typRef
+    comment' <- traverse resolve field.info.comment
+    pure C.ImplicitField{
+        info   = C.FieldInfo{
+                     loc     = field.info.loc
+                   , name    = field.info.name
+                   , comment = comment'
+                   }
+      , typRef    = typRef'
+      , offset = field.offset
+      , ann    = field.ann
       }
 
-instance Resolve C.UnionField where
-  resolve field = do
-    typ'     <- resolve field.typ
-    comment' <- traverse resolve field.info.comment
-    pure C.UnionField{
-        info = C.FieldInfo{
-                   loc     = field.info.loc
-                 , name    = field.info.name
-                 , comment = comment'
-                 }
-      , typ  = typ'
-      , ann  = field.ann
-      }
+instance Resolve C.AnonRef where
+  resolve = \case
+      C.AnonRef ref -> C.AnonRef <$> lookupTypePairR ref
+      C.AnonExtBinding ext -> C.AnonExtBinding <$> resolveExtBindingRef ext
 
 instance Resolve C.Enum where
   resolve enum = do
@@ -364,14 +375,7 @@ instance Resolve C.Type where
       C.TypeIncompleteArray typ        -> C.TypeIncompleteArray <$> resolve typ
       C.TypeBlock typ                  -> C.TypeBlock <$> resolve typ
       C.TypeQual qual typ              -> C.TypeQual qual <$> resolve typ
-      C.TypeExtBinding (C.Ref ext uTy) ->
-        -- The underlying type may reference the external binding itself (e.g.
-        -- the typedef name that was replaced). We extend the 'NameMap' with the
-        -- external binding so that such references can be resolved.
-        fmap C.TypeExtBinding $ C.Ref ext <$>
-          local
-            ( #typeConstrs %~ Map.insert ext.cName ext.hsName.name )
-            ( resolve uTy )
+      C.TypeExtBinding ref             -> C.TypeExtBinding <$> resolveExtBindingRef ref
 
       -- The other entries do not need any name mangling
       C.TypePrim prim                  -> pure $ C.TypePrim prim
@@ -380,6 +384,18 @@ instance Resolve C.Type where
 
 instance Resolve C.TypeFunArg where
   resolve arg = C.TypeFunArgF <$> resolve arg.typ <*> pure arg.ann
+
+resolveExtBindingRef ::
+     C.ExtBindingRef CreateNames
+  -> ResolveE (C.ExtBindingRef MangleNames)
+resolveExtBindingRef (C.Ref ext uTy) =
+    -- The underlying type may reference the external binding itself (e.g.
+    -- the typedef name that was replaced). We extend the 'NameMap' with the
+    -- external binding so that such references can be resolved.
+    C.Ref ext <$>
+      local
+        ( #typeConstrs %~ Map.insert ext.cName ext.hsName.name )
+        ( resolve uTy )
 
 {-------------------------------------------------------------------------------
   Resolving comment references

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -272,14 +272,14 @@ structDecl macroLang enclosing ctx info = \curr -> do
         alignment <- clang_Type_getAlignOf ty
         isAnon    <- clang_Cursor_isAnonymousRecordDecl curr
 
-        let mkStruct :: [C.StructField Parse] -> C.Decl l Parse
+        let mkStruct :: [C.Field Parse] -> C.Decl l Parse
             mkStruct allFields = C.Decl {
                   info = info
                 , ann  = NoAnn
                 , kind = C.DeclStruct C.Struct{
                       sizeof    = fromIntegral sizeof
                     , alignment = fromIntegral alignment
-                    , fields    = filter isField regularFields
+                    , fields    = mapMaybe removePaddingFields regularFields
                     , flam      = maybe C.NoFlam (`C.Flam` NoAnn) mFlam
                     , ann       = IsAnon isAnon
                     }
@@ -292,7 +292,7 @@ structDecl macroLang enclosing ctx info = \curr -> do
 
         -- Recursively parse all members of the struct. These members include
         -- field declarations and nested struct/union declarations.
-        parseStructMembersWith ty ctx (parseDeclNested macroLang enclosing') $ \membersResult ->
+        parseMembersWith ty ctx (parseDeclNested macroLang enclosing') $ \membersResult ->
           -- The parse results of nested struct/union declarations are returned
           -- regardless of the parse status of field declarations.
           --
@@ -321,28 +321,24 @@ structDecl macroLang enclosing ctx info = \curr -> do
   where
     -- Split off FLAM, if any
     partitionFields ::
-         [C.StructField Parse]
-      -> ([C.StructField Parse], Maybe (C.StructField Parse))
+         [C.Field Parse]
+      -> ([C.Field Parse], Maybe (C.ExplicitField Parse))
     partitionFields = go []
       where
         go ::
-             [C.StructField Parse]
-          -> [C.StructField Parse]
-          -> ([C.StructField Parse], Maybe (C.StructField Parse))
+             [C.Field Parse]
+          -> [C.Field Parse]
+          -> ([C.Field Parse], Maybe (C.ExplicitField Parse))
         go acc []     = (reverse acc, Nothing)
-        go acc (f:fs) = case f.typ of
-                          C.TypeIncompleteArray ty ->
-                            let f' = f & #typ .~ ty
-                            in (reverse acc ++ fs, Just f')
-                          _otherwise->
-                            go (f:acc) fs
+        go acc (f:fs) = case f of
+            -- only an explicit field can be FLAM
+            C.FieldExplicit f'
+              | C.TypeIncompleteArray ty <- f'.typ ->
+                  let f'' = f' & #typ .~ ty
+                  in (reverse acc ++ fs, Just f'')
+            _otherwise ->
+              go (f:acc) fs
 
-    -- An unnamed bit-field is used to specify padding, using a specified
-    -- padding width or zero to instruct the compiler to not pack any more
-    -- fields into the current storage unit.  This predicate is used to filter
-    -- out such bit-fields.
-    isField :: C.StructField Parse -> Bool
-    isField field = not $ Text.null field.info.name.text && isJust field.width
 
 -- | Parse a union declaration
 --
@@ -363,14 +359,14 @@ unionDecl macroLang enclosing ctx info = \curr -> do
         alignment <- clang_Type_getAlignOf ty
         isAnon    <- clang_Cursor_isAnonymousRecordDecl curr
 
-        let mkUnion :: [C.UnionField Parse] -> C.Decl l Parse
+        let mkUnion :: [C.Field Parse] -> C.Decl l Parse
             mkUnion fields = C.Decl{
                   info = info
                 , ann  = NoAnn
                 , kind = C.DeclUnion C.Union{
                              sizeof    = fromIntegral sizeof
                            , alignment = fromIntegral alignment
-                           , fields    = filter isField fields
+                           , fields    = mapMaybe removePaddingFields fields
                            , ann       = IsAnon isAnon
                            }
                 }
@@ -379,7 +375,7 @@ unionDecl macroLang enclosing ctx info = \curr -> do
 
         -- Recursively parse all members of the union. These members include
         -- field declarations and nested struct/union declarations.
-        parseUnionMembersWith ty ctx (parseDeclNested macroLang enclosing') $ \membersResult ->
+        parseMembersWith ty ctx (parseDeclNested macroLang enclosing') $ \membersResult ->
           -- The parse results of nested struct/union declarations are returned
           -- regardless of the parse status of field declarations.
           --
@@ -406,12 +402,20 @@ unionDecl macroLang enclosing ctx info = \curr -> do
       DefinitionElsewhere _ ->
         foldContinue
   where
-    -- An unnamed bit-field is used to specify padding, using a specified
-    -- padding width or zero to instruct the compiler to not pack any more
-    -- fields into the current storage unit.  This predicate is used to filter
-    -- out such bit-fields.
-    isField :: C.UnionField Parse -> Bool
-    isField field = not $ Text.null field.info.name.text
+
+-- An unnamed bit-field is used to specify padding, using a specified
+-- padding width or zero to instruct the compiler to not pack any more
+-- fields into the current storage unit.  This predicate is used to filter
+-- out such bit-fields.
+removePaddingFields :: C.Field Parse -> Maybe (C.Field Parse)
+removePaddingFields = \case
+    C.FieldExplicit field ->
+      if Text.null field.info.name.text && isJust field.width
+      then Nothing
+      else Just (C.FieldExplicit field)
+    C.FieldImplicit field ->
+      -- implicit fields don't have a bit-width
+      Just (C.FieldImplicit field)
 
 typedefDecl ::
      forall l.

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Field.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Field.hs
@@ -1,7 +1,6 @@
 -- | Parse functions related to struct and union fields
 module HsBindgen.Frontend.Pass.Parse.Decl.Field (
-    structFieldDecl
-  , unionFieldDecl
+    explicitFieldDecl
   , getFieldInfo
   ) where
 
@@ -14,45 +13,32 @@ import Clang.LowLevel.Core (CXCursor, clang_Cursor_getOffsetOfField,
 
 import HsBindgen.Frontend.Pass.Parse.Context (ParseCtx)
 import HsBindgen.Frontend.Pass.Parse.Decl.Macro (getReparseInfo)
-import HsBindgen.Frontend.Pass.Parse.IsPass (ExplicitFieldOrigin (ExplicitFieldOrigin),
-                                             FieldOrigin (ExplicitParsed),
-                                             Parse)
+import HsBindgen.Frontend.Pass.Parse.IsPass (Parse)
 import HsBindgen.Frontend.Pass.Parse.Monad.Decl (ParseDecl)
 import HsBindgen.Frontend.Pass.Parse.Type (fromCXType)
 import HsBindgen.IR.C qualified as C
 
-structFieldDecl :: ParseCtx -> CXCursor -> ParseDecl (C.StructField Parse)
-structFieldDecl ctx = \curr -> do
-    structFieldInfo   <- getFieldInfo curr
-    structFieldType   <- fromCXType ctx =<< clang_getCursorType curr
-    structFieldOffset <- fromIntegral <$> clang_Cursor_getOffsetOfField curr
-    structFieldAnn    <- getReparseInfo curr
-    structFieldWidth  <- structWidth curr
-    pure C.StructField{
-        info   = structFieldInfo
-      , typ    = structFieldType
-      , offset = structFieldOffset
-      , width  = structFieldWidth
-      , ann    = (structFieldAnn, ExplicitParsed ExplicitFieldOrigin)
+explicitFieldDecl :: ParseCtx -> CXCursor -> ParseDecl (C.ExplicitField Parse)
+explicitFieldDecl ctx = \curr -> do
+    info   <- getFieldInfo curr
+    typ    <- fromCXType ctx =<< clang_getCursorType curr
+    offset <- fromIntegral <$> clang_Cursor_getOffsetOfField curr
+    width  <- getFieldWidth curr
+    ann    <- getReparseInfo curr
+    pure C.ExplicitField{
+        info   = info
+      , typ    = typ
+      , offset = offset
+      , width  = width
+      , ann    = ann
       }
 
-structWidth :: MonadIO m => CXCursor -> m (Maybe Int)
-structWidth = \curr -> do
+getFieldWidth :: MonadIO m => CXCursor -> m (Maybe Int)
+getFieldWidth = \curr -> do
     isBitField <- clang_Cursor_isBitField curr
     if isBitField
       then Just . fromIntegral <$> clang_getFieldDeclBitWidth curr
       else return Nothing
-
-unionFieldDecl :: ParseCtx -> CXCursor -> ParseDecl (C.UnionField Parse)
-unionFieldDecl ctx = \curr -> do
-    unionFieldInfo <- getFieldInfo curr
-    unionFieldType <- fromCXType ctx =<< clang_getCursorType curr
-    unionFieldAnn  <- getReparseInfo curr
-    pure C.UnionField{
-        info = unionFieldInfo
-      , typ  = unionFieldType
-      , ann  = (unionFieldAnn, ExplicitParsed ExplicitFieldOrigin)
-      }
 
 -- | Get field info from a cursor
 --

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/ImplicitFields.hs
@@ -11,7 +11,6 @@ module HsBindgen.Frontend.Pass.Parse.Decl.ImplicitFields (
   , Outputs (..)
     -- * Top-level
   , EnclosingObject(..)
-  , MakeImplicitField
   , withImplicitFields
   ) where
 
@@ -23,19 +22,15 @@ import Data.Foldable (minimumBy)
 import Data.List (sortOn)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as Text
-import GHC.Records (HasField (getField))
 
-import Clang.HighLevel.Types (SingleLoc)
 import Clang.LowLevel.Core (CXType, CallFailed, clang_Type_getOffsetOf)
 
-import HsBindgen.Frontend.Analysis.Deps (depsOfField, depsOfStruct, depsOfUnion)
-import HsBindgen.Frontend.Pass.Parse.IsPass (IsAnon (..), Parse,
-                                             ReparseInfo (..), Tokens)
-import HsBindgen.Frontend.Pass.Parse.IsPass qualified as Origin (ExplicitFieldOrigin (..),
-                                                                 FieldOrigin (..),
-                                                                 ImplicitFieldOrigin (..))
+import HsBindgen.Frontend.Analysis.Deps (depsOfExplicitField, depsOfStruct,
+                                         depsOfUnion)
+import HsBindgen.Frontend.Pass.Parse.IsPass (IsAnon (isAnon), Parse)
+import HsBindgen.Frontend.Pass.Parse.IsPass qualified as Origin (FieldOrigin (..))
 import HsBindgen.Frontend.Pass.Parse.Msg (ParseImplicitFieldsMsg (..))
-import HsBindgen.Imports (Bifunctor (bimap), MonadIO (..), NonEmpty, Text)
+import HsBindgen.Imports (Bifunctor (bimap), MonadIO (..), NonEmpty, forM)
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass (PassScopedName (ScopedName))
 
@@ -44,32 +39,32 @@ import HsBindgen.IR.Pass (PassScopedName (ScopedName))
 -------------------------------------------------------------------------------}
 
 -- | A list of nested struct\/union declarations and field declarations
-newtype Inputs field l = Inputs {
-    nestedDecls :: [Either (C.Decl l Parse) (field Parse)]
+newtype Inputs l = Inputs {
+    nestedDecls :: [Either (C.Decl l Parse) (C.ExplicitField Parse)]
   }
   deriving newtype (Semigroup, Monoid)
 
-inputEmpty :: Inputs field l
+inputEmpty :: Inputs l
 inputEmpty = Inputs []
 
-inputField :: field Parse -> Inputs field l
+inputField :: C.ExplicitField Parse -> Inputs l
 inputField x = Inputs [Right x]
 
-inputDecl :: C.Decl l Parse -> Inputs field l
+inputDecl :: C.Decl l Parse -> Inputs l
 inputDecl x = Inputs [Left x]
 
 {-------------------------------------------------------------------------------
   Outputs
 -------------------------------------------------------------------------------}
 
-data Outputs field =
+data Outputs =
     -- | An exception occurred
     OutputFail {
         exception :: ParseImplicitFieldsMsg
       }
     -- | All explicit and implicit fields
   | OutputSuccess {
-        fields    :: [field Parse]
+        fields    :: [C.Field Parse]
       }
 
 {-------------------------------------------------------------------------------
@@ -166,14 +161,12 @@ data Outputs field =
 -- > };
 --
 withImplicitFields ::
-     forall m field l. (
+     forall m l. (
        MonadIO m
-     , MakeImplicitField field
-     , HasField "typ" (field Parse) (C.Type Parse)
      )
   => EnclosingObject
-  -> Inputs field l
-  -> m (Outputs field)
+  -> Inputs l
+  -> m Outputs
 withImplicitFields encObj inputs = do
     resultsE <- runM $ mapM getImplicitField' classifications.candidates
     case resultsE of
@@ -184,14 +177,14 @@ withImplicitFields encObj inputs = do
           fields =
               fmap (.numberee)
             $ sortOn (.number)
-            $ classifications.explicitFields ++ implicitFields
+            $ fmap (fmap C.FieldExplicit) classifications.explicitFields ++ implicitFields
         }
   where
     classifications = classifyInputs inputs
 
     getImplicitField' ::
         Numbered (C.Decl l Parse)
-      -> M m (Numbered (field Parse))
+      -> M m (Numbered (C.Field Parse))
     getImplicitField' decl =
         Numbered decl.number <$> getImplicitField encObj decl.numberee
 
@@ -199,9 +192,9 @@ withImplicitFields encObj inputs = do
   Inputs classification
 -------------------------------------------------------------------------------}
 
-data Classification field l = Classification {
+data Classification l = Classification {
     -- | Parsed explicit fields
-    explicitFields :: [Numbered (field Parse)]
+    explicitFields :: [Numbered (C.ExplicitField Parse)]
     -- | Candidates for implicit fields
   , candidates     :: [Numbered (C.Decl l Parse)]
   }
@@ -214,10 +207,7 @@ data Numbered a = Numbered {
   }
   deriving stock (Functor, Foldable, Traversable)
 
-classifyInputs ::
-     forall field l. HasField "typ" (field Parse) (C.Type Parse)
-  => Inputs field l
-  -> Classification field l
+classifyInputs :: forall l. Inputs l -> Classification l
 classifyInputs inputs = Classification {
       explicitFields = explicitFields
     , candidates = candidates
@@ -226,10 +216,10 @@ classifyInputs inputs = Classification {
     -- | Number all the declarations so that we can re-sort them at the end of
     -- the algorithm
     membersNumbered ::
-      [Numbered (Either (C.Decl l Parse) (field Parse))]
+      [Numbered (Either (C.Decl l Parse) (C.ExplicitField Parse))]
     membersNumbered = zipWith Numbered [0..] inputs.nestedDecls
     nestedDecls :: [Numbered (C.Decl l Parse)]
-    explicitFields :: [Numbered (field Parse)]
+    explicitFields :: [Numbered (C.ExplicitField Parse)]
     (nestedDecls, explicitFields) = partitionEithers $ fmap numberedIn membersNumbered
 
     -- | A struct\/union declaration requires an implicit field if the
@@ -261,16 +251,15 @@ isAnonymous decl = case decl.kind of
 --
 -- Note: the nested structs and unions should include implicit fields.
 isReferenced ::
-     HasField "typ" (field Parse) (C.Type Parse)
-  => C.Decl l Parse
+     C.Decl l Parse
      -- | Fields that are declared directly in the enclosing object
-  -> [field Parse]
+  -> [C.ExplicitField Parse]
      -- | Struct and union declarations (recursively) nested in the enclosing
      -- object
   -> [C.Decl l Parse]
   -> Bool
 isReferenced decl fields decls =
-       decl.info.id `elem` map fst (concatMap depsOfField fields)
+       decl.info.id `elem` map fst (concatMap depsOfExplicitField fields)
     || decl.info.id `elem` map fst (concatMap depsOfStructOrUnion decls)
   where
     depsOfStructOrUnion d = case d.kind of
@@ -284,18 +273,17 @@ isReferenced decl fields decls =
 
 -- | Generate an implicit field for an anonymous object
 getImplicitField ::
-     forall m field l. (
-      MonadIO m
-    , MakeImplicitField field
-    )
+     forall m l. (
+       MonadIO m
+     )
      -- | The enclosing object
   => EnclosingObject
      -- | An anonymous object nested in the enclosing object
   -> C.Decl l Parse
-  -> M m (field Parse)
+  -> M m (C.Field Parse)
 getImplicitField encObj decl = do
-    targetsNE <- liftEither $ checkNonEmpty targets
-    offsets <- mapM offsetOf' targetsNE
+    indFields <- getIndirectFields encObj decl
+    indFieldsNE <- liftEither $ checkNonEmpty indFields
     -- The offset to the implicit field is equal to the offset to any of the
     -- nested object's fields, subtracted by the offset of that same field with
     -- respect to the nested object.
@@ -304,38 +292,34 @@ getImplicitField encObj decl = do
     -- 'minimumBy' to determine which /named/ field is the first. We need to
     -- know which field is first so that we can use that field's name as the
     -- implicit field's name as well.
-    let (target, offset) = minimumBy (\x y -> compare (snd x) (snd y)) offsets
-        offset' = offset - target.fieldOffset
-    makeImplicitFieldM
-      decl.info.loc
-      (mkScopedName target)
-      (C.TypeRef decl.info.id)
-      offset'
-      (mkOrigin target)
-  where
-    targets :: [Target]
-    targets = case decl.kind of
-        C.DeclStruct struct -> map getOffsetOfTarget struct.fields
-        C.DeclUnion  union  -> map getOffsetOfTarget union.fields
-        _                   -> []
+    let (origField, indField) = minimumBy (\x y -> compare (snd x).offset (snd y).offset) indFieldsNE
+        offset' = indField.offset - origField.offset
 
-    checkNonEmpty :: [Target] -> Either ParseImplicitFieldsMsg (NonEmpty Target)
+    let implicitField = makeImplicitField origField indField offset'
+
+    pure (C.FieldImplicit implicitField)
+  where
+    checkNonEmpty :: [a] -> Either ParseImplicitFieldsMsg (NonEmpty a)
     checkNonEmpty xs = case NonEmpty.nonEmpty xs of
         Nothing -> Left UnsupportedEmptyAnon
         Just ys -> Right ys
 
-    offsetOf' :: Target -> M m (Target, FieldOffset)
-    offsetOf' target = do
-        offset <- offsetOf encObj target.originName
-        pure (target, offset)
-
-    mkOrigin ::
-         Target
-      -> Origin.ImplicitFieldOrigin
-    mkOrigin target = Origin.ImplicitFieldOrigin (C.ScopedName target.originName.text)
-
-    mkScopedName :: Target -> ScopedName Parse
-    mkScopedName target = C.ScopedName ("anon'" <> target.fieldName.text)
+    makeImplicitField ::
+         C.Field Parse
+      -> IndirectField Parse
+      -> Int
+      -> C.ImplicitField Parse
+    makeImplicitField origField indField offset =
+        C.ImplicitField {
+            info = C.FieldInfo {
+                loc = decl.info.loc
+              , name = C.ScopedName ("anon'" <> indField.info.name.text)
+              , comment = ()
+              }
+          , typRef = C.AnonRef decl.info.id
+          , offset = offset
+          , ann = Origin.FieldOrigin (getOrigin origField)
+          }
 
 -- | When the field is implicit and we want to ask for its offset using its
 -- name, then we should ask for the offset to an explicit field of the
@@ -347,70 +331,62 @@ getImplicitField encObj decl = do
 -- careful with implicit field names. @libclang@ won't recognise the implicit
 -- field names.
 --
-getOffsetOfTarget ::
-     IsField field
-  => field Parse
-  -> Target
-getOffsetOfTarget (Field -> field) =
-    Target {
-        fieldName = FieldName field.info.name.text
-      , originName = FieldName $ case snd field.ann of
-          Origin.ExplicitParsed Origin.ExplicitFieldOrigin
-            -> field.info.name.text
-          Origin.ImplicitGenerated origin
-            -> origin.field.text
-      , fieldOffset = FieldOffset $ field.offset
-      }
-
-data Target = Target {
-      fieldName  :: FieldName
-    , originName :: FieldName
-    , fieldOffset :: FieldOffset
-    }
+getOrigin :: C.Field Parse -> ScopedName Parse
+getOrigin = C.elimField (.info.name) (.ann.field)
 
 {-------------------------------------------------------------------------------
-  Field
+  Indirect field
 -------------------------------------------------------------------------------}
 
-class ( HasField "ann" (Field field) (ReparseInfo Tokens, Origin.FieldOrigin)
-      , HasField "info" (Field field) (C.FieldInfo Parse)
-      , HasField "width" (Field field) (Maybe Int)
-      , HasField "offset" (Field field) Int
-      )
-   => IsField field
+getIndirectFields ::
+     forall m l. (
+       MonadIO m
+     )
+     -- | The enclosing object
+  => EnclosingObject
+     -- | An anonymous object nested in the enclosing object
+  -> C.Decl l Parse
+  -> M m [(C.Field Parse, IndirectField Parse)]
+getIndirectFields encObj decl = forM fields $ \field ->
+    (field,) <$> getIndirectField encObj decl field
+  where
+    fields :: [C.Field Parse]
+    fields = case decl.kind of
+        C.DeclStruct struct -> struct.fields
+        C.DeclUnion  union  -> union.fields
+        _ -> []
 
-instance IsField C.StructField
-instance IsField C.UnionField
+getIndirectField ::
+     forall m l. (
+       MonadIO m
+     )
+     -- | The enclosing object
+  => EnclosingObject
+     -- | An anonymous object nested in the enclosing object
+  -> C.Decl l Parse
+     -- | A field of the anonymous object
+  -> C.Field Parse
+  -> M m (IndirectField Parse)
+getIndirectField encObj _decl field = do
+    offsetOuter <- offsetOf encObj (getOrigin field)
+    pure $ mkIndirectField offsetOuter
+  where
+    mkIndirectField :: Int -> IndirectField Parse
+    mkIndirectField offset = IndirectField {
+          info = field.info
+        , typ = field.typ
+        , offset = offset
+        , width = field.width
+        , origin = Origin.FieldOrigin (getOrigin field)
+        }
 
-newtype Field field = Field { unwrap :: field Parse }
-
-instance HasField "ann" (Field C.StructField) (ReparseInfo Tokens, Origin.FieldOrigin) where
-  getField x = getField @"ann" x.unwrap
-
-instance HasField "info" (Field C.StructField) (C.FieldInfo Parse) where
-  getField x = getField @"info" x.unwrap
-
-instance HasField "width" (Field C.StructField) (Maybe Int) where
-  getField x = getField @"width" x.unwrap
-
-instance HasField "offset" (Field C.StructField) Int where
-  getField x = getField @"offset" x.unwrap
-
-instance HasField "ann" (Field C.UnionField) (ReparseInfo Tokens, Origin.FieldOrigin) where
-  getField x = getField @"ann" x.unwrap
-
-instance HasField "info" (Field C.UnionField) (C.FieldInfo Parse) where
-  getField x = getField @"info" x.unwrap
-
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
--- Once bit-fields are supported in union fields, then we can implement this
--- instance properly
-instance HasField "width" (Field C.UnionField) (Maybe Int) where
-  getField _ = Nothing
-
--- offsets for union fields are always 0
-instance HasField "offset" (Field C.UnionField) Int where
-  getField _ = 0
+data IndirectField p = IndirectField {
+      info :: C.FieldInfo p
+    , typ :: C.Type p
+    , offset :: Int
+    , width  :: Maybe Int
+    , origin :: Origin.FieldOrigin
+    }
 
 {-------------------------------------------------------------------------------
   Field offset
@@ -418,13 +394,6 @@ instance HasField "offset" (Field C.UnionField) Int where
 
 newtype EnclosingObject = EnclosingObject { typ :: CXType }
   deriving stock Show
-
-newtype FieldName = FieldName { text :: Text }
-  deriving stock (Show, Eq, Ord)
-
-newtype FieldOffset = FieldOffset { int :: Int }
-  deriving stock (Show, Eq, Ord)
-  deriving newtype (Num)
 
 -- | Get the offset of a named field with respect to an enclosing object.
 --
@@ -434,78 +403,17 @@ newtype FieldOffset = FieldOffset { int :: Int }
 offsetOf ::
      MonadIO m
   => EnclosingObject
-  -> FieldName
-  -> M m FieldOffset
+  -> ScopedName Parse
+  -> M m Int
 offsetOf encObj name = do
     offsetE <- liftIO $ try @CallFailed $ clang_Type_getOffsetOf encObj.typ fieldName
     case offsetE of
       Left e
         -> throwError (UnexpectedClangOffsetOfException name.text (show e))
       Right offset
-        -> pure (FieldOffset (fromIntegral offset))
+        -> pure (fromIntegral offset)
   where
     fieldName = Text.unpack name.text
-
-
-{-------------------------------------------------------------------------------
-  MakeImplicitField
--------------------------------------------------------------------------------}
-
--- | Create an implicit field monadically
-makeImplicitFieldM ::
-     (Monad m, MakeImplicitField field)
-  => SingleLoc                  -- ^ Field location
-  -> ScopedName Parse           -- ^ Field name
-  -> C.Type Parse               -- ^ Field type
-  -> FieldOffset                -- ^ Field offset
-  -> Origin.ImplicitFieldOrigin -- ^ Field origin
-  -> M m (field Parse)
-makeImplicitFieldM loc name typ off orig = do
-    let field = makeImplicitField loc name typ off orig
-    case field of
-      Left e -> throwError e
-      Right x -> pure x
-
--- | A common interface to creating an implicit field for a struct or union
--- object.
-class MakeImplicitField field where
-  -- | Create an implicit field
-  makeImplicitField ::
-       SingleLoc                  -- ^ Field location
-    -> ScopedName Parse           -- ^ Field name
-    -> C.Type Parse               -- ^ Field type
-    -> FieldOffset                -- ^ Field offset
-    -> Origin.ImplicitFieldOrigin -- ^ Field origin
-    -> Either ParseImplicitFieldsMsg (field Parse)
-
-instance MakeImplicitField C.StructField where
-  makeImplicitField loc name typ off orig =
-      Right C.StructField {
-          info = C.FieldInfo {
-              loc = loc
-            , name = name
-            , comment = ()
-            }
-        , typ = typ
-        , offset = off.int
-        , width = Nothing
-        , ann = (ReparseNotNeeded, Origin.ImplicitGenerated orig)
-        }
-
-instance MakeImplicitField C.UnionField where
-  makeImplicitField loc name typ off orig
-    | off.int /= 0
-    = Left (UnexpectedNonZeroFieldOffset off.int)
-    | otherwise
-    = Right C.UnionField {
-          info = C.FieldInfo {
-              loc = loc
-            , name = name
-            , comment = ()
-            }
-        , typ = typ
-        , ann = (ReparseNotNeeded, Origin.ImplicitGenerated orig)
-        }
 
 {-------------------------------------------------------------------------------
   Monad

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Members.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl/Members.hs
@@ -1,13 +1,11 @@
 -- | Parse functions related to struct and union members
 module HsBindgen.Frontend.Pass.Parse.Decl.Members (
     ParseMembersResult (..)
-  , parseStructMembersWith
-  , parseUnionMembersWith
+  , parseMembersWith
   ) where
 
 import Data.Either (partitionEithers)
 import Data.List.NonEmpty qualified as NE
-import GHC.Records (HasField)
 
 import Clang.Enum.Simple (fromSimpleEnum)
 import Clang.HighLevel.Types (Fold, FoldException (exception), Next,
@@ -17,8 +15,7 @@ import Clang.LowLevel.Core (CXCursor, CXCursorKind (CXCursor_FieldDecl), CXType,
 
 import HsBindgen.Frontend.Pass.Parse.Context (ExceptionInCtx (exception),
                                               ParseCtx)
-import HsBindgen.Frontend.Pass.Parse.Decl.Field (structFieldDecl,
-                                                 unionFieldDecl)
+import HsBindgen.Frontend.Pass.Parse.Decl.Field (explicitFieldDecl)
 import HsBindgen.Frontend.Pass.Parse.Decl.ImplicitFields qualified as IFields
 import HsBindgen.Frontend.Pass.Parse.IsPass (Parse)
 import HsBindgen.Frontend.Pass.Parse.Monad.Decl (ParseDecl)
@@ -33,65 +30,32 @@ import HsBindgen.Macro.Type qualified as Macro
 type Parser l = CXCursor -> ParseDecl (Next ParseDecl [ParseResult l Parse])
 
 -- | The result of parsing the members of a struct\/union
-data ParseMembersResult field l = ParseMembersResult {
+data ParseMembersResult l = ParseMembersResult {
       -- | Nested object declarations (i.e., structs and unions)
       declMembers  :: [ParseResult l Parse]
       -- | Field declarations
       --
       -- Returns 'Left' if any nested struct\/union declarations or field
       -- declarations failed to be parsed. Returns 'Right' otherwise.
-    , fieldMembers :: Either DelayedParseMsg [field Parse]
+    , fieldMembers :: Either DelayedParseMsg [C.Field Parse]
     }
 
-deriving stock instance (Show (field Parse), Macro.HasTypes l)
-  => Show (ParseMembersResult field l)
-
--- | Parse the members of a struct
-parseStructMembersWith ::
-     CXType
-     -- ^ Type of the enclosing object
-  -> ParseCtx
-     -- | How to parse a non-field declaration (e.g., a union or struct
-     -- declaration)
-  -> (ParseCtx -> Parser l)
-      -- | How to continue with the result of parsing members
-  -> (ParseMembersResult C.StructField l -> ParseDecl a)
-  -> ParseDecl (Next ParseDecl a)
-parseStructMembersWith ty ctx parseObject k =
-    parseMembersWith ty ctx structFieldDecl parseObject k
-
--- | Parse the members of a union
-parseUnionMembersWith ::
-     CXType
-     -- ^ Type of the enclosing object
-  -> ParseCtx
-     -- | How to parse a non-field declaration (e.g., a union or struct
-     -- declaration)
-  -> (ParseCtx -> Parser l)
-      -- | How to continue with the result of parsing members
-  -> (ParseMembersResult C.UnionField l -> ParseDecl a)
-  -> ParseDecl (Next ParseDecl a)
-parseUnionMembersWith ty ctx parseObject k =
-    parseMembersWith ty ctx unionFieldDecl parseObject k
+deriving stock instance (Macro.HasTypes l)
+  => Show (ParseMembersResult l)
 
 -- | Parse all members of a struct\/union
 parseMembersWith ::
-     ( IFields.MakeImplicitField field
-     , HasField "typ" (field Parse) (C.Type Parse)
-     )
      -- | Type of the enclosing object
-  => CXType
+     CXType
   -> ParseCtx
-     -- | How to parse a field declaration
-  -> (ParseCtx -> CXCursor -> ParseDecl (field Parse))
      -- | How to parse a non-field declaration (e.g., a union or struct
      -- declaration)
   -> (ParseCtx -> Parser l)
      -- | How to continue with the result of parsing members
-  -> (ParseMembersResult field l -> ParseDecl a)
+  -> (ParseMembersResult l -> ParseDecl a)
   -> ParseDecl (Next ParseDecl a)
-parseMembersWith ty ctx parseField parseObject k =
-    foldRecurseWith (parseMember ctx parseField parseObject) $ \xs -> do
+parseMembersWith ty ctx parseObject k =
+    foldRecurseWith (parseMember ctx parseObject) $ \xs -> do
       let (foldExceptions, allDecls, fails, successes) = partitionParseMemberResults xs
           -- Always return all nested declarations, regardless of their parse
           -- status. The @Select@ pass wil handle deselecting declarations if
@@ -144,17 +108,17 @@ parseMembersWith ty ctx parseField parseObject k =
                     }
 
 -- | The result of parsing a single member of a struct\/union
-data ParseMemberResult field l =
+data ParseMemberResult l =
     ParseMemberResultFoldException (FoldException (ExceptionInCtx DelayedParseMsg))
   | ParseMemberResultDecls [ParseResult l Parse]
-  | ParseMemberResultField (field Parse)
+  | ParseMemberResultField (C.ExplicitField Parse)
 
 partitionParseMemberResults ::
-     [ParseMemberResult field l]
+     [ParseMemberResult l]
   -> ( [FoldException (ExceptionInCtx DelayedParseMsg)]
      , [ParseResult l Parse]  -- ^ All parse results
      , [ParseResult l Parse]  -- ^ Only parse failures
-     , IFields.Inputs field l -- ^ Only parse successes
+     , IFields.Inputs l -- ^ Only parse successes
      )
 partitionParseMemberResults = mconcat . fmap f
   where
@@ -174,19 +138,17 @@ partitionParseMemberResults = mconcat . fmap f
 -- | Parse a single member of a struct\/union
 parseMember ::
      ParseCtx
-     -- | How to parse a field declaration
-  -> (ParseCtx -> CXCursor -> ParseDecl (field Parse))
      -- | How to parse a non-field declaration (e.g., a union or struct
      -- declaration)
   -> (ParseCtx -> Parser l)
-  -> Fold ParseDecl (ParseMemberResult field l)
-parseMember ctx parseField parseObject =
+  -> Fold ParseDecl (ParseMemberResult l)
+parseMember ctx parseObject =
     fmap flatten $
     foldTry $ \curr -> do
       kind <- fromSimpleEnum <$> clang_getCursorKind curr
       case kind of
         Right CXCursor_FieldDecl -> do
-          field <- parseField ctx curr
+          field <- explicitFieldDecl ctx curr
           -- Field declarations can have struct\/union declarations as children in
           -- the clang AST; however, those are duplicates of declarations that
           -- appear elsewhere, so here we choose not to recurse.
@@ -195,8 +157,8 @@ parseMember ctx parseField parseObject =
           fmap ParseMemberResultDecls <$> parseObject ctx curr
   where
     flatten ::
-         Either (FoldException (ExceptionInCtx DelayedParseMsg)) (ParseMemberResult field l)
-      -> ParseMemberResult field l
+         Either (FoldException (ExceptionInCtx DelayedParseMsg)) (ParseMemberResult l)
+      -> ParseMemberResult l
     flatten = \case
         Left e -> ParseMemberResultFoldException e
         Right x -> x

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -6,8 +6,6 @@ module HsBindgen.Frontend.Pass.Parse.IsPass (
   , Tokens
     -- * Fields
   , FieldOrigin(..)
-  , ExplicitFieldOrigin(..)
-  , ImplicitFieldOrigin(..)
     -- * IsAnon
   , IsAnon(..)
   ) where
@@ -31,14 +29,14 @@ type Parse :: Pass
 data Parse a
 
 type family AnnParse (ix :: Symbol) :: Star where
-  AnnParse "Function"    = ReparseInfo Tokens
-  AnnParse "Global"      = ReparseInfo Tokens
-  AnnParse "Struct"      = IsAnon
-  AnnParse "StructField" = (ReparseInfo Tokens, FieldOrigin)
-  AnnParse "Typedef"     = ReparseInfo Tokens
-  AnnParse "Union"       = IsAnon
-  AnnParse "UnionField"  = (ReparseInfo Tokens, FieldOrigin)
-  AnnParse _             = NoAnn
+  AnnParse "ExplicitField" = ReparseInfo Tokens
+  AnnParse "Function"      = ReparseInfo Tokens
+  AnnParse "Global"        = ReparseInfo Tokens
+  AnnParse "ImplicitField" = FieldOrigin
+  AnnParse "Struct"        = IsAnon
+  AnnParse "Typedef"       = ReparseInfo Tokens
+  AnnParse "Union"         = IsAnon
+  AnnParse _               = NoAnn
 
 instance IsPass Parse
 
@@ -93,18 +91,6 @@ type Tokens = [Token TokenSpelling]
   Fields
 -------------------------------------------------------------------------------}
 
--- | How a struct or union field came to be
-data FieldOrigin =
-    ExplicitParsed ExplicitFieldOrigin
-  | ImplicitGenerated ImplicitFieldOrigin
-  deriving stock (Show, Eq, Ord)
-
--- | An explicit struct or union field is parsed directly from a C header file
---
--- Named fields are always parsed directly from a C header file.
-data ExplicitFieldOrigin = ExplicitFieldOrigin
-  deriving stock (Show, Eq, Ord)
-
 -- | An implicit struct or union field is generated for nested anonymous structs
 -- and unions
 --
@@ -112,7 +98,7 @@ data ExplicitFieldOrigin = ExplicitFieldOrigin
 -- about implicit fields, so we have to derive the information ourselves using a
 -- custom algorithm. See the "HsBindgen.Frontend.Pass.Parse.Decl.ImplicitFields"
 -- module for the algorithm.
-newtype ImplicitFieldOrigin = ImplicitFieldOrigin {
+data FieldOrigin = FieldOrigin {
     -- | The name of the first field of the anonymous object
     --
     -- The offset from the enclosing object to an anonymous struct or union is

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -510,11 +510,6 @@ data ParseImplicitFieldsMsg =
     --
     -- This is likely a bug in implicit field parsing.
   | UnexpectedClangOffsetOfException Text String
-    -- | An unexpected non-zero field offset for an implicit field of a union
-    -- was computed
-    --
-    -- This is likely a bug in implicit field parsing.
-  | UnexpectedNonZeroFieldOffset Int
   deriving stock (Show, Eq, Ord, Generic)
 
 
@@ -528,16 +523,11 @@ instance PrettyForTrace ParseImplicitFieldsMsg where
           "Unexpected exception when using clang_Type_getOffsetOf"
         , "with field name", PP.text field, ":", PP.string exc
         ]
-      UnexpectedNonZeroFieldOffset off -> PP.hsep [
-          "Unexpected non-zero field offset for an implicit field of a union:"
-        , PP.show off
-        ]
 
 -- | Unsupported features are warnings
 instance IsTrace Level ParseImplicitFieldsMsg where
   getDefaultLogLevel = \case
       UnsupportedEmptyAnon{}              -> Warning
-      UnexpectedNonZeroFieldOffset{}      -> Bug
       UnexpectedClangOffsetOfException{}  -> Bug
   getSource  = const HsBindgen
   getTraceId = const "implicit-fields"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
@@ -27,12 +27,11 @@ type PrepareReparse :: Pass
 data PrepareReparse a
 
 type family AnnPrepareReparse (ix :: Symbol) :: Star where
-  AnnPrepareReparse "Function"    = ReparseInfo FlatTokens
-  AnnPrepareReparse "Global"      = ReparseInfo FlatTokens
-  AnnPrepareReparse "StructField" = ReparseInfo FlatTokens
-  AnnPrepareReparse "Typedef"     = ReparseInfo FlatTokens
-  AnnPrepareReparse "UnionField"  = ReparseInfo FlatTokens
-  AnnPrepareReparse _             = NoAnn
+  AnnPrepareReparse "ExplicitField" = ReparseInfo FlatTokens
+  AnnPrepareReparse "Function"      = ReparseInfo FlatTokens
+  AnnPrepareReparse "Global"        = ReparseInfo FlatTokens
+  AnnPrepareReparse "Typedef"       = ReparseInfo FlatTokens
+  AnnPrepareReparse _               = NoAnn
 
 instance IsPass PrepareReparse
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Simplifier.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Simplifier.hs
@@ -91,20 +91,20 @@ instance Simplify C.Struct where
       concatMap (simplifyIt info) struct.fields ++
       foldMap (simplifyIt info) (C.flamStructField struct.flam)
 
-instance Simplify C.StructField where
-  simplifyIt info field = case field.ann of
-      ReparseNotNeeded -> nothing
-      ReparseNeeded tokens _macroInvs -> singleTarget $
-        Target (fieldTag info field.info) (defaultDecl tokens)
-
 instance Simplify C.Union where
   simplifyIt info union = concatMap (simplifyIt info) union.fields
 
-instance Simplify C.UnionField where
+instance Simplify C.Field where
+  simplifyIt info = C.elimField (simplifyIt info) (simplifyIt info)
+
+instance Simplify C.ExplicitField where
   simplifyIt info field = case field.ann of
-      ReparseNotNeeded -> nothing
-      ReparseNeeded tokens _macroInvs -> singleTarget $
-        Target (fieldTag info field.info) (defaultDecl tokens)
+        ReparseNotNeeded -> nothing
+        ReparseNeeded tokens _macroInvs -> singleTarget $
+          Target (fieldTag info field.info) (defaultDecl tokens)
+
+instance Simplify C.ImplicitField where
+  simplifyIt _ _ = nothing
 
 instance Simplify C.Typedef where
   simplifyIt info typedef = case typedef.ann of

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Update.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/Update.hs
@@ -187,16 +187,6 @@ instance Update C.Struct where
         , ann       = struct.ann
         }
 
-instance Update C.StructField where
-  updateIt info field = do
-      ann' <- updateReparseInfo info (fieldTag info field.info) field.ann
-      pure C.StructField {
-          info   = coercePass field.info
-        , typ    = coercePass field.typ
-        , offset = field.offset
-        , width  = field.width
-        , ann    = ann'
-        }
 
 instance Update C.Union where
   updateIt info union = do
@@ -208,14 +198,22 @@ instance Update C.Union where
         , ann       = union.ann
         }
 
-instance Update C.UnionField where
+instance Update C.Field where
+  updateIt info = C.mapMField (updateIt info) (updateIt info)
+
+instance Update C.ExplicitField where
   updateIt info field = do
       ann' <- updateReparseInfo info (fieldTag info field.info) field.ann
-      pure C.UnionField {
-          info = coercePass field.info
-        , typ  = coercePass field.typ
-        , ann  = ann'
+      pure C.ExplicitField {
+          info   = coercePass field.info
+        , typ    = coercePass field.typ
+        , offset = field.offset
+        , width  = field.width
+        , ann    = ann'
         }
+
+instance Update C.ImplicitField where
+  updateIt _info field = pure $ coercePass field
 
 instance Update C.Typedef where
   updateIt info typedef = do

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -154,11 +154,11 @@ processStruct ::
   -> M (C.Decl l ReparseMacroExpansions)
 processStruct info struct = do
     mkDecl
-      <$> mapM (processStructField info.id) struct.fields
-      <*> C.traverseFlamField (processStructField info.id) struct.flam
+      <$> mapM (processField info.id) struct.fields
+      <*> C.traverseFlamField (processExplicitField info.id) struct.flam
   where
     mkDecl ::
-         [C.StructField ReparseMacroExpansions]
+         [C.Field ReparseMacroExpansions]
       -> C.Flam ReparseMacroExpansions
       -> C.Decl l ReparseMacroExpansions
     mkDecl fields flam = C.Decl{
@@ -170,6 +170,27 @@ processStruct info struct = do
             , sizeof    = struct.sizeof
             , alignment = struct.alignment
             , ann       = struct.ann
+            }
+        }
+
+processUnion ::
+     C.DeclInfo ReparseMacroExpansions
+  -> C.Union PrepareReparse
+  -> M (C.Decl l ReparseMacroExpansions)
+processUnion info union = do
+    combineFields <$> mapM (processField info.id) union.fields
+  where
+    combineFields ::
+         [C.Field ReparseMacroExpansions]
+      -> C.Decl l ReparseMacroExpansions
+    combineFields fields = C.Decl{
+          info = info
+        , ann  = NoAnn
+        , kind = C.DeclUnion C.Union{
+              fields    = fields
+            , sizeof    = union.sizeof
+            , alignment = union.alignment
+            , ann       = union.ann
             }
         }
 
@@ -187,61 +208,31 @@ mkFieldInfo info mName = C.FieldInfo{
     , loc     = info.loc
     }
 
-processStructField ::
+processField ::
      C.DeclId
-  -> C.StructField PrepareReparse
-  -> M (C.StructField ReparseMacroExpansions)
-processStructField declId field =
+  -> C.Field PrepareReparse
+  -> M (C.Field ReparseMacroExpansions)
+processField declId = \case
+    C.FieldExplicit field -> C.FieldExplicit <$> processExplicitField declId field
+    C.FieldImplicit field -> pure $ C.FieldImplicit $ coercePass field
+
+processExplicitField ::
+     C.DeclId
+  -> C.ExplicitField PrepareReparse
+  -> M (C.ExplicitField ReparseMacroExpansions)
+processExplicitField declId field =
     reparseWith declId LanC.reparseField field.ann withoutReparse withReparse
   where
-    withoutReparse :: C.StructField PrepareReparse
+    withoutReparse :: C.ExplicitField PrepareReparse
     withoutReparse = field
 
-    withReparse :: (C.Type LanC, Text) -> M (C.StructField LanC)
-    withReparse (ty, name) = pure C.StructField{
-          typ    = ty
-        , ann    = NoAnn
+    withReparse :: (C.Type LanC, Text) -> M (C.ExplicitField LanC)
+    withReparse (ty, name) = pure C.ExplicitField{
+          info   = mkFieldInfo field.info (Just name)
+        , typ    = ty
         , offset = field.offset
         , width  = field.width
-        , info   = mkFieldInfo field.info (Just name)
-        }
-
-processUnion ::
-     C.DeclInfo ReparseMacroExpansions
-  -> C.Union PrepareReparse
-  -> M (C.Decl l ReparseMacroExpansions)
-processUnion info union = do
-    combineFields <$> mapM (processUnionField info.id) union.fields
-  where
-    combineFields ::
-         [C.UnionField ReparseMacroExpansions]
-      -> C.Decl l ReparseMacroExpansions
-    combineFields fields = C.Decl{
-          info = info
-        , ann  = NoAnn
-        , kind = C.DeclUnion C.Union{
-              fields    = fields
-            , sizeof    = union.sizeof
-            , alignment = union.alignment
-            , ann       = union.ann
-            }
-        }
-
-processUnionField ::
-     C.DeclId
-  -> C.UnionField PrepareReparse
-  -> M (C.UnionField ReparseMacroExpansions)
-processUnionField declId field =
-    reparseWith declId LanC.reparseField field.ann withoutReparse withReparse
-  where
-    withoutReparse :: C.UnionField PrepareReparse
-    withoutReparse = field
-
-    withReparse :: (C.Type LanC, Text) -> M (C.UnionField LanC)
-    withReparse (ty, name) = pure C.UnionField{
-          typ  = ty
-        , ann  = NoAnn
-        , info = mkFieldInfo field.info (Just name)
+        , ann    = NoAnn
         }
 
 processOpaque ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/ForgetAnn.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/ForgetAnn.hs
@@ -27,19 +27,12 @@ class ForgetAnn a where
   Instances
 -------------------------------------------------------------------------------}
 
-instance ForgetAnn C.StructField where
-  forgetAnn field = C.StructField{
+instance ForgetAnn C.ExplicitField where
+  forgetAnn field = C.ExplicitField{
           typ    = coercePass field.typ
         , ann    = NoAnn
         , offset = field.offset
         , width  = field.width
-        , info   = coercePass field.info
-        }
-
-instance ForgetAnn C.UnionField where
-  forgetAnn field = C.UnionField{
-          typ    = coercePass field.typ
-        , ann    = NoAnn
         , info   = coercePass field.info
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
@@ -150,28 +150,18 @@ zipEither pre post =
   Instances
 -------------------------------------------------------------------------------}
 
-instance ZipReparsed C.StructField where
+instance ZipReparsed C.ExplicitField where
   zipReparsed fieldPre field = do
+      info'   <- checkEqCoerce fieldPre.info   field.info
       typ'    <- zipType      fieldPre.typ    field.typ
       offset' <- checkEq      fieldPre.offset field.offset
       width'  <- checkEq      fieldPre.width  field.width
-      info'   <- checkEqCoerce fieldPre.info   field.info
-      success C.StructField{
-          typ    = typ'
-        , ann    = NoAnn
+      success C.ExplicitField{
+          info   = info'
+        , typ    = typ'
         , offset = offset'
         , width  = width'
-        , info   = info'
-        }
-
-instance ZipReparsed C.UnionField where
-  zipReparsed fieldPre field = do
-      typ'  <- zipType      fieldPre.typ  field.typ
-      info' <- checkEqCoerce fieldPre.info field.info
-      success C.UnionField{
-          typ  = typ'
-        , ann  = NoAnn
-        , info = info'
+        , ann    = NoAnn
         }
 
 instance ZipReparsed C.Typedef where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -441,7 +441,7 @@ instance Resolve C.Struct l where
         <*> C.traverseFlamField (resolve ctx) struct.flam
     where
       reconstruct ::
-           [C.StructField ResolveBindingSpecs]
+           [C.Field ResolveBindingSpecs]
         -> C.Flam ResolveBindingSpecs
         -> C.Struct ResolveBindingSpecs
       reconstruct structFields' structFlam' = C.Struct {
@@ -452,27 +452,12 @@ instance Resolve C.Struct l where
           , ann       = struct.ann
           }
 
-instance Resolve C.StructField l where
-  resolve ctx field =
-      reconstruct <$> resolve ctx field.typ
-    where
-      reconstruct ::
-           C.Type ResolveBindingSpecs
-        -> C.StructField ResolveBindingSpecs
-      reconstruct structFieldType' = C.StructField {
-          typ    = structFieldType'
-        , info   = coercePass field.info
-        , offset = field.offset
-        , width  = field.width
-        , ann    = field.ann
-        }
-
 instance Resolve C.Union l where
   resolve ctx union =
       reconstruct <$> mapM (resolve ctx) union.fields
     where
       reconstruct ::
-           [C.UnionField ResolveBindingSpecs]
+           [C.Field ResolveBindingSpecs]
         -> C.Union ResolveBindingSpecs
       reconstruct unionFields' = C.Union {
           fields    = unionFields'
@@ -481,17 +466,47 @@ instance Resolve C.Union l where
         , ann       = union.ann
         }
 
-instance Resolve C.UnionField l where
+instance Resolve C.Field l where
+  resolve ctx = \case
+      C.FieldExplicit field -> C.FieldExplicit <$> resolve ctx field
+      C.FieldImplicit field -> C.FieldImplicit <$> resolve ctx field
+
+instance Resolve C.ExplicitField l where
   resolve ctx field =
       reconstruct <$> resolve ctx field.typ
     where
-      reconstruct :: C.Type ResolveBindingSpecs
-                 -> C.UnionField ResolveBindingSpecs
-      reconstruct unionFieldType' = C.UnionField {
-          typ  = unionFieldType'
-        , info = coercePass field.info
-        , ann  = field.ann
+      reconstruct ::
+           C.Type ResolveBindingSpecs
+        -> C.ExplicitField ResolveBindingSpecs
+      reconstruct typ' = C.ExplicitField {
+          typ    = typ'
+        , info   = coercePass field.info
+        , offset = field.offset
+        , width  = field.width
+        , ann    = field.ann
         }
+
+instance Resolve C.ImplicitField l where
+  resolve ctx field = do
+      reconstruct <$> resolve ctx field.typRef
+    where
+      reconstruct ::
+           C.AnonRef ResolveBindingSpecs
+        -> C.ImplicitField ResolveBindingSpecs
+      reconstruct typRef' = C.ImplicitField {
+          typRef    = typRef'
+        , info   = coercePass field.info
+        , offset = field.offset
+        , ann    = field.ann
+        }
+
+instance Resolve C.AnonRef l where
+  resolve ctx (C.AnonRef ref) = do
+      mResolved <- resolveUseSite ctx ref
+      let underlying' = C.TypeRef ref
+      case mResolved of
+        Just r  -> return $ C.AnonExtBinding $ C.Ref r underlying'
+        Nothing -> return $ C.AnonRef ref
 
 instance Resolve C.Enum l where
   resolve ctx enum =
@@ -591,32 +606,32 @@ instance Resolve (TypecheckedMacroType l) l where
 instance Resolve C.Type l where
   resolve ctx = \case
       C.TypeRef uid -> do
-        mResolved <- aux uid
+        mResolved <- resolveUseSite ctx uid
         let ref' = C.TypeRef uid
         case mResolved of
-          Just r  -> return $ r ref'
+          Just r  -> return $ C.TypeExtBinding $ C.Ref r ref'
           Nothing -> return ref'
       C.TypeEnum ref -> do
-        mResolved <- aux ref.name
+        mResolved <- resolveUseSite ctx ref.name
         underlying' <- resolve ctx ref.underlying
-        let enum' = C.TypeEnum (C.Ref ref.name underlying')
+        let ref' = C.TypeEnum (C.Ref ref.name underlying')
         case mResolved of
-          Just r  -> return $ r enum'
-          Nothing -> return enum'
+          Just r  -> return $ C.TypeExtBinding $ C.Ref r ref'
+          Nothing -> return ref'
       C.TypeMacro ref -> do
-        mResolved <- aux ref.name
+        mResolved <- resolveUseSite ctx ref.name
         underlying' <- resolve ctx ref.underlying
-        let macro' = C.TypeMacro (C.MacroRef ref.name underlying')
+        let ref' = C.TypeMacro (C.MacroRef ref.name underlying')
         case mResolved of
-          Just r  -> return $ r macro'
-          Nothing -> return macro'
+          Just r  -> return $ C.TypeExtBinding $ C.Ref r ref'
+          Nothing -> return ref'
       C.TypeTypedef ref -> do
-        mResolved <- aux ref.name
+        mResolved <- resolveUseSite ctx ref.name
         underlying' <- resolve ctx ref.underlying
-        let typedef' = C.TypeTypedef (C.Ref ref.name underlying')
+        let ref' = C.TypeTypedef (C.Ref ref.name underlying')
         case mResolved of
-          Just r  -> return $ r typedef'
-          Nothing -> return typedef'
+          Just r  -> return $ C.TypeExtBinding $ C.Ref r ref'
+          Nothing -> return ref'
 
       -- Recursive cases
       C.TypePointers n t      -> C.TypePointers n <$> resolve ctx t
@@ -631,14 +646,6 @@ instance Resolve C.Type l where
       C.TypePrim t         -> return (C.TypePrim t)
       C.TypeVoid           -> return (C.TypeVoid)
       C.TypeComplex t      -> return (C.TypeComplex t)
-    where
-      aux ::
-           HasCallStack
-        => C.DeclId
-        -> M l (Maybe (C.Type ResolveBindingSpecs -> C.Type ResolveBindingSpecs))
-      aux cDeclId = fmap reconstruct <$> resolveUseSite ctx cDeclId
-        where
-          reconstruct ty uTy = C.TypeExtBinding $ C.Ref ty uTy
 
 instance Resolve C.TypeFunArg l where
   resolve ctx arg = do

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -22,14 +22,14 @@ data SimplifyAST a
 
 -- Preserve annotations from @Parse@ pass
 type family AnnSimplifyAST (ix :: Symbol) where
-  AnnSimplifyAST "Function"    = ReparseInfo Tokens
-  AnnSimplifyAST "Global"      = ReparseInfo Tokens
-  AnnSimplifyAST "Struct"      = IsAnon
-  AnnSimplifyAST "StructField" = (ReparseInfo Tokens, FieldOrigin)
-  AnnSimplifyAST "Typedef"     = ReparseInfo Tokens
-  AnnSimplifyAST "Union"       = IsAnon
-  AnnSimplifyAST "UnionField"  = (ReparseInfo Tokens, FieldOrigin)
-  AnnSimplifyAST _             = NoAnn
+  AnnSimplifyAST "ExplicitField" = ReparseInfo Tokens
+  AnnSimplifyAST "Function"      = ReparseInfo Tokens
+  AnnSimplifyAST "Global"        = ReparseInfo Tokens
+  AnnSimplifyAST "ImplicitField" = FieldOrigin
+  AnnSimplifyAST "Struct"        = IsAnon
+  AnnSimplifyAST "Typedef"       = ReparseInfo Tokens
+  AnnSimplifyAST "Union"         = IsAnon
+  AnnSimplifyAST _               = NoAnn
 
 instance IsPass SimplifyAST
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -27,12 +27,11 @@ data TypecheckMacros a
 -- 'ConstructTranslationUnit'; these are consumed in the following
 -- 'ReparseMacroExpansions' pass.
 type family AnnTypecheckMacros (ix :: Symbol) :: Star where
-  AnnTypecheckMacros "Function"    = ReparseInfo Tokens
-  AnnTypecheckMacros "Global"      = ReparseInfo Tokens
-  AnnTypecheckMacros "StructField" = ReparseInfo Tokens
-  AnnTypecheckMacros "Typedef"     = ReparseInfo Tokens
-  AnnTypecheckMacros "UnionField"  = ReparseInfo Tokens
-  AnnTypecheckMacros _             = NoAnn
+  AnnTypecheckMacros "ExplicitField" = ReparseInfo Tokens
+  AnnTypecheckMacros "Function"      = ReparseInfo Tokens
+  AnnTypecheckMacros "Global"        = ReparseInfo Tokens
+  AnnTypecheckMacros "Typedef"       = ReparseInfo Tokens
+  AnnTypecheckMacros _               = NoAnn
 
 instance IsPass TypecheckMacros
 
@@ -144,11 +143,10 @@ instance CoercePassMacroId          ConstructTranslationUnit TypecheckMacros whe
     coercePassMacroId _ = absurd
 instance CoercePassMacroUnderlying  ConstructTranslationUnit TypecheckMacros
 
-instance CoercePassAnn "Function"    ConstructTranslationUnit TypecheckMacros
-instance CoercePassAnn "Global"      ConstructTranslationUnit TypecheckMacros
-instance CoercePassAnn "StructField" ConstructTranslationUnit TypecheckMacros
-instance CoercePassAnn "TypeFunArg"  ConstructTranslationUnit TypecheckMacros
-instance CoercePassAnn "Typedef"     ConstructTranslationUnit TypecheckMacros
-instance CoercePassAnn "UnionField"  ConstructTranslationUnit TypecheckMacros
-instance CoercePassCommentDecl       ConstructTranslationUnit TypecheckMacros where
+instance CoercePassAnn "ExplicitField" ConstructTranslationUnit TypecheckMacros
+instance CoercePassAnn "Function"      ConstructTranslationUnit TypecheckMacros
+instance CoercePassAnn "Global"        ConstructTranslationUnit TypecheckMacros
+instance CoercePassAnn "TypeFunArg"    ConstructTranslationUnit TypecheckMacros
+instance CoercePassAnn "Typedef"       ConstructTranslationUnit TypecheckMacros
+instance CoercePassCommentDecl         ConstructTranslationUnit TypecheckMacros where
   coercePassCommentDecl _ = fmap coercePass

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
@@ -22,9 +22,8 @@ module HsBindgen.IR.C.Decl (
   , flamStructField
   , traverseFlamField
   , mapFlamField
-  , StructField(..)
   , Union(..)
-  , UnionField(..)
+
   , Typedef(..)
   , Enum(..)
   , EnumConstant(..)
@@ -35,6 +34,14 @@ module HsBindgen.IR.C.Decl (
   , FunctionPurity(..)
   , decideFunctionPurity
   , Global(..)
+    -- ** Fields
+  , Field(..)
+  , mapField
+  , mapMField
+  , elimField
+  , ExplicitField(..)
+  , ImplicitField(..)
+  , AnonRef(..)
     -- ** Comments
   , Comment(..)
   , CommentRef(..)
@@ -43,11 +50,14 @@ module HsBindgen.IR.C.Decl (
 import Prelude hiding (Enum)
 import Prelude qualified as P
 
+import GHC.Records (HasField (getField))
+
 import Clang.HighLevel.Types
 
 import HsBindgen.Imports
 import HsBindgen.IR.C.HashIncludeArg qualified as C
 import HsBindgen.IR.C.Naming qualified as C
+import HsBindgen.IR.C.Type (CoercePassExtBindingRef (coercePassExtBindingRef))
 import HsBindgen.IR.C.Type qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.Language.C (PrimType)
@@ -184,7 +194,7 @@ data OpaqueSize = OpaqueSize {
 data Struct (p :: Pass) = Struct {
       sizeof    :: Int
     , alignment :: Int
-    , fields    :: [StructField p]
+    , fields    :: [Field p]
     , flam      :: Flam p
     , ann       :: Ann "Struct" p
     }
@@ -205,11 +215,11 @@ data Struct (p :: Pass) = Struct {
 -- minted (see <https://github.com/well-typed/hs-bindgen/issues/1925>).
 data Flam (p :: Pass) =
     NoFlam
-  | Flam (StructField p) (Ann "Flam" p)
+  | Flam (ExplicitField p) (Ann "Flam" p)
   deriving stock (Generic)
 
 -- | The element-type field of a FLAM, if present
-flamStructField :: Flam p -> Maybe (StructField p)
+flamStructField :: Flam p -> Maybe (ExplicitField p)
 flamStructField = \case
     NoFlam   -> Nothing
     Flam f _ -> Just f
@@ -217,7 +227,7 @@ flamStructField = \case
 -- | Traverse the element-type field of a FLAM, preserving its annotation
 traverseFlamField ::
      (Applicative f, Ann "Flam" p ~ Ann "Flam" p')
-  => (StructField p -> f (StructField p'))
+  => (ExplicitField p -> f (ExplicitField p'))
   -> Flam p
   -> f (Flam p')
 traverseFlamField f = \case
@@ -227,36 +237,21 @@ traverseFlamField f = \case
 -- | Map over the element-type field of a FLAM, preserving its annotation
 mapFlamField ::
      (Ann "Flam" p ~ Ann "Flam" p')
-  => (StructField p -> StructField p')
+  => (ExplicitField p -> ExplicitField p')
   -> Flam p
   -> Flam p'
 mapFlamField f = \case
     NoFlam       -> NoFlam
     Flam fld ann -> Flam (f fld) ann
 
-data StructField (p :: Pass) = StructField {
-      info   :: FieldInfo p
-    , typ    :: C.Type p
-    , offset :: Int     -- ^ Offset in bits
-    , width  :: Maybe Int
-    , ann    :: Ann "StructField" p
-    }
-  deriving stock (Generic)
-
 data Union (p :: Pass) = Union {
       sizeof    :: Int
     , alignment :: Int
-    , fields    :: [UnionField p]
+    , fields    :: [Field p]
     , ann       :: Ann "Union" p
     }
   deriving stock (Generic)
 
-data UnionField (p :: Pass) = UnionField {
-      info :: FieldInfo p
-    , typ  :: C.Type p
-    , ann  :: Ann "UnionField" p
-    }
-  deriving stock (Generic)
 
 data Typedef (p :: Pass) = Typedef {
       typ :: C.Type p
@@ -405,6 +400,86 @@ data Global (p :: Pass) = Global {
   deriving stock (Generic)
 
 {-------------------------------------------------------------------------------
+  Fields
+-------------------------------------------------------------------------------}
+
+data Field p =
+    FieldExplicit (ExplicitField p)
+  | FieldImplicit (ImplicitField p)
+  deriving stock (Generic)
+
+instance HasField "info" (Field p) (FieldInfo p) where
+  getField = elimField (.info) (.info)
+
+instance HasField "typ" (Field p) (C.Type p) where
+  getField = elimField (.typ) (.typ)
+
+instance HasField "offset" (Field p) Int where
+  getField = elimField (.offset) (.offset)
+
+instance HasField "width" (Field p) (Maybe Int) where
+  getField = elimField (.width) (.width)
+
+mapField :: (ExplicitField p -> ExplicitField p') -> (ImplicitField p -> ImplicitField p') -> Field p -> Field p'
+mapField f g = \case
+    FieldExplicit field -> FieldExplicit $ f field
+    FieldImplicit field -> FieldImplicit $ g field
+
+mapMField ::
+     Monad m
+  => (ExplicitField p -> m (ExplicitField p'))
+  -> (ImplicitField p -> m (ImplicitField p'))
+  -> Field p
+  -> m (Field p')
+mapMField f g = \case
+    FieldExplicit field -> FieldExplicit <$> f field
+    FieldImplicit field -> FieldImplicit <$> g field
+
+elimField :: (ExplicitField p -> a) -> (ImplicitField p -> a) -> Field p -> a
+elimField f g = \case
+    FieldExplicit field -> f field
+    FieldImplicit field -> g field
+
+data ExplicitField p = ExplicitField {
+      info   :: FieldInfo p
+    , typ    :: C.Type p
+      -- | Offset in bits
+    , offset :: Int
+    , width  :: Maybe Int
+    , ann    :: Ann "ExplicitField" p
+    }
+    deriving stock (Generic)
+
+data ImplicitField p = ImplicitField {
+      info     :: FieldInfo p
+      -- | Implicit fields can only refer to anonymous structs or unions
+    , typRef   :: AnonRef p
+      -- | Offset in bits
+    , offset   :: Int
+    , ann      :: Ann "ImplicitField" p
+    }
+    deriving stock (Generic)
+
+-- | A reference to an anonymous struct or union
+data AnonRef p =
+    AnonRef (Id p)
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
+  | AnonExtBinding !(C.ExtBindingRef p)
+
+-- | Implicit fields can only refer to anonymous structs or unions, so the type
+-- of the field is always @TypeRef typRef@. Use the @typRef@ field to access the
+-- reference directly.
+instance HasField "typ" (ImplicitField p) (C.Type p) where
+  getField x = case x.typRef of
+      AnonRef ref -> C.TypeRef ref
+      AnonExtBinding ext -> C.TypeExtBinding ext
+
+-- | Implicit fields can only refer to anonymous structs or unions, so they have
+-- no bit width.
+instance HasField "width" (ImplicitField p) (Maybe Int) where
+  getField _x = Nothing
+
+{-------------------------------------------------------------------------------
   Comments
 -------------------------------------------------------------------------------}
 
@@ -426,38 +501,42 @@ data CommentRef p = CommentRef Text (Maybe (Id p)) (Maybe Doxy.RefKind)
 -------------------------------------------------------------------------------}
 
 deriving stock instance IsPass p => Eq (AnonEnumConstant p)
+deriving stock instance IsPass p => Eq (AnonRef          p)
 deriving stock instance IsPass p => Eq (Comment          p)
 deriving stock instance IsPass p => Eq (CommentRef       p)
 deriving stock instance IsPass p => Eq (DeclInfo         p)
 deriving stock instance IsPass p => Eq (Enum             p)
 deriving stock instance IsPass p => Eq (EnumConstant     p)
+deriving stock instance IsPass p => Eq (ExplicitField    p)
+deriving stock instance IsPass p => Eq (Field            p)
 deriving stock instance IsPass p => Eq (FieldInfo        p)
 deriving stock instance IsPass p => Eq (Flam             p)
 deriving stock instance IsPass p => Eq (Function         p)
 deriving stock instance IsPass p => Eq (FunctionArg      p)
 deriving stock instance IsPass p => Eq (Global           p)
+deriving stock instance IsPass p => Eq (ImplicitField    p)
 deriving stock instance IsPass p => Eq (Struct           p)
-deriving stock instance IsPass p => Eq (StructField      p)
 deriving stock instance IsPass p => Eq (Typedef          p)
 deriving stock instance IsPass p => Eq (Union            p)
-deriving stock instance IsPass p => Eq (UnionField       p)
 
 deriving stock instance IsPass p => Show (AnonEnumConstant p)
+deriving stock instance IsPass p => Show (AnonRef          p)
 deriving stock instance IsPass p => Show (Comment          p)
 deriving stock instance IsPass p => Show (CommentRef       p)
 deriving stock instance IsPass p => Show (DeclInfo         p)
 deriving stock instance IsPass p => Show (Enum             p)
 deriving stock instance IsPass p => Show (EnumConstant     p)
+deriving stock instance IsPass p => Show (ExplicitField    p)
+deriving stock instance IsPass p => Show (Field            p)
 deriving stock instance IsPass p => Show (FieldInfo        p)
 deriving stock instance IsPass p => Show (Flam             p)
 deriving stock instance IsPass p => Show (Function         p)
 deriving stock instance IsPass p => Show (FunctionArg      p)
 deriving stock instance IsPass p => Show (Global           p)
+deriving stock instance IsPass p => Show (ImplicitField    p)
 deriving stock instance IsPass p => Show (Struct           p)
-deriving stock instance IsPass p => Show (StructField      p)
 deriving stock instance IsPass p => Show (Typedef          p)
 deriving stock instance IsPass p => Show (Union            p)
-deriving stock instance IsPass p => Show (UnionField       p)
 
 deriving stock instance (Macro.HasTypes l, IsPass p) => Eq (DeclKind l p)
 
@@ -532,8 +611,8 @@ instance (
       DeclOpaque        mSize -> DeclOpaque mSize
 
 instance (
-      CoercePass StructField p p'
-    , CoercePass Flam p p'
+      CoercePass Flam p p'
+    , CoercePass Field p p'
     , Ann "Struct" p ~ Ann "Struct" p'
     ) => CoercePass Struct p p' where
   coercePass struct = Struct{
@@ -545,7 +624,7 @@ instance (
       }
 
 instance (
-      CoercePass StructField p p'
+      CoercePass ExplicitField p p'
     , Ann "Flam" p ~ Ann "Flam" p'
     ) => CoercePass Flam p p' where
   coercePass = \case
@@ -553,21 +632,7 @@ instance (
     Flam fld ann -> Flam (coercePass fld) ann
 
 instance (
-      CoercePass C.Type p p'
-    , CoercePassCommentDecl p p'
-    , ScopedName p ~ ScopedName p'
-    , Ann "StructField" p ~ Ann "StructField" p'
-    ) => CoercePass StructField p p' where
-  coercePass field = StructField{
-        info   = coercePass field.info
-      , typ    = coercePass field.typ
-      , offset = field.offset
-      , width  = field.width
-      , ann    = field.ann
-      }
-
-instance (
-      CoercePass UnionField p p'
+      CoercePass Field p p'
     , Ann "Union" p ~ Ann "Union" p'
     ) => CoercePass Union p p' where
   coercePass union = Union{
@@ -578,16 +643,45 @@ instance (
       }
 
 instance (
-      CoercePass C.Type p p'
-    , CoercePassCommentDecl p p'
-    , ScopedName p ~ ScopedName p'
-    , Ann "UnionField" p ~ Ann "UnionField" p'
-    ) => CoercePass UnionField p p' where
-  coercePass field = UnionField{
+      CoercePass ExplicitField p p'
+    , CoercePass ImplicitField p p'
+    ) => CoercePass Field p p' where
+  coercePass = \case
+      FieldExplicit field -> FieldExplicit (coercePass field)
+      FieldImplicit field -> FieldImplicit (coercePass field)
+
+instance (
+      CoercePass FieldInfo p p'
+    , CoercePass C.Type p p'
+    , Ann "ExplicitField" p ~ Ann "ExplicitField" p'
+    ) => CoercePass ExplicitField p p' where
+  coercePass field = ExplicitField {
         info = coercePass field.info
-      , typ  = coercePass field.typ
-      , ann  = field.ann
+      , typ = coercePass field.typ
+      , offset = field.offset
+      , width = field.width
+      , ann = field.ann
       }
+
+instance (
+      CoercePass FieldInfo p p'
+    , CoercePass AnonRef p p'
+    , Ann "ImplicitField" p ~ Ann "ImplicitField" p'
+    ) => CoercePass ImplicitField p p' where
+  coercePass field = ImplicitField {
+        info = coercePass field.info
+      , typRef = coercePass field.typRef
+      , offset = field.offset
+      , ann = field.ann
+      }
+
+instance (
+      CoercePassId p p'
+    , CoercePassExtBindingRef p p'
+    ) => CoercePass AnonRef p p' where
+  coercePass = \case
+      AnonRef ref -> AnonRef $ coercePassId (Proxy @'(p, p')) ref
+      AnonExtBinding ext -> AnonExtBinding $ coercePassExtBindingRef ext
 
 instance (
       CoercePass C.Type p p'

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
@@ -37,6 +37,7 @@ module HsBindgen.IR.C.Type (
   , EnumRef
   , MacroRef(..)
   , TypedefRef
+  , ExtBindingRef
 
     -- * Normal forms
   , Normalize(..)
@@ -58,6 +59,9 @@ module HsBindgen.IR.C.Type (
   , isCanonicalTypeUnion
   , isCanonicalTypeArray
   , isErasedTypeConstQualified
+
+    -- * CoercePass
+  , CoercePassExtBindingRef(..)
   ) where
 
 import Data.Foldable qualified as Foldable
@@ -93,20 +97,17 @@ data TypeF (tag :: TypeTag) (p :: Pass) =
 
     -- | Reference to an @enum@
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that
-    -- pattern matches are redundant when @TypeEnumRefF tag p ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | TypeEnum !(TypeEnumRefF tag p)
 
     -- | Reference to a macro type
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that
-    -- pattern matches are redundant when @TypeMacroRefF tag p ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | TypeMacro !(TypeMacroRefF tag p)
 
     -- | Reference to a @typedef@
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that
-    -- pattern matches are redundant when @TypedefRefF tag p ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | TypeTypedef !(TypedefRefF tag p)
 
     -- | Pointer
@@ -150,14 +151,12 @@ data TypeF (tag :: TypeTag) (p :: Pass) =
 
     -- | Qualified type (such as @const@)
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that pattern
-    -- matches are redundant when @TypeQualifierF tag p ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | TypeQual !(TypeQualifierF tag p) (TypeF tag p)
 
     -- | Type with an external binding
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that pattern
-    -- matches are redundant when @TypeExtBindingRefF tag p ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | TypeExtBinding !(TypeExtBindingRefF tag p)
   deriving stock Generic
 
@@ -244,8 +243,7 @@ data TypeQual =
 data Ref a (p :: Pass) = Ref {
     -- | The reference type: a name
     --
-    -- NOTE: has a strictness annotation, which allows GHC to infer that pattern
-    -- matches are redundant when @a ~ Void@.
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
     name :: !a
     -- | The underlying type.
     --
@@ -820,7 +818,7 @@ isErasedTypeConstQualified ty =
       _ -> False
 
 {-------------------------------------------------------------------------------
-  CoercePass instances
+  CoercePass
 -------------------------------------------------------------------------------}
 
 -- NOTE: types do not contain 'ScopedName's, so unlike most other 'CoercePass'
@@ -845,7 +843,7 @@ instance (
       TypeVoid                -> TypeVoid
       TypeConstArray n typ    -> TypeConstArray n (coercePass typ)
       TypeIncompleteArray typ -> TypeIncompleteArray (coercePass typ)
-      TypeExtBinding ref      -> TypeExtBinding (Ref ref.name (coercePass ref.underlying))
+      TypeExtBinding ref      -> TypeExtBinding (coercePassExtBindingRef ref)
       TypeBlock typ           -> TypeBlock (coercePass typ)
       TypeQual qual typ       -> TypeQual qual (coercePass typ)
       TypeComplex prim        -> TypeComplex prim
@@ -858,6 +856,15 @@ instance (
 
       goMacroUnderlying :: MacroUnderlying p -> MacroUnderlying p'
       goMacroUnderlying = coercePassMacroUnderlying (Proxy @'(p, p'))
+
+class CoercePassExtBindingRef p p' where
+  coercePassExtBindingRef :: ExtBindingRef p -> ExtBindingRef p'
+
+instance (
+      CoercePass Type p p'
+    , ExtBinding p ~ ExtBinding p'
+    ) => CoercePassExtBindingRef p p' where
+  coercePassExtBindingRef ref = Ref ref.name (coercePass ref.underlying)
 
 -- NOTE: see the 'CoercePass Type' instance for why there is no
 -- @ScopedName p ~ ScopedName p'@ constraint here.

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass/Ann.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass/Ann.hs
@@ -25,16 +25,16 @@ import HsBindgen.IR.Pass.Definition
 class (
       -- For @Eq DeclKind@ in @DeclIndex@ construction
       Eq   (Ann "Enum"                 p)
+    , Eq   (Ann "ExplicitField"        p)
     , Eq   (Ann "Flam"                 p)
     , Eq   (Ann "Function"             p)
     , Eq   (Ann "Global"               p)
+    , Eq   (Ann "ImplicitField"        p)
     , Eq   (Ann "Struct"               p)
-    , Eq   (Ann "StructField"          p)
     , Eq   (Ann "TypeFunArg"           p)
     , Eq   (Ann "TypecheckedMacroType" p)
     , Eq   (Ann "Typedef"              p)
     , Eq   (Ann "Union"                p)
-    , Eq   (Ann "UnionField"           p)
 
       -- For de-duplicating types
     , Ord  (Ann "TypeFunArg"           p)
@@ -42,17 +42,17 @@ class (
       -- For debugging
     , Show (Ann "Decl"                 p)
     , Show (Ann "Enum"                 p)
+    , Show (Ann "ExplicitField"        p)
     , Show (Ann "Flam"                 p)
     , Show (Ann "Function"             p)
     , Show (Ann "Global"               p)
+    , Show (Ann "ImplicitField"        p)
     , Show (Ann "Struct"               p)
-    , Show (Ann "StructField"          p)
     , Show (Ann "TranslationUnit"      p)
     , Show (Ann "TypeFunArg"           p)
     , Show (Ann "TypecheckedMacroType" p)
     , Show (Ann "Typedef"              p)
     , Show (Ann "Union"                p)
-    , Show (Ann "UnionField"           p)
     ) => PassAnn (p :: Pass) where
 
   -- | Generic TTG-style annotation

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/Example.hs
@@ -1,0 +1,1445 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoFieldSelectors #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.SSS_anon'anon'x_anon'x(..)
+    , Example.SSS_anon'anon'x(..)
+    , Example.SSS(..)
+    , Example.USS_anon'anon'x_anon'x(..)
+    , Example.USS_anon'anon'x(..)
+    , Example.USS(..)
+    , Example.SUS_anon'anon'x_anon'x(..)
+    , Example.SUS_anon'anon'x(..)
+    , Example.SUS(..)
+    , Example.UUS_anon'anon'x_anon'x(..)
+    , Example.UUS_anon'anon'x(..)
+    , Example.UUS(..)
+    , Example.SSU_anon'anon'x_anon'x(..)
+    , Example.SSU_anon'anon'x(..)
+    , Example.SSU(..)
+    , Example.USU_anon'anon'x_anon'x(..)
+    , Example.USU_anon'anon'x(..)
+    , Example.USU(..)
+    , Example.SUU_anon'anon'x_anon'x(..)
+    , Example.SUU_anon'anon'x(..)
+    , Example.SUU(..)
+    , Example.UUU_anon'anon'x_anon'x(..)
+    , Example.UUU_anon'anon'x(..)
+    , Example.UUU(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Union as Union
+
+{-| __C declaration:__ @struct \@SSS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 17:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS_anon'anon'x_anon'x = SSS_anon'anon'x_anon'x
+  { x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 18:11@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize SSS_anon'anon'x_anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SSS_anon'anon'x_anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure SSS_anon'anon'x_anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"x") ptr0
+
+instance Marshal.WriteRaw SSS_anon'anon'x_anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SSS_anon'anon'x_anon'x x2 ->
+            HasCField.writeRaw (RIP.Proxy @"x") ptr0 x2
+
+deriving via Marshal.EquivStorable SSS_anon'anon'x_anon'x instance RIP.Storable SSS_anon'anon'x_anon'x
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" SSS_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SSS_anon'anon'x_anon'x {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr SSS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField SSS_anon'anon'x_anon'x "x" where
+
+  type CFieldType SSS_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@SSS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 16:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS_anon'anon'x = SSS_anon'anon'x
+  { anon'x :: SSS_anon'anon'x_anon'x
+    {- ^ __C declaration:__ @anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 17:5@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize SSS_anon'anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SSS_anon'anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure SSS_anon'anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"anon'x") ptr0
+
+instance Marshal.WriteRaw SSS_anon'anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SSS_anon'anon'x anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'x") ptr0 anon'x2
+
+deriving via Marshal.EquivStorable SSS_anon'anon'x instance RIP.Storable SSS_anon'anon'x
+
+instance ( ty ~ SSS_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" SSS_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SSS_anon'anon'x {anon'x = y1}, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ SSS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr SSS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField SSS_anon'anon'x "anon'x" where
+
+  type CFieldType SSS_anon'anon'x "anon'x" =
+    SSS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct SSS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 15:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS = SSS
+  { anon'anon'x :: SSS_anon'anon'x
+    {- ^ __C declaration:__ @anon\'anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 16:3@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize SSS where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SSS where
+
+  readRaw =
+    \ptr0 ->
+          pure SSS
+      <*> HasCField.readRaw (RIP.Proxy @"anon'anon'x") ptr0
+
+instance Marshal.WriteRaw SSS where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SSS anon'anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'anon'x") ptr0 anon'anon'x2
+
+deriving via Marshal.EquivStorable SSS instance RIP.Storable SSS
+
+instance ( ty ~ SSS_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" SSS ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SSS {anon'anon'x = y1}, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ SSS_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr SSS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField SSS "anon'anon'x" where
+
+  type CFieldType SSS "anon'anon'x" = SSS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@USS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 25:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USS_anon'anon'x_anon'x = USS_anon'anon'x_anon'x
+  { x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 26:11@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize USS_anon'anon'x_anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw USS_anon'anon'x_anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure USS_anon'anon'x_anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"x") ptr0
+
+instance Marshal.WriteRaw USS_anon'anon'x_anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          USS_anon'anon'x_anon'x x2 ->
+            HasCField.writeRaw (RIP.Proxy @"x") ptr0 x2
+
+deriving via Marshal.EquivStorable USS_anon'anon'x_anon'x instance RIP.Storable USS_anon'anon'x_anon'x
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" USS_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         USS_anon'anon'x_anon'x {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr USS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField USS_anon'anon'x_anon'x "x" where
+
+  type CFieldType USS_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@USS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 24:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USS_anon'anon'x = USS_anon'anon'x
+  { anon'x :: USS_anon'anon'x_anon'x
+    {- ^ __C declaration:__ @anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 25:5@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize USS_anon'anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw USS_anon'anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure USS_anon'anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"anon'x") ptr0
+
+instance Marshal.WriteRaw USS_anon'anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          USS_anon'anon'x anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'x") ptr0 anon'x2
+
+deriving via Marshal.EquivStorable USS_anon'anon'x instance RIP.Storable USS_anon'anon'x
+
+instance ( ty ~ USS_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" USS_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         USS_anon'anon'x {anon'x = y1}, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ USS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr USS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField USS_anon'anon'x "anon'x" where
+
+  type CFieldType USS_anon'anon'x "anon'x" =
+    USS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union USS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 23:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USS = USS
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize USS
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw USS
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw USS
+
+deriving via Marshal.EquivStorable USS instance RIP.Storable USS
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion USS
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 24:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ USS_anon'anon'x) => RIP.HasField "anon'anon'x" USS ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 24:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ USS_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" USS ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ USS_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr USS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField USS "anon'anon'x" where
+
+  type CFieldType USS "anon'anon'x" = USS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@SUS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 33:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUS_anon'anon'x_anon'x = SUS_anon'anon'x_anon'x
+  { x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 34:11@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize SUS_anon'anon'x_anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SUS_anon'anon'x_anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure SUS_anon'anon'x_anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"x") ptr0
+
+instance Marshal.WriteRaw SUS_anon'anon'x_anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SUS_anon'anon'x_anon'x x2 ->
+            HasCField.writeRaw (RIP.Proxy @"x") ptr0 x2
+
+deriving via Marshal.EquivStorable SUS_anon'anon'x_anon'x instance RIP.Storable SUS_anon'anon'x_anon'x
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" SUS_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SUS_anon'anon'x_anon'x {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr SUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField SUS_anon'anon'x_anon'x "x" where
+
+  type CFieldType SUS_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@SUS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 32:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUS_anon'anon'x = SUS_anon'anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize SUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw SUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw SUS_anon'anon'x
+
+deriving via Marshal.EquivStorable SUS_anon'anon'x instance RIP.Storable SUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion SUS_anon'anon'x
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 33:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ SUS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" SUS_anon'anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 33:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ SUS_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" SUS_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ SUS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr SUS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField SUS_anon'anon'x "anon'x" where
+
+  type CFieldType SUS_anon'anon'x "anon'x" =
+    SUS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct SUS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 31:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUS = SUS
+  { anon'anon'x :: SUS_anon'anon'x
+    {- ^ __C declaration:__ @anon\'anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 32:3@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize SUS where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SUS where
+
+  readRaw =
+    \ptr0 ->
+          pure SUS
+      <*> HasCField.readRaw (RIP.Proxy @"anon'anon'x") ptr0
+
+instance Marshal.WriteRaw SUS where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SUS anon'anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'anon'x") ptr0 anon'anon'x2
+
+deriving via Marshal.EquivStorable SUS instance RIP.Storable SUS
+
+instance ( ty ~ SUS_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" SUS ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SUS {anon'anon'x = y1}, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ SUS_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr SUS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField SUS "anon'anon'x" where
+
+  type CFieldType SUS "anon'anon'x" = SUS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@UUS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 41:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data UUS_anon'anon'x_anon'x = UUS_anon'anon'x_anon'x
+  { x :: RIP.CInt
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 42:11@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize UUS_anon'anon'x_anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw UUS_anon'anon'x_anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure UUS_anon'anon'x_anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"x") ptr0
+
+instance Marshal.WriteRaw UUS_anon'anon'x_anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          UUS_anon'anon'x_anon'x x2 ->
+            HasCField.writeRaw (RIP.Proxy @"x") ptr0 x2
+
+deriving via Marshal.EquivStorable UUS_anon'anon'x_anon'x instance RIP.Storable UUS_anon'anon'x_anon'x
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" UUS_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         UUS_anon'anon'x_anon'x {x = y1}, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr UUS_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField UUS_anon'anon'x_anon'x "x" where
+
+  type CFieldType UUS_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@UUS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 40:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUS_anon'anon'x = UUS_anon'anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize UUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw UUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw UUS_anon'anon'x
+
+deriving via Marshal.EquivStorable UUS_anon'anon'x instance RIP.Storable UUS_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion UUS_anon'anon'x
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 41:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" UUS_anon'anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 41:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUS_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" UUS_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ UUS_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr UUS_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField UUS_anon'anon'x "anon'x" where
+
+  type CFieldType UUS_anon'anon'x "anon'x" =
+    UUS_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union UUS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 39:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUS = UUS
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize UUS
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw UUS
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw UUS
+
+deriving via Marshal.EquivStorable UUS instance RIP.Storable UUS
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion UUS
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 40:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ UUS_anon'anon'x) => RIP.HasField "anon'anon'x" UUS ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 40:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUS_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" UUS ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ UUS_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr UUS) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField UUS "anon'anon'x" where
+
+  type CFieldType UUS "anon'anon'x" = UUS_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@SSU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 49:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SSU_anon'anon'x_anon'x = SSU_anon'anon'x_anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize SSU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw SSU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw SSU_anon'anon'x_anon'x
+
+deriving via Marshal.EquivStorable SSU_anon'anon'x_anon'x instance RIP.Storable SSU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion SSU_anon'anon'x_anon'x
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 50:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ RIP.CInt) => RIP.HasField "x" SSU_anon'anon'x_anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 50:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" SSU_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 -> (RIP.setUnionPayload, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr SSU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField SSU_anon'anon'x_anon'x "x" where
+
+  type CFieldType SSU_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@SSU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 48:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSU_anon'anon'x = SSU_anon'anon'x
+  { anon'x :: SSU_anon'anon'x_anon'x
+    {- ^ __C declaration:__ @anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 49:5@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize SSU_anon'anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SSU_anon'anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure SSU_anon'anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"anon'x") ptr0
+
+instance Marshal.WriteRaw SSU_anon'anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SSU_anon'anon'x anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'x") ptr0 anon'x2
+
+deriving via Marshal.EquivStorable SSU_anon'anon'x instance RIP.Storable SSU_anon'anon'x
+
+instance ( ty ~ SSU_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" SSU_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SSU_anon'anon'x {anon'x = y1}, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ SSU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr SSU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField SSU_anon'anon'x "anon'x" where
+
+  type CFieldType SSU_anon'anon'x "anon'x" =
+    SSU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct SSU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 47:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSU = SSU
+  { anon'anon'x :: SSU_anon'anon'x
+    {- ^ __C declaration:__ @anon\'anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 48:3@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize SSU where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SSU where
+
+  readRaw =
+    \ptr0 ->
+          pure SSU
+      <*> HasCField.readRaw (RIP.Proxy @"anon'anon'x") ptr0
+
+instance Marshal.WriteRaw SSU where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SSU anon'anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'anon'x") ptr0 anon'anon'x2
+
+deriving via Marshal.EquivStorable SSU instance RIP.Storable SSU
+
+instance ( ty ~ SSU_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" SSU ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SSU {anon'anon'x = y1}, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ SSU_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr SSU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField SSU "anon'anon'x" where
+
+  type CFieldType SSU "anon'anon'x" = SSU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@USU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 57:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USU_anon'anon'x_anon'x = USU_anon'anon'x_anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize USU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw USU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw USU_anon'anon'x_anon'x
+
+deriving via Marshal.EquivStorable USU_anon'anon'x_anon'x instance RIP.Storable USU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion USU_anon'anon'x_anon'x
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 58:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ RIP.CInt) => RIP.HasField "x" USU_anon'anon'x_anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 58:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" USU_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 -> (RIP.setUnionPayload, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr USU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField USU_anon'anon'x_anon'x "x" where
+
+  type CFieldType USU_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct \@USU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 56:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USU_anon'anon'x = USU_anon'anon'x
+  { anon'x :: USU_anon'anon'x_anon'x
+    {- ^ __C declaration:__ @anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 57:5@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize USU_anon'anon'x where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw USU_anon'anon'x where
+
+  readRaw =
+    \ptr0 ->
+          pure USU_anon'anon'x
+      <*> HasCField.readRaw (RIP.Proxy @"anon'x") ptr0
+
+instance Marshal.WriteRaw USU_anon'anon'x where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          USU_anon'anon'x anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'x") ptr0 anon'x2
+
+deriving via Marshal.EquivStorable USU_anon'anon'x instance RIP.Storable USU_anon'anon'x
+
+instance ( ty ~ USU_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" USU_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         USU_anon'anon'x {anon'x = y1}, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ USU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr USU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField USU_anon'anon'x "anon'x" where
+
+  type CFieldType USU_anon'anon'x "anon'x" =
+    USU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union USU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 55:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USU = USU
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize USU
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw USU
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw USU
+
+deriving via Marshal.EquivStorable USU instance RIP.Storable USU
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion USU
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 56:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ USU_anon'anon'x) => RIP.HasField "anon'anon'x" USU ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 56:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ USU_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" USU ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ USU_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr USU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField USU "anon'anon'x" where
+
+  type CFieldType USU "anon'anon'x" = USU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@SUU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 65:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUU_anon'anon'x_anon'x = SUU_anon'anon'x_anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize SUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw SUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw SUU_anon'anon'x_anon'x
+
+deriving via Marshal.EquivStorable SUU_anon'anon'x_anon'x instance RIP.Storable SUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion SUU_anon'anon'x_anon'x
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 66:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ RIP.CInt) => RIP.HasField "x" SUU_anon'anon'x_anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 66:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" SUU_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 -> (RIP.setUnionPayload, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr SUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField SUU_anon'anon'x_anon'x "x" where
+
+  type CFieldType SUU_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@SUU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 64:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUU_anon'anon'x = SUU_anon'anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize SUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw SUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw SUU_anon'anon'x
+
+deriving via Marshal.EquivStorable SUU_anon'anon'x instance RIP.Storable SUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion SUU_anon'anon'x
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 65:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ SUU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" SUU_anon'anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 65:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ SUU_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" SUU_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ SUU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr SUU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField SUU_anon'anon'x "anon'x" where
+
+  type CFieldType SUU_anon'anon'x "anon'x" =
+    SUU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct SUU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 63:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUU = SUU
+  { anon'anon'x :: SUU_anon'anon'x
+    {- ^ __C declaration:__ @anon\'anon\'x@
+
+         __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 64:3@
+
+         __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+    -}
+  }
+  deriving stock (RIP.Generic)
+
+instance Marshal.StaticSize SUU where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw SUU where
+
+  readRaw =
+    \ptr0 ->
+          pure SUU
+      <*> HasCField.readRaw (RIP.Proxy @"anon'anon'x") ptr0
+
+instance Marshal.WriteRaw SUU where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          SUU anon'anon'x2 ->
+            HasCField.writeRaw (RIP.Proxy @"anon'anon'x") ptr0 anon'anon'x2
+
+deriving via Marshal.EquivStorable SUU instance RIP.Storable SUU
+
+instance ( ty ~ SUU_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" SUU ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         SUU {anon'anon'x = y1}, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ SUU_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr SUU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField SUU "anon'anon'x" where
+
+  type CFieldType SUU "anon'anon'x" = SUU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@UUU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 73:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU_anon'anon'x_anon'x = UUU_anon'anon'x_anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize UUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw UUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw UUU_anon'anon'x_anon'x
+
+deriving via Marshal.EquivStorable UUU_anon'anon'x_anon'x instance RIP.Storable UUU_anon'anon'x_anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion UUU_anon'anon'x_anon'x
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 74:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ RIP.CInt) => RIP.HasField "x" UUU_anon'anon'x_anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 74:11@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ RIP.CInt
+         ) => RIP.CompatHasField.HasField "x" UUU_anon'anon'x_anon'x ty where
+
+  hasField =
+    \x0 -> (RIP.setUnionPayload, RIP.getField @"x" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "x" (RIP.Ptr UUU_anon'anon'x_anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"x")
+
+instance HasCField.HasCField UUU_anon'anon'x_anon'x "x" where
+
+  type CFieldType UUU_anon'anon'x_anon'x "x" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union \@UUU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 72:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU_anon'anon'x = UUU_anon'anon'x
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize UUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw UUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw UUU_anon'anon'x
+
+deriving via Marshal.EquivStorable UUU_anon'anon'x instance RIP.Storable UUU_anon'anon'x
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion UUU_anon'anon'x
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 73:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" UUU_anon'anon'x ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 73:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUU_anon'anon'x_anon'x
+         ) => RIP.CompatHasField.HasField "anon'x" UUU_anon'anon'x ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'x" x0)
+
+instance ( ty ~ UUU_anon'anon'x_anon'x
+         ) => RIP.HasField "anon'x" (RIP.Ptr UUU_anon'anon'x) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"anon'x")
+
+instance HasCField.HasCField UUU_anon'anon'x "anon'x" where
+
+  type CFieldType UUU_anon'anon'x "anon'x" =
+    UUU_anon'anon'x_anon'x
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @union UUU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 71:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU = UUU
+  { unwrap :: RIP.ByteArray
+  }
+  deriving stock (RIP.Generic)
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.StaticSize UUU
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.ReadRaw UUU
+
+deriving via RIP.SizedByteArray 4 4 instance Marshal.WriteRaw UUU
+
+deriving via Marshal.EquivStorable UUU instance RIP.Storable UUU
+
+deriving via RIP.SizedByteArray 4 4 instance Union.IsUnion UUU
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 72:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance (ty ~ UUU_anon'anon'x) => RIP.HasField "anon'anon'x" UUU ty where
+
+  getField = RIP.getUnionPayload
+
+{-| __C declaration:__ @anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 72:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+instance ( ty ~ UUU_anon'anon'x
+         ) => RIP.CompatHasField.HasField "anon'anon'x" UUU ty where
+
+  hasField =
+    \x0 ->
+      (RIP.setUnionPayload, RIP.getField @"anon'anon'x" x0)
+
+instance ( ty ~ UUU_anon'anon'x
+         ) => RIP.HasField "anon'anon'x" (RIP.Ptr UUU) (RIP.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (RIP.Proxy @"anon'anon'x")
+
+instance HasCField.HasCField UUU "anon'anon'x" where
+
+  type CFieldType UUU "anon'anon'x" = UUU_anon'anon'x
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/bindingspec.yaml
@@ -1,0 +1,488 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct SSS
+  hsname: SSS
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @SSS_anon'anon'x
+  hsname: SSS_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @SSS_anon'anon'x_anon'x
+  hsname: SSS_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union USS
+  hsname: USS
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @USS_anon'anon'x
+  hsname: USS_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @USS_anon'anon'x_anon'x
+  hsname: USS_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct SUS
+  hsname: SUS
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @SUS_anon'anon'x
+  hsname: SUS_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @SUS_anon'anon'x_anon'x
+  hsname: SUS_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union UUS
+  hsname: UUS
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @UUS_anon'anon'x
+  hsname: UUS_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @UUS_anon'anon'x_anon'x
+  hsname: UUS_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct SSU
+  hsname: SSU
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @SSU_anon'anon'x
+  hsname: SSU_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @SSU_anon'anon'x_anon'x
+  hsname: SSU_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union USU
+  hsname: USU
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct @USU_anon'anon'x
+  hsname: USU_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @USU_anon'anon'x_anon'x
+  hsname: USU_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: struct SUU
+  hsname: SUU
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @SUU_anon'anon'x
+  hsname: SUU_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @SUU_anon'anon'x_anon'x
+  hsname: SUU_anon'anon'x_anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union UUU
+  hsname: UUU
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @UUU_anon'anon'x
+  hsname: UUU_anon'anon'x
+- headers: types/anonymous/edge-cases/multi_nesting.h
+  cname: union @UUU_anon'anon'x_anon'x
+  hsname: UUU_anon'anon'x_anon'x
+hstypes:
+- hsname: SSS
+  representation:
+    record:
+      constructor: SSS
+      fields:
+      - anon'anon'x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SSS_anon'anon'x
+  representation:
+    record:
+      constructor: SSS_anon'anon'x
+      fields:
+      - anon'x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SSS_anon'anon'x_anon'x
+  representation:
+    record:
+      constructor: SSS_anon'anon'x_anon'x
+      fields:
+      - x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SSU
+  representation:
+    record:
+      constructor: SSU
+      fields:
+      - anon'anon'x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SSU_anon'anon'x
+  representation:
+    record:
+      constructor: SSU_anon'anon'x
+      fields:
+      - anon'x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SSU_anon'anon'x_anon'x
+  representation:
+    newtype:
+      constructor: SSU_anon'anon'x_anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUS
+  representation:
+    record:
+      constructor: SUS
+      fields:
+      - anon'anon'x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUS_anon'anon'x
+  representation:
+    newtype:
+      constructor: SUS_anon'anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUS_anon'anon'x_anon'x
+  representation:
+    record:
+      constructor: SUS_anon'anon'x_anon'x
+      fields:
+      - x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUU
+  representation:
+    record:
+      constructor: SUU
+      fields:
+      - anon'anon'x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUU_anon'anon'x
+  representation:
+    newtype:
+      constructor: SUU_anon'anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: SUU_anon'anon'x_anon'x
+  representation:
+    newtype:
+      constructor: SUU_anon'anon'x_anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USS
+  representation:
+    newtype:
+      constructor: USS
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USS_anon'anon'x
+  representation:
+    record:
+      constructor: USS_anon'anon'x
+      fields:
+      - anon'x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USS_anon'anon'x_anon'x
+  representation:
+    record:
+      constructor: USS_anon'anon'x_anon'x
+      fields:
+      - x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USU
+  representation:
+    newtype:
+      constructor: USU
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USU_anon'anon'x
+  representation:
+    record:
+      constructor: USU_anon'anon'x
+      fields:
+      - anon'x
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: USU_anon'anon'x_anon'x
+  representation:
+    newtype:
+      constructor: USU_anon'anon'x_anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUS
+  representation:
+    newtype:
+      constructor: UUS
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUS_anon'anon'x
+  representation:
+    newtype:
+      constructor: UUS_anon'anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUS_anon'anon'x_anon'x
+  representation:
+    record:
+      constructor: UUS_anon'anon'x_anon'x
+      fields:
+      - x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUU
+  representation:
+    newtype:
+      constructor: UUU
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUU_anon'anon'x
+  representation:
+    newtype:
+      constructor: UUU_anon'anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: UUU_anon'anon'x_anon'x
+  representation:
+    newtype:
+      constructor: UUU_anon'anon'x_anon'x
+      fields:
+      - unwrap
+  instances:
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/edge-cases/multi_nesting.omit_field_prefixes/th.txt
@@ -1,0 +1,721 @@
+-- addDependentFile test-artefacts/headers/golden/types/anonymous/edge-cases/multi_nesting.h
+{-| __C declaration:__ @struct \@SSS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 17:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS_anon'anon'x_anon'x
+    = SSS_anon'anon'x_anon'x {x :: CInt
+                              {- ^ __C declaration:__ @x@
+
+                                   __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 18:11@
+
+                                   __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize SSS_anon'anon'x_anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SSS_anon'anon'x_anon'x
+    where readRaw = \ptr_0 -> pure SSS_anon'anon'x_anon'x <*> readRaw (Proxy @"x") ptr_0
+instance WriteRaw SSS_anon'anon'x_anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SSS_anon'anon'x_anon'x x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
+deriving via (EquivStorable SSS_anon'anon'x_anon'x) instance Storable SSS_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" SSS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SSS_anon'anon'x_anon'x{x = y_1},
+                              getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr SSS_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField SSS_anon'anon'x_anon'x "x"
+    where type CFieldType SSS_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@SSS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 16:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS_anon'anon'x
+    = SSS_anon'anon'x {anon'x :: SSS_anon'anon'x_anon'x
+                       {- ^ __C declaration:__ @anon\'x@
+
+                            __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 17:5@
+
+                            __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                       -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize SSS_anon'anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SSS_anon'anon'x
+    where readRaw = \ptr_0 -> pure SSS_anon'anon'x <*> readRaw (Proxy @"anon'x") ptr_0
+instance WriteRaw SSS_anon'anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SSS_anon'anon'x anon'x_2 -> writeRaw (Proxy @"anon'x") ptr_0 anon'x_2
+deriving via (EquivStorable SSS_anon'anon'x) instance Storable SSS_anon'anon'x
+instance (~) ty SSS_anon'anon'x_anon'x =>
+         HasField "anon'x" SSS_anon'anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SSS_anon'anon'x{anon'x = y_1},
+                              getField @"anon'x" x_0)
+instance (~) ty SSS_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr SSS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField SSS_anon'anon'x "anon'x"
+    where type CFieldType SSS_anon'anon'x
+                          "anon'x" = SSS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct SSS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 15:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSS
+    = SSS {anon'anon'x :: SSS_anon'anon'x
+           {- ^ __C declaration:__ @anon\'anon\'x@
+
+                __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 16:3@
+
+                __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+           -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize SSS
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SSS
+    where readRaw = \ptr_0 -> pure SSS <*> readRaw (Proxy @"anon'anon'x") ptr_0
+instance WriteRaw SSS
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SSS anon'anon'x_2 -> writeRaw (Proxy @"anon'anon'x") ptr_0 anon'anon'x_2
+deriving via (EquivStorable SSS) instance Storable SSS
+instance (~) ty SSS_anon'anon'x => HasField "anon'anon'x" SSS ty
+    where hasField = \x_0 -> (\y_1 -> SSS{anon'anon'x = y_1},
+                              getField @"anon'anon'x" x_0)
+instance (~) ty SSS_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr SSS) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField SSS "anon'anon'x"
+    where type CFieldType SSS "anon'anon'x" = SSS_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@USS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 25:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USS_anon'anon'x_anon'x
+    = USS_anon'anon'x_anon'x {x :: CInt
+                              {- ^ __C declaration:__ @x@
+
+                                   __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 26:11@
+
+                                   __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize USS_anon'anon'x_anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw USS_anon'anon'x_anon'x
+    where readRaw = \ptr_0 -> pure USS_anon'anon'x_anon'x <*> readRaw (Proxy @"x") ptr_0
+instance WriteRaw USS_anon'anon'x_anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       USS_anon'anon'x_anon'x x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
+deriving via (EquivStorable USS_anon'anon'x_anon'x) instance Storable USS_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" USS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> USS_anon'anon'x_anon'x{x = y_1},
+                              getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr USS_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField USS_anon'anon'x_anon'x "x"
+    where type CFieldType USS_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@USS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 24:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USS_anon'anon'x
+    = USS_anon'anon'x {anon'x :: USS_anon'anon'x_anon'x
+                       {- ^ __C declaration:__ @anon\'x@
+
+                            __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 25:5@
+
+                            __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                       -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize USS_anon'anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw USS_anon'anon'x
+    where readRaw = \ptr_0 -> pure USS_anon'anon'x <*> readRaw (Proxy @"anon'x") ptr_0
+instance WriteRaw USS_anon'anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       USS_anon'anon'x anon'x_2 -> writeRaw (Proxy @"anon'x") ptr_0 anon'x_2
+deriving via (EquivStorable USS_anon'anon'x) instance Storable USS_anon'anon'x
+instance (~) ty USS_anon'anon'x_anon'x =>
+         HasField "anon'x" USS_anon'anon'x ty
+    where hasField = \x_0 -> (\y_1 -> USS_anon'anon'x{anon'x = y_1},
+                              getField @"anon'x" x_0)
+instance (~) ty USS_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr USS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField USS_anon'anon'x "anon'x"
+    where type CFieldType USS_anon'anon'x
+                          "anon'x" = USS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union USS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 23:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USS = USS {unwrap :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize USS
+deriving via (SizedByteArray 4 4) instance ReadRaw USS
+deriving via (SizedByteArray 4 4) instance WriteRaw USS
+deriving via (EquivStorable USS) instance Storable USS
+deriving via (SizedByteArray 4 4) instance IsUnion USS
+instance (~) ty USS_anon'anon'x => HasField "anon'anon'x" USS ty
+    where getField = getUnionPayload
+instance (~) ty USS_anon'anon'x => HasField "anon'anon'x" USS ty
+    where hasField = \x_0 -> (setUnionPayload,
+                              getField @"anon'anon'x" x_0)
+instance (~) ty USS_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr USS) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField USS "anon'anon'x"
+    where type CFieldType USS "anon'anon'x" = USS_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@SUS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 33:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUS_anon'anon'x_anon'x
+    = SUS_anon'anon'x_anon'x {x :: CInt
+                              {- ^ __C declaration:__ @x@
+
+                                   __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 34:11@
+
+                                   __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize SUS_anon'anon'x_anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SUS_anon'anon'x_anon'x
+    where readRaw = \ptr_0 -> pure SUS_anon'anon'x_anon'x <*> readRaw (Proxy @"x") ptr_0
+instance WriteRaw SUS_anon'anon'x_anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SUS_anon'anon'x_anon'x x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
+deriving via (EquivStorable SUS_anon'anon'x_anon'x) instance Storable SUS_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" SUS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SUS_anon'anon'x_anon'x{x = y_1},
+                              getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr SUS_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField SUS_anon'anon'x_anon'x "x"
+    where type CFieldType SUS_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@SUS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 32:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUS_anon'anon'x
+    = SUS_anon'anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize SUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance ReadRaw SUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance WriteRaw SUS_anon'anon'x
+deriving via (EquivStorable SUS_anon'anon'x) instance Storable SUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance IsUnion SUS_anon'anon'x
+instance (~) ty SUS_anon'anon'x_anon'x =>
+         HasField "anon'x" SUS_anon'anon'x ty
+    where getField = getUnionPayload
+instance (~) ty SUS_anon'anon'x_anon'x =>
+         HasField "anon'x" SUS_anon'anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"anon'x" x_0)
+instance (~) ty SUS_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr SUS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField SUS_anon'anon'x "anon'x"
+    where type CFieldType SUS_anon'anon'x
+                          "anon'x" = SUS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct SUS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 31:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUS
+    = SUS {anon'anon'x :: SUS_anon'anon'x
+           {- ^ __C declaration:__ @anon\'anon\'x@
+
+                __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 32:3@
+
+                __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+           -}}
+    deriving stock Generic
+instance StaticSize SUS
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SUS
+    where readRaw = \ptr_0 -> pure SUS <*> readRaw (Proxy @"anon'anon'x") ptr_0
+instance WriteRaw SUS
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SUS anon'anon'x_2 -> writeRaw (Proxy @"anon'anon'x") ptr_0 anon'anon'x_2
+deriving via (EquivStorable SUS) instance Storable SUS
+instance (~) ty SUS_anon'anon'x => HasField "anon'anon'x" SUS ty
+    where hasField = \x_0 -> (\y_1 -> SUS{anon'anon'x = y_1},
+                              getField @"anon'anon'x" x_0)
+instance (~) ty SUS_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr SUS) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField SUS "anon'anon'x"
+    where type CFieldType SUS "anon'anon'x" = SUS_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@UUS_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 41:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data UUS_anon'anon'x_anon'x
+    = UUS_anon'anon'x_anon'x {x :: CInt
+                              {- ^ __C declaration:__ @x@
+
+                                   __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 42:11@
+
+                                   __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                              -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize UUS_anon'anon'x_anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw UUS_anon'anon'x_anon'x
+    where readRaw = \ptr_0 -> pure UUS_anon'anon'x_anon'x <*> readRaw (Proxy @"x") ptr_0
+instance WriteRaw UUS_anon'anon'x_anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       UUS_anon'anon'x_anon'x x_2 -> writeRaw (Proxy @"x") ptr_0 x_2
+deriving via (EquivStorable UUS_anon'anon'x_anon'x) instance Storable UUS_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" UUS_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (\y_1 -> UUS_anon'anon'x_anon'x{x = y_1},
+                              getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr UUS_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField UUS_anon'anon'x_anon'x "x"
+    where type CFieldType UUS_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@UUS_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 40:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUS_anon'anon'x
+    = UUS_anon'anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize UUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance ReadRaw UUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance WriteRaw UUS_anon'anon'x
+deriving via (EquivStorable UUS_anon'anon'x) instance Storable UUS_anon'anon'x
+deriving via (SizedByteArray 4 4) instance IsUnion UUS_anon'anon'x
+instance (~) ty UUS_anon'anon'x_anon'x =>
+         HasField "anon'x" UUS_anon'anon'x ty
+    where getField = getUnionPayload
+instance (~) ty UUS_anon'anon'x_anon'x =>
+         HasField "anon'x" UUS_anon'anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"anon'x" x_0)
+instance (~) ty UUS_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr UUS_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField UUS_anon'anon'x "anon'x"
+    where type CFieldType UUS_anon'anon'x
+                          "anon'x" = UUS_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union UUS@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 39:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUS = UUS {unwrap :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize UUS
+deriving via (SizedByteArray 4 4) instance ReadRaw UUS
+deriving via (SizedByteArray 4 4) instance WriteRaw UUS
+deriving via (EquivStorable UUS) instance Storable UUS
+deriving via (SizedByteArray 4 4) instance IsUnion UUS
+instance (~) ty UUS_anon'anon'x => HasField "anon'anon'x" UUS ty
+    where getField = getUnionPayload
+instance (~) ty UUS_anon'anon'x => HasField "anon'anon'x" UUS ty
+    where hasField = \x_0 -> (setUnionPayload,
+                              getField @"anon'anon'x" x_0)
+instance (~) ty UUS_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr UUS) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField UUS "anon'anon'x"
+    where type CFieldType UUS "anon'anon'x" = UUS_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@SSU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 49:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SSU_anon'anon'x_anon'x
+    = SSU_anon'anon'x_anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize SSU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance ReadRaw SSU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance WriteRaw SSU_anon'anon'x_anon'x
+deriving via (EquivStorable SSU_anon'anon'x_anon'x) instance Storable SSU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance IsUnion SSU_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" SSU_anon'anon'x_anon'x ty
+    where getField = getUnionPayload
+instance (~) ty CInt => HasField "x" SSU_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr SSU_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField SSU_anon'anon'x_anon'x "x"
+    where type CFieldType SSU_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@SSU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 48:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSU_anon'anon'x
+    = SSU_anon'anon'x {anon'x :: SSU_anon'anon'x_anon'x
+                       {- ^ __C declaration:__ @anon\'x@
+
+                            __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 49:5@
+
+                            __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                       -}}
+    deriving stock Generic
+instance StaticSize SSU_anon'anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SSU_anon'anon'x
+    where readRaw = \ptr_0 -> pure SSU_anon'anon'x <*> readRaw (Proxy @"anon'x") ptr_0
+instance WriteRaw SSU_anon'anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SSU_anon'anon'x anon'x_2 -> writeRaw (Proxy @"anon'x") ptr_0 anon'x_2
+deriving via (EquivStorable SSU_anon'anon'x) instance Storable SSU_anon'anon'x
+instance (~) ty SSU_anon'anon'x_anon'x =>
+         HasField "anon'x" SSU_anon'anon'x ty
+    where hasField = \x_0 -> (\y_1 -> SSU_anon'anon'x{anon'x = y_1},
+                              getField @"anon'x" x_0)
+instance (~) ty SSU_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr SSU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField SSU_anon'anon'x "anon'x"
+    where type CFieldType SSU_anon'anon'x
+                          "anon'x" = SSU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct SSU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 47:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SSU
+    = SSU {anon'anon'x :: SSU_anon'anon'x
+           {- ^ __C declaration:__ @anon\'anon\'x@
+
+                __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 48:3@
+
+                __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+           -}}
+    deriving stock Generic
+instance StaticSize SSU
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SSU
+    where readRaw = \ptr_0 -> pure SSU <*> readRaw (Proxy @"anon'anon'x") ptr_0
+instance WriteRaw SSU
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SSU anon'anon'x_2 -> writeRaw (Proxy @"anon'anon'x") ptr_0 anon'anon'x_2
+deriving via (EquivStorable SSU) instance Storable SSU
+instance (~) ty SSU_anon'anon'x => HasField "anon'anon'x" SSU ty
+    where hasField = \x_0 -> (\y_1 -> SSU{anon'anon'x = y_1},
+                              getField @"anon'anon'x" x_0)
+instance (~) ty SSU_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr SSU) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField SSU "anon'anon'x"
+    where type CFieldType SSU "anon'anon'x" = SSU_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@USU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 57:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USU_anon'anon'x_anon'x
+    = USU_anon'anon'x_anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize USU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance ReadRaw USU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance WriteRaw USU_anon'anon'x_anon'x
+deriving via (EquivStorable USU_anon'anon'x_anon'x) instance Storable USU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance IsUnion USU_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" USU_anon'anon'x_anon'x ty
+    where getField = getUnionPayload
+instance (~) ty CInt => HasField "x" USU_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr USU_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField USU_anon'anon'x_anon'x "x"
+    where type CFieldType USU_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct \@USU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 56:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data USU_anon'anon'x
+    = USU_anon'anon'x {anon'x :: USU_anon'anon'x_anon'x
+                       {- ^ __C declaration:__ @anon\'x@
+
+                            __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 57:5@
+
+                            __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+                       -}}
+    deriving stock Generic
+instance StaticSize USU_anon'anon'x
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw USU_anon'anon'x
+    where readRaw = \ptr_0 -> pure USU_anon'anon'x <*> readRaw (Proxy @"anon'x") ptr_0
+instance WriteRaw USU_anon'anon'x
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       USU_anon'anon'x anon'x_2 -> writeRaw (Proxy @"anon'x") ptr_0 anon'x_2
+deriving via (EquivStorable USU_anon'anon'x) instance Storable USU_anon'anon'x
+instance (~) ty USU_anon'anon'x_anon'x =>
+         HasField "anon'x" USU_anon'anon'x ty
+    where hasField = \x_0 -> (\y_1 -> USU_anon'anon'x{anon'x = y_1},
+                              getField @"anon'x" x_0)
+instance (~) ty USU_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr USU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField USU_anon'anon'x "anon'x"
+    where type CFieldType USU_anon'anon'x
+                          "anon'x" = USU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union USU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 55:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype USU = USU {unwrap :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize USU
+deriving via (SizedByteArray 4 4) instance ReadRaw USU
+deriving via (SizedByteArray 4 4) instance WriteRaw USU
+deriving via (EquivStorable USU) instance Storable USU
+deriving via (SizedByteArray 4 4) instance IsUnion USU
+instance (~) ty USU_anon'anon'x => HasField "anon'anon'x" USU ty
+    where getField = getUnionPayload
+instance (~) ty USU_anon'anon'x => HasField "anon'anon'x" USU ty
+    where hasField = \x_0 -> (setUnionPayload,
+                              getField @"anon'anon'x" x_0)
+instance (~) ty USU_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr USU) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField USU "anon'anon'x"
+    where type CFieldType USU "anon'anon'x" = USU_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@SUU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 65:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUU_anon'anon'x_anon'x
+    = SUU_anon'anon'x_anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize SUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance ReadRaw SUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance WriteRaw SUU_anon'anon'x_anon'x
+deriving via (EquivStorable SUU_anon'anon'x_anon'x) instance Storable SUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance IsUnion SUU_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" SUU_anon'anon'x_anon'x ty
+    where getField = getUnionPayload
+instance (~) ty CInt => HasField "x" SUU_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr SUU_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField SUU_anon'anon'x_anon'x "x"
+    where type CFieldType SUU_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@SUU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 64:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype SUU_anon'anon'x
+    = SUU_anon'anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize SUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance ReadRaw SUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance WriteRaw SUU_anon'anon'x
+deriving via (EquivStorable SUU_anon'anon'x) instance Storable SUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance IsUnion SUU_anon'anon'x
+instance (~) ty SUU_anon'anon'x_anon'x =>
+         HasField "anon'x" SUU_anon'anon'x ty
+    where getField = getUnionPayload
+instance (~) ty SUU_anon'anon'x_anon'x =>
+         HasField "anon'x" SUU_anon'anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"anon'x" x_0)
+instance (~) ty SUU_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr SUU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField SUU_anon'anon'x "anon'x"
+    where type CFieldType SUU_anon'anon'x
+                          "anon'x" = SUU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct SUU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 63:8@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+data SUU
+    = SUU {anon'anon'x :: SUU_anon'anon'x
+           {- ^ __C declaration:__ @anon\'anon\'x@
+
+                __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 64:3@
+
+                __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+           -}}
+    deriving stock Generic
+instance StaticSize SUU
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw SUU
+    where readRaw = \ptr_0 -> pure SUU <*> readRaw (Proxy @"anon'anon'x") ptr_0
+instance WriteRaw SUU
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       SUU anon'anon'x_2 -> writeRaw (Proxy @"anon'anon'x") ptr_0 anon'anon'x_2
+deriving via (EquivStorable SUU) instance Storable SUU
+instance (~) ty SUU_anon'anon'x => HasField "anon'anon'x" SUU ty
+    where hasField = \x_0 -> (\y_1 -> SUU{anon'anon'x = y_1},
+                              getField @"anon'anon'x" x_0)
+instance (~) ty SUU_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr SUU) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField SUU "anon'anon'x"
+    where type CFieldType SUU "anon'anon'x" = SUU_anon'anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@UUU_anon\'anon\'x_anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 73:5@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU_anon'anon'x_anon'x
+    = UUU_anon'anon'x_anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize UUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance ReadRaw UUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance WriteRaw UUU_anon'anon'x_anon'x
+deriving via (EquivStorable UUU_anon'anon'x_anon'x) instance Storable UUU_anon'anon'x_anon'x
+deriving via (SizedByteArray 4
+                             4) instance IsUnion UUU_anon'anon'x_anon'x
+instance (~) ty CInt => HasField "x" UUU_anon'anon'x_anon'x ty
+    where getField = getUnionPayload
+instance (~) ty CInt => HasField "x" UUU_anon'anon'x_anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"x" x_0)
+instance (~) ty CInt =>
+         HasField "x" (Ptr UUU_anon'anon'x_anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"x")
+instance HasCField UUU_anon'anon'x_anon'x "x"
+    where type CFieldType UUU_anon'anon'x_anon'x "x" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union \@UUU_anon\'anon\'x@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 72:3@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU_anon'anon'x
+    = UUU_anon'anon'x {unwrap :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4
+                             4) instance StaticSize UUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance ReadRaw UUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance WriteRaw UUU_anon'anon'x
+deriving via (EquivStorable UUU_anon'anon'x) instance Storable UUU_anon'anon'x
+deriving via (SizedByteArray 4 4) instance IsUnion UUU_anon'anon'x
+instance (~) ty UUU_anon'anon'x_anon'x =>
+         HasField "anon'x" UUU_anon'anon'x ty
+    where getField = getUnionPayload
+instance (~) ty UUU_anon'anon'x_anon'x =>
+         HasField "anon'x" UUU_anon'anon'x ty
+    where hasField = \x_0 -> (setUnionPayload, getField @"anon'x" x_0)
+instance (~) ty UUU_anon'anon'x_anon'x =>
+         HasField "anon'x" (Ptr UUU_anon'anon'x) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'x")
+instance HasCField UUU_anon'anon'x "anon'x"
+    where type CFieldType UUU_anon'anon'x
+                          "anon'x" = UUU_anon'anon'x_anon'x
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @union UUU@
+
+    __defined at:__ @types\/anonymous\/edge-cases\/multi_nesting.h 71:7@
+
+    __exported by:__ @types\/anonymous\/edge-cases\/multi_nesting.h@
+-}
+newtype UUU = UUU {unwrap :: ByteArray} deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize UUU
+deriving via (SizedByteArray 4 4) instance ReadRaw UUU
+deriving via (SizedByteArray 4 4) instance WriteRaw UUU
+deriving via (EquivStorable UUU) instance Storable UUU
+deriving via (SizedByteArray 4 4) instance IsUnion UUU
+instance (~) ty UUU_anon'anon'x => HasField "anon'anon'x" UUU ty
+    where getField = getUnionPayload
+instance (~) ty UUU_anon'anon'x => HasField "anon'anon'x" UUU ty
+    where hasField = \x_0 -> (setUnionPayload,
+                              getField @"anon'anon'x" x_0)
+instance (~) ty UUU_anon'anon'x =>
+         HasField "anon'anon'x" (Ptr UUU) (Ptr ty)
+    where getField = fromPtr (Proxy @"anon'anon'x")
+instance HasCField UUU "anon'anon'x"
+    where type CFieldType UUU "anon'anon'x" = UUU_anon'anon'x
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
@@ -24,7 +24,6 @@ testCases = [
       defaultTest "types/anonymous/edge-cases/anon_in_nonanon"
     , defaultTest "types/anonymous/edge-cases/bitfield"
     , defaultTest "types/anonymous/edge-cases/duplicate_field_names"
-    , defaultTest "types/anonymous/edge-cases/multi_nesting"
     , defaultTest "types/anonymous/edge-cases/padding"
     , defaultTest "types/anonymous/struct_in_struct"
     , defaultTest "types/anonymous/struct_in_union"
@@ -63,6 +62,8 @@ testCases = [
     , defaultTest "types/unions/unions"
       -- Bespoke tests
     , test_types_anonymous_edge_cases_empty_anon
+    , test_types_anonymous_edge_cases_multi_nesting
+    , test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes
     , test_types_long_double
     , test_types_primitives_bool_c23
     , test_types_primitives_bool_macro_override
@@ -98,6 +99,15 @@ test_types_anonymous_edge_cases_empty_anon =
   where
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct S1", "struct S2"]
+
+test_types_anonymous_edge_cases_multi_nesting :: TestCase
+test_types_anonymous_edge_cases_multi_nesting =
+    defaultTest "types/anonymous/edge-cases/multi_nesting"
+
+test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes :: TestCase
+test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes =
+    testVariant "types/anonymous/edge-cases/multi_nesting" "omit_field_prefixes"
+      & #onFrontend .~ ( #fieldNamingStrategy .~ OmitFieldPrefixes )
 
 test_types_long_double :: TestCase
 test_types_long_double =


### PR DESCRIPTION
Part of #2061

Previously, implicit fields and explicit fields represented as the same save for annotations. We make the difference explicit now using a `Field` sum datatype that can either be `ExplicitField` or `ImplicitField`. We make this change now because we will be shortly adding a third type of field: `IndirectField`.

### PR checklist

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
- [x] Did you update the manual?
- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?
- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:
