### PR TITLE
Skip CXCursor_StaticAssert in the parse pass

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -278,6 +278,7 @@
 * Fix duplicated `--safe`, `--unsafe`, and `--pointer` options in the
   `preprocess --help` output. See
   [#2010](https://github.com/well-typed/hs-bindgen/issues/2010).
+* `CXCursor_StaticAssert` is now ignored in the parse pass.
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
 [is-1382]: https://github.com/well-typed/hs-bindgen/issues/1382

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -126,6 +126,10 @@ parseDecl' macroLang enclosing mCtx = withCursorKindNoCtx $ \case
       -- are resolved by the linker regardless of the DLL annotation.
       Right CXCursor_DLLImport          -> \_curr -> foldContinue
       Right CXCursor_DLLExport          -> \_curr -> foldContinue
+      -- C11 @_Static_assert@ declarations (e.g. SDL's
+      -- @SDL_COMPILE_TIME_ASSERT@): compile-time checks that declare
+      -- nothing bindable.
+      Right CXCursor_StaticAssert       -> \_curr -> foldContinue
 
       -- Report error for declarations we don't recognize
       eKind -> case mCtx of


### PR DESCRIPTION
I vendored `hs-bindgen` for some SDL3 bindings and parse panicked on `CXCursor_StaticAssert`. Since C11 `_Static_assert` declarations don't declare anything bindable, I skipped them in the parse pass. I thought I'd try upstreaming the change.

This was actually the only alteration I had to make to get a rendering triangle from raw bindings, which is really neat.

(In SDL3 this affected `SDL_COMPILE_TIME_ASSERT` in `SDL_stdinc.h` )

---
Some reminders, in case they are helpful:

- [X] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
