### PR TITLE
Fix duplicate `help` in the --path-style parser

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -230,6 +230,11 @@
 
 ### Bug fixes
 
+* The `--path-style` CLI option now shows its intended help text and value hint.
+  Previously two `help` modifiers were given, so the descriptive text and the
+  `(short|full)` hint clobbered each other; its default is also now displayed in
+  the lowercase form the option accepts. See [issue
+  #2163](https://github.com/well-typed/hs-bindgen/issues/2163).
 * Macro name-resolution failures (e.g. references to unresolved tagged types)
   produce an `Info`-level diagnostic (`MacroResolutionError`) instead of
   panicking. Such failures are common in real headers (e.g. preprocessor-only

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -516,10 +516,9 @@ parsePathStyle :: Parser PathStyle
 parsePathStyle = option readPathStyle $ mconcat [
       long "path-style"
     , metavar "STYLE"
-    , help "Path display style (short|full)"
-    , showDefault
+    , help "Render style of file paths in Haddock comments (short|full)"
+    , showDefaultWith renderPathStyle
     , value Short
-    , help "Render style of file paths in Haddock comments"
     ]
   where
     readPathStyle :: ReadM PathStyle
@@ -527,6 +526,11 @@ parsePathStyle = option readPathStyle $ mconcat [
       "full"  -> Right Full
       "short" -> Right Short
       _       -> Left $ "Invalid path style: " ++ s ++ ". Expected 'full' or 'short'"
+
+    renderPathStyle :: PathStyle -> String
+    renderPathStyle = \case
+      Short -> "short"
+      Full  -> "full"
 
 {-------------------------------------------------------------------------------
   Auxiliary optparse-applicative functions


### PR DESCRIPTION
Closes #2163
