### PR TITLE
`MangleNames`: support non-local mangling of scoped names

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames.hs
@@ -34,19 +34,19 @@ import HsBindgen.Util.Tracer (withCallStack)
 
   Name mangling proceeds in three traversals:
 
-  1. 'createNames' chooses top-level names and all within-declaration
-     names (annotations and 'ScopedNamePair's), producing a 'CreateNames'
-     AST whose 'Id' references are still unresolved. It also produces the
+  1. 'createNames' chooses top-level names and all within-declaration names
+     (annotations and 'ScopedNamePair's), producing a 'CreateNames' AST whose
+     'Id' and 'ScopedName' references are still unresolved. It also produces the
      'NameMap' and squash records.
 
   2. 'detectClashes' assembles a single 'NameRegistry' from the 'NameMap'
-     (top-level names) and the 'CreateNames' AST (derived names) and reports
-     collisions.
+     (top-level names and scoped names) and the 'CreateNames' AST (local names
+     in annotations) and reports collisions.
 
-  3. 'resolveNames' rewrites 'C.DeclId' references into 'DeclIdPair's using the
-     'NameMap', copying annotations and scoped names across unchanged, and
-     dropping the declarations flagged by 'detectClashes'. This produces the
-     final 'MangleNames' AST.
+  3. 'resolveNames' rewrites 'C.DeclId' references into 'DeclIdPair's and
+     'C.ScopedName' references into 'ScopedNamePair' using the 'NameMap',
+     copying annotations across unchanged, and dropping the declarations flagged
+     by 'detectClashes'. This produces the final 'MangleNames' AST.
 
   Importantly, name mangling can fail (Traversal 1), and names can conflict
   (Traversal 2), ultimately leading to dangling references (Traversal 3) in
@@ -76,9 +76,10 @@ mangleNames fieldNaming unit = (
                             squashes
                             unit.meta
         }
-    , msgs1 ++ [
-          debugMsg $ MangleNamesNameMap nameMap
-        , debugMsg $ MangleNamesNameRegistry registry
+    , msgs1 ++ catMaybes [
+          Just $ debugMsg $ MangleNamesNameMap nameMap
+        , bugMsg . MangleNamesNameMapDuplicates <$> nameMapDups
+        , Just $ debugMsg $ MangleNamesNameRegistry registry
         ]
     )
   where
@@ -89,12 +90,13 @@ mangleNames fieldNaming unit = (
     mangleCandidateConfig = MangleCandidate.mangleCandidateDefault
 
     -- Traversal 1: choose top-level names and within-declaration names.
-    declsC    :: [C.Decl l CreateNames]
-    squashes  :: [(C.DeclId, Hs.Name Hs.NsTypeConstr, TypedefAnalysis.Squash)]
-    nameMap   :: NameMap
-    failures1 :: [MangleNamesFailure]
-    msgs1     :: [AnnMsg MangleNames]
-    (declsC, squashes, nameMap, failures1, msgs1) =
+    declsC      :: [C.Decl l CreateNames]
+    squashes    :: [(C.DeclId, Hs.Name Hs.NsTypeConstr, TypedefAnalysis.Squash)]
+    nameMap     :: NameMap
+    nameMapDups :: Maybe (NonEmpty DupAssign)
+    failures1   :: [MangleNamesFailure]
+    msgs1       :: [AnnMsg MangleNames]
+    (declsC, squashes, nameMap, nameMapDups, failures1, msgs1) =
       createNames typedefAnalysis mangleCandidateConfig fieldNaming unit.decls
 
     -- Traversal 2: detect clashes among all names.
@@ -143,3 +145,6 @@ updateDeclMeta failures squashes declMeta = declMeta{
 
 debugMsg :: MangleNamesMsg -> AnnMsg MangleNames
 debugMsg = withCallStack . C.WithLocationInfo C.LocationUnavailable
+
+bugMsg :: MangleNamesMsg -> AnnMsg MangleNames
+bugMsg = withCallStack . C.WithLocationInfo C.LocationUnavailable

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
@@ -14,6 +14,7 @@ import Control.Applicative ((<|>))
 import Control.Monad.Except (ExceptT, MonadError (..), liftEither, runExcept,
                              runExceptT)
 import Control.Monad.Reader (Reader, asks, runReader)
+import Control.Monad.State (StateT (runStateT), modify)
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import Data.Proxy
@@ -44,15 +45,23 @@ import HsBindgen.Util.Tracer (WithCallStack, withCallStack)
 
   This pass is local to name mangling: it is /not/ exposed as a frontend
   artefact and not selectable via the CLI. It is the result of the first of the
-  three name-mangling traversals ("create names"): it has all within-declaration
-  names minted (as annotations and 'ScopedNamePair' slots), but all references
-  (the 'Id' slots) are still unresolved 'DeclId's. The final 'resolveNames'
-  traversal rewrites these into 'DeclIdPair's, producing 'MangleNames'.
+  three name-mangling traversals ("create names").
+
+  'CreateNames' creates top-level declaration names (the 'Id' slots), scoped
+  names ('ScopedName'), and all local auxiliary names such as auxiliary type or
+  data constructor names.
+
+  'CreateNames', however, does not resolve names within declarations; names that
+  can be referred to from other declarations are stored in the 'NameMap'
+  (top-level names and scoped names). Names that are used purely locally are
+  stored in annotations (local auxiliary type and data constructor names).
+
+  The final 'resolveNames' traversal rewrites 'C.DeclId's into 'DeclIdPair's and
+  'C.ScopedName's into 'ScopedNamePair's, producing 'MangleNames'.
 
   Note that @'Ann' ix 'CreateNames'@ and @'Ann' ix 'MangleNames'@ reduce to the
-  same bundle types, and 'ScopedName' is 'ScopedNamePair' in both. The
-  annotations and scoped names can therefore be carried across directly during
-  'resolveNames'.
+  same bundle types. The annotations can therefore be carried across directly
+  during 'resolveNames'.
 -------------------------------------------------------------------------------}
 
 -- | Create names pass (local to name mangling)
@@ -75,7 +84,7 @@ instance PassId CreateNames where
   type Id CreateNames = C.DeclId
 
 instance PassScopedName CreateNames where
-  type ScopedName CreateNames = ScopedNamePair
+  type ScopedName CreateNames = C.ScopedName
 
 instance PassMacro CreateNames where
   type MacroId         CreateNames = C.DeclId
@@ -102,9 +111,10 @@ instance PassMsg CreateNames where
   CoercePass: ResolveBindingSpecs → CreateNames
 
   Used by the "create names" traversal to reindex the parts of a declaration
-  that do not change representation (types, comments, enclosing references). The
-  'Id' (and hence 'MacroId') and 'ExtBinding' representations agree between the
-  two passes, so these coercions are pure reindexing.
+  that do not change representation (types, comments, scoped names, enclosing
+  references). The 'Id' (and hence 'MacroId'), 'ScopedName', and 'ExtBinding'
+  representations agree between the two passes, so these coercions are pure
+  reindexing.
 -------------------------------------------------------------------------------}
 
 instance CoercePassId               ResolveBindingSpecs CreateNames
@@ -177,11 +187,13 @@ mangleCandidate mc _ cName =
   Traversal 1: Create names
 
   For each declaration we first choose its top-level name (step 1a,
-  'nameForDecl') and, when that succeeds, immediately mint all its
-  within-declaration names (step 1b, 'createDecl').
+  'nameForDecl'). When that succeeds, we immediately create all its
+  within-declaration names (step 1b, 'createDecl'). This includes creating
+  scoped names and purely local names.
 
   The top-level name feeds the 'NameMap' regardless of what happens in 1b: a
   squashed or otherwise un-emitted declaration must still be resolvable by name.
+  Scoped names are also fed into the 'NameMap'.
 -------------------------------------------------------------------------------}
 
 createNames ::
