### PR TITLE
`ReparseMacroExpansions`: replace `zipWithM` by `zipList`

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -290,6 +290,8 @@
   macro in a struct tag is no longer mis-attributed to a field on the same
   line (which caused spurious "expansion not unique" and "unknown type of
   expanded macro" messages). See [issue #2049][is-2049].
+* Fix cases where macro reparsing could accidentally produce more or fewer
+  function arguments than required. See [PR #2153][pr-2153].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
 [is-1382]: https://github.com/well-typed/hs-bindgen/issues/1382
@@ -321,6 +323,7 @@
 [pr-2087]: https://github.com/well-typed/hs-bindgen/pull/2087
 [pr-2091]: https://github.com/well-typed/hs-bindgen/pull/2091
 [pr-2094]: https://github.com/well-typed/hs-bindgen/pull/2094
+[pr-2153]: https://github.com/well-typed/hs-bindgen/pull/2153
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
@@ -5,7 +5,7 @@ module HsBindgen.Frontend.Pass.ReparseMacroExpansions.Zip (
   , zipEither
   ) where
 
-import Control.Monad
+import Control.Monad qualified as M
 
 import HsBindgen.Frontend.Pass.PrepareReparse.IsPass
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.ForgetAnn (coerceNonMacroType)
@@ -172,12 +172,11 @@ instance ZipReparsed C.Typedef where
         , ann = NoAnn
         }
 
-
 instance ZipReparsed C.Function where
   zipReparsed funPre fun = do
-      args'  <- zipWithM zipFunctionArg funPre.args fun.args
-      res'   <- zipType                 funPre.res   fun.res
-      attrs' <- checkEq                 funPre.attrs fun.attrs
+      args'  <- zipList zipFunctionArg funPre.args fun.args
+      res'   <- zipType                funPre.res   fun.res
+      attrs' <- checkEq                funPre.attrs fun.attrs
       success C.Function{
           args  = args'
         , res   = res'
@@ -244,7 +243,7 @@ zipType t1 t2 = case (t1, t2) of
         C.TypeIncompleteArray <$> zipType et1 et2
       (C.TypeFun args1 res1, C.TypeFun args2 res2) ->
         C.TypeFun
-          <$> zipWithM zipTypeFunArg args1 args2
+          <$> zipList zipTypeFunArg args1 args2
           <*> zipType res1 res2
       (C.TypeVoid, C.TypeVoid) ->
         success C.TypeVoid
@@ -338,3 +337,16 @@ zipRef ref1 ref2 =
     C.Ref
       <$> checkEq ref1.name ref2.name
       <*> zipType ref1.underlying ref2.underlying
+
+{-------------------------------------------------------------------------------
+  Zip lists
+-------------------------------------------------------------------------------}
+
+-- | Like 'M.zipWithM', but fails if the two arguments lists are of non-equal
+-- length
+zipList :: (Show a, Show b) => (a -> b -> ZipResult c) -> [a] -> [b] -> ZipResult [c]
+zipList zipOne xs ys
+  | length xs /= length ys
+  = failure $ zipErrorNotZipped xs ys
+  | otherwise
+  = M.zipWithM zipOne xs ys


### PR DESCRIPTION
`zipWithM` is unsafe because it silently forgets about list elements if the two arguments lists are of non-equal length. The new `zipList` function replaces `zipWithM` and will throw a `ZipError` in case the lists are not of equal length.

### PR checklist

- [x] Did you update the changelog? Please be sure to give a "migration hint" if this is a breaking change.
- [x] Did you update the manual?
- [x] If you are closing a ticket, did you grep for all mentions of that ticket in the code?
- [x] If you added new TODOs, did you associate each TODO with a ticket? 