### PR TITLE
SourceRangeMap is now (line, column) precise

### DIFF
--- a/hs-bindgen-test-runtime/CHANGELOG.md
+++ b/hs-bindgen-test-runtime/CHANGELOG.md
@@ -1,5 +1,0 @@
-# Revision history for hs-bindgen-test-runtime
-
-## ?.?.? -- YYYY-mm-dd
-
-* First version. Released on an unsuspecting world.

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -286,6 +286,10 @@
   `preprocess --help` output. See
   [#2010](https://github.com/well-typed/hs-bindgen/issues/2010).
 * `CXCursor_StaticAssert` is now ignored in the parse pass.
+* Attribute macro expansions to declarations by column, not just line, so a
+  macro in a struct tag is no longer mis-attributed to a field on the same
+  line (which caused spurious "expansion not unique" and "unknown type of
+  expanded macro" messages). See [issue #2049][is-2049].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
 [is-1382]: https://github.com/well-typed/hs-bindgen/issues/1382
@@ -300,6 +304,7 @@
 [is-2059]: https://github.com/well-typed/hs-bindgen/issues/2059
 [is-2060]: https://github.com/well-typed/hs-bindgen/issues/2060
 [is-2064]: https://github.com/well-typed/hs-bindgen/issues/2064
+[is-2049]: https://github.com/well-typed/hs-bindgen/issues/2049
 [is-2083]: https://github.com/well-typed/hs-bindgen/issues/2083
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion.hs
@@ -91,10 +91,20 @@ parseInvocation inv =
 -- A macro invocation has a /unique/ expansion if it can be moved to any
 -- location further down the source file without changing the expansion result.
 --
--- This true as long as a macro (transitively) referenced by an invocation is
--- not captured by a new macro definition. Such capturing would cause the
--- expansion of the macro invocation to change. A macro invocation has a unique
--- expansion if all these conditions are met:
+-- In particular, even /two macros with the same name and definition can be
+-- ambiguous/. For example,
+--
+-- @
+-- #define A Foo
+-- #define B A
+-- #define A Bar
+-- #define B A
+-- @
+--
+-- A macro expansion has a unique expansion iff a macro (transitively)
+-- referenced by an invocation is not captured by a new macro definition. Such
+-- capturing would cause the expansion of the macro invocation to change. A
+-- macro invocation has a unique expansion if all these conditions are met:
 --
 -- * The invoked macro only has a single definition in the translation unit
 -- * The body of the invoked macro only invokes macros that have a unique
@@ -106,7 +116,6 @@ parseInvocation inv =
 -- invocation has a unique expansion, we recursively check whether macro
 -- invocations in the body have unique expansions, and we check the same for
 -- parameters to the invocation.
---
 isExpansionUnique ::
      [ParseResult Definition]
   -> ParseResult Invocation

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/SourceRangeMap.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Monad/SourceRangeMap.hs
@@ -19,14 +19,32 @@ import Data.Map.Strict qualified as Map
 import Data.Semigroup (Semigroup (sconcat))
 
 import Clang.HighLevel.Types (Range (rangeEnd, rangeStart),
-                              SingleLoc (singleLocLine, singleLocPath))
+                              SingleLoc (singleLocColumn, singleLocLine, singleLocPath))
 import Clang.Paths (SourcePath)
+
+-- | Position storing @(line, column)@ so that lookups are precise to the
+-- column: two values recorded on the same line (e.g. a struct tag and a field
+-- type, both macro expansions) are attributed to the correct extent.
+--
+-- See https://github.com/well-typed/hs-bindgen/issues/2049.
+data Pos = Pos {
+    line :: Int
+  , column :: Int
+  }
+  deriving stock (Eq, Show)
+
+-- | We provide a custom 'Ord' instance because it is important to compare lines
+--   before columns!
+instance Ord Pos where
+  left `compare` right =
+       left.line   `compare` right.line
+    <> left.column `compare` right.column
 
 -- | Mapping of source location ranges in C code to @a@ values
 newtype SourceRangeMap a = SRM {
     -- | We use a stacked map so we can lookup values in source location ranges
     -- reasonably fast.
-    unwrap :: Map SourcePath (Map Int (NonEmpty a))
+    unwrap :: Map SourcePath (Map Pos (NonEmpty a))
   }
 
 -- | An empty 'SourceRangeMap'
@@ -37,22 +55,25 @@ initSourceRangeMap = SRM Map.empty
 recordAt :: forall a. SingleLoc -> a -> SourceRangeMap a -> SourceRangeMap a
 recordAt loc new srm = SRM (addMacro srm.unwrap)
   where
+    pos :: Pos
+    pos = Pos loc.singleLocLine loc.singleLocColumn
+
     addMacro ::
-         Map SourcePath (Map Int (NonEmpty a))
-      -> Map SourcePath (Map Int (NonEmpty a))
+         Map SourcePath (Map Pos (NonEmpty a))
+      -> Map SourcePath (Map Pos (NonEmpty a))
     addMacro = Map.alter addMacroAtFile loc.singleLocPath
 
     addMacroAtFile ::
-         Maybe (Map Int (NonEmpty a))
-      -> Maybe (Map Int (NonEmpty a))
+         Maybe (Map Pos (NonEmpty a))
+      -> Maybe (Map Pos (NonEmpty a))
     addMacroAtFile = Just . \case
       Nothing ->
-        Map.singleton loc.singleLocLine $ NonEmpty.singleton new
-      Just lineMap ->
-        Map.alter addMacroAtLine loc.singleLocLine lineMap
+        Map.singleton pos $ NonEmpty.singleton new
+      Just posMap ->
+        Map.alter addMacroAtPos pos posMap
 
-    addMacroAtLine :: Maybe (NonEmpty a) -> Maybe (NonEmpty a)
-    addMacroAtLine = Just . \case
+    addMacroAtPos :: Maybe (NonEmpty a) -> Maybe (NonEmpty a)
+    addMacroAtPos = Just . \case
       Nothing     -> NonEmpty.singleton new
       Just macros -> NonEmpty.cons      new macros
 
@@ -73,10 +94,20 @@ lookupRange range srm
     sourcePath :: SourcePath
     sourcePath = range.rangeStart.singleLocPath
 
+    topLeft, bottomRight :: Pos
+    topLeft = Pos{
+        line   = range.rangeStart.singleLocLine
+      , column = range.rangeStart.singleLocColumn
+      }
+    bottomRight = Pos{
+        line   = range.rangeEnd.singleLocLine
+      , column = range.rangeEnd.singleLocColumn
+      }
+
     aux :: Maybe (NonEmpty a)
     aux = do
         let fileMap = srm.unwrap
-        lineMap <- Map.lookup sourcePath fileMap
+        posMap <- Map.lookup sourcePath fileMap
         fmap sconcat $ NE.nonEmpty $ Map.elems $
-          Map.takeWhileAntitone (range.rangeEnd.singleLocLine >=) $
-            Map.dropWhileAntitone (range.rangeStart.singleLocLine >) lineMap
+          Map.takeWhileAntitone (bottomRight >=) $
+            Map.dropWhileAntitone (topLeft >) posMap

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/Example.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.B(..)
+    , Example.S(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Internal.Prelude as RIP
+import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+
+{-| __C declaration:__ @macro B@
+
+    __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 14:9@
+
+    __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+-}
+newtype B = B
+  { unwrapB :: RIP.CInt
+  }
+  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving newtype
+    ( RIP.Bitfield
+    , RIP.Bits
+    , Bounded
+    , Enum
+    , RIP.FiniteBits
+    , RIP.HasFFIType
+    , Integral
+    , RIP.Ix
+    , Num
+    , RIP.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , RIP.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapB" B ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+
+instance ( ty ~ RIP.CInt
+         ) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
+
+instance HasCField.HasCField B "unwrapB" where
+
+  type CFieldType B "unwrapB" = RIP.CInt
+
+  offset# = \_ -> \_ -> 0
+
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 15:8@
+
+    __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+-}
+data S = S
+  { s_x :: B
+    {- ^ __C declaration:__ @x@
+
+         __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 15:13@
+
+         __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+    -}
+  }
+  deriving stock (Eq, RIP.Generic, Show)
+
+instance Marshal.StaticSize S where
+
+  staticSizeOf = \_ -> (4 :: Int)
+
+  staticAlignment = \_ -> (4 :: Int)
+
+instance Marshal.ReadRaw S where
+
+  readRaw =
+    \ptr0 ->
+          pure S
+      <*> HasCField.readRaw (RIP.Proxy @"s_x") ptr0
+
+instance Marshal.WriteRaw S where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          S s_x2 ->
+            HasCField.writeRaw (RIP.Proxy @"s_x") ptr0 s_x2
+
+deriving via Marshal.EquivStorable S instance RIP.Storable S
+
+instance (ty ~ B) => RIP.CompatHasField.HasField "s_x" S ty where
+
+  hasField =
+    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
+
+instance (ty ~ B) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+
+  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
+
+instance HasCField.HasCField S "s_x" where
+
+  type CFieldType S "s_x" = B
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/Example.hs
@@ -21,9 +21,9 @@ module Example
   where
 
 import qualified HsBindgen.Runtime.HasCField as HasCField
-import qualified HsBindgen.Runtime.Internal.Prelude as RIP
-import qualified HsBindgen.Runtime.Internal.Prelude.CompatHasField as RIP.CompatHasField
 import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @macro B@
 
@@ -32,41 +32,40 @@ import qualified HsBindgen.Runtime.Marshal as Marshal
     __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
 -}
 newtype B = B
-  { unwrapB :: RIP.CInt
+  { unwrapB :: BG.CInt
   }
-  deriving stock (Eq, RIP.Generic, Ord, Read, Show)
+  deriving stock (Eq, BG.Generic, Ord, Read, Show)
   deriving newtype
-    ( RIP.Bitfield
-    , RIP.Bits
+    ( BG.Bitfield
+    , BG.Bits
     , Bounded
     , Enum
-    , RIP.FiniteBits
-    , RIP.HasFFIType
+    , BG.FiniteBits
+    , BG.HasFFIType
     , Integral
-    , RIP.Ix
+    , BG.Ix
     , Num
-    , RIP.Prim
+    , BG.Prim
     , Marshal.ReadRaw
     , Real
     , Marshal.StaticSize
-    , RIP.Storable
+    , BG.Storable
     , Marshal.WriteRaw
     )
 
-instance (ty ~ RIP.CInt) => RIP.CompatHasField.HasField "unwrapB" B ty where
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "unwrapB" B ty where
 
   hasField =
     \x0 ->
-      (\y1 -> B {unwrapB = y1}, RIP.getField @"unwrapB" x0)
+      (\y1 -> B {unwrapB = y1}, BG.getField @"unwrapB" x0)
 
-instance ( ty ~ RIP.CInt
-         ) => RIP.HasField "unwrapB" (RIP.Ptr B) (RIP.Ptr ty) where
+instance (ty ~ BG.CInt) => BG.HasField "unwrapB" (BG.Ptr B) (BG.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"unwrapB")
+  getField = HasCField.fromPtr (BG.Proxy @"unwrapB")
 
 instance HasCField.HasCField B "unwrapB" where
 
-  type CFieldType B "unwrapB" = RIP.CInt
+  type CFieldType B "unwrapB" = BG.CInt
 
   offset# = \_ -> \_ -> 0
 
@@ -85,7 +84,7 @@ data S = S
          __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
     -}
   }
-  deriving stock (Eq, RIP.Generic, Show)
+  deriving stock (Eq, BG.Generic, Show)
 
 instance Marshal.StaticSize S where
 
@@ -98,7 +97,7 @@ instance Marshal.ReadRaw S where
   readRaw =
     \ptr0 ->
           pure S
-      <*> HasCField.readRaw (RIP.Proxy @"s_x") ptr0
+      <*> HasCField.readRaw (BG.Proxy @"s_x") ptr0
 
 instance Marshal.WriteRaw S where
 
@@ -107,18 +106,18 @@ instance Marshal.WriteRaw S where
       \s1 ->
         case s1 of
           S s_x2 ->
-            HasCField.writeRaw (RIP.Proxy @"s_x") ptr0 s_x2
+            HasCField.writeRaw (BG.Proxy @"s_x") ptr0 s_x2
 
-deriving via Marshal.EquivStorable S instance RIP.Storable S
+deriving via Marshal.EquivStorable S instance BG.Storable S
 
-instance (ty ~ B) => RIP.CompatHasField.HasField "s_x" S ty where
+instance (ty ~ B) => BG.CompatHasField.HasField "s_x" S ty where
 
   hasField =
-    \x0 -> (\y1 -> S {s_x = y1}, RIP.getField @"s_x" x0)
+    \x0 -> (\y1 -> S {s_x = y1}, BG.getField @"s_x" x0)
 
-instance (ty ~ B) => RIP.HasField "s_x" (RIP.Ptr S) (RIP.Ptr ty) where
+instance (ty ~ B) => BG.HasField "s_x" (BG.Ptr S) (BG.Ptr ty) where
 
-  getField = HasCField.fromPtr (RIP.Proxy @"s_x")
+  getField = HasCField.fromPtr (BG.Proxy @"s_x")
 
 instance HasCField.HasCField S "s_x" where
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/bindingspec.yaml
@@ -1,0 +1,61 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/redeclaration/same_line_tag_field.h
+  cname: macro B
+  hsname: B
+- headers: macros/redeclaration/same_line_tag_field.h
+  cname: struct S
+  hsname: S
+hstypes:
+- hsname: B
+  representation:
+    newtype:
+      constructor: B
+      fields:
+      - unwrapB
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: S
+  representation:
+    record:
+      constructor: S
+      fields:
+      - s_x
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/same_line_tag_field/th.txt
@@ -1,0 +1,65 @@
+-- addDependentFile test-artefacts/headers/golden/macros/redeclaration/same_line_tag_field.h
+{-| __C declaration:__ @macro B@
+
+    __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 14:9@
+
+    __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+-}
+newtype B
+    = B {unwrapB :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapB" B ty
+    where hasField = \x_0 -> (\y_1 -> B{unwrapB = y_1},
+                              getField @"unwrapB" x_0)
+instance (~) ty CInt => HasField "unwrapB" (Ptr B) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapB")
+instance HasCField B "unwrapB"
+    where type CFieldType B "unwrapB" = CInt
+          offset# = \_ -> \_ -> 0
+{-| __C declaration:__ @struct S@
+
+    __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 15:8@
+
+    __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+-}
+data S
+    = S {s_x :: B
+         {- ^ __C declaration:__ @x@
+
+              __defined at:__ @macros\/redeclaration\/same_line_tag_field.h 15:13@
+
+              __exported by:__ @macros\/redeclaration\/same_line_tag_field.h@
+         -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize S
+    where staticSizeOf = \_ -> 4 :: Int
+          staticAlignment = \_ -> 4 :: Int
+instance ReadRaw S
+    where readRaw = \ptr_0 -> pure S <*> readRaw (Proxy @"s_x") ptr_0
+instance WriteRaw S
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       S s_x_2 -> writeRaw (Proxy @"s_x") ptr_0 s_x_2
+deriving via (EquivStorable S) instance Storable S
+instance (~) ty B => HasField "s_x" S ty
+    where hasField = \x_0 -> (\y_1 -> S{s_x = y_1},
+                              getField @"s_x" x_0)
+instance (~) ty B => HasField "s_x" (Ptr S) (Ptr ty)
+    where getField = fromPtr (Proxy @"s_x")
+instance HasCField S "s_x"
+    where type CFieldType S "s_x" = B
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/headers/golden/macros/redeclaration/same_line_tag_field.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/redeclaration/same_line_tag_field.h
@@ -1,0 +1,15 @@
+// Regression test: a macro expansion in the struct *tag* must not be
+// mis-attributed to a *field* that happens to be on the same source line.
+//
+// `A` is defined twice (identically) and expands to the struct tag `S`; `B`
+// expands to the field type `int`. Both expansions sit on line 4. Reparse
+// info is attached to the field, not the struct, so only `B` should be
+// recorded for the field. Previously `SourceRangeMap` keyed lookups by line
+// only, so the field also picked up the (redefined, hence "ambiguous") `A`,
+// producing a spurious "expansion not unique" warning and an "unknown type of
+// expanded macro A" error. With column-precise attribution the field sees
+// only `B`.
+#define A S
+#define A S
+#define B int
+struct A {B x;};

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
@@ -26,6 +26,7 @@ testCases = [
     , TestCaseLeaf test_different
     , TestCaseLeaf test_identical_semantics
     , TestCaseLeaf test_identical_syntax
+    , TestCaseLeaf test_same_line_tag_field
     ]
 
 {-------------------------------------------------------------------------------
@@ -154,6 +155,28 @@ test_identical_syntax =
       MatchDelayedReparseMacroExpansions name@"bar" (ReparseMacroExpansionUnknownType "T") ->
         Just $ Expected name
       MatchDelayedReparseMacroExpansions name@"bar" ReparseMacroExpansionsLanC{} ->
+        Just $ Expected name
+      _otherwise ->
+        Nothing
+
+-- | A tag macro expansion must not leak into a same-line field.
+--
+-- @A@ (redefined, hence conflicting) expands to the struct tag; @B@ expands to
+-- the field type. Only @B@ belongs to the field's reparse info, so no
+-- reparse-related messages should be emitted for the struct. The default
+-- predicate flags any such message as unexpected, so a regression of the
+-- same-line mis-attribution fails this test.
+test_same_line_tag_field :: TestCase
+test_same_line_tag_field =
+    defaultTest_custom "macros/redeclaration/same_line_tag_field"
+      & #tracePredicate .~ multiTracePredicate_custom expected trace
+  where
+    expected :: [C.DeclName]
+    expected = ["macro A"]
+
+    trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
+    trace = \case
+      MatchSelect name@"macro A" SelectConflict{} ->
         Just $ Expected name
       _otherwise ->
         Nothing


### PR DESCRIPTION
Fixes https://github.com/well-typed/hs-bindgen/issues/2049.

Some reminders, in case they are helpful:

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.

- [x] Did you update the manual?

- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?

- [x] If you added new TODOs, did you associate each TODO with a ticket? Please use this syntax:

```hs
-- TODO <link to issue>
-- Brief description
```

(If this does not apply, feel free to delete this template text.)