@@ -193,13 +205,15 @@ createNames ::
   -> ( [C.Decl l CreateNames]
      , [(C.DeclId, Hs.Name Hs.NsTypeConstr, TypedefAnalysis.Squash)]
      , NameMap
+     , Maybe (NonEmpty DupAssign)
      , [MangleNamesFailure]
      , [AnnMsg MangleNames]
      )
 createNames td mc strategy decls = (
-      map snd successes
+      map (snd . snd) successes
     , squashes
     , nameMap
+    , nameMapDups
     , failures
     , messages
     )
@@ -217,17 +231,17 @@ createNames td mc strategy decls = (
       , fieldNamingStrategy = strategy
       }
 
-    results :: [CreateNamesResult (C.Decl l CreateNames)]
+    results :: [CreateNamesResult ([ScopedNamePair], C.Decl l CreateNames)]
     messages :: [AnnMsg MangleNames]
     (results, messages) = second concat $ unzip $ map perDecl decls
 
     perDecl ::
          C.Decl l ResolveBindingSpecs
-      -> (CreateNamesResult (C.Decl l CreateNames), [AnnMsg MangleNames])
+      -> (CreateNamesResult ([ScopedNamePair], C.Decl l CreateNames), [AnnMsg MangleNames])
     perDecl decl = (,msgs) $ case nameResult of
         CnFailure err      -> CnFailure err
         CnSquashed nC nH s -> CnSquashed nC nH s
-        CnMangled name _   -> createNamesWithin env name decl
+        CnMangled name ()  -> createNamesWithin env name decl
       where
         nameResult :: CreateNamesResult ()
         msgs       :: [AnnMsg MangleNames]
