### PR TITLE
Add a convenience module for rebindable syntax

### DIFF
--- a/hs-bindgen-runtime/CHANGELOG.md
+++ b/hs-bindgen-runtime/CHANGELOG.md
@@ -14,6 +14,9 @@
 * Add `get`/`set` functions that serve as getters/setters for union values.
   These depend `HasField` instances. See [issue #2060][is-2060] and [PR
   #2091][pr-2091].
+* Add a new `HsBindgen.Runtime.Overloading` module that restores the default
+  environment when using the `RebindableSyntax` language extension for
+  overloaded record updates. See [issue #2085][is-2085] and [PR #2168][pr-2168].
 
 ### Minor changes
 
@@ -25,7 +28,9 @@
 None
 
 [is-2060]: https://github.com/well-typed/hs-bindgen/issues/2060
+[is-2085]: https://github.com/well-typed/hs-bindgen/issues/2085
 [pr-2091]: https://github.com/well-typed/hs-bindgen/pull/2091
+[pr-2168]: https://github.com/well-typed/hs-bindgen/pull/2168
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -81,6 +81,7 @@ library
     HsBindgen.Runtime.IsArray
     HsBindgen.Runtime.LibC
     HsBindgen.Runtime.Marshal
+    HsBindgen.Runtime.Overloading
     HsBindgen.Runtime.Prelude
     HsBindgen.Runtime.PtrConst
     HsBindgen.Runtime.Support

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Overloading.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Overloading.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
+
+-- | Restore the default environment when using @RebindableSyntax@
+--
+-- The @RebindableSyntax@ extension is currently required when using
+-- @OverloadedRecordUpdate@, but when using this extension, a number of
+-- functions are suddenly no longer in scope that normally are. This module
+-- restores those functions to their standard definition.
+module HsBindgen.Runtime.Overloading (
+    module Prelude
+  , Control.Arrow.app
+  , Control.Arrow.arr
+  , Control.Arrow.first
+  , Control.Arrow.loop
+  , (Control.Arrow.>>>)
+  , (Control.Arrow.|||)
+  , Data.String.fromString
+  , GHC.OverloadedLabels.fromLabel
+  , GHC.Records.getField
+    -- * New definitions
+  , ifThenElse
+  , setField
+  ) where
+
+import Control.Arrow qualified
+import Data.String qualified
+import GHC.OverloadedLabels qualified
+import GHC.Records qualified
+import GHC.Records.Compat qualified
+
+{-------------------------------------------------------------------------------
+  Other exports
+-------------------------------------------------------------------------------}
+
+ifThenElse :: Bool -> a -> a -> a
+ifThenElse b x y = if b then x else y
+
+-- | Set a field in a record.
+--
+-- NOTE: the order of arguments is GHC version dependent.
+#if __GLASGOW_HASKELL__ >=914
+setField :: forall x r a. GHC.Records.Compat.HasField x r a => a -> r -> r
+setField = flip (fst . GHC.Records.Compat.hasField @x)
+#else
+setField :: forall x r a. GHC.Records.Compat.HasField x r a => r -> a -> r
+setField = fst . GHC.Records.Compat.hasField @x
+#endif


### PR DESCRIPTION
Resolves #2085

Add a new `HsBindgen.Runtime.Overloading` module that restores the default environment when using the `RebindableSyntax` language extension for overloaded record updates.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.
