### PR TITLE
Separate Unusable Conflict constructor

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclIndex.hs
@@ -7,8 +7,9 @@
 module HsBindgen.Frontend.Analysis.DeclIndex (
     DeclIndex -- opaque
     -- * Entry
-  , Usable(..)
-  , Unusable(..)
+  , UsableEntry(..)
+  , UnusableEntry(..)
+  , UnusableReason(..)
   , Success(..)
   , Squashed(..)
   , Entry(..)
@@ -158,7 +159,7 @@ data DeclIndex l = DeclIndex {
 --
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
-data Usable l =
+data UsableEntry l =
     UsableSuccess (Success l Out)
   | UsableExternal C.DeclLocs
     -- Squashed declarations are always "usable" because we only squash
@@ -166,7 +167,7 @@ data Usable l =
   | UsableSquashed Squashed
   deriving stock (Show, Generic)
 
-usableToLoc :: Usable l -> C.DeclLocs
+usableToLoc :: UsableEntry l -> C.DeclLocs
 usableToLoc = \case
     UsableSuccess  x    -> C.DeclLoc x.decl.info.loc
     UsableExternal locs -> locs
@@ -180,44 +181,44 @@ usableToLoc = \case
 --
 -- (We avoid the term available, because it is overloaded with Clang's
 -- CXAvailabilityKind).
-data Unusable =
-    UnusableParseUnavailable       SingleLoc
-  | UnusableParseFailure           SingleLoc DelayedParseMsg
-  | UnusableConflict               C.Conflict
-  | UnusableMangleNamesFailure     SingleLoc MangleNamesError
-  | UnusableTypecheckMacrosError   SingleLoc MacroTypecheckError
-  | UnusableMacroResolutionFailure SingleLoc MacroResolutionError
-
-    -- | Omitted by prescriptive binding specifications
-  | UnusableOmitted              SingleLoc
+data UnusableEntry =
+    UnusableReason SingleLoc UnusableReason
+  | UnusableConflict C.Conflict
   deriving stock (Show, Generic)
 
-instance PrettyForTrace Unusable where
+instance PrettyForTrace UnusableEntry where
   prettyForTrace = \case
-    UnusableParseUnavailable{} ->
-      "Declaration unavailable"
+    UnusableReason   _loc unusable -> prettyForTrace unusable
+    UnusableConflict      conflict -> prettyForTrace conflict
+
+data UnusableReason =
+    UnusableUnavailable
+  | UnusableOmitted
+  | UnusableParseFailure           DelayedParseMsg
+  | UnusableMacroTypecheckFailure  MacroTypecheckError
+  | UnusableMacroResolutionFailure MacroResolutionError
+  | UnusableMangleNamesFailure     MangleNamesError
+  deriving stock (Show, Generic)
+
+instance PrettyForTrace UnusableReason where
+  prettyForTrace = \case
+    UnusableUnavailable{} ->
+      "Declaration is 'unavailable' on this platform"
+    UnusableOmitted{} ->
+      "Omitted by prescriptive binding specification"
     UnusableParseFailure{} ->
       "Parse failed"
-    UnusableConflict{} ->
-      "Conflicting declarations"
     UnusableMangleNamesFailure{} ->
       "Name mangler failure"
-    UnusableTypecheckMacrosError{} ->
+    UnusableMacroTypecheckFailure{} ->
       "Macro type-checking failed"
     UnusableMacroResolutionFailure{} ->
       "Macro name resolution failed"
-    UnusableOmitted{} ->
-      "Omitted by prescriptive binding specification"
 
-unusableToLoc :: Unusable -> C.DeclLocs
+unusableToLoc :: UnusableEntry -> C.DeclLocs
 unusableToLoc = \case
-    UnusableParseUnavailable loc         -> C.DeclLoc loc
-    UnusableParseFailure loc _           -> C.DeclLoc loc
-    UnusableConflict conflict            -> C.DeclLocsConflict conflict
-    UnusableMangleNamesFailure loc _     -> C.DeclLoc loc
-    UnusableTypecheckMacrosError loc _   -> C.DeclLoc loc
-    UnusableMacroResolutionFailure loc _ -> C.DeclLoc loc
-    UnusableOmitted loc                  -> C.DeclLoc loc
+  UnusableReason   loc _ -> C.DeclLoc          loc
+  UnusableConflict     c -> C.DeclLocsConflict c
 
 data Success l p = Success {
     decl                              :: C.Decl l p
@@ -241,22 +242,22 @@ data Squashed = Squashed {
 
 -- | Entry of declaration index
 data Entry l =
-    UsableE   (Usable l)
-  | UnusableE Unusable
+    UsableEntry   (UsableEntry l)
+  | UnusableEntry UnusableEntry
   deriving stock (Show, Generic)
 
 entryToLoc :: Entry l -> C.DeclLocs
 entryToLoc = \case
-  (UnusableE e) -> unusableToLoc e
-  (UsableE   e) -> usableToLoc e
+  UnusableEntry e -> unusableToLoc e
+  UsableEntry   e -> usableToLoc e
 
 entryToAvailability :: Entry l -> C.Availability
 entryToAvailability = \case
-    UsableE e   -> case e of
+    UsableEntry e   -> case e of
       UsableSuccess success -> success.decl.info.availability
       UsableExternal{}      -> C.Available
       UsableSquashed{}      -> C.Available
-    UnusableE{} -> C.Available
+    UnusableEntry{} -> C.Available
 
 {-------------------------------------------------------------------------------
   Construction
@@ -313,16 +314,16 @@ resolvedResultLoc = \case
 resolvedResultToEntry :: ResolvedResult l -> Entry l
 resolvedResultToEntry = \case
     Resolved result      -> parseResultToEntry result
-    Unresolved _ loc err -> UnusableE $ UnusableMacroResolutionFailure loc err
+    Unresolved _ loc err -> UnusableEntry $ UnusableReason loc (UnusableMacroResolutionFailure err)
   where
     parseResultToEntry :: ParseResult l Out -> Entry l
     parseResultToEntry result = case result.classification of
       ParseResultSuccess r ->
-        UsableE $ UsableSuccess (parseSuccessToSuccess r)
+        UsableEntry $ UsableSuccess (parseSuccessToSuccess r)
       ParseResultUnavailable ->
-        UnusableE $ UnusableParseUnavailable result.loc
+        UnusableEntry $ UnusableReason result.loc UnusableUnavailable
       ParseResultFailure r ->
-        UnusableE $ UnusableParseFailure result.loc r
+        UnusableEntry $ UnusableReason result.loc $ UnusableParseFailure r
 
     parseSuccessToSuccess :: ParseSuccess l Out -> Success l Out
     parseSuccessToSuccess success = Success {
@@ -416,11 +417,11 @@ buildIndex results = flip execState empty $ mapM_ aux results
             Nothing ->
               Map.insert declId (resolvedResultToEntry new) index.map
             Just (Redefinition success) ->
-              Map.insert declId (UsableE $ UsableSuccess success) index.map
+              Map.insert declId (UsableEntry $ UsableSuccess success) index.map
             Just (SingleConflict ids conflict) ->
               Map.union
                 ( Map.fromList
-                    [ (x,UnusableE $ UnusableConflict conflict)
+                    [ (x, UnusableEntry (UnusableConflict conflict))
                     | x <- Set.toList ids
                     ]
                 )
@@ -441,7 +442,7 @@ checkIsConflict ::
   -> IsConflict l
 checkIsConflict new (oldId, old) = case new of
     Resolved new' -> case (new'.classification, old) of
-      (ParseResultSuccess newSuccess, UsableE (UsableSuccess oldSuccess))
+      (ParseResultSuccess newSuccess, UsableEntry (UsableSuccess oldSuccess))
         | newSuccess.decl.kind == oldSuccess.decl.kind ->
           -- TODO <https://github.com/well-typed/hs-bindgen/issues/2099?
           --
@@ -465,7 +466,7 @@ checkIsConflict new (oldId, old) = case new of
       let newLoc = resolvedResultLoc new
           conflict :: C.Conflict
           conflict = case old of
-            UnusableE (UnusableConflict c) ->
+            UnusableEntry (UnusableConflict c) ->
               C.conflictInsert c newLoc
             _otherwise ->
               C.conflictFromList $
@@ -496,7 +497,7 @@ withoutKeys index xs = DeclIndex $ Map.withoutKeys index.map xs
 lookup :: C.DeclId -> DeclIndex l -> Maybe (C.Decl l Out)
 lookup declId (DeclIndex i) = case Map.lookup declId i of
   Nothing                          -> Nothing
-  Just (UsableE (UsableSuccess x)) -> Just $ x.decl
+  Just (UsableEntry (UsableSuccess x)) -> Just $ x.decl
   _                                -> Nothing
 
 -- | Get all parse successes.
@@ -504,7 +505,7 @@ getDecls :: DeclIndex l -> [C.Decl l Out]
 getDecls index = mapMaybe toDecl $ Map.elems index.map
   where
     toDecl = \case
-      UsableE (UsableSuccess x) -> Just x.decl
+      UsableEntry (UsableSuccess x) -> Just x.decl
       _otherEntries             -> Nothing
 
 {-------------------------------------------------------------------------------
@@ -535,11 +536,14 @@ getOmitted index = Map.mapMaybe toOmitted index.map
   where
     toOmitted :: Entry l -> Maybe SourcePath
     toOmitted = \case
-      UsableE (UsableSquashed e) -> lookupEntry e.targetNameC index >>= toOmitted
-      UsableE{}                  -> Nothing
-      UnusableE e                -> case e of
-        UnusableOmitted sloc -> Just sloc.singleLocPath
-        _otherEntry          -> Nothing
+      UsableEntry   (UsableSquashed e) ->
+        lookupEntry e.targetNameC index >>= toOmitted
+      UsableEntry{} ->
+        Nothing
+      UnusableEntry (UnusableReason loc UnusableOmitted) ->
+        Just loc.singleLocPath
+      UnusableEntry{} ->
+        Nothing
 
 -- | Get squashed entries.
 --
@@ -555,7 +559,7 @@ getSquashed index targets = Map.mapMaybe onlySquashedTargetingSet index.map
          Entry l
       -> Maybe (SourcePath, Hs.Name Hs.NsTypeConstr)
     onlySquashedTargetingSet = \case
-      UsableE (UsableSquashed e) ->
+      UsableEntry (UsableSquashed e) ->
         if Set.member e.targetNameC targets then
           Just (e.typedefLoc.singleLocPath, e.targetNameHs)
         else
@@ -563,13 +567,13 @@ getSquashed index targets = Map.mapMaybe onlySquashedTargetingSet index.map
       _otherwise  -> Nothing
 
 -- | Restrict the declaration index to unusable declarations in a given set.
-getUnusables :: DeclIndex l -> Set C.DeclId -> Map C.DeclId Unusable
+getUnusables :: DeclIndex l -> Set C.DeclId -> Map C.DeclId UnusableEntry
 getUnusables index = Map.mapMaybe onlyUnusable . (.map) . restrictKeys index
   where
-    onlyUnusable :: Entry l -> Maybe Unusable
+    onlyUnusable :: Entry l -> Maybe UnusableEntry
     onlyUnusable = \case
-      UsableE   _ -> Nothing
-      UnusableE e -> Just e
+      UsableEntry   _ -> Nothing
+      UnusableEntry e -> Just e
 
 {-------------------------------------------------------------------------------
   Support for delayed parse messages
@@ -587,8 +591,8 @@ registerDelayedParseMsg (declId, msg) (DeclIndex i) = DeclIndex $
     Map.adjust addMsg declId i
   where
     addMsg :: Entry l -> Entry l
-    addMsg (UsableE (UsableSuccess ps)) =
-      UsableE $ UsableSuccess ps {
+    addMsg (UsableEntry (UsableSuccess ps)) =
+      UsableEntry $ UsableSuccess ps {
           HsBindgen.Frontend.Analysis.DeclIndex.delayedParseMsgs =
             ps.delayedParseMsgs ++ [msg]
         }
@@ -603,7 +607,8 @@ registerMacroTypecheckFailure ::
   -> (C.DeclInfo TypecheckMacros, MacroTypecheckError)
   -> DeclIndex l
 registerMacroTypecheckFailure (DeclIndex i) (info, err)  = DeclIndex $
-    Map.insert info.id (UnusableE $ UnusableTypecheckMacrosError info.loc err) i
+    Map.insert info.id (UnusableEntry $ UnusableReason info.loc $
+      UnusableMacroTypecheckFailure err) i
 
 {-------------------------------------------------------------------------------
   Support for @PrepareReparse@ pass
@@ -621,8 +626,8 @@ registerDelayedPrepareReparseMsg (declId, msg) (DeclIndex i) = DeclIndex $
     Map.adjust addMsg declId i
   where
     addMsg :: Entry l -> Entry l
-    addMsg (UsableE (UsableSuccess ps)) =
-      UsableE $ UsableSuccess ps{
+    addMsg (UsableEntry (UsableSuccess ps)) =
+      UsableEntry $ UsableSuccess ps{
           delayedPrepareReparseMsgs = ps.delayedPrepareReparseMsgs ++ [msg]
         }
     addMsg entry = entry
@@ -644,8 +649,8 @@ registerDelayedReparseMacroExpansionsMsg (declId, msg) (DeclIndex i) = DeclIndex
     Map.adjust addMsg declId i
   where
     addMsg :: Entry l -> Entry l
-    addMsg (UsableE (UsableSuccess ps)) =
-      UsableE $ UsableSuccess ps{
+    addMsg (UsableEntry (UsableSuccess ps)) =
+      UsableEntry $ UsableSuccess ps{
           delayedReparseMacroExpansionsMsgs = ps.delayedReparseMacroExpansionsMsgs ++ [msg]
         }
     addMsg entry = entry
@@ -659,7 +664,9 @@ registerOmittedDeclarations ::
   -> DeclIndex l
   -> DeclIndex l
 registerOmittedDeclarations xs index = DeclIndex $
-    Map.union (UnusableE . UnusableOmitted <$> xs) index.map
+    Map.union (toOmitted <$> xs) index.map
+  where
+    toOmitted loc = UnusableEntry $ UnusableReason loc UnusableOmitted
 
 registerExternalDeclarations ::
      [(C.DeclId, C.DeclLocs)]
@@ -669,7 +676,7 @@ registerExternalDeclarations xs index = Foldable.foldl' insert index xs
   where
     insert :: DeclIndex l -> (C.DeclId, C.DeclLocs) -> DeclIndex l
     insert (DeclIndex i) (declId, locs) =
-      DeclIndex $ Map.insert declId (UsableE $ UsableExternal locs) i
+      DeclIndex $ Map.insert declId (UsableEntry $ UsableExternal locs) i
 
 {-------------------------------------------------------------------------------
   Support for mangle names
@@ -680,11 +687,14 @@ registerSquashedDeclarations ::
   -> DeclIndex l
   -> DeclIndex l
 registerSquashedDeclarations xs index = DeclIndex $
-    Map.union (UsableE . UsableSquashed <$> xs) index.map
+    Map.union (UsableEntry . UsableSquashed <$> xs) index.map
 
 registerMangleNamesFailure ::
      Map C.DeclId (SingleLoc, MangleNamesError)
   -> DeclIndex l
   -> DeclIndex l
 registerMangleNamesFailure xs index = DeclIndex $
-    Map.union (UnusableE . uncurry UnusableMangleNamesFailure <$> xs) index.map
+    Map.union (toEntry <$> xs) index.map
+  where
+    toEntry (loc, err) =
+      UnusableEntry $ UnusableReason loc $ UnusableMangleNamesFailure err

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
@@ -39,6 +39,15 @@ instance PrettyForTrace MangleNamesError where
       MangleNamesCollisionError  e -> prettyForTrace e
       MangleNamesResolutionError e -> prettyForTrace e
 
+instance IsTrace Level MangleNamesError where
+  getDefaultLogLevel = \case
+    MangleNamesCreationError CreateNamesSquashMustBeTypeConstr{} -> Bug
+    MangleNamesCreationError{}                                   -> Warning
+    MangleNamesCollisionError{}                                  -> Warning
+    MangleNamesResolutionError{}                                 -> Warning
+  getSource  = const HsBindgen
+  getTraceId = const "mangle-names"
+
 {-------------------------------------------------------------------------------
   Traversal 1: create names
 -------------------------------------------------------------------------------}

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Result.hs
@@ -55,15 +55,16 @@ deriving stock instance ( IsPass p
                         , Macro.HasTypes l
                         ) => Show (ParseClassification l p)
 
-instance PrettyForTrace (ParseClassification l p) where
-  prettyForTrace = \case
-    ParseResultSuccess x ->
-      prettyForTrace x
-    ParseResultUnavailable ->
-      PP.hang "Parse not attempted: " 2
-        "Declaration is 'unavailable' on this platform"
-    ParseResultFailure msg ->
-      PP.hang "Parse failure:" 2 $ prettyForTrace msg
+-- TODO-D
+-- instance PrettyForTrace (ParseClassification l p) where
+--   prettyForTrace = \case
+--     ParseResultSuccess x ->
+--       prettyForTrace x
+--     ParseResultUnavailable ->
+--       PP.hang "Parse not attempted: " 2
+--         "Declaration is 'unavailable' on this platform"
+--     ParseResultFailure msg ->
+--       PP.hang "Parse failure:" 2 $ prettyForTrace msg
 
 data ParseSuccess l p = ParseSuccess {
       decl             :: C.Decl l p
@@ -80,12 +81,13 @@ deriving stock instance (
   Pretty-printing
 -------------------------------------------------------------------------------}
 
-instance IsPass p => PrettyForTrace (ParseResult l p) where
-  prettyForTrace result =
-      prettyForTrace $ C.WithLocationInfo{
-          loc = idLocationInfo (Proxy @p) result.id [result.loc]
-        , msg = result.classification
-        }
+-- TODO-D
+-- instance IsPass p => PrettyForTrace (ParseResult l p) where
+--   prettyForTrace result =
+--       prettyForTrace $ C.WithLocationInfo{
+--           loc = idLocationInfo (Proxy @p) result.id [result.loc]
+--         , msg = result.classification
+--         }
 
 instance PrettyForTrace (ParseSuccess l p) where
   prettyForTrace success =

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -681,7 +681,7 @@ resolveUseSite ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
               <> " not in declaration index"
           -- Interesting case, an unusable declaration may have an external
           -- binding specification.
-          Just (DeclIndex.UnusableE x) -> do
+          Just (DeclIndex.UnusableEntry x) -> do
               let locs :: C.DeclLocs
                   locs = DeclIndex.unusableToLoc x
                   declPaths =
@@ -697,7 +697,7 @@ resolveUseSite ctx cDeclId = Reader.ask >>= \env -> State.get >>= \state ->
                   pure (Just ty)
                 Nothing -> pure Nothing
           -- Cannot have an external binding specification.
-          Just DeclIndex.UsableE{} ->
+          Just DeclIndex.UsableEntry{} ->
             pure Nothing
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -17,8 +17,9 @@ import Clang.Paths
 
 import HsBindgen.Errors (panicPure)
 import HsBindgen.Frontend.Analysis.DeclIndex (DeclIndex, Entry (..),
-                                              Success (..), Unusable (..),
-                                              Usable (..))
+                                              Success (..), UnusableEntry (..),
+                                              UnusableReason (..),
+                                              UsableEntry (..))
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Analysis.DeclUseGraph (DeclUseGraph)
 import HsBindgen.Frontend.Analysis.DeclUseGraph qualified as DeclUseGraph
@@ -45,10 +46,10 @@ import HsBindgen.Util.Tracer
 -- Declaration itself.
 type Decl l = C.Decl l Select
 
--- | Internal data type! This data type 'HsBindgen.Frontend.Pass.Select.Unselectable' refers to declarations
--- that are not selectable _from the perspective of `hs-bindgen`_; and, in
--- particular, not from the perspective of the user (they can change the select
--- predicate).
+-- | Internal data type! This data type
+-- 'HsBindgen.Frontend.Pass.Select.Unselectable' refers to declarations that are
+-- not selectable _from the perspective of `hs-bindgen`_; and, in particular,
+-- not from the perspective of the user (they can change the select predicate).
 --
 -- Also, (and in contrast to 'Usable'/'Unusable'), selectability _is concerned
 -- with transitivity_. All transitive dependencies of a selectable declaration
@@ -56,10 +57,10 @@ type Decl l = C.Decl l Select
 data Unselectable =
     -- | We (i.e., `hs-bindgen`) can not select a declaration selected because
     --   it or one of its dependencies is unusable.
-    Unselectable Unusable
+    Unselectable UnusableEntry
     -- | We (i.e., `hs-bindgen`) can not select a declaration because one of its
     --   dependencies has not been selected by the user.
-  | UnselectableNotSelected
+  | UnselectableDependencyNotSelected
   deriving stock (Show)
 
 -- | We have to treat with two notions of usability here:
@@ -147,7 +148,7 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
 
             nonselected :: Map C.DeclId Unselectable
             nonselected  =
-              Map.fromSet (const UnselectableNotSelected) $
+              Map.fromSet (const UnselectableDependencyNotSelected) $
                 transDeps \\ selectedIds
 
             unusabilityReasons :: Map C.DeclId Unselectable
@@ -161,18 +162,19 @@ selectDecls isMainHeader isInMainHeaderDir config unit =
             -- declaration is unselectable.
             getMostNaturalUnselectable ::
               Unselectable -> Unselectable -> Unselectable
-            getMostNaturalUnselectable l r = case (l,r) of
-              (UnselectableNotSelected, Unselectable u         ) ->
-                case u of
-                  UnusableParseUnavailable{} -> r
-                  UnusableOmitted{}          -> r
-                  _otherReason               -> l
-              (Unselectable u         , UnselectableNotSelected) ->
-                case u of
-                  UnusableParseUnavailable{} -> l
-                  UnusableOmitted{}          -> l
-                  _otherReason               -> r
-              (_, _) -> l
+            getMostNaturalUnselectable l r =
+              case (l,r) of
+                (UnselectableDependencyNotSelected, Unselectable u) ->
+                  case u of
+                    UnusableReason _ UnusableUnavailable -> r
+                    UnusableReason _ UnusableOmitted     -> r
+                    _otherReason                         -> l
+                (Unselectable u, UnselectableDependencyNotSelected) ->
+                  case u of
+                    UnusableReason _ UnusableUnavailable -> l
+                    UnusableReason _ UnusableOmitted{}   -> l
+                    _otherReason                         -> r
+                (_, _) -> l
 
         selectDecl :: Decl l -> Maybe (Decl l)
         selectDecl =
@@ -379,7 +381,7 @@ getSelectMsgsDeclId
                case r of
                  Unselectable u ->
                    TransitiveDependencyUnusable i u
-                 UnselectableNotSelected ->
+                 UnselectableDependencyNotSelected ->
                    TransitiveDependencyNotSelected i locs
              | (i, r) <- Map.toList unavailReasons
              , let locs = case DeclIndex.lookupLoc i declIndex of
@@ -428,7 +430,7 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
       -> Entry l
       -> [AnnMsg Select]
     aux declId = \case
-      UsableE e -> case e of
+      UsableEntry e -> case e of
         UsableSuccess success ->
           mkSuccessMessages declId success
         UsableExternal{} -> []
@@ -439,39 +441,18 @@ getDelayedMsgsSelectionRoots = concatMap (uncurry aux) . DeclIndex.toList
                 loc = C.declIdLocationInfo declId [x.typedefLoc]
               , msg = SelectMangleNamesSquashed x
               }
-      UnusableE e -> case e of
-        UnusableParseUnavailable loc ->
+      UnusableEntry e -> case e of
+        UnusableReason loc s ->
+            List.singleton $ withCallStack C.WithLocationInfo{
+                  loc = C.declIdLocationInfo declId [loc]
+                , msg = SelectUnusable s
+                }
+        UnusableConflict c ->
           List.singleton $ withCallStack C.WithLocationInfo{
-                loc = C.declIdLocationInfo declId [loc]
-              , msg = SelectParseUnavailable
-              }
-        UnusableParseFailure loc x ->
-          List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId [loc]
-            , msg = SelectParseFailure x
-            }
-        UnusableConflict x ->
-          List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId $ NonEmpty.toList $ C.conflictToList x
+              loc = C.declIdLocationInfo declId $
+                NonEmpty.toList $ C.conflictToList c
             , msg = SelectConflict
             }
-        UnusableMangleNamesFailure loc x ->
-          List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId [loc]
-            , msg = SelectMangleNamesFailure x
-            }
-        UnusableTypecheckMacrosError loc err ->
-          List.singleton$ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId [loc]
-            , msg = SelectMacroTypecheckFailure err
-            }
-        UnusableMacroResolutionFailure loc err ->
-          List.singleton $ withCallStack C.WithLocationInfo{
-              loc = C.declIdLocationInfo declId [loc]
-            , msg = SelectMacroResolutionFailure err
-            }
-        UnusableOmitted{} ->
-          []
 
 getDelayedMsgsAdditionalSelectedTransDeps ::
      HasCallStack
@@ -485,7 +466,7 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
       -> Entry l
       -> [AnnMsg Select]
     aux declId = \case
-      UsableE e -> case e of
+      UsableEntry e -> case e of
         UsableSuccess success ->
           mkSuccessMessages declId success
         UsableExternal{} -> []
@@ -499,7 +480,7 @@ getDelayedMsgsAdditionalSelectedTransDeps = concatMap (uncurry aux) . DeclIndex.
           ]
       -- Messages for unusable transitive dependencies are already attached to
       -- the traces of the reverse transitive dependencies.
-      UnusableE _ -> []
+      UnusableEntry _ -> []
 
 -- NOTE: We emit delayed BUG-level parse messages even for declarations that are
 -- not selected. We do not have a test for this; please ensure delayed BUG-level
@@ -513,38 +494,31 @@ getBugMsgsNotSelected = concatMap (uncurry aux) . DeclIndex.toList
       -> Entry l
       -> [AnnMsg Select]
     aux declId = \case
-      UsableE e -> case e of
+      UsableEntry e -> case e of
         UsableSuccess success ->
           let isBugLevel x = getDefaultLogLevel x == Bug
           in  filter isBugLevel $ mkSuccessMessages declId success
         UsableExternal{} -> []
         UsableSquashed{} -> []
-      UnusableE e -> case e of
-        UnusableParseUnavailable{} -> []
-        UnusableParseFailure loc x -> case getDefaultLogLevel x of
-          Bug ->
-            List.singleton $ withCallStack C.WithLocationInfo{
-                loc = C.declIdLocationInfo declId [loc]
-              , msg = SelectDelayedParseMsg x
-              }
-          _otherLvl -> []
+      UnusableEntry e -> case e of
+        UnusableReason loc reason ->
+          if isBug reason then
+              List.singleton $ withCallStack C.WithLocationInfo{
+                  loc = C.declIdLocationInfo declId [loc]
+                , msg = SelectUnusable reason
+                }
+          else
+            []
         UnusableConflict{} -> []
-        UnusableMangleNamesFailure{} -> []
-        UnusableTypecheckMacrosError loc err -> case getDefaultLogLevel err of
-          Bug ->
-            List.singleton $ withCallStack C.WithLocationInfo{
-                loc = C.declIdLocationInfo declId [loc]
-              , msg = SelectMacroTypecheckFailure err
-              }
-          _otherLvl -> []
-        UnusableMacroResolutionFailure loc err -> case getDefaultLogLevel err of
-          Bug ->
-            List.singleton $ withCallStack C.WithLocationInfo{
-                loc = C.declIdLocationInfo declId [loc]
-              , msg = SelectMacroResolutionFailure err
-              }
-          _otherLvl -> []
-        UnusableOmitted{} -> []
+
+    isBug :: UnusableReason -> Bool
+    isBug = \case
+      UnusableUnavailable                -> False
+      UnusableOmitted                    -> False
+      UnusableParseFailure           err -> getDefaultLogLevel err == Bug
+      UnusableMangleNamesFailure     err -> getDefaultLogLevel err == Bug
+      UnusableMacroTypecheckFailure  err -> getDefaultLogLevel err == Bug
+      UnusableMacroResolutionFailure err -> getDefaultLogLevel err == Bug
 
 {-------------------------------------------------------------------------------
   Sort traces
@@ -625,9 +599,9 @@ selectDeclIndex declUseGraph predicate declIndex =
     -- Returns multiple locations only for conflicts.
     entryInfo :: Entry l -> Maybe (C.DeclLocs, C.Availability)
     entryInfo entry = case entry of
-        UsableE UsableExternal{} ->
+        UsableEntry UsableExternal{} ->
           Nothing
-        UnusableE UnusableOmitted{} ->
+        UnusableEntry (UnusableReason _loc UnusableOmitted{}) ->
           Nothing
         _otherwise ->
           Just (DeclIndex.entryToLoc entry, DeclIndex.entryToAvailability entry)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -17,14 +17,12 @@ import Text.SimplePrettyPrint qualified as PP
 import Clang.HighLevel.Types
 
 import HsBindgen.BindingSpec qualified as BindingSpec
-import HsBindgen.Frontend.Analysis.DeclIndex (Entry (..), Squashed (..),
-                                              Unusable (..))
+import HsBindgen.Frontend.Analysis.DeclIndex (Squashed (..), UnusableEntry,
+                                              UnusableReason (..))
 import HsBindgen.Frontend.Analysis.DeclIndex qualified as DeclIndex
 import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
-import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.MangleNames.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
-import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg)
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass.Msg (DelayedReparseMacroExpansionsMsg)
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
@@ -33,7 +31,6 @@ import HsBindgen.Frontend.Predicate
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
 import HsBindgen.IR.Translation
-import HsBindgen.Macro.Error
 import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
@@ -133,20 +130,19 @@ data SelectStatus =
 
 data TransitiveDependencyMissing =
     -- | Transitive dependency is 'Unusable'.
-    TransitiveDependencyUnusable C.DeclId Unusable
+    TransitiveDependencyUnusable C.DeclId UnusableEntry
     -- | Transitive dependency is not selected.
   | TransitiveDependencyNotSelected C.DeclId [SingleLoc]
   deriving stock (Show)
 
 instance PrettyForTrace TransitiveDependencyMissing where
   prettyForTrace = \case
-      TransitiveDependencyUnusable i r ->
+      TransitiveDependencyUnusable i u ->
         let intro = "Transitive dependency unusable:"
         in  PP.hang intro 2 $ prettyForTrace $ C.WithLocationInfo{
                 loc = C.declIdLocationInfo i $
-                        C.declLocsToList $
-                          DeclIndex.entryToLoc (UnusableE r)
-              , msg = r
+                  C.declLocsToList $ DeclIndex.unusableToLoc u
+              , msg = u
               }
       TransitiveDependencyNotSelected i ls ->
         let intro = "Transitive dependency not selected:"
@@ -168,22 +164,10 @@ data SelectMsg =
   | SelectDeprecated SelectReason
     -- | Delayed parse message.
   | SelectDelayedParseMsg DelayedParseMsg
-    -- | Delayed parse message for declarations that are "unavailable".
-  | SelectParseUnavailable
-    -- | Delayed parse message for declarations the user wants to select
-    -- directly, but we have failed to parse.
-  | SelectParseFailure DelayedParseMsg
-    -- | Delayed construct translation unit message for conflicting declarations
-    -- the user wants to select directly.
+    -- | A directly or transitively selected declaration is unusable.
+  | SelectUnusable UnusableReason
   | SelectConflict
-  | SelectMangleNamesFailure MangleNamesError
   | SelectMangleNamesSquashed Squashed
-    -- | Delayed handle macros message for macros the user wants to select
-    -- directly, but we have failed to parse.
-  | SelectMacroTypecheckFailure MacroTypecheckError
-    -- | Delayed macro name-resolution failure for macros the user wants to
-    -- select directly.
-  | SelectMacroResolutionFailure MacroResolutionError
     -- | Delayed @PrepareReparse@ message
   | SelectDelayedPrepareReparseMsg DelayedPrepareReparseMsg
     -- | Delayed @ReparseMacroExpansions@ message
@@ -205,22 +189,27 @@ instance PrettyForTrace SelectMsg where
         withSelectReason r "Selected a deprecated declaration"
       SelectDelayedParseMsg x ->
         during x $ prettyForTrace x
-      SelectParseUnavailable ->
-        couldNotSelect $ prettyForTrace ParseResultUnavailable
-      SelectParseFailure x ->
-        couldNotSelect $ prettyForTrace x
+      SelectUnusable reason -> case reason of
+        UnusableUnavailable ->
+          couldNotSelect $ PP.hang "Parse not attempted: " 2
+            "Declaration is 'unavailable' on this platform"
+        UnusableOmitted ->
+          couldNotSelect $
+            "Declaration omitted by prescriptive binding specifications"
+        UnusableParseFailure x ->
+          couldNotSelect $ prettyForTrace x
+        UnusableMangleNamesFailure x ->
+          couldNotSelect $ prettyForTrace x
+        UnusableMacroTypecheckFailure x ->
+          couldNotSelect $ prettyForTrace x
+        UnusableMacroResolutionFailure x ->
+          couldNotSelect $ prettyForTrace x
       SelectConflict ->
         couldNotSelect "Conflicting declarations"
-      SelectMangleNamesFailure x ->
-        couldNotSelect $ prettyForTrace x
       SelectMangleNamesSquashed x -> PP.hsep [
           "Squashed typedef to"
         , prettyForTrace x.targetNameC
         ]
-      SelectMacroTypecheckFailure x ->
-        couldNotSelect $ prettyForTrace x
-      SelectMacroResolutionFailure x ->
-        couldNotSelect $ prettyForTrace x
       SelectDelayedPrepareReparseMsg x ->
         during x $ prettyForTrace x
       SelectDelayedReparseMacroExpansionsMsg x ->
@@ -251,15 +240,15 @@ instance IsTrace Level SelectMsg where
     TransitiveDependenciesMissing{}          -> Warning
     SelectDeprecated{}                       -> Notice
     SelectDelayedParseMsg x                  -> getDefaultLogLevel x
-    SelectParseUnavailable                   -> Warning
-    SelectParseFailure x                     -> getDefaultLogLevel x
+    SelectUnusable r -> case r of
+      UnusableUnavailable              -> Warning
+      UnusableOmitted                  -> Info
+      UnusableParseFailure x           -> getDefaultLogLevel x
+      UnusableMangleNamesFailure x     -> getDefaultLogLevel x
+      UnusableMacroTypecheckFailure x  -> getDefaultLogLevel x
+      UnusableMacroResolutionFailure x -> getDefaultLogLevel x
     SelectConflict{}                         -> Warning
-    SelectMangleNamesFailure x               -> case x of
-      MangleNamesCreationError CreateNamesSquashMustBeTypeConstr{} -> Bug
-      _                                                            -> Warning
     SelectMangleNamesSquashed{}              -> Notice
-    SelectMacroTypecheckFailure x            -> getDefaultLogLevel x
-    SelectMacroResolutionFailure x           -> getDefaultLogLevel x
     SelectDelayedPrepareReparseMsg x         -> getDefaultLogLevel x
     SelectDelayedReparseMacroExpansionsMsg x -> getDefaultLogLevel x
     SelectNoDeclarationsMatched              -> Warning
@@ -269,13 +258,15 @@ instance IsTrace Level SelectMsg where
     TransitiveDependenciesMissing{}          -> "select"
     SelectDeprecated{}                       -> "select"
     SelectDelayedParseMsg x                  -> "select-" <> getTraceId x
-    SelectParseUnavailable                   -> "select-parse"
-    SelectParseFailure x                     -> "select-" <> getTraceId x
+    SelectUnusable r -> case r of
+      UnusableUnavailable              -> "select-parse"
+      UnusableOmitted                  -> "select-omitted"
+      UnusableParseFailure           x -> "select-" <> getTraceId x
+      UnusableMangleNamesFailure     x -> "select-" <> getTraceId x
+      UnusableMacroTypecheckFailure  x -> "select-" <> getTraceId x
+      UnusableMacroResolutionFailure x -> "select-" <> getTraceId x
     SelectConflict{}                         -> "select"
-    SelectMangleNamesFailure{}               -> "select-mangle-names-failure"
     SelectMangleNamesSquashed{}              -> "select-mangle-names-squashed"
-    SelectMacroTypecheckFailure x            -> "select-" <> getTraceId x
-    SelectMacroResolutionFailure x           -> "select-" <> getTraceId x
     SelectDelayedPrepareReparseMsg x         -> "select-" <> getTraceId x
     SelectDelayedReparseMacroExpansionsMsg x -> "select-" <> getTraceId x
     SelectNoDeclarationsMatched              -> "select"

--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Patterns.hs
@@ -20,6 +20,7 @@ module Test.Common.HsBindgen.Trace.Patterns (
     -- * Select
   , pattern MatchNoDeclarations
   , pattern MatchSelect
+  , pattern MatchUnusable
   , pattern MatchTransMissing
   , pattern MatchTransNotSelected
   , pattern MatchTransUnusable
@@ -169,6 +170,9 @@ pattern MatchSelect name x <- TraceFrontend (
         }
     )
 
+pattern MatchUnusable :: C.DeclName -> UnusableReason -> TraceMsg
+pattern MatchUnusable name x <- MatchSelect name (SelectUnusable x)
+
 -- | Transitive dependencies of a declaration are missing
 pattern MatchTransMissing :: [TransitiveDependencyMissing] -> SelectMsg
 pattern MatchTransMissing xs <- TransitiveDependenciesMissing _ xs
@@ -178,7 +182,7 @@ pattern MatchTransNotSelected :: TransitiveDependencyMissing
 pattern MatchTransNotSelected <- TransitiveDependencyNotSelected _ _
 
 -- | A single transitive dependency of a declaration is unusable
-pattern MatchTransUnusable :: Unusable -> TransitiveDependencyMissing
+pattern MatchTransUnusable :: UnusableEntry -> TransitiveDependencyMissing
 pattern MatchTransUnusable x <- TransitiveDependencyUnusable _ x
 
 {-------------------------------------------------------------------------------
@@ -206,6 +210,6 @@ pattern MatchDoxygen x <- TraceFrontend (FrontendDoxygen x)
 
 matchDelayed :: SelectMsg -> Maybe DelayedParseMsg
 matchDelayed = \case
-    SelectDelayedParseMsg x -> Just x
-    SelectParseFailure x -> Just x
-    _otherwise -> Nothing
+    SelectDelayedParseMsg x                 -> Just x
+    SelectUnusable (UnusableParseFailure x) -> Just x
+    _otherwise                              -> Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
@@ -2,6 +2,7 @@
 module Test.HsBindgen.Golden.Declarations (testCases) where
 
 import HsBindgen.Config.Internal
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
@@ -72,7 +73,7 @@ test_declarations_duplicate_field_name_omit =
             & #fieldNamingStrategy .~ OmitFieldPrefixes
           )
       & #tracePredicate  .~ multiTracePredicate declsWithMsgs (\case
-            MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesDuplicateFieldName{})) ->
+            MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesDuplicateFieldName{})) ->
               Just $ Expected name
             _otherwise ->
               Nothing
@@ -113,7 +114,7 @@ test_declarations_field_name_reuse_omit =
 test_declarations_name_collision :: TestCase
 test_declarations_name_collision =
     testTraceMulti "declarations/name_collision" declsWithMsgs $ \case
-      MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
+      MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name
       _otherwise ->
         Nothing
@@ -132,7 +133,7 @@ test_declarations_name_collision =
 test_declarations_name_collision_aux :: TestCase
 test_declarations_name_collision_aux =
     testTraceMulti "declarations/name_collision_aux" declsWithMsgs $ \case
-      MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
+      MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name
       _otherwise ->
         Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
@@ -3,7 +3,8 @@ module Test.HsBindgen.Golden.EdgeCases (testCases) where
 
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
-import HsBindgen.Frontend.Analysis.DeclIndex (Unusable (..))
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableEntry (..),
+                                              UnusableReason (..))
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
@@ -65,7 +66,7 @@ test_edgeCases_clang_generated_collision =
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchSelect name SelectConflict{} ->
               Just $ Expected name
-            MatchSelect _ (MatchTransMissing [MatchTransUnusable UnusableConflict{}]) ->
+            MatchSelect _ (MatchTransMissing [MatchTransUnusable (UnusableConflict{})]) ->
               Just Tolerated
             _otherwise ->
               Nothing
@@ -88,7 +89,7 @@ test_edgeCases_duplicate =
               Just $ Expected (name, "conflict")
             MatchSelect name (MatchTransMissing [MatchTransUnusable UnusableConflict{}]) ->
               Just $ Expected (name, "transitive conflict")
-            MatchSelect name SelectMangleNamesFailure{} ->
+            MatchUnusable name UnusableMangleNamesFailure{} ->
               Just $ Expected (name, "mangle")
             _otherwise ->
                Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
@@ -3,6 +3,7 @@ module Test.HsBindgen.Golden.Functions (testCases) where
 
 import HsBindgen.Backend.Category
 import HsBindgen.Config.Internal
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
@@ -73,7 +74,7 @@ test_functions_fun_attributes =
               Just $ Expected name
             MatchSelect name SelectDeprecated{} ->
               Just $ Expected name
-            MatchSelect name SelectParseUnavailable ->
+            MatchUnusable name UnusableUnavailable ->
               Just $ Expected name
             _otherwise ->
               Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -2,6 +2,7 @@
 module Test.HsBindgen.Golden.Macros (testCases) where
 
 import HsBindgen.Config.Internal
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Imports
@@ -60,17 +61,17 @@ test_macros_macro_ext_binding_dep =
 test_macros_macro_type_unresolved_tagged :: TestCase
 test_macros_macro_type_unresolved_tagged =
     testTraceMulti "macros/macro_type_unresolved_tagged" declsWithMsgs $ \case
-      MatchSelect name@"struct Unparsable" (SelectParseFailure ParseUnsupportedLongDouble) ->
+      MatchUnusable name@"struct Unparsable" (UnusableParseFailure ParseUnsupportedLongDouble) ->
         Just $ Expected (name, "select-parse-failure")
       MatchSelect name@"macro PTR_UNPARSABLE" (TransitiveDependenciesMissing{}) ->
         Just $ Expected (name, "select-transitive-dependencies-missing")
-      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMangleNamesFailure{}) ->
+      MatchUnusable name@"macro PTR_UNPARSABLE" (UnusableMangleNamesFailure{}) ->
         Just $ Expected (name, "select-mangle-names-failure")
-      MatchSelect name@"macro PTR_UNPARSABLE" (SelectMacroResolutionFailure{}) ->
+      MatchUnusable name@"macro PTR_UNPARSABLE" (UnusableMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
-      MatchSelect name@"macro PTR_DOES_NOT_EXIST" (SelectMacroResolutionFailure{}) ->
+      MatchUnusable name@"macro PTR_DOES_NOT_EXIST" (UnusableMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
-      MatchSelect name@"macro DOES_NOT_EXIST" (SelectMacroResolutionFailure{}) ->
+      MatchUnusable name@"macro DOES_NOT_EXIST" (UnusableMacroResolutionFailure{}) ->
         Just $ Expected (name, "macro-unresolved-tagged-type")
       _otherwise ->
         Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
@@ -3,7 +3,6 @@ module Test.HsBindgen.Golden.Macros.Reparse (testCases) where
 
 import Control.Applicative
 
-import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
 import HsBindgen.TraceMsg
 import HsBindgen.Util.Tracer
@@ -55,7 +54,7 @@ test_arithmetic_types :: TestCase
 test_arithmetic_types =
     defaultTest "macros/reparse/arithmetic_types"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
-            MatchSelect name@"f29" (SelectParseFailure ParseUnsupportedLongDouble) ->
+            MatchDelayed name@"f29" ParseUnsupportedLongDouble ->
               Just $ Expected name
             _otherwise ->
               Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
@@ -4,6 +4,7 @@ module Test.HsBindgen.Golden.ProgramAnalysis (testCases) where
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Predicate
@@ -110,7 +111,7 @@ test_programAnalysis_circular_macro =
           multiTracePredicateCustomLogLevel
             -- We want to check macro traces.
             (getCustomLogLevel [EnableMacroWarnings]) declsWithMsgs (\case
-                MatchSelect name SelectMacroTypecheckFailure{} ->
+                MatchUnusable name UnusableMacroTypecheckFailure{} ->
                   Just $ Expected (name, "typecheck")
                 MatchSelect name TransitiveDependenciesMissing{} ->
                   Just $ Expected (name, "transitive")
@@ -247,13 +248,13 @@ test_programAnalysis_selection_bad =
 test_programAnalysis_selection_fail :: TestCase
 test_programAnalysis_selection_fail =
     testTraceMulti "program-analysis/selection_fail" declsWithMsgs $ \case
-      MatchSelect name SelectParseFailure{} ->
+      MatchUnusable name UnusableParseFailure{} ->
         Just $ Expected name
       MatchSelect name (MatchTransMissing [MatchTransUnusable _unusable]) ->
         Just $ Expected name
       MatchSelect name (SelectStatusInfo (Selected SelectionRoot)) ->
         Just $ Expected name
-      MatchSelect name (SelectMangleNamesFailure{}) ->
+      MatchUnusable name (UnusableMangleNamesFailure{}) ->
         Just $ Expected name
       _otherwise ->
         Nothing
@@ -282,7 +283,7 @@ test_programAnalysis_selection_fail_variant_1 =
               Just $ Expected name
             MatchSelect name (SelectStatusInfo (Selected SelectionRoot)) ->
               Just $ Expected name
-            MatchSelect name (SelectMangleNamesFailure{}) ->
+            MatchUnusable name (UnusableMangleNamesFailure{}) ->
               Just $ Expected name
             _otherwise ->
               Nothing
@@ -312,7 +313,7 @@ test_programAnalysis_selection_fail_variant_2 =
              Just $ Expected name
            MatchSelect name (SelectStatusInfo (Selected SelectionRoot)) ->
              Just $ Expected name
-           MatchSelect name (SelectMangleNamesFailure{}) ->
+           MatchUnusable name (UnusableMangleNamesFailure{}) ->
              Just $ Expected name
            _otherwise ->
              Nothing
@@ -355,9 +356,9 @@ test_programAnalysis_selection_foo =
 
       -- We get a transient name mangler failure here because @foo_t@ is
       -- unsupported, and so, it is not mangled.
-      MatchSelect _name SelectMangleNamesFailure{} ->
+      MatchUnusable _name UnusableMangleNamesFailure{} ->
         Just $ Expected ("macro A", "foo_t not mangled")
-      MatchSelect _name SelectParseFailure{} ->
+      MatchUnusable _name UnusableParseFailure{} ->
         Just $ Expected ("f", "unsupported underlying type")
       _otherwise ->
         Nothing
@@ -451,7 +452,7 @@ test_programAnalysis_selection_omit_prescriptive =
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchSelect name (MatchTransMissing{}) ->
               Just $ Expected (name, "select")
-            MatchSelect name (SelectMangleNamesFailure (MangleNamesResolutionError ResolveNamesUnderlyingDeclNotMangled{})) ->
+            MatchUnusable name (UnusableMangleNamesFailure (MangleNamesResolutionError ResolveNamesUnderlyingDeclNotMangled{})) ->
               Just $ Expected (name, "mangle")
             _otherwise ->
               Nothing
@@ -558,7 +559,7 @@ test_programAnalysis_typedef_block =
 test_programAnalysis_typedef_name_clash :: TestCase
 test_programAnalysis_typedef_name_clash =
     testTraceMulti "program-analysis/typedef_name_clash" declsWithMsgs $ \case
-      MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
+      MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected (name, "collision")
       MatchSelect name (TransitiveDependenciesMissing{}) ->
         Just $ Expected (name, "transitivity")
@@ -588,7 +589,7 @@ test_programAnalysis_typedef_name_clash =
 test_programAnalysis_typedef_suffix_clash :: TestCase
 test_programAnalysis_typedef_suffix_clash =
     testTraceMulti "program-analysis/typedef_suffix_clash" declsWithMsgs $ \case
-      MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
+      MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected (name, "collision")
       MatchSelect name (TransitiveDependenciesMissing{}) ->
         Just $ Expected (name, "transitivity")

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
@@ -3,6 +3,7 @@ module Test.HsBindgen.Golden.Types (testCases) where
 
 import HsBindgen.Config.ClangArgs
 import HsBindgen.Config.Internal
+import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.MangleNames.Error
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Select.IsPass
@@ -242,7 +243,7 @@ test_types_typedefs_typedefs =
 test_types_typedefs_typenames :: TestCase
 test_types_typedefs_typenames =
     testTraceMulti "types/typedefs/typenames" declsWithMsgs $ \case
-      MatchSelect name (SelectMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
+      MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name
       _otherwise ->
         Nothing


### PR DESCRIPTION
Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] Did you update the manual?

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