@@ -235,13 +249,20 @@ createNames td mc strategy decls = (
 
     failures  :: [MangleNamesFailure]
     squashes  :: [(C.DeclId, Hs.Name Hs.NsTypeConstr, TypedefAnalysis.Squash)]
-    successes :: [(DeclIdPair, C.Decl l CreateNames)]
-    (failures, squashes, successes) = partitionCreateResults results
+    successes :: [(DeclIdPair, ([ScopedNamePair], C.Decl l CreateNames))]
+    (failures, squashes, successes) = partitionCreateNamesResults results
 
     nameMap :: NameMap
-    nameMap = fromDeclIdPairs $
-         map fst successes
-      ++ map (\(cN, hN, _) -> DeclIdPair cN (Hs.demoteNs hN)) squashes
+    nameMapDups :: Maybe (NonEmpty DupAssign)
+    (nameMap, nameMapDups) = fromNames $
+         map fromSuccess successes
+      ++ map fromSquash squashes
+      where
+        fromSuccess (declIdPair, (scopedNamePairs, _)) = (declIdPair, scopedNamePairs)
+        fromSquash (cN, hN, _)                         = (declIdPair, scopedNamePairs)
+          where
+            declIdPair = DeclIdPair cN (Hs.demoteNs hN)
+            scopedNamePairs = []
 
 nameForDecl ::
      HasCallStack
@@ -353,10 +374,21 @@ data CreateEnv = CreateEnv{
   deriving stock (Generic)
 
 type CreateM   = Reader CreateEnv
-type CreateE a = ExceptT MangleNamesCreationError CreateM a
 
-runCreate :: CreateEnv -> CreateE a -> Either MangleNamesCreationError a
-runCreate env action = runReader (runExceptT action) env
+data CreateSt = CreateSt{
+      scopedNames :: [ScopedNamePair]
+    }
+  deriving stock (Generic)
+
+emptyCreateSt :: CreateSt
+emptyCreateSt = CreateSt []
+
+type CreateS   = StateT CreateSt CreateM
+
+type CreateE a = ExceptT MangleNamesCreationError CreateS a
+
+runCreate :: CreateEnv -> CreateSt -> CreateE a -> (Either MangleNamesCreationError a, CreateSt)
+runCreate env st action = runReader (runStateT (runExceptT action) st) env
 
 -- | Apply Haskell naming rules to a candidate name
 mkName ::
@@ -371,12 +403,12 @@ data CreateNamesResult a =
     | CnSquashed  C.DeclId (Hs.Name Hs.NsTypeConstr) TypedefAnalysis.Squash
     | CnMangled   DeclIdPair a
 
-partitionCreateResults ::
+partitionCreateNamesResults ::
      [CreateNamesResult a]
   -> ( [MangleNamesFailure]
      , [(C.DeclId, Hs.Name Hs.NsTypeConstr, TypedefAnalysis.Squash)]
      , [(DeclIdPair, a)] )
-partitionCreateResults = rev . Foldable.foldl' aux ([], [], [])
+partitionCreateNamesResults = rev . Foldable.foldl' aux ([], [], [])
   where
     aux (fs, ss, ds) = \case
       CnFailure  f       -> (f:fs, ss,           ds      )
@@ -385,22 +417,25 @@ partitionCreateResults = rev . Foldable.foldl' aux ([], [], [])
 
     rev (fs, ss, ds) = (reverse fs, reverse ss, reverse ds)
 
--- | Mint the within-declaration names of a declaration whose top-level name
+-- | Create the within-declaration names of a declaration whose top-level name
 -- ('hsName') has already been chosen in step 1a.
 createNamesWithin ::
      Macro.HasTypes l
   => CreateEnv
   -> DeclIdPair
   -> C.Decl l ResolveBindingSpecs
-  -> CreateNamesResult (C.Decl l CreateNames)
+  -> CreateNamesResult ([ScopedNamePair], C.Decl l CreateNames)
 createNamesWithin env declIdPair decl =
-    case runCreate env (createDeclKind declIdPair.hsName.text decl.kind) of
-      Left err   -> CnFailure $ toFailure decl.info (MangleNamesCreationError err)
-      Right kind -> CnMangled declIdPair C.Decl{
-          info = coercePass decl.info
-        , kind = kind
-        , ann  = decl.ann
-        }
+    case runCreate env emptyCreateSt (createDeclKind declIdPair.hsName.text decl.kind) of
+      (Left err, _)   -> CnFailure $ toFailure decl.info (MangleNamesCreationError err)
+      (Right kind, st) -> CnMangled declIdPair (
+          st.scopedNames
+        , C.Decl{
+              info = coercePass decl.info
+            , kind = kind
+            , ann  = decl.ann
+            }
+        )
 
 createDeclKind ::
      Macro.HasTypes l
@@ -429,9 +464,9 @@ createStructNames name = do
         constr = constr
       }
 
--- | Mint names for the flexible array member (FLAM), if present
+-- | Create names for the flexible array member (FLAM), if present
 --
--- The auxiliary type-constructor name is minted exactly when there is a FLAM
+-- The auxiliary type-constructor name is created exactly when there is a FLAM
 -- and carried inside the 'C.Flam' constructor alongside the field, so that name
 -- creation cannot diverge from code generation
 -- (<https://github.com/well-typed/hs-bindgen/issues/1925>).
@@ -486,24 +521,28 @@ createFieldName hsName fieldCName = do
           AddFieldPrefixes  -> hsName <> "_" <> fieldCName.text
           OmitFieldPrefixes -> fieldCName.text
     name <- mkName (Proxy @Hs.NsVar) candidate
-    pure ScopedNamePair{
+    let scopedNamePair = ScopedNamePair{
         cName  = fieldCName
       , hsName = Hs.demoteNs name
       }
+    modify $ #scopedNames %~ (scopedNamePair:)
+    pure scopedNamePair
 
--- | Mangle an enum constant name
+-- | Create an enum constant name
 --
 -- Since these live in the global namespace, we do not prepend the name of the
 -- enclosing enum.
 createEnumConstantName :: C.ScopedName -> CreateE ScopedNamePair
 createEnumConstantName cName = do
     name <- mkName (Proxy @Hs.NsConstr) cName.text
-    pure ScopedNamePair{
+    let scopedNamePair = ScopedNamePair{
         cName  = cName
       , hsName = Hs.demoteNs name
       }
+    modify $ #scopedNames %~ (scopedNamePair:)
+    pure scopedNamePair
 
--- | Mangle function argument name
+-- | Create function argument name
 --
 -- Function argument names are not really used when generating Haskell code.
 -- They are more relevant for documentation purposes so we don't do any
@@ -511,10 +550,12 @@ createEnumConstantName cName = do
 createArgumentName :: C.ScopedName -> CreateE ScopedNamePair
 createArgumentName argName = do
     name <- mkName (Proxy @Hs.NsVar) argName.text
-    pure ScopedNamePair{
+    let scopedNamePair = ScopedNamePair{
         cName  = argName
       , hsName = Hs.demoteNs name
       }
+    modify $ #scopedNames %~ (scopedNamePair:)
+    pure scopedNamePair
 
 {-------------------------------------------------------------------------------
   Traversal 1b: per-construct creators
@@ -562,7 +603,7 @@ createExplicitField hsName field = do
     pure C.ExplicitField{
         info   = C.FieldInfo{
                      loc     = field.info.loc
-                   , name    = name'
+                   , name    = name'.cName
                    , comment = fmap coercePass field.info.comment
                    }
       , typ    = coercePass field.typ
@@ -581,7 +622,7 @@ createImplicitField hsName field = do
     pure C.ImplicitField{
         info = C.FieldInfo{
                    loc     = field.info.loc
-                 , name    = name'
+                 , name    = name'.cName
                  , comment = fmap coercePass field.info.comment
                  }
       , typRef = typRef'
@@ -617,7 +658,7 @@ createEnumConstant constant = do
     pure C.EnumConstant{
         info  = C.FieldInfo{
                     loc     = constant.info.loc
-                  , name    = name'
+                  , name    = name'.cName
                   , comment = fmap coercePass constant.info.comment
                   }
       , value = constant.value
@@ -667,7 +708,7 @@ createFunction function = do
     createFunctionArg arg = do
       name' <- traverse createArgumentName arg.name
       pure C.FunctionArg{
-          name   = name'
+          name   = fmap (.cName) name'
         , argTyp = coercePass arg.argTyp
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/DetectClashes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/DetectClashes.hs
@@ -2,6 +2,7 @@ module HsBindgen.Frontend.Pass.MangleNames.DetectClashes (
     detectClashes
   ) where
 
+import Data.Either (partitionEithers)
 import Data.Foldable qualified as Foldable
 import Data.Map qualified as Map
 import Data.Maybe (maybeToList)
@@ -16,16 +17,16 @@ import HsBindgen.Frontend.Pass.MangleNames.Names
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports ()
 import HsBindgen.IR.C qualified as C
-import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
   Traversal 2: Detect clashes
 
-  Build a single 'NameRegistry' from the 'NameMap' (top-level names) and the
-  'CreateNames' AST (derived names), then report all collisions in one sweep.
-  Over-removal is explicitly accepted: a single declaration may participate in
-  several collisions, and every participating owner is dropped.
+  Build a single 'NameRegistry' from the 'NameMap' (top-level names and scoped
+  names) and the 'CreateNames' AST (local names in annotations), then report all
+  collisions in one sweep. Over-removal is explicitly accepted: a single
+  declaration may participate in several collisions, and every participating
+  owner is dropped.
 
   Ideally, we'd not purge all conflicts, but instead let selection resolve
   conflict groups. While this is possible, it is also a difficult problem: If we
@@ -42,17 +43,20 @@ detectClashes ::
   -> [C.Decl l CreateNames]
   -> (NameRegistry, [MangleNamesFailure])
 detectClashes strategy nameMap decls =
-    (registry, collisionFailures (collisions registry))
+    (registry, collisionFailures (collisions registry) ++ deriveFailures)
   where
     registry :: NameRegistry
-    registry = Foldable.foldl' registerDecl emptyNameRegistry decls
+    deriveFailures :: [MangleNamesFailure]
+    (registry, deriveFailures) = Foldable.foldl' aux (emptyNameRegistry, []) decls
+      where
+        aux (nameRegistry, failures) decl = fmap (++failures) (registerDecl nameRegistry decl)
 
-    registerDecl :: NameRegistry -> C.Decl l CreateNames -> NameRegistry
-    registerDecl reg decl =
+    registerDecl :: NameRegistry -> C.Decl l CreateNames -> (NameRegistry, [MangleNamesFailure])
+    registerDecl reg decl = (,failures) $
         Foldable.foldl'
           (\r (role, scope, loc', sname) -> registerSomeName role scope owner loc' sname r)
           reg0
-          (derivedNames strategy owner loc decl.kind)
+          successes
       where
         owner :: C.DeclId
         owner = decl.info.id
@@ -67,6 +71,11 @@ detectClashes strategy nameMap decls =
           Just sname -> registerSomeName Declaration GlobalScope owner loc sname reg
           Nothing    -> reg
 
+        (failures, successes) = partitionEithers $ derivedNames strategy nameMap owner loc decl.kind
+
+-- | Looking up created names for scoped names can fail
+type DerivedNamesResult = Either MangleNamesFailure (NameRole, Scope, SingleLoc, Hs.SomeName)
+
 -- | All derived (non-top-level) names of a declaration, with the role, scope,
 -- and location under which they must be unique.
 --
@@ -76,14 +85,15 @@ detectClashes strategy nameMap decls =
 -- offending fields.
 derivedNames :: forall l.
      FieldNamingStrategy
+  -> NameMap
   -> C.DeclId
   -> SingleLoc
   -> C.DeclKind l CreateNames
-  -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
-derivedNames strategy owner loc = \case
+  -> [DerivedNamesResult]
+derivedNames strategy nameMap owner loc = \case
     C.DeclStruct struct ->
-         (Constructor, GlobalScope, loc, Hs.demoteNs struct.ann.constr)
-       : [ (AuxType, GlobalScope, loc, Hs.demoteNs flamNames.aux)
+         success (Constructor, GlobalScope, loc, Hs.demoteNs struct.ann.constr)
+       : [ success (AuxType, GlobalScope, loc, Hs.demoteNs flamNames.aux)
          | C.Flam _ flamNames <- [struct.flam] ]
       ++ concatMap fieldNames struct.fields
       ++ foldMap explicitFieldNames (C.flamStructField struct.flam)
@@ -92,7 +102,7 @@ derivedNames strategy owner loc = \case
       ++ concatMap fieldNames union.fields
     C.DeclEnum enum ->
          newtypeNames enum.ann
-      ++ map enumConstantName enum.constants
+      ++ concatMap enumConstantName enum.constants
     -- An anonymous enum constant is a top-level declaration in its own right;
     -- its name is registered as a 'Declaration'. We must /not/ also register
     -- the inner enum-constant scoped name, or it would collide with itself.
@@ -104,39 +114,56 @@ derivedNames strategy owner loc = \case
     C.DeclGlobal{}           -> []
     C.DeclOpaque{}           -> []
   where
-    -- Field selectors minted under 'OmitFieldPrefixes' enable
+    success :: (NameRole, Scope, SingleLoc, Hs.SomeName) -> DerivedNamesResult
+    success = Right
+
+    failure :: C.DeclId -> C.ScopedName -> DerivedNamesResult
+    failure declId scopedName =
+        Left $ MangleNamesFailure owner loc $
+          MangleNamesCollisionError $ DetectClashesScopedNameNotMangled declId scopedName
+
+    -- Field selectors created under 'OmitFieldPrefixes' enable
     -- @DuplicateRecordFields@, so they need only be unique within a record.
     fieldScope :: Scope
     fieldScope = case strategy of
       AddFieldPrefixes  -> GlobalScope
       OmitFieldPrefixes -> DeclScope owner
 
-    fieldNames :: C.Field CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    fieldNames :: C.Field CreateNames -> [DerivedNamesResult]
     fieldNames = C.elimField explicitFieldNames implicitFieldNames
 
-    explicitFieldNames :: C.ExplicitField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
-    explicitFieldNames field = [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
+    explicitFieldNames :: C.ExplicitField CreateNames -> [DerivedNamesResult]
+    explicitFieldNames field =
+        case lookupScopedName owner field.info.name nameMap of
+          Nothing     -> [ failure owner field.info.name ]
+          Just hsName -> [ success (Field, fieldScope, field.info.loc, hsName) ]
 
-    implicitFieldNames :: C.ImplicitField CreateNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
-    implicitFieldNames field = [ (Field, fieldScope, field.info.loc, field.info.name.hsName) ]
+    implicitFieldNames :: C.ImplicitField CreateNames -> [DerivedNamesResult]
+    implicitFieldNames field =
+        case lookupScopedName owner field.info.name nameMap of
+          Nothing     -> [ failure owner field.info.name ]
+          Just hsName -> [ success (Field, fieldScope, field.info.loc, hsName) ]
 
-    enumConstantName :: C.EnumConstant CreateNames -> (NameRole, Scope, SingleLoc, Hs.SomeName)
-    enumConstantName constant = (Constructor, GlobalScope, loc, constant.info.name.hsName)
+    enumConstantName :: C.EnumConstant CreateNames -> [DerivedNamesResult]
+    enumConstantName constant =
+        case lookupScopedName owner constant.info.name nameMap of
+          Nothing     -> [ failure owner constant.info.name ]
+          Just hsName -> [ success (Constructor, GlobalScope, constant.info.loc, hsName) ]
 
     -- The newtype "unwrap" field is recorded only under 'AddFieldPrefixes',
     -- where it is the globally-unique @unwrap<TypeName>@. Under
     -- 'OmitFieldPrefixes' it is simply @unwrap@, lives alone in its own record,
     -- and so can never collide.
-    newtypeNames :: NewtypeNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    newtypeNames :: NewtypeNames -> [DerivedNamesResult]
     newtypeNames n =
-        (Constructor, GlobalScope, loc, Hs.demoteNs n.dataConstr)
-      : [ (Field, GlobalScope, loc, Hs.demoteNs n.field)
+        success (Constructor, GlobalScope, loc, Hs.demoteNs n.dataConstr)
+      : [ success (Field, GlobalScope, loc, Hs.demoteNs n.field)
         | AddFieldPrefixes <- [strategy] ]
 
-    typedefNames :: TypedefNames -> [(NameRole, Scope, SingleLoc, Hs.SomeName)]
+    typedefNames :: TypedefNames -> [DerivedNamesResult]
     typedefNames t =
          newtypeNames t.orig
-      ++ concat [ (AuxType, GlobalScope, loc, Hs.demoteNs auxName) : newtypeNames auxNames
+      ++ concat [ success (AuxType, GlobalScope, loc, Hs.demoteNs auxName) : newtypeNames auxNames
                 | (auxName, auxNames) <- maybeToList t.aux ]
 
 -- | Turn registry collisions into per-declaration failures

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Error.hs
@@ -43,8 +43,13 @@ instance IsTrace Level MangleNamesError where
   getDefaultLogLevel = \case
     MangleNamesCreationError CreateNamesSquashMustBeTypeConstr{} -> Bug
     MangleNamesCreationError{}                                   -> Warning
-    MangleNamesCollisionError{}                                  -> Warning
-    MangleNamesResolutionError{}                                 -> Warning
+    MangleNamesCollisionError e -> case e of
+      DetectClashesCollision{}            -> Warning
+      DetectClashesDuplicateFieldName{}   -> Warning
+      DetectClashesScopedNameNotMangled{} -> Warning
+    MangleNamesResolutionError e -> case e of
+      ResolveNamesUnderlyingDeclNotMangled{} -> Warning
+      ResolveNamesScopedNameNotMangled{}     -> Warning
   getSource  = const HsBindgen
   getTraceId = const "mangle-names"
 
@@ -85,6 +90,8 @@ data MangleNamesCollisionError =
     -- Only fires under 'OmitFieldPrefixes'; under 'AddFieldPrefixes' mangling
     -- is injective within a record.
   | DetectClashesDuplicateFieldName Hs.SomeName [SingleLoc]
+    -- | A name scoped within a declaration was not mangled
+  | DetectClashesScopedNameNotMangled C.DeclId C.ScopedName
   deriving stock (Show, Eq, Ord)
 
 instance PrettyForTrace MangleNamesCollisionError where
@@ -103,6 +110,12 @@ instance PrettyForTrace MangleNamesCollisionError where
               , ":"
               ]
         in  PP.hang intro 2 $ PP.vcat $ map PP.show locs
+      DetectClashesScopedNameNotMangled declId scopedName -> PP.hsep [
+          "Name scoped in"
+        , prettyForTrace declId
+        , "not mangled:"
+        , prettyForTrace scopedName
+        ]
 
 {-------------------------------------------------------------------------------
   Traversal 3: resolve names
@@ -114,6 +127,8 @@ data MangleNamesResolutionError =
     -- (because it failed to mangle, or was dropped due to a collision), leaving
     -- a dangling reference.
     ResolveNamesUnderlyingDeclNotMangled C.DeclId (NonEmpty Hs.Namespace)
+    -- | A name scoped within a declaration was not mangled
+  | ResolveNamesScopedNameNotMangled C.DeclId C.ScopedName
   deriving stock (Show, Eq, Ord)
 
 instance PrettyForTrace MangleNamesResolutionError where
@@ -124,4 +139,10 @@ instance PrettyForTrace MangleNamesResolutionError where
             map prettyForTrace $ NonEmpty.toList namespaces
         , "not mangled:"
         , prettyForTrace declId
+        ]
+      ResolveNamesScopedNameNotMangled declId scopedName -> PP.hsep [
+          "Name scoped in"
+        , prettyForTrace declId
+        , "not mangled:"
+        , prettyForTrace scopedName
         ]

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -79,7 +79,7 @@ instance PassMsg MangleNames where
 
 -- | The auxiliary type-constructor name for a @struct@ with a flexible array
 -- member (FLAM) no longer lives here: it is bundled with the FLAM field in the
--- 'C.Flam' constructor (as 'FlamNames'), so that the name is minted exactly when
+-- 'C.Flam' constructor (as 'FlamNames'), so that the name is created exactly when
 -- the FLAM is present (see <https://github.com/well-typed/hs-bindgen/issues/1925>).
 data StructNames = StructNames {
       constr :: Hs.Name Hs.NsConstr
@@ -123,6 +123,7 @@ data MangleNamesMsg =
     MangleNamesAssignedName       Hs.SomeName
   | MangleNamesReusedAssignedName Hs.SomeName
   | MangleNamesNameMap            NameMap
+  | MangleNamesNameMapDuplicates  (NonEmpty DupAssign)
   | MangleNamesNameRegistry       NameRegistry
   deriving stock (Show)
 
@@ -140,6 +141,10 @@ instance PrettyForTrace MangleNamesMsg where
           "The name map is:"
         , PP.show nm
         ]
+      MangleNamesNameMapDuplicates dups -> PP.hsep [
+          "Assigned multiple Haskel names to one C name in the name map:"
+        , PP.show dups
+        ]
       MangleNamesNameRegistry rg -> PP.hsep [
           "The name registry is:"
         , PP.show rg
@@ -150,6 +155,7 @@ instance IsTrace Level MangleNamesMsg where
       MangleNamesAssignedName{}       -> Info
       MangleNamesReusedAssignedName{} -> Info
       MangleNamesNameMap{}            -> Debug
+      MangleNamesNameMapDuplicates{}  -> Bug
       MangleNamesNameRegistry{}       -> Debug
 
   getSource  = const HsBindgen
@@ -157,4 +163,5 @@ instance IsTrace Level MangleNamesMsg where
     MangleNamesAssignedName{}       -> "mangle-names-assigned-name"
     MangleNamesReusedAssignedName{} -> "mangle-names-reused-assigned-name"
     MangleNamesNameMap{}            -> "mangle-names-name-map"
+    MangleNamesNameMapDuplicates{}  -> "mangle-names-name-map-duplicates"
     MangleNamesNameRegistry{}       -> "mangle-names-name-registry"

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Names.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/Names.hs
@@ -1,34 +1,34 @@
 -- | Name bookkeeping for the name mangler
 --
 -- The name mangler maintains /two/ indices over the set of Haskell names it
--- mints. They answer opposite questions and are keyed differently, so they are
+-- creates. They answer opposite questions and are keyed differently, so they are
 -- distinct structures:
 --
--- * 'NameMap' is the /resolution index/: @'DeclId' -> 'Hs.Name'@. Pass 2 uses
---   it to resolve a /reference/ (it holds a target 'DeclId' and wants the
---   Haskell name that was assigned to it). It only ever contains the top-level,
---   'DeclId'-addressable names.
+-- * 'NameMap' is the /resolution index/: @'C.DeclId' -> ('Hs.Name', Map
+--   'C.ScopedName' 'HsName')@. Pass 2 uses it to resolve a /reference/ (it
+--   holds a target 'DeclId' or 'ScopedName' and wants the Haskell name that was
+--   assigned to it).
 --
 -- * 'NameRegistry' is the /collision index/: @'Hs.Name' -> ['NameOrigin']@. It
---   records minted names that may collide (top-level and derived) -- together
+--   records created names that may collide (top-level and derived) -- together
 --   with the declaration responsible for it. Hence, we can detect when the same
 --   Haskell name is produced more than once in the same namespace, whether by
 --   two distinct declarations (e.g. two structs) or by a single declaration via
 --   two of its members (e.g. an enum tag and one of its enumerators).
 --
--- Both hold three maps, one per Haskell namespace ('Hs.NsTypeConstr',
--- 'Hs.NsConstr', 'Hs.NsVar') with types ensuring that names cannot collide
--- spuriously across namespaces.
+-- The types ensure that names cannot collide spuriously across namespaces.
 --
 -- Intended for unqualified import.
 module HsBindgen.Frontend.Pass.MangleNames.Names (
     -- * Resolution index
     NameMap(..)
+  , DupAssign(..)
   , emptyNameMap
-  , fromDeclIdPairs
+  , fromNames
   , lookupType
   , lookupData
   , lookupVar
+  , lookupScopedName
   , lookupSomeName
     -- * Collision index
   , NameRole(..)
@@ -43,7 +43,9 @@ module HsBindgen.Frontend.Pass.MangleNames.Names (
   ) where
 
 import Control.Applicative (asum)
+import Control.Monad.State
 import Data.Foldable qualified as Foldable
+import Data.List.NonEmpty qualified as NE
 import Data.Map qualified as Map
 
 import Clang.HighLevel.Types (SingleLoc)
@@ -57,33 +59,92 @@ import HsBindgen.Language.Haskell qualified as Hs
   Resolution index
 -------------------------------------------------------------------------------}
 
--- | Maps each declaration to the Haskell name assigned to it
---
--- One map per Haskell namespace.
+-- | Maps each declaration to the Haskell name assigned to it. Each scoped name
+-- for a declaration is also mapped to the Haskell name assigned to it.
 data NameMap = NameMap {
       typeConstrs :: Map C.DeclId (Hs.Name Hs.NsTypeConstr)
     , dataConstrs :: Map C.DeclId (Hs.Name Hs.NsConstr)
     , vars        :: Map C.DeclId (Hs.Name Hs.NsVar)
+    , scopedNames :: Map C.DeclId ScopedNameMap
     }
-  deriving stock (Show, Eq, Generic)
+  deriving stock (Show, Generic)
+
+-- | Maps each scoped name to the Haskell name assigned to it.
+type ScopedNameMap = Map C.ScopedName Hs.SomeName
 
 emptyNameMap :: NameMap
-emptyNameMap = NameMap Map.empty Map.empty Map.empty
+emptyNameMap = NameMap Map.empty Map.empty Map.empty Map.empty
 
-fromDeclIdPairs :: [DeclIdPair] -> NameMap
-fromDeclIdPairs = Foldable.foldl' aux emptyNameMap
+-- | If we assign multiple Haskell names to the same C name, then there is a
+-- bug in our code.
+--
+-- * Each 'C.DeclId' should have a single created name assigned to it
+-- * Each 'C.ScopedName' should have a single created name assigned to it
+--   (within a given scope)
+data DupAssign =
+    DupTypeConstr C.DeclId (Hs.Name Hs.NsTypeConstr) (Hs.Name Hs.NsTypeConstr)
+  | DupDataConstr C.DeclId (Hs.Name Hs.NsConstr) (Hs.Name Hs.NsConstr)
+  | DupVar        C.DeclId (Hs.Name Hs.NsVar) (Hs.Name Hs.NsVar)
+  | DupScopedName C.DeclId C.ScopedName Hs.SomeName Hs.SomeName
+  deriving stock (Show)
+
+fromNames :: [(DeclIdPair, [ScopedNamePair])] -> (NameMap, Maybe (NonEmpty DupAssign))
+fromNames names =
+    let action = Foldable.foldlM (uncurry . addNames) emptyNameMap names
+    in  NE.nonEmpty <$> runState action []
   where
-    aux :: NameMap -> DeclIdPair -> NameMap
-    aux nameMap pair = case pair.hsName.ns of
-      Hs.NsTypeConstr ->
-        nameMap & #typeConstrs %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsTypeConstr) pair.hsName)
-      Hs.NsConstr ->
-        nameMap & #dataConstrs %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsConstr)     pair.hsName)
-      Hs.NsVar ->
-        nameMap & #vars %~
-          Map.insert pair.cName (Hs.assertNs (Proxy @Hs.NsVar)        pair.hsName)
+    addNames :: NameMap -> DeclIdPair -> [ScopedNamePair] -> State [DupAssign] NameMap
+    addNames nameMap pair scopedPairs = do
+      nameMap' <- addDeclIdPair nameMap pair
+      Foldable.foldlM (addScopedNamePair pair) nameMap' scopedPairs
+
+    addDeclIdPair :: NameMap -> DeclIdPair -> State [DupAssign] NameMap
+    addDeclIdPair nameMap pair = case pair.hsName.ns of
+        Hs.NsTypeConstr -> do
+          let hsName' = Hs.assertNs (Proxy @Hs.NsTypeConstr)     pair.hsName
+              upd = insertChecked (DupTypeConstr pair.cName) hsName'
+          typeConstrs' <- Map.alterF upd pair.cName nameMap.typeConstrs
+          pure $ nameMap & #typeConstrs .~ typeConstrs'
+        Hs.NsConstr -> do
+          let hsName' = Hs.assertNs (Proxy @Hs.NsConstr)     pair.hsName
+              upd = insertChecked (DupDataConstr pair.cName) hsName'
+          dataConstrs' <- Map.alterF upd pair.cName nameMap.dataConstrs
+          pure $ nameMap & #dataConstrs .~ dataConstrs'
+        Hs.NsVar -> do
+          let hsName' = Hs.assertNs (Proxy @Hs.NsVar)     pair.hsName
+              upd = insertChecked (DupVar pair.cName) hsName'
+          vars' <- Map.alterF upd pair.cName nameMap.vars
+          pure $ nameMap & #vars .~ vars'
+
+    addScopedNamePair :: DeclIdPair -> NameMap -> ScopedNamePair -> State [DupAssign] NameMap
+    addScopedNamePair pair nameMap scopedPair = do
+        scopedNames' <- Map.alterF upd1 pair.cName nameMap.scopedNames
+        pure nameMap { scopedNames = scopedNames' }
+      where
+        upd1 :: Maybe ScopedNameMap -> State [DupAssign] (Maybe ScopedNameMap)
+        upd1 scopedNameMapMay = do
+          let scopedNameMap = fromMaybe Map.empty scopedNameMapMay
+          scopedNameMap' <- Map.alterF upd2 scopedPair.cName scopedNameMap
+          pure $ Just scopedNameMap'
+
+        upd2 :: Maybe Hs.SomeName -> State [DupAssign] (Maybe Hs.SomeName)
+        upd2 = insertChecked (DupScopedName pair.cName scopedPair.cName) scopedPair.hsName
+
+    -- | Insert a created name unless there is already a created name present
+    insertChecked ::
+         -- | In case of a duplicate insert, how to construct a 'Dup' error from
+         -- the new and existing name respectively
+         (name -> name -> DupAssign)
+         -- | New name
+      -> name
+         -- | Existing name (possibly)
+      -> Maybe name
+      -> State [DupAssign] (Maybe name)
+    insertChecked mkDup name' nameMay = do
+        case nameMay of
+          Nothing -> pure ()
+          Just name ->  modify (mkDup name' name : )
+        pure $ Just name'
 
 lookupType :: C.DeclId -> NameMap -> Maybe (Hs.Name Hs.NsTypeConstr)
 lookupType declId nameMap = Map.lookup declId nameMap.typeConstrs
@@ -93,6 +154,11 @@ lookupData declId nameMap = Map.lookup declId nameMap.dataConstrs
 
 lookupVar :: C.DeclId -> NameMap -> Maybe (Hs.Name Hs.NsVar)
 lookupVar declId nameMap = Map.lookup declId nameMap.vars
+
+lookupScopedName :: C.DeclId -> C.ScopedName -> NameMap -> Maybe Hs.SomeName
+lookupScopedName declId scopedName nameMap = do
+    scopedNameMap <- Map.lookup declId nameMap.scopedNames
+    Map.lookup scopedName scopedNameMap
 
 -- | Look up the (namespace-tagged) Haskell name assigned to a declaration,
 -- trying every namespace.
@@ -112,7 +178,7 @@ lookupSomeName declId nameMap = asum [
 
 -- | What a registered Haskell name denotes
 --
--- Stored with every 'NameOrigin' to document what was minted and to give
+-- Stored with every 'NameOrigin' to document what was created and to give
 -- collision diagnostics something to say.
 data NameRole =
     -- | A top-level declaration's own name (chosen in pass 1)
@@ -121,16 +187,14 @@ data NameRole =
   | Constructor
     -- | A generated record field selector or newtype unwrapper
   | Field
-    -- | A generated union getter or setter
-  | Accessor
     -- | A generated auxiliary type constructor (FLAM or function pointer)
   | AuxType
   deriving stock (Show, Eq, Ord, Generic)
 
--- | The scope in which a minted Haskell name must be unique
+-- | The scope in which a created Haskell name must be unique
 --
 -- Most Haskell names we generate are top-level and must be globally unique
--- ('GlobalScope'). Record field selectors minted under
+-- ('GlobalScope'). Record field selectors created under
 -- 'HsBindgen.Config.Prelims.OmitFieldPrefixes' are an exception: the generated
 -- code enables @DuplicateRecordFields@, so the same selector name may appear in
 -- different records, but it must still be unique /within/ a single record. Such
@@ -140,7 +204,7 @@ data Scope =
   | DeclScope C.DeclId
   deriving stock (Show, Eq, Ord, Generic)
 
--- | A single site at which a Haskell name was minted
+-- | A single site at which a Haskell name was created
 data NameOrigin = NameOrigin {
       -- | The declaration to blame should this name collide
       owner :: C.DeclId
@@ -151,7 +215,7 @@ data NameOrigin = NameOrigin {
     }
   deriving stock (Show, Eq, Ord, Generic)
 
--- | Records every minted Haskell name and the sites that minted it
+-- | Records every created Haskell name and the sites that created it
 --
 -- One map per Haskell namespace, keyed by the fully-typed name.
 data NameRegistry = NameRegistry {
@@ -164,7 +228,7 @@ data NameRegistry = NameRegistry {
 emptyNameRegistry :: NameRegistry
 emptyNameRegistry = NameRegistry Map.empty Map.empty Map.empty
 
--- | Register a minted name, retaining its type-level namespace
+-- | Register a created name, retaining its type-level namespace
 registerName :: forall ns.
      Hs.SingNamespace ns
   => NameRole
@@ -212,7 +276,7 @@ registerSomeName role scope owner loc sname = case sname.ns of
     Hs.NsVar ->
       registerName role scope owner loc (Hs.assertNs (Proxy @Hs.NsVar) sname)
 
--- | A Haskell name minted by two or more distinct declarations
+-- | A Haskell name created by two or more distinct declarations
 data Collision = Collision {
       name    :: Hs.SomeName
     , origins :: [NameOrigin]
@@ -221,12 +285,12 @@ data Collision = Collision {
 
 -- | All collisions in the registry, across all three namespaces
 --
--- A name collides when it was minted at least twice in the same namespace
--- /and/ the same 'Scope'. Names minted in different scopes (e.g. two record
+-- A name collides when it was created at least twice in the same namespace
+-- /and/ the same 'Scope'. Names created in different scopes (e.g. two record
 -- field selectors in different records under @DuplicateRecordFields@) do not
 -- collide.
 --
--- Field selectors minted in a 'DeclScope' (under 'OmitFieldPrefixes') need only
+-- Field selectors created in a 'DeclScope' (under 'OmitFieldPrefixes') need only
 -- be unique within their record: @DuplicateRecordFields@ permits the same field
 -- name in different records, and @NoFieldSelectors@ (also enabled under
 -- 'OmitFieldPrefixes') means no top-level selector is generated, so such a name
@@ -249,14 +313,14 @@ collisions reg = concat [
         , isCollision scopedOrigins
         ]
 
-    -- Partition origins of a single name by the scope they were minted in.
+    -- Partition origins of a single name by the scope they were created in.
     groupByScope :: [NameOrigin] -> [[NameOrigin]]
     groupByScope =
         Map.elems . Map.fromListWith (++) . map (\o -> (o.scope, [o]))
 
     -- A name is registered once per emitted top-level Haskell entity that wants
     -- it: top-level declaration names are seeded once each (redeclarations are
-    -- deduplicated by 'DeclId' before this pass), and derived names are minted
+    -- deduplicated by 'DeclId' before this pass), and derived names are created
     -- once each. So two or more registrations of the same name in the same
     -- namespace and scope always mean two or more distinct entities competing
     -- for it -- be they different declarations or members of the same

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
@@ -19,7 +19,6 @@ import HsBindgen.Frontend.Pass.MangleNames.Names
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.IR.Pass ()
 import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Macro.Type qualified as Macro
@@ -29,11 +28,14 @@ import Doxygen.Parser.Types qualified as Doxy
 {-------------------------------------------------------------------------------
   Traversal 3: Resolve names
 
-  Rewrite every 'C.DeclId' reference into a 'DeclIdPair' using the 'NameMap',
-  copying annotations and scoped names across unchanged. Declarations flagged by
-  'detectClashes' are dropped (their failure is already recorded); a reference
-  to an unmangleable declaration drops the referring declaration with a
-  'ResolveNamesUnderlyingDeclNotMangled' failure.
+  Rewrite every 'C.DeclId' reference into a 'DeclIdPair' and every
+  'C.ScopedName' reference into a 'ScopedNamePair' using the 'NameMap', copying
+  annotations across unchanged. Declarations flagged by 'detectClashes' are
+  dropped (their failure is already recorded); a reference to an unmangleable
+  declaration drops the referring declaration with a
+  'ResolveNamesUnderlyingDeclNotMangled' failure. A reference to an unmangleable
+  scoped name drops the referring declaration with a
+  'ResolveNamesScopedNameNotMangled' failure.
 -------------------------------------------------------------------------------}
 
 type ResolveM   = Reader NameMap
@@ -68,7 +70,7 @@ resolveDecl ::
 resolveDecl decl =
     withDeclNamespace decl.kind $ \nsProxy -> do
       info' <- resolveDeclInfo nsProxy decl.info
-      kind' <- resolveDeclKind decl.kind
+      kind' <- resolveDeclKind decl.info decl.kind
       pure C.Decl{
           info = info'
         , kind = kind'
@@ -82,7 +84,7 @@ resolveDeclInfo ::
   -> ResolveE (C.DeclInfo MangleNames)
 resolveDeclInfo nsProxy info = do
     hsName     <- resolveDeclName nsProxy info.id
-    comment'   <- traverse resolve info.comment
+    comment'   <- traverse (resolve info) info.comment
     enclosing' <- mapM resolveEnclosingRef info.enclosing
     pure C.DeclInfo{
         loc          = info.loc
@@ -95,6 +97,19 @@ resolveDeclInfo nsProxy info = do
       , availability = info.availability
       , comment      = comment'
       , enclosing    = enclosing'
+      }
+
+resolveFieldInfo ::
+     C.DeclInfo CreateNames
+  -> C.FieldInfo CreateNames
+  -> ResolveE (C.FieldInfo MangleNames)
+resolveFieldInfo info fieldInfo = do
+    name'    <- lookupScopedNamePairR info.id fieldInfo.name
+    comment' <- traverse (resolve info) fieldInfo.comment
+    pure C.FieldInfo{
+        loc   = fieldInfo.loc
+      , name  = name'
+      , comment = comment'
       }
 
 resolveDeclName ::
@@ -120,17 +135,18 @@ resolveEnclosingRef = \case
 
 resolveDeclKind ::
      Macro.HasTypes l
-  => C.DeclKind l CreateNames
+  => C.DeclInfo CreateNames
+  -> C.DeclKind l CreateNames
   -> ResolveE (C.DeclKind l MangleNames)
-resolveDeclKind = \case
-    C.DeclStruct           x -> C.DeclStruct           <$> resolve x
-    C.DeclUnion            x -> C.DeclUnion            <$> resolve x
-    C.DeclEnum             x -> C.DeclEnum             <$> resolve x
-    C.DeclAnonEnumConstant x -> C.DeclAnonEnumConstant <$> resolve x
-    C.DeclTypedef          x -> C.DeclTypedef          <$> resolve x
-    C.DeclFunction         x -> C.DeclFunction         <$> resolve x
+resolveDeclKind info = \case
+    C.DeclStruct           x -> C.DeclStruct           <$> resolve info x
+    C.DeclUnion            x -> C.DeclUnion            <$> resolve info x
+    C.DeclEnum             x -> C.DeclEnum             <$> resolve info x
+    C.DeclAnonEnumConstant x -> C.DeclAnonEnumConstant <$> resolve info x
+    C.DeclTypedef          x -> C.DeclTypedef          <$> resolve info x
+    C.DeclFunction         x -> C.DeclFunction         <$> resolve info x
     C.DeclMacro            x -> C.DeclMacro            <$> resolveMacro x
-    C.DeclGlobal           x -> C.DeclGlobal           <$> resolve x
+    C.DeclGlobal           x -> C.DeclGlobal           <$> resolve info x
     C.DeclOpaque mSize       -> pure (C.DeclOpaque mSize)
 
 {-------------------------------------------------------------------------------
@@ -164,6 +180,15 @@ lookupVarR declId = do
           ResolveNamesUnderlyingDeclNotMangled declId (NonEmpty.singleton Hs.NsVar)
       Just hsNm -> pure hsNm
 
+lookupScopedNameR :: C.DeclId -> C.ScopedName -> ResolveE Hs.SomeName
+lookupScopedNameR declId scopedName = do
+    nameMap <- ask
+    case lookupScopedName declId scopedName nameMap of
+      Nothing ->
+        throwError $
+          ResolveNamesScopedNameNotMangled declId scopedName
+      Just hsNm -> pure hsNm
+
 lookupTypePairR :: C.DeclId -> ResolveE DeclIdPair
 lookupTypePairR declId =
     (\hsName -> DeclIdPair declId (Hs.demoteNs hsName)) <$> lookupTypeR declId
@@ -172,17 +197,21 @@ lookupVarPairR :: C.DeclId -> ResolveE DeclIdPair
 lookupVarPairR declId =
     (\hsName -> DeclIdPair declId (Hs.demoteNs hsName)) <$> lookupVarR declId
 
+lookupScopedNamePairR :: C.DeclId -> C.ScopedName -> ResolveE ScopedNamePair
+lookupScopedNamePairR declId scopedName =
+    ScopedNamePair scopedName <$> lookupScopedNameR declId scopedName
+
 {-------------------------------------------------------------------------------
   Traversal 3: Resolve instances
 -------------------------------------------------------------------------------}
 
 class Resolve a where
-  resolve :: a CreateNames -> ResolveE (a MangleNames)
+  resolve :: C.DeclInfo CreateNames -> a CreateNames -> ResolveE (a MangleNames)
 
 instance Resolve C.Struct where
-  resolve struct = do
-    fields <- mapM resolve struct.fields
-    flam   <- C.traverseFlamField resolve struct.flam
+  resolve info struct = do
+    fields <- mapM (resolve info) struct.fields
+    flam   <- C.traverseFlamField (resolve info) struct.flam
     pure C.Struct{
         fields    = fields
       , flam      = flam
@@ -192,8 +221,8 @@ instance Resolve C.Struct where
       }
 
 instance Resolve C.Union where
-  resolve union = do
-    fields <- mapM resolve union.fields
+  resolve info union = do
+    fields <- mapM (resolve info) union.fields
     pure C.Union{
         fields    = fields
       , ann       = union.ann
@@ -202,20 +231,16 @@ instance Resolve C.Union where
       }
 
 instance Resolve C.Field where
-  resolve = \case
-      C.FieldExplicit field -> C.FieldExplicit <$> resolve field
-      C.FieldImplicit field -> C.FieldImplicit <$> resolve field
+  resolve info = \case
+      C.FieldExplicit field -> C.FieldExplicit <$> (resolve info) field
+      C.FieldImplicit field -> C.FieldImplicit <$> (resolve info) field
 
 instance Resolve C.ExplicitField where
-  resolve field = do
-    typ'     <- resolve field.typ
-    comment' <- traverse resolve field.info.comment
+  resolve info field = do
+    fieldInfo' <- resolveFieldInfo info field.info
+    typ'       <- (resolve info) field.typ
     pure C.ExplicitField{
-        info   = C.FieldInfo{
-                     loc     = field.info.loc
-                   , name    = field.info.name
-                   , comment = comment'
-                   }
+        info   = fieldInfo'
       , typ    = typ'
       , offset = field.offset
       , width  = field.width
@@ -223,29 +248,25 @@ instance Resolve C.ExplicitField where
       }
 
 instance Resolve C.ImplicitField where
-  resolve field = do
-    typRef'     <- resolve field.typRef
-    comment' <- traverse resolve field.info.comment
+  resolve info field = do
+    fieldInfo' <- resolveFieldInfo info field.info
+    typRef'    <- resolve info field.typRef
     pure C.ImplicitField{
-        info   = C.FieldInfo{
-                     loc     = field.info.loc
-                   , name    = field.info.name
-                   , comment = comment'
-                   }
+        info   = fieldInfo'
       , typRef    = typRef'
       , offset = field.offset
       , ann    = field.ann
       }
 
 instance Resolve C.AnonRef where
-  resolve = \case
+  resolve info = \case
       C.AnonRef ref -> C.AnonRef <$> lookupTypePairR ref
-      C.AnonExtBinding ext -> C.AnonExtBinding <$> resolveExtBindingRef ext
+      C.AnonExtBinding ext -> C.AnonExtBinding <$> resolveExtBindingRef info ext
 
 instance Resolve C.Enum where
-  resolve enum = do
-    typ'       <- resolve enum.typ
-    constants' <- mapM resolve enum.constants
+  resolve info enum = do
+    typ'       <- (resolve info) enum.typ
+    constants' <- mapM (resolve info) enum.constants
     pure C.Enum{
         typ       = typ'
       , constants = constants'
@@ -255,37 +276,33 @@ instance Resolve C.Enum where
       }
 
 instance Resolve C.EnumConstant where
-  resolve constant = do
-    comment' <- traverse resolve constant.info.comment
+  resolve info constant = do
+    fieldInfo' <- resolveFieldInfo info constant.info
     pure C.EnumConstant{
-        info  = C.FieldInfo{
-                    loc     = constant.info.loc
-                  , name    = constant.info.name
-                  , comment = comment'
-                  }
+        info  = fieldInfo'
       , value = constant.value
       }
 
 instance Resolve C.AnonEnumConstant where
-  resolve (C.AnonEnumConstant primTyp constant) = do
-    constant' <- resolve constant
+  resolve info (C.AnonEnumConstant primTyp constant) = do
+    constant' <- (resolve info) constant
     pure C.AnonEnumConstant{
         typ      = primTyp
       , constant = constant'
       }
 
 instance Resolve C.Typedef where
-  resolve typedef = do
-    typ' <- resolve typedef.typ
+  resolve info typedef = do
+    typ' <- (resolve info) typedef.typ
     pure C.Typedef{
         typ = typ'
       , ann = typedef.ann
       }
 
 instance Resolve C.Function where
-  resolve function = do
+  resolve info function = do
     args <- mapM resolveArg function.args
-    res' <- resolve function.res
+    res' <- (resolve info) function.res
     pure C.Function{
         args  = args
       , res   = res'
@@ -296,15 +313,16 @@ instance Resolve C.Function where
       resolveArg ::
            C.FunctionArg CreateNames -> ResolveE (C.FunctionArg MangleNames)
       resolveArg arg = do
-        argTyp' <- resolve arg.argTyp
+        name' <- mapM (lookupScopedNamePairR info.id) arg.name
+        argTyp' <- (resolve info) arg.argTyp
         pure C.FunctionArg{
-            name   = arg.name
+            name   = name'
           , argTyp = argTyp'
           }
 
 instance Resolve C.Global where
-  resolve global = do
-    typ' <- resolve global.typ
+  resolve info global = do
+    typ' <- resolve info global.typ
     pure C.Global{
         typ = typ'
       , ann = global.ann
@@ -346,10 +364,10 @@ resolveMacroValue macroValue = do
     pure $ TypecheckedMacroValue body' macroValue.deps
 
 instance Resolve C.Comment where
-  resolve (C.Comment comment) = C.Comment <$> mapM resolve comment
+  resolve info (C.Comment comment) = C.Comment <$> mapM (resolve info) comment
 
 instance Resolve C.CommentRef where
-  resolve = \case
+  resolve _info = \case
     C.CommentRef name Nothing mKind -> do
       nameMap <- ask
       pure $ C.CommentRef name (searchNameMap nameMap name mKind) mKind
@@ -357,25 +375,25 @@ instance Resolve C.CommentRef where
       (\pair -> C.CommentRef name (Just pair) mKind) <$> lookupAnyPair declId
 
 instance Resolve C.Type where
-  resolve = \case
+  resolve info = \case
       -- Interesting cases
       C.TypeRef declId  -> fmap C.TypeRef $
         lookupTypePairR declId
       C.TypeEnum ref -> fmap C.TypeEnum $
-        C.Ref <$> lookupTypePairR ref.name <*> resolve ref.underlying
+        C.Ref <$> lookupTypePairR ref.name <*> resolve info ref.underlying
       C.TypeMacro ref -> fmap C.TypeMacro $
-        C.MacroRef <$> lookupTypePairR ref.name <*> resolve ref.underlying
+        C.MacroRef <$> lookupTypePairR ref.name <*> resolve info ref.underlying
       C.TypeTypedef ref -> fmap C.TypeTypedef $
-        C.Ref <$> lookupTypePairR ref.name <*> resolve ref.underlying
+        C.Ref <$> lookupTypePairR ref.name <*> resolve info ref.underlying
 
       -- Recursive cases
-      C.TypePointers n typ             -> C.TypePointers n <$> resolve typ
-      C.TypeFun args res               -> C.TypeFun <$> mapM resolve args <*> resolve res
-      C.TypeConstArray n typ           -> C.TypeConstArray n <$> resolve typ
-      C.TypeIncompleteArray typ        -> C.TypeIncompleteArray <$> resolve typ
-      C.TypeBlock typ                  -> C.TypeBlock <$> resolve typ
-      C.TypeQual qual typ              -> C.TypeQual qual <$> resolve typ
-      C.TypeExtBinding ref             -> C.TypeExtBinding <$> resolveExtBindingRef ref
+      C.TypePointers n typ             -> C.TypePointers n <$> resolve info typ
+      C.TypeFun args res               -> C.TypeFun <$> mapM (resolve info) args <*> resolve info res
+      C.TypeConstArray n typ           -> C.TypeConstArray n <$> resolve info typ
+      C.TypeIncompleteArray typ        -> C.TypeIncompleteArray <$> resolve info typ
+      C.TypeBlock typ                  -> C.TypeBlock <$> resolve info typ
+      C.TypeQual qual typ              -> C.TypeQual qual <$> resolve info typ
+      C.TypeExtBinding ref             -> C.TypeExtBinding <$> resolveExtBindingRef info ref
 
       -- The other entries do not need any name mangling
       C.TypePrim prim                  -> pure $ C.TypePrim prim
@@ -383,19 +401,20 @@ instance Resolve C.Type where
       C.TypeComplex prim               -> pure $ C.TypeComplex prim
 
 instance Resolve C.TypeFunArg where
-  resolve arg = C.TypeFunArgF <$> resolve arg.typ <*> pure arg.ann
+  resolve info arg = C.TypeFunArgF <$> resolve info arg.typ <*> pure arg.ann
 
 resolveExtBindingRef ::
-     C.ExtBindingRef CreateNames
+     C.DeclInfo CreateNames
+  -> C.ExtBindingRef CreateNames
   -> ResolveE (C.ExtBindingRef MangleNames)
-resolveExtBindingRef (C.Ref ext uTy) =
+resolveExtBindingRef info (C.Ref ext uTy) =
     -- The underlying type may reference the external binding itself (e.g.
     -- the typedef name that was replaced). We extend the 'NameMap' with the
     -- external binding so that such references can be resolved.
     C.Ref ext <$>
       local
         ( #typeConstrs %~ Map.insert ext.cName ext.hsName.name )
-        ( resolve uTy )
+        ( resolve info uTy )
 
 {-------------------------------------------------------------------------------
   Resolving comment references


### PR DESCRIPTION
Preparation for #2061

Scoped names are historically only referenced locally. For example, the name of struct/union field is only referenced by the field itself. This makes mangling of scoped names a purely local computation. However, as part of #2061, we will need to reference field names from elsewhere in the C AST. To support non-local referencing of scoped names, we have to make sure that the mangling of scoped names also happens non-locally. Currently the `MangleNames` pass creates Haskell names for C scoped names locally and immediately replaces them with a `ScopedNamePair`. This PR changes this so that we first create a Haskell name for each C scoped name while leaving all references to C scoped names unresolved. Only after all names have been chosen do we resolve each C scoped name reference to the `ScopedNamePair` that we created for it before. This follows the approach used for mangling `DeclId`: we first create a Haskell name for each `DeclId`, and only then we do resolve each `DeclId` reference to the `DeclIdPair` that was created for it.

### PR checklist

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
- [x] Did you update the manual?
- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?
- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:
