### PR TITLE
Remove c-expr source-repository-package stanza

### DIFF
--- a/cabal.project.base
+++ b/cabal.project.base
@@ -1,10 +1,4 @@
-index-state: 2026-07-20T12:50:32Z
-
-source-repository-package
-    type: git
-    location: https://github.com/well-typed/c-expr
-    tag: 19aeaeb8d58ea6c49ee8cbb7ac741bb981e6f27d
-    subdir: c-expr-runtime c-expr-dsl
+index-state: 2026-07-22T07:21:27Z
 
 --
 -- Temporary package bounds overrides for ghc 9.14

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1777988971,
-        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778580735,
-        "narHash": "sha256-t+8AVV8ExvOmslz2sLIgw/hJBKlyl65rJvxjvvjHgpE=",
+        "lastModified": 1784555310,
+        "narHash": "sha256-/FCliTPgiuV1owejZFNx3Ch9irdvkOfOFl+HHZ+DrtM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48d91f2c0ce7b9e589f967d4f685153dd765dcdd",
+        "rev": "421eebfd0ec7bccd4abe826ce62d7e6e83129493",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {

--- a/nix/generate.sh
+++ b/nix/generate.sh
@@ -21,8 +21,18 @@ project=cabal.project.base
 
 # External packages we build ourselves (not available from Nixpkgs). Those with
 # a source-repository-package stanza in $project are fetched from git; the rest
-# are fetched from Hackage.
-HACKAGE_PACKAGES=(libclang-bindings doxygen-parser c-expr-dsl c-expr-runtime)
+# are fetched from Hackage. An entry may pin a version as "name=version"
+# (otherwise the latest Hackage version is used).
+HACKAGE_PACKAGES=(
+  libclang-bindings
+  doxygen-parser
+  c-expr-dsl
+  c-expr-runtime
+  # libclang-bindings requires tasty 1.5.3, but Nixpkgs has 1.5.4; also
+  # overridden (scoped to libclang-bindings only) in
+  # nix/overlay/libclang-bindings.nix, keep both in sync.
+  tasty=1.5.3
+)
 
 # Our own packages, built from their in-repo directory.
 LOCAL_PACKAGES=(hs-bindgen hs-bindgen-runtime hs-bindgen-test-runtime)
@@ -75,10 +85,17 @@ while IFS=$'\t' read -r name url rev subpath; do
 done < <(parse_stanzas)
 
 # Hackage: any external package without a git stanza.
-for p in "${HACKAGE_PACKAGES[@]}"; do
+for entry in "${HACKAGE_PACKAGES[@]}"; do
+  p=${entry%=*}
   [ -z "${from_git[$p]:-}" ] || continue
-  echo "generating $out/$p.nix (hackage)"
-  c2n "cabal://$p" >"$out/$p.nix"
+  if [ "$entry" != "$p" ]; then
+    ver=${entry#*=}
+    echo "generating $out/$p.nix (hackage, pinned $ver)"
+    c2n "cabal://$p-$ver" >"$out/$p.nix"
+  else
+    echo "generating $out/$p.nix (hackage)"
+    c2n "cabal://$p" >"$out/$p.nix"
+  fi
 done
 
 # Local: `src` is the in-repo directory, relative to the generated file.

--- a/nix/generated/c-expr-dsl.nix
+++ b/nix/generated/c-expr-dsl.nix
@@ -1,18 +1,12 @@
 { mkDerivation, base, bytestring, c-expr-runtime, containers
-, debruijn, fetchgit, filepath, fin, indexed-traversable, lib
+, debruijn, filepath, fin, indexed-traversable, lib
 , libclang-bindings, mtl, parsec, scientific, some, tasty
 , tasty-golden, tasty-hunit, text, vec
 }:
 mkDerivation {
   pname = "c-expr-dsl";
-  version = "0.1.0.0";
-  src = fetchgit {
-    url = "https://github.com/well-typed/c-expr";
-    sha256 = "1fns28r1g4aa6876gwni50ky9f2kwdzgbw7a886xrfc0vslg0rm0";
-    rev = "19aeaeb8d58ea6c49ee8cbb7ac741bb981e6f27d";
-    fetchSubmodules = true;
-  };
-  postUnpack = "sourceRoot+=/c-expr-dsl; echo source root reset to $sourceRoot";
+  version = "0.1.0.1";
+  sha256 = "87789fe7531880ac4fee53dfb6ea13ae6cdbcc7ab75265610bb6732e7a7a6de5";
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [
     base bytestring c-expr-runtime containers debruijn fin

--- a/nix/generated/c-expr-runtime.nix
+++ b/nix/generated/c-expr-runtime.nix
@@ -1,16 +1,10 @@
-{ mkDerivation, base, containers, data-default, fetchgit, fin, lib
+{ mkDerivation, base, containers, data-default, fin, lib
 , libclang-bindings, some, template-haskell, text, vec
 }:
 mkDerivation {
   pname = "c-expr-runtime";
   version = "0.1.0.0";
-  src = fetchgit {
-    url = "https://github.com/well-typed/c-expr";
-    sha256 = "1fns28r1g4aa6876gwni50ky9f2kwdzgbw7a886xrfc0vslg0rm0";
-    rev = "19aeaeb8d58ea6c49ee8cbb7ac741bb981e6f27d";
-    fetchSubmodules = true;
-  };
-  postUnpack = "sourceRoot+=/c-expr-runtime; echo source root reset to $sourceRoot";
+  sha256 = "827b0a340f914f2d627e09852fca87df3092c691179ae9db039415772aad7d35";
   libraryHaskellDepends = [
     base containers fin some template-haskell vec
   ];

--- a/nix/generated/tasty.nix
+++ b/nix/generated/tasty.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, ansi-terminal, base, containers, lib
+, optparse-applicative, stm, tagged, transformers, unix
+}:
+mkDerivation {
+  pname = "tasty";
+  version = "1.5.3";
+  sha256 = "54a0c7b644813af871a3726ac8771b5e17b5158c792a7acf8f9e2d3ae9360780";
+  revision = "2";
+  editedCabalFile = "04llcf1i3gawdik0bjhxdgls2wkiqlx0gi76nfh784nv2qzxlpbb";
+  libraryHaskellDepends = [
+    ansi-terminal base containers optparse-applicative stm tagged
+    transformers unix
+  ];
+  homepage = "https://github.com/UnkindPartition/tasty";
+  description = "Modern and extensible testing framework";
+  license = lib.licenses.mit;
+}

--- a/nix/hs-bindgen.nix
+++ b/nix/hs-bindgen.nix
@@ -16,6 +16,7 @@ let
     ghc98 = "ghc98";
     ghc910 = "ghc910";
     ghc912 = "ghc912";
+    ghc914 = "ghc914";
   };
   llvms = {
     llvm18 = "18";

--- a/nix/overlay/libclang-bindings.nix
+++ b/nix/overlay/libclang-bindings.nix
@@ -11,10 +11,28 @@ in
   haskell = prev.haskell // {
     packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
       hfinal: hprev: {
-        libclang-bindings = hlib.addBuildDepends [
-          llvmPackages.libclang
-          llvmPackages.llvm
-        ] (hfinal.callPackage ../generated/libclang-bindings.nix { });
+        libclang-bindings =
+          let
+            # `.override` swaps tasty just for this package's closure, so only
+            # tasty, its reverse deps below, and libclang-bindings rebuild —
+            # not everything else that depends on tasty. tasty-hunit and
+            # tasty-quickcheck must be rebuilt against it too, since GHC
+            # requires a single tasty instance across the whole closure. Also
+            # pinned in nix/generate.sh (HACKAGE_PACKAGES), keep both in sync.
+            tasty' = hfinal.callPackage ../generated/tasty.nix { };
+            tasty-hunit' = hprev.tasty-hunit.override { tasty = tasty'; };
+            tasty-quickcheck' = hprev.tasty-quickcheck.override { tasty = tasty'; };
+          in
+          hlib.addBuildDepends [
+            llvmPackages.libclang
+            llvmPackages.llvm
+          ] (
+            (hfinal.callPackage ../generated/libclang-bindings.nix { }).override {
+              tasty = tasty';
+              tasty-hunit = tasty-hunit';
+              tasty-quickcheck = tasty-quickcheck';
+            }
+          );
       }
     );
   };


### PR DESCRIPTION
Pull Nix setup along

Nix had detected a `c-expr-dsl` test failure which was fixed in the meantime (c-expr-dsl 0.1.0.1)

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.

- [x] I have updated the manual.

- [x] I have removed all mentions of closed tickets in the code.

- [x] I have associated each new TODO item with a ticket, using the following syntax:

```hs
-- TODO <link to issue>
-- Brief description
```
