### PR TITLE
Support bit-fields in unions

### DIFF
--- a/examples/feature-tests/c/Makefile
+++ b/examples/feature-tests/c/Makefile
@@ -19,6 +19,8 @@ clean:
 	rm -f *.o *.so *.dylib *.dll
 
 libfeature-tests$(TARGET_EXT): \
+		bit-fields/structs.o \
+		bit-fields/unions.o \
 		callbacks/arrays/known_size.o \
 		callbacks/arrays/unknown_size.o \
 		callbacks/basic.o \
@@ -27,10 +29,11 @@ libfeature-tests$(TARGET_EXT): \
 		pointer_manipulation.o \
 		types/anonymous.o \
 		types/anonymous/indirect_fields.o \
-		types/bitfields.o \
 		unions.o
 
 	$(CC) -Wall -shared -o libfeature-tests$(TARGET_EXT) \
+		bit-fields/structs.o \
+		bit-fields/unions.o \
 		callbacks/arrays/known_size.o \
 		callbacks/arrays/unknown_size.o \
 		callbacks/basic.o \
@@ -39,8 +42,15 @@ libfeature-tests$(TARGET_EXT): \
 		pointer_manipulation.o \
 		types/anonymous.o \
 		types/anonymous/indirect_fields.o \
-		types/bitfields.o \
 		unions.o
+
+## bit-fields
+
+bit-fields/structs.o: bit-fields/structs.h bit-fields/structs.c
+	$(CC) -Wall -o bit-fields/structs.o -c -fPIC bit-fields/structs.c
+
+bit-fields/unions.o: bit-fields/unions.h bit-fields/unions.c
+	$(CC) -Wall -o bit-fields/unions.o -c -fPIC bit-fields/unions.c
 
 # callbacks
 
@@ -73,11 +83,6 @@ types/anonymous.o: types/anonymous.h types/anonymous.c
 
 types/anonymous/indirect_fields.o: types/anonymous/indirect_fields.h types/anonymous/indirect_fields.c
 	$(CC) -Wall -o types/anonymous/indirect_fields.o -c -fPIC types/anonymous/indirect_fields.c
-
-## bitfields
-
-types/bitfields.o: types/bitfields.h types/bitfields.c
-	$(CC) -Wall -o types/bitfields.o -c -fPIC types/bitfields.c
 
 # unions
 

--- a/examples/feature-tests/c/bit-fields/structs.c
+++ b/examples/feature-tests/c/bit-fields/structs.c
@@ -1,0 +1,1 @@
+#include "structs.h"

--- a/examples/feature-tests/c/bit-fields/structs.h
+++ b/examples/feature-tests/c/bit-fields/structs.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Bitfield tests
+ * Bit-field tests
  *
  * This header defines various structs with bit-fields as well as static
  * functions used to test them.

--- a/examples/feature-tests/c/bit-fields/unions.c
+++ b/examples/feature-tests/c/bit-fields/unions.c
@@ -1,0 +1,1 @@
+#include "unions.h"

--- a/examples/feature-tests/c/bit-fields/unions.h
+++ b/examples/feature-tests/c/bit-fields/unions.h
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Bit-field tests for unions
+ *
+ * This header defines various unions with bit-fields as well as static
+ * functions used to test them.
+ *
+ * Comments concerning alignment of fields in packed unions are valid for
+ * objects at 64-bit aligned addresses, but note that hs-bindgen is able to
+ * read/write bit-fields using only aligned peeks/pokes even when an object is
+ * not aligned.
+ ******************************************************************************/
+
+#pragma once
+
+#include <stdbool.h>
+
+/*******************************************************************************
+ * not packed, <=8-bit fields
+ ******************************************************************************/
+
+union U_8 {
+  signed char a : 3;
+  signed char b : 3;
+  signed char c : 2;
+  signed char d : 3;
+  signed char e : 8;
+  signed char f : 5;
+};
+
+#define MkSetFunName_U_8(fieldName) set_U_8_ ## fieldName
+#define MkSetFun_U_8(fieldName, fieldType)\
+  static inline void MkSetFunName_U_8(fieldName) (\
+        union U_8 *x\
+      , fieldType fieldValue) {\
+    x->fieldName = fieldValue;\
+  };
+
+MkSetFun_U_8(a, signed char)
+MkSetFun_U_8(b, signed char)
+MkSetFun_U_8(c, signed char)
+MkSetFun_U_8(d, signed char)
+MkSetFun_U_8(e, signed char)
+MkSetFun_U_8(f, signed char)
+
+#define MkGetFunName_U_8(fieldName) get_U_8_ ## fieldName
+#define MkGetFun_U_8(fieldName, fieldType)\
+  static inline fieldType MkGetFunName_U_8(fieldName) (\
+        union U_8 *x) {\
+    return x->fieldName;\
+  };
+
+MkGetFun_U_8(a, signed char)
+MkGetFun_U_8(b, signed char)
+MkGetFun_U_8(c, signed char)
+MkGetFun_U_8(d, signed char)
+MkGetFun_U_8(e, signed char)
+MkGetFun_U_8(f, signed char)
+
+
+#define MkEqFunName_U_8(fieldName) eq_U_8_ ## fieldName
+#define MkEqFun_U_8(fieldName, fieldType)\
+  static inline bool MkEqFunName_U_8(fieldName) (\
+        union U_8 *x\
+      , fieldType fieldValue) {\
+    return x->fieldName == fieldValue;\
+  };
+
+MkEqFun_U_8(a, signed char)
+MkEqFun_U_8(b, signed char)
+MkEqFun_U_8(c, signed char)
+MkEqFun_U_8(d, signed char)
+MkEqFun_U_8(e, signed char)
+MkEqFun_U_8(f, signed char)
+
+/*******************************************************************************
+ * not packed, <=16-bit fields
+ ******************************************************************************/
+
+union U_16 {
+  signed char a :  6;
+  signed int  b : 10;
+  signed int  c : 16;
+  signed int  d : 16;
+  signed int  e : 12;
+  signed int  f : 12;
+};
+
+#define MkSetFunName_U_16(fieldName) set_U_16_ ## fieldName
+#define MkSetFun_U_16(fieldName, fieldType)\
+  static inline void MkSetFunName_U_16(fieldName) (\
+        union U_16 *x\
+      , fieldType fieldValue) {\
+    x->fieldName = fieldValue;\
+  };
+
+MkSetFun_U_16(a, signed char)
+MkSetFun_U_16(b, signed int)
+MkSetFun_U_16(c, signed int)
+MkSetFun_U_16(d, signed int)
+MkSetFun_U_16(e, signed int)
+MkSetFun_U_16(f, signed int)
+
+#define MkGetFunName_U_16(fieldName) get_U_16_ ## fieldName
+#define MkGetFun_U_16(fieldName, fieldType)\
+  static inline fieldType MkGetFunName_U_16(fieldName) (\
+        union U_16 *x) {\
+    return x->fieldName;\
+  };
+
+MkGetFun_U_16(a, signed char)
+MkGetFun_U_16(b, signed int)
+MkGetFun_U_16(c, signed int)
+MkGetFun_U_16(d, signed int)
+MkGetFun_U_16(e, signed int)
+MkGetFun_U_16(f, signed int)
+
+#define MkEqFunName_U_16(fieldName) eq_U_16_ ## fieldName
+#define MkEqFun_U_16(fieldName, fieldType)\
+  static inline bool MkEqFunName_U_16(fieldName) (\
+        union U_16 *x\
+      , fieldType fieldValue) {\
+    return x->fieldName == fieldValue;\
+  };
+
+MkEqFun_U_16(a, signed char)
+MkEqFun_U_16(b, signed int)
+MkEqFun_U_16(c, signed int)
+MkEqFun_U_16(d, signed int)
+MkEqFun_U_16(e, signed int)
+MkEqFun_U_16(f, signed int)

--- a/examples/feature-tests/c/pointer_manipulation.h
+++ b/examples/feature-tests/c/pointer_manipulation.h
@@ -39,20 +39,26 @@ enum MyEnum {
 /* Bit-fields */
 
 struct MyStructBF {
-  unsigned int x : 6;
+  unsigned int x : 7;
   unsigned char y : 6;
 };
 
+/**
+ * The Haskell bindings for bit-fields in structs (i.e., Haskell record fields)
+ * do not perform packing in any way like the C code does. So if we want to
+ * create a Haskell value of a properly packed MyStructBF, then we use this C
+ * function instead.
+ */
 static inline struct MyStructBF __attribute__((const)) make_MyStructBF(
     unsigned int x,
     unsigned char y) {
-  struct MyStructBF s = {x, y};
+  struct MyStructBF s = {.x=x, .y=y};
   return s;
 }
 
 union MyUnionBF {
   unsigned int x : 3;
-  unsigned char y : 3;
+  unsigned char y : 5;
 };
 
 /* -------------------------------------------------------------------------- */

--- a/examples/feature-tests/c/types/bitfields.c
+++ b/examples/feature-tests/c/types/bitfields.c
@@ -1,1 +1,0 @@
-#include "bitfields.h"

--- a/examples/feature-tests/generate-and-run.sh
+++ b/examples/feature-tests/generate-and-run.sh
@@ -40,6 +40,29 @@ if [ -d "$GENERATED_DIR" ]; then
   rm -r "$GENERATED_DIR"
 fi
 
+
+echo "## Bit-fields"
+
+cabal run --project-file="${PROJECT_ROOT}/cabal.project" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Bitfields.Structs \
+    bit-fields/structs.h
+
+cabal run --project-file="${PROJECT_ROOT}/cabal.project" -- hs-bindgen-cli \
+    preprocess \
+    -I c \
+    --hs-output-dir hs-project/src-generated \
+    --unique-id feature-tests.well-typed.com \
+    --create-output-dirs \
+    --overwrite-files \
+    --module Generated.Bitfields.Unions \
+    bit-fields/unions.h
+
 echo "## Callbacks"
 
 cabal run --project-file="${PROJECT_ROOT}/cabal.project" -- hs-bindgen-cli \
@@ -136,18 +159,6 @@ cabal run --project-file="${PROJECT_ROOT}/cabal.project" -- hs-bindgen-cli \
     --module Generated.Types.Anonymous.IndirectFields \
     types/anonymous/indirect_fields.h \
     --omit-field-prefixes
-
-echo "### Bit-fields"
-
-cabal run --project-file="${PROJECT_ROOT}/cabal.project" -- hs-bindgen-cli \
-    preprocess \
-    -I c \
-    --hs-output-dir hs-project/src-generated \
-    --unique-id feature-tests.well-typed.com \
-    --create-output-dirs \
-    --overwrite-files \
-    --module Generated.Types.Bitfields \
-    types/bitfields.h
 
 echo "## Unions"
 

--- a/examples/feature-tests/hs-project/feature-tests.cabal
+++ b/examples/feature-tests/hs-project/feature-tests.cabal
@@ -45,6 +45,14 @@ library generated
   visibility:      private
   hs-source-dirs:  src-generated
   exposed-modules:
+    Generated.Bitfields.Structs
+    Generated.Bitfields.Structs.FunPtr
+    Generated.Bitfields.Structs.Safe
+    Generated.Bitfields.Structs.Unsafe
+    Generated.Bitfields.Unions
+    Generated.Bitfields.Unions.FunPtr
+    Generated.Bitfields.Unions.Safe
+    Generated.Bitfields.Unions.Unsafe
     Generated.Callbacks.Arrays.KnownSize
     Generated.Callbacks.Arrays.KnownSize.FunPtr
     Generated.Callbacks.Arrays.KnownSize.Safe
@@ -72,10 +80,6 @@ library generated
     Generated.Types.Anonymous.Global
     Generated.Types.Anonymous.IndirectFields
     Generated.Types.Anonymous.IndirectFields.Safe
-    Generated.Types.Bitfields
-    Generated.Types.Bitfields.FunPtr
-    Generated.Types.Bitfields.Safe
-    Generated.Types.Bitfields.Unsafe
     Generated.Unions
     Generated.Unions.FunPtr
     Generated.Unions.Safe
@@ -94,6 +98,9 @@ test-suite feature-tests
   hs-source-dirs: test
   main-is:        Main.hs
   other-modules:
+    Test.Bitfields.Structs
+    Test.Bitfields.Unions
+    Test.Bitfields.Unions.TH
     Test.Callbacks.Arrays.KnownSize
     Test.Callbacks.Arrays.UnknownSize
     Test.Callbacks.Basic
@@ -110,7 +117,6 @@ test-suite feature-tests
     Test.PointerManipulation.Unions.Bitfields
     Test.Types.Anonymous
     Test.Types.Anonymous.IndirectFields
-    Test.Types.Bitfields
     Test.Unions
     Test.Util
     Test.Util.Orphans
@@ -127,4 +133,5 @@ test-suite feature-tests
     , QuickCheck
     , tasty
     , tasty-quickcheck
+    , template-haskell
     , vector

--- a/examples/feature-tests/hs-project/test/Main.hs
+++ b/examples/feature-tests/hs-project/test/Main.hs
@@ -2,6 +2,8 @@ module Main (main) where
 
 import Test.Tasty
 
+import Test.Bitfields.Structs qualified
+import Test.Bitfields.Unions qualified
 import Test.Callbacks.Arrays.KnownSize qualified
 import Test.Callbacks.Arrays.UnknownSize qualified
 import Test.Callbacks.Basic qualified
@@ -14,14 +16,16 @@ import Test.PointerManipulation.Structs qualified
 import Test.PointerManipulation.Structs.Bitfields qualified
 import Test.PointerManipulation.Typedefs qualified
 import Test.PointerManipulation.Unions qualified
+import Test.PointerManipulation.Unions.Bitfields qualified
 import Test.Types.Anonymous qualified
 import Test.Types.Anonymous.IndirectFields qualified
-import Test.Types.Bitfields qualified
 import Test.Unions qualified
 
 main :: IO ()
 main = defaultMain $ testGroup "feature-tests" [
-      Test.Callbacks.Arrays.KnownSize.tests
+      Test.Bitfields.Structs.tests
+    , Test.Bitfields.Unions.tests
+    , Test.Callbacks.Arrays.KnownSize.tests
     , Test.Callbacks.Arrays.UnknownSize.tests
     , Test.Callbacks.Basic.tests
     , Test.Callbacks.Structs.tests
@@ -33,8 +37,8 @@ main = defaultMain $ testGroup "feature-tests" [
     , Test.PointerManipulation.Structs.Bitfields.tests
     , Test.PointerManipulation.Typedefs.tests
     , Test.PointerManipulation.Unions.tests
+    , Test.PointerManipulation.Unions.Bitfields.tests
     , Test.Types.Anonymous.tests
     , Test.Types.Anonymous.IndirectFields.tests
-    , Test.Types.Bitfields.tests
     , Test.Unions.tests
     ]

--- a/examples/feature-tests/hs-project/test/Test/Bitfields/Structs.hs
+++ b/examples/feature-tests/hs-project/test/Test/Bitfields/Structs.hs
@@ -1,4 +1,4 @@
--- | C bit-field tests
+-- | C bit-field tests for structs
 --
 -- This module implements two types of tests for various @struct@s:
 --
@@ -13,13 +13,18 @@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Types.Bitfields (tests) where
+module Test.Bitfields.Structs (
+    tests
+  -- * Auxiliary functions
+  , initValue
+  , allocaAligned
+  ) where
 
 import Data.Bits ((.&.))
 import Data.Bits qualified as Bits
 import Data.Maybe qualified as Maybe
-import Data.Proxy
-import Data.Word
+import Data.Proxy (Proxy (Proxy))
+import Data.Word (Word64)
 import Foreign qualified
 import Foreign.C qualified as C
 import Test.QuickCheck ((===))
@@ -31,8 +36,8 @@ import HsBindgen.Runtime.Marshal qualified as Marshal
 import HsBindgen.Runtime.Support.Bitfield (Bitfield)
 import HsBindgen.Runtime.Support.Bitfield qualified as Bitfield
 
-import Generated.Types.Bitfields qualified as Bitfields
-import Generated.Types.Bitfields.Unsafe qualified as Bitfields
+import Generated.Bitfields.Structs qualified as Bitfields
+import Generated.Bitfields.Structs.Unsafe qualified as Bitfields
 
 {-------------------------------------------------------------------------------
   Auxiliary functions
@@ -814,7 +819,7 @@ test_bar_64_64 = testGroup "<=64-bit field crosses 64-bit word boundary" [
 -------------------------------------------------------------------------------}
 
 tests :: TestTree
-tests = testGroup "Test.Types.Bitfields" [
+tests = testGroup "Test.Bitfields.Structs" [
       testGroup "non-packed" [
           test_foo_8
         , test_foo_16

--- a/examples/feature-tests/hs-project/test/Test/Bitfields/Unions.hs
+++ b/examples/feature-tests/hs-project/test/Test/Bitfields/Unions.hs
@@ -1,0 +1,285 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+{-# OPTIONS_GHC -ddump-splices #-}
+
+-- | C bit-field tests for unions
+--
+-- This module implements two types of tests for various @union@s:
+--
+-- * Peek tests use a C function to set the fields of a @union@, peek the
+--   @union@, and check that the read field values are as expected.
+-- * Poke tests poke the @union@ and then use a C function to check that the
+--   fields are as expected.
+--
+-- Much of the code in this module follows the same pattern. Some of it has been
+-- abstracted using TH, but not all of it, because this whole module will
+-- eventually be replaced with generated tests.
+module Test.Bitfields.Unions (tests) where
+
+import Data.Proxy (Proxy (Proxy))
+import Foreign qualified
+import Foreign.C qualified as C
+import Foreign.C.Types
+import Foreign.Storable (Storable)
+import GHC.Exts (proxy#)
+import GHC.Records (HasField (getField))
+import GHC.TypeLits (KnownSymbol)
+import Test.QuickCheck ((===))
+import Test.QuickCheck qualified as QC
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+import HsBindgen.Runtime.HasCBitfield qualified as HasCBitfield
+import HsBindgen.Runtime.Prelude
+import HsBindgen.Runtime.Support.Bitfield (Bitfield)
+import HsBindgen.Runtime.Support.CompatHasField qualified as Compat
+import HsBindgen.Runtime.Union as Union
+
+import Generated.Bitfields.Unions qualified as Bitfields
+import Generated.Bitfields.Unions.Unsafe qualified as Bitfields
+import Test.Bitfields.Structs (allocaAligned, initValue)
+import Test.Bitfields.Unions.TH
+
+{-------------------------------------------------------------------------------
+  not packed, <=8-bit fields
+-------------------------------------------------------------------------------}
+
+newtype U_8 fn = U_8 Bitfields.U_8
+  deriving newtype (StaticSize, Storable)
+
+instance HasCBitfield Bitfields.U_8 fn => HasCBitfield (U_8 fn) fn where
+  type CBitfieldType (U_8 fn) fn = CBitfieldType Bitfields.U_8 fn
+  bitfieldOffset# _ = bitfieldOffset# (proxy# @Bitfields.U_8)
+  bitfieldWidth# _  = bitfieldWidth# (proxy# @Bitfields.U_8)
+
+instance (
+      ty ~ CBitfieldType Bitfields.U_8 fn
+    , HasField fn Bitfields.U_8 ty
+    ) => HasField fn (U_8 fn) ty where
+  getField (U_8 x) = getField @fn x
+
+instance (
+      HasCBitfield Bitfields.U_8 fn
+    , Compat.HasField fn Bitfields.U_8 (CBitfieldType Bitfields.U_8 fn)
+    , Bitfield (CBitfieldType Bitfields.U_8 fn)
+    , QC.Arbitrary (CBitfieldType Bitfields.U_8 fn)
+    ) => QC.Arbitrary (U_8 fn) where
+  arbitrary = do
+      w1 <- QC.arbitrarySizedBoundedIntegral
+      pure $ U_8 $ Union.set @fn $ initValue off sz w1
+    where
+      off = HasCBitfield.offset (Proxy @Bitfields.U_8) (Proxy @fn)
+      sz  = HasCBitfield.width  (Proxy @Bitfields.U_8) (Proxy @fn)
+
+  shrink (U_8 x) = [
+        U_8 $ Union.set @fn x'
+      | x' <- QC.shrink (Union.get @fn x)
+      ]
+
+$(showD ''U_8)
+$(eqD ''U_8)
+
+$(hasSetFunD "u_8_a" ''U_8 ''CSChar 'Bitfields.set_U_8_a)
+$(hasSetFunD "u_8_b" ''U_8 ''CSChar 'Bitfields.set_U_8_b)
+$(hasSetFunD "u_8_c" ''U_8 ''CSChar 'Bitfields.set_U_8_c)
+$(hasSetFunD "u_8_d" ''U_8 ''CSChar 'Bitfields.set_U_8_d)
+$(hasSetFunD "u_8_e" ''U_8 ''CSChar 'Bitfields.set_U_8_e)
+$(hasSetFunD "u_8_f" ''U_8 ''CSChar 'Bitfields.set_U_8_f)
+
+$(hasGetFunD "u_8_a" ''U_8 ''CSChar 'Bitfields.get_U_8_a)
+$(hasGetFunD "u_8_b" ''U_8 ''CSChar 'Bitfields.get_U_8_b)
+$(hasGetFunD "u_8_c" ''U_8 ''CSChar 'Bitfields.get_U_8_c)
+$(hasGetFunD "u_8_d" ''U_8 ''CSChar 'Bitfields.get_U_8_d)
+$(hasGetFunD "u_8_e" ''U_8 ''CSChar 'Bitfields.get_U_8_e)
+$(hasGetFunD "u_8_f" ''U_8 ''CSChar 'Bitfields.get_U_8_f)
+
+$(hasEqFunD "u_8_a" ''U_8 ''CSChar 'Bitfields.eq_U_8_a)
+$(hasEqFunD "u_8_b" ''U_8 ''CSChar 'Bitfields.eq_U_8_b)
+$(hasEqFunD "u_8_c" ''U_8 ''CSChar 'Bitfields.eq_U_8_c)
+$(hasEqFunD "u_8_d" ''U_8 ''CSChar 'Bitfields.eq_U_8_d)
+$(hasEqFunD "u_8_e" ''U_8 ''CSChar 'Bitfields.eq_U_8_e)
+$(hasEqFunD "u_8_f" ''U_8 ''CSChar 'Bitfields.eq_U_8_f)
+
+test_U_8 :: TestTree
+test_U_8 = testGroup "<=8-bit fields" [
+      -- peek
+      testProperty "peek @u_8_a" $ peek_prop @"u_8_a"
+    , testProperty "peek @u_8_b" $ peek_prop @"u_8_b"
+    , testProperty "peek @u_8_c" $ peek_prop @"u_8_c"
+    , testProperty "peek @u_8_d" $ peek_prop @"u_8_d"
+    , testProperty "peek @u_8_e" $ peek_prop @"u_8_e"
+    , testProperty "peek @u_8_f" $ peek_prop @"u_8_f"
+
+      -- poke
+    , testProperty "poke @u_8_a" $ poke_prop @"u_8_a"
+    , testProperty "poke @u_8_b" $ poke_prop @"u_8_b"
+    , testProperty "poke @u_8_c" $ poke_prop @"u_8_c"
+    , testProperty "poke @u_8_d" $ poke_prop @"u_8_d"
+    , testProperty "poke @u_8_e" $ poke_prop @"u_8_e"
+    , testProperty "poke @u_8_f" $ poke_prop @"u_8_f"
+    ]
+  where
+    peek_prop ::
+        forall fn. (
+           U_8_C fn
+         , HasSetFun (U_8 fn) (CBitfieldType Bitfields.U_8 fn)
+         )
+      => U_8 fn -> QC.Property
+    peek_prop x = QC.ioProperty $ do
+        y <- allocaAligned $ \ptr -> do
+          setFun @(U_8 fn) @(CBitfieldType Bitfields.U_8 fn)
+            ptr
+            (getField @fn x)
+          Foreign.peek ptr
+        return $ y === x
+
+    poke_prop ::
+         forall fn. (
+           U_8_C fn
+         , HasEqFun (U_8 fn) (CBitfieldType Bitfields.U_8 fn)
+         )
+      => U_8 fn -> QC.Property
+    poke_prop x = QC.ioProperty $ do
+      isEq <- allocaAligned $ \ptr -> do
+        Foreign.poke ptr x
+        eqFun @(U_8 fn) @(CBitfieldType Bitfields.U_8 fn)
+          ptr
+          (getField @fn x)
+      return $ isEq === C.CBool 1
+
+type U_8_C fn = (
+      HasField fn Bitfields.U_8 (CBitfieldType Bitfields.U_8 fn)
+    , Eq (CBitfieldType Bitfields.U_8 fn)
+    , Show (CBitfieldType Bitfields.U_8 fn)
+    , KnownSymbol fn
+    )
+
+{-------------------------------------------------------------------------------
+  not packed, <=16-bit fields
+-------------------------------------------------------------------------------}
+
+newtype U_16 fn = U_16 Bitfields.U_16
+  deriving newtype (StaticSize, Storable)
+
+instance HasCBitfield Bitfields.U_16 fn => HasCBitfield (U_16 fn) fn where
+  type CBitfieldType (U_16 fn) fn = CBitfieldType Bitfields.U_16 fn
+  bitfieldOffset# _ = bitfieldOffset# (proxy# @Bitfields.U_16)
+  bitfieldWidth# _  = bitfieldWidth# (proxy# @Bitfields.U_16)
+
+instance (
+      ty ~ CBitfieldType Bitfields.U_16 fn
+    , HasField fn Bitfields.U_16 ty
+    ) => HasField fn (U_16 fn) ty where
+  getField (U_16 x) = getField @fn x
+
+instance (
+      HasCBitfield Bitfields.U_16 fn
+    , Compat.HasField fn Bitfields.U_16 (CBitfieldType Bitfields.U_16 fn)
+    , Bitfield (CBitfieldType Bitfields.U_16 fn)
+    , QC.Arbitrary (CBitfieldType Bitfields.U_16 fn)
+    ) => QC.Arbitrary (U_16 fn) where
+  arbitrary = do
+      w1 <- QC.arbitrarySizedBoundedIntegral
+      pure $ U_16 $ Union.set @fn $ initValue off sz w1
+    where
+      off = HasCBitfield.offset (Proxy @Bitfields.U_16) (Proxy @fn)
+      sz  = HasCBitfield.width  (Proxy @Bitfields.U_16) (Proxy @fn)
+
+  shrink (U_16 x) = [
+        U_16 $ Union.set @fn x'
+      | x' <- QC.shrink (Union.get @fn x)
+      ]
+
+$(showD ''U_16)
+$(eqD ''U_16)
+
+$(hasSetFunD "u_16_a" ''U_16 ''CSChar 'Bitfields.set_U_16_a)
+$(hasSetFunD "u_16_b" ''U_16 ''CInt   'Bitfields.set_U_16_b)
+$(hasSetFunD "u_16_c" ''U_16 ''CInt   'Bitfields.set_U_16_c)
+$(hasSetFunD "u_16_d" ''U_16 ''CInt   'Bitfields.set_U_16_d)
+$(hasSetFunD "u_16_e" ''U_16 ''CInt   'Bitfields.set_U_16_e)
+$(hasSetFunD "u_16_f" ''U_16 ''CInt   'Bitfields.set_U_16_f)
+
+$(hasGetFunD "u_16_a" ''U_16 ''CSChar 'Bitfields.get_U_16_a)
+$(hasGetFunD "u_16_b" ''U_16 ''CInt   'Bitfields.get_U_16_b)
+$(hasGetFunD "u_16_c" ''U_16 ''CInt   'Bitfields.get_U_16_c)
+$(hasGetFunD "u_16_d" ''U_16 ''CInt   'Bitfields.get_U_16_d)
+$(hasGetFunD "u_16_e" ''U_16 ''CInt   'Bitfields.get_U_16_e)
+$(hasGetFunD "u_16_f" ''U_16 ''CInt   'Bitfields.get_U_16_f)
+
+$(hasEqFunD "u_16_a" ''U_16 ''CSChar 'Bitfields.eq_U_16_a)
+$(hasEqFunD "u_16_b" ''U_16 ''CInt   'Bitfields.eq_U_16_b)
+$(hasEqFunD "u_16_c" ''U_16 ''CInt   'Bitfields.eq_U_16_c)
+$(hasEqFunD "u_16_d" ''U_16 ''CInt   'Bitfields.eq_U_16_d)
+$(hasEqFunD "u_16_e" ''U_16 ''CInt   'Bitfields.eq_U_16_e)
+$(hasEqFunD "u_16_f" ''U_16 ''CInt   'Bitfields.eq_U_16_f)
+
+test_U_16 :: TestTree
+test_U_16 = testGroup "<=16-bit fields" [
+      -- peek
+      testProperty "peek @u_16_a" $ peek_prop @"u_16_a"
+    , testProperty "peek @u_16_b" $ peek_prop @"u_16_b"
+    , testProperty "peek @u_16_c" $ peek_prop @"u_16_c"
+    , testProperty "peek @u_16_d" $ peek_prop @"u_16_d"
+    , testProperty "peek @u_16_e" $ peek_prop @"u_16_e"
+    , testProperty "peek @u_16_f" $ peek_prop @"u_16_f"
+
+      -- poke
+    , testProperty "poke @u_16_a" $ poke_prop @"u_16_a"
+    , testProperty "poke @u_16_b" $ poke_prop @"u_16_b"
+    , testProperty "poke @u_16_c" $ poke_prop @"u_16_c"
+    , testProperty "poke @u_16_d" $ poke_prop @"u_16_d"
+    , testProperty "poke @u_16_e" $ poke_prop @"u_16_e"
+    , testProperty "poke @u_16_f" $ poke_prop @"u_16_f"
+    ]
+  where
+    peek_prop ::
+        forall fn. (
+           U_16_C fn
+         , HasSetFun (U_16 fn) (CBitfieldType Bitfields.U_16 fn)
+         )
+      => U_16 fn -> QC.Property
+    peek_prop x = QC.ioProperty $ do
+        y <- allocaAligned $ \ptr -> do
+          setFun @(U_16 fn) @(CBitfieldType Bitfields.U_16 fn)
+            ptr
+            (getField @fn x)
+          Foreign.peek ptr
+        return $ y === x
+
+    poke_prop ::
+         forall fn. (
+           U_16_C fn
+         , HasEqFun (U_16 fn) (CBitfieldType Bitfields.U_16 fn)
+         )
+      => U_16 fn -> QC.Property
+    poke_prop x = QC.ioProperty $ do
+      isEq <- allocaAligned $ \ptr -> do
+        Foreign.poke ptr x
+        eqFun @(U_16 fn) @(CBitfieldType Bitfields.U_16 fn)
+          ptr
+          (getField @fn x)
+      return $ isEq === C.CBool 1
+
+type U_16_C fn = (
+      HasField fn Bitfields.U_16 (CBitfieldType Bitfields.U_16 fn)
+    , Eq (CBitfieldType Bitfields.U_16 fn)
+    , Show (CBitfieldType Bitfields.U_16 fn)
+    , KnownSymbol fn
+    )
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.Bitfields.Unions" [
+      testGroup "non-packed" [
+          test_U_8
+        , test_U_16
+        ]
+    ]

--- a/examples/feature-tests/hs-project/test/Test/Bitfields/Unions/TH.hs
+++ b/examples/feature-tests/hs-project/test/Test/Bitfields/Unions/TH.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | Utility: templates for class instances
+module Test.Bitfields.Unions.TH (
+    showD
+  , eqD
+  , HasSetFun(..)
+  , hasSetFunD
+  , HasGetFun(..)
+  , hasGetFunD
+  , HasEqFun(..)
+  , hasEqFunD
+  ) where
+
+import Foreign.C.Types
+import Foreign.Ptr (Ptr, castPtr)
+import GHC.Records
+import GHC.TypeLits
+import Language.Haskell.TH qualified as TH
+
+import HsBindgen.Runtime.Prelude
+
+{-------------------------------------------------------------------------------
+  Show
+-------------------------------------------------------------------------------}
+
+-- | Create an instance for 'Show'
+showD :: TH.Name -> TH.Q [TH.Dec]
+showD unionName = [d|
+      instance (
+            KnownSymbol fn
+          , HasField fn ($unionNameT fn) (CBitfieldType ($unionNameT fn) fn)
+          , Show (CBitfieldType ($unionNameT fn) fn)
+          ) => Show ($unionNameT fn) where
+        showsPrec d x =
+          showParen (d >= 11) $
+              showString $unionNameE
+            . showString " {"
+            . showString fieldName
+            . showString " = "
+            . showsPrec 0 (getField @fn x)
+            . showString "}"
+          where
+            fieldName = symbolVal (Proxy @fn)
+    |]
+  where
+    unionNameT = [t| $(TH.conT unionName) |]
+    unionNameE = [e| $(TH.stringE (TH.nameBase unionName)) |]
+
+{-------------------------------------------------------------------------------
+  Eq
+-------------------------------------------------------------------------------}
+
+-- | Create an instance for 'Eq'
+eqD :: TH.Name -> TH.Q [TH.Dec]
+eqD unionName = [d|
+    instance (
+          HasField fn ($unionNameT fn) (CBitfieldType ($unionNameT fn) fn)
+        , Eq (CBitfieldType ($unionNameT fn) fn)
+        ) => Eq ($unionNameT fn) where
+      x == y = getField @fn x == getField @fn y
+    |]
+  where
+    unionNameT = [t| $(TH.conT unionName) |]
+
+{-------------------------------------------------------------------------------
+  HasSetFun
+-------------------------------------------------------------------------------}
+
+class HasSetFun u a where
+  setFun :: Ptr u -> a -> IO ()
+
+-- | Create an instance for 'HasSetFun'
+hasSetFunD :: String -> TH.Name -> TH.Name -> TH.Name -> TH.Q [TH.Dec]
+hasSetFunD fieldName unionName fieldType funName  = [d|
+      instance HasSetFun $unionTypeT $fieldTypeT where
+        setFun ptr = $funNameE (castPtr ptr)
+    |]
+  where
+    unionTypeT = [t| $(TH.conT unionName) $(TH.litT (TH.strTyLit fieldName)) |]
+    fieldTypeT = [t| $(TH.conT fieldType) |]
+    funNameE   = [e| $(TH.varE funName) |]
+
+{-------------------------------------------------------------------------------
+  HasGetFun
+-------------------------------------------------------------------------------}
+
+-- | Create an instance for 'HasGetFun'
+class HasGetFun u a where
+  getFun :: Ptr u -> IO a
+
+hasGetFunD :: String -> TH.Name -> TH.Name -> TH.Name -> TH.Q [TH.Dec]
+hasGetFunD fieldName unionName fieldType funName  = [d|
+      instance HasGetFun $unionTypeT $fieldTypeT where
+        getFun ptr = $funNameE (castPtr ptr)
+    |]
+  where
+    unionTypeT = [t| $(TH.conT unionName) $(TH.litT (TH.strTyLit fieldName)) |]
+    fieldTypeT = [t| $(TH.conT fieldType) |]
+    funNameE   = [e| $(TH.varE funName) |]
+
+{-------------------------------------------------------------------------------
+  HasEqFun
+-------------------------------------------------------------------------------}
+
+-- | Create an instance for 'HasEqFun'
+class HasEqFun u a where
+  eqFun :: Ptr u -> a -> IO CBool
+
+hasEqFunD :: String -> TH.Name -> TH.Name -> TH.Name -> TH.Q [TH.Dec]
+hasEqFunD fieldName unionName fieldType funName  = [d|
+      instance HasEqFun $unionTypeT $fieldTypeT where
+        eqFun ptr = $funNameE (castPtr ptr)
+    |]
+  where
+    unionTypeT = [t| $(TH.conT unionName) $(TH.litT (TH.strTyLit fieldName)) |]
+    fieldTypeT = [t| $(TH.conT fieldType) |]
+    funNameE   = [e| $(TH.varE funName) |]

--- a/examples/feature-tests/hs-project/test/Test/PointerManipulation.hs
+++ b/examples/feature-tests/hs-project/test/Test/PointerManipulation.hs
@@ -117,16 +117,12 @@ dict_hasField_MyStructBF_y :: Dict $
      HasField "y" (Ptr Types.MyStructBF) (BitfieldPtr CUChar)
 dict_hasField_MyStructBF_y = Dict
 
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>: It should be
--- @BitfieldPtr CInt@ instead of @Ptr CInt@
 dict_hasField_MyUnionBF_x :: Dict $
-     HasField "x" (Ptr Types.MyUnionBF) (Ptr CUInt)
+     HasField "x" (Ptr Types.MyUnionBF) (BitfieldPtr CUInt)
 dict_hasField_MyUnionBF_x = Dict
 
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>: It should be
--- @BitfieldPtr CChar@ instead of @Ptr CChar@
 dict_hasField_MyUnionBF_y :: Dict $
-     HasField "y" (Ptr Types.MyUnionBF) (Ptr CUChar)
+     HasField "y" (Ptr Types.MyUnionBF) (BitfieldPtr CUChar)
 dict_hasField_MyUnionBF_y = Dict
 
 {-------------------------------------------------------------------------------

--- a/examples/feature-tests/hs-project/test/Test/PointerManipulation/Unions/Bitfields.hs
+++ b/examples/feature-tests/hs-project/test/Test/PointerManipulation/Unions/Bitfields.hs
@@ -1,12 +1,134 @@
+{-# LANGUAGE OverloadedRecordUpdate #-}
+{-# LANGUAGE RebindableSyntax #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.PointerManipulation.Unions.Bitfields (
     tests
+    -- * Properties (exported for haddocks)
+  , prop_applyValue_equiv_applyPointer_x
+  , prop_applyPointer_equiv_applyPointerFields_x
+  , prop_applyValue_equiv_applyPointer_y
+  , prop_applyPointer_equiv_applyPointerFields_y
   ) where
 
+import Data.Proxy (Proxy (..))
+import Foreign.C.Types (CUChar, CUInt)
 import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (Arbitrary (..), Fun, Large (getLarge), Property,
+                              applyFun, testProperty)
+
+import HsBindgen.Runtime.Overloading (Show, fromString, getField, setField,
+                                      (<$>))
+
+import Generated.PointerManipulation qualified as Types (MyUnionBF (..))
+import Test.PointerManipulation.Infra (ComposableFunc, FieldFunc (..), Func)
+import Test.PointerManipulation.Infra qualified as Infra
+import Test.Util.Orphans ()
+import Test.Util.TypedUnion (FieldKind (..), TypedUnion, liftArbitraryField,
+                             shrinkField)
+
+{-------------------------------------------------------------------------------
+  Tests
+-------------------------------------------------------------------------------}
 
 tests :: TestTree
 tests = testGroup "Test.PointerManipulation.Unions.Bitfields" [
+      testProperty "prop_applyValue_equiv_applyPointer_x"
+        prop_applyValue_equiv_applyPointer_x
+    , testProperty "prop_applyPointer_equiv_applyPointerFields_x"
+        prop_applyPointer_equiv_applyPointerFields_x
+
+    , testProperty "prop_applyValue_equiv_applyPointer_y"
+        prop_applyValue_equiv_applyPointer_y
+    , testProperty "prop_applyPointer_equiv_applyPointerFields_y"
+        prop_applyPointer_equiv_applyPointerFields_y
     ]
 
--- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>: implement these
--- tests once bit-fields in unions are properly supported
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+type MyUnionBF fn ft = TypedUnion Types.MyUnionBF fn ft Bitfield
+
+-- | See 'Infra.prop_applyValue_equiv_applyPointer'
+prop_applyValue_equiv_applyPointer_x ::
+     Func (MyUnionBF "x" CUInt)
+  -> MyUnionBF "x" CUInt
+  -> Property
+prop_applyValue_equiv_applyPointer_x =
+    Infra.prop_applyValue_equiv_applyPointer
+
+-- | See 'Infra.prop_applyPointer_equiv_applyPointerFields'
+prop_applyPointer_equiv_applyPointerFields_x ::
+     Func (MyUnionBF "x" CUInt)
+  -> MyUnionBF "x" CUInt
+  -> Property
+prop_applyPointer_equiv_applyPointerFields_x =
+    Infra.prop_applyPointer_equiv_applyPointerFields
+
+-- | See 'Infra.prop_applyValue_equiv_applyPointer'
+prop_applyValue_equiv_applyPointer_y ::
+     Func (MyUnionBF "y" CUChar)
+  -> MyUnionBF "y" CUChar
+  -> Property
+prop_applyValue_equiv_applyPointer_y =
+    Infra.prop_applyValue_equiv_applyPointer
+
+-- | See 'Infra.prop_applyPointer_equiv_applyPointerFields'
+prop_applyPointer_equiv_applyPointerFields_y ::
+     Func (MyUnionBF "y" CUChar)
+  -> MyUnionBF "y" CUChar
+  -> Property
+prop_applyPointer_equiv_applyPointerFields_y =
+    Infra.prop_applyPointer_equiv_applyPointerFields
+
+{-------------------------------------------------------------------------------
+  Infra
+-------------------------------------------------------------------------------}
+
+instance Arbitrary (MyUnionBF "x" CUInt) where
+  arbitrary = liftArbitraryField (getLarge <$> arbitrary)
+  shrink = shrinkField
+
+instance Arbitrary (MyUnionBF "y" CUChar) where
+  arbitrary = liftArbitraryField (getLarge <$> arbitrary)
+  shrink = shrinkField
+
+instance ComposableFunc (MyUnionBF "x" CUInt) where
+  data Func (MyUnionBF "x" CUInt) = FuncMyUnionBF_x {
+      x :: Fun CUInt CUInt
+    }
+
+  composed :: Func (MyUnionBF "x" CUInt) -> MyUnionBF "x" CUInt -> MyUnionBF "x" CUInt
+  composed f union = union { x = applyFun f.x union.x }
+
+  decomposed :: Func (MyUnionBF "x" CUInt) -> [FieldFunc (MyUnionBF "x" CUInt)]
+  decomposed f = [
+        BitfieldFunc (Proxy @"x") (applyFun f.x)
+      ]
+
+deriving stock instance Show (Func (MyUnionBF "x" CUInt))
+
+instance Arbitrary (Func (MyUnionBF "x" CUInt)) where
+  arbitrary = FuncMyUnionBF_x <$> arbitrary
+  shrink (FuncMyUnionBF_x x) = FuncMyUnionBF_x <$> shrink x
+
+instance ComposableFunc (MyUnionBF "y" CUChar) where
+  data Func (MyUnionBF "y" CUChar) = FuncMyUnionBF_y {
+      y :: Fun CUChar CUChar
+    }
+
+  composed :: Func (MyUnionBF "y" CUChar) -> MyUnionBF "y" CUChar -> MyUnionBF "y" CUChar
+  composed f union = union { y = applyFun f.y union.y }
+
+  decomposed :: Func (MyUnionBF "y" CUChar) -> [FieldFunc (MyUnionBF "y" CUChar)]
+  decomposed f = [
+        BitfieldFunc (Proxy @"y") (applyFun f.y)
+      ]
+
+deriving stock instance Show (Func (MyUnionBF "y" CUChar))
+
+instance Arbitrary (Func (MyUnionBF "y" CUChar)) where
+  arbitrary = FuncMyUnionBF_y <$> arbitrary
+  shrink (FuncMyUnionBF_y x) = FuncMyUnionBF_y <$> shrink x

--- a/examples/feature-tests/hs-project/test/Test/Util/TypedUnion.hs
+++ b/examples/feature-tests/hs-project/test/Test/Util/TypedUnion.hs
@@ -8,6 +8,7 @@ module Test.Util.TypedUnion (
   , unsafeUnwrap
     -- * Arbitrary
   , arbitraryField
+  , liftArbitraryField
   , shrinkField
   ) where
 
@@ -99,6 +100,14 @@ arbitraryField::
      )
   => Gen (TypedUnion u fn ft fk)
 arbitraryField  = TypedUnion . Union.set @fn <$> arbitrary
+
+liftArbitraryField ::
+     forall fn u ft fk. (
+       Compat.HasField fn u ft
+     , IsUnion u
+     )
+  => Gen ft -> Gen (TypedUnion u fn ft fk)
+liftArbitraryField gen = TypedUnion . Union.set @fn <$> gen
 
 shrinkField ::
      forall fn u ft fk. (

--- a/hs-bindgen-runtime/CHANGELOG.md
+++ b/hs-bindgen-runtime/CHANGELOG.md
@@ -8,7 +8,7 @@
   `Internal.Prelude` is now `HsBindgen.Runtime.Support`.
 * `setUnionPayload` would previously generate a zeroed out byte array and write
   a `Storable` value to it. It now takes a byte array argument that the
-  `Storable` value is written to. See [Issue #2183][is-2183].
+  `Storable` value is written to. See [issue #2183][is-2183].
 
 ### New features
 
@@ -25,6 +25,8 @@
 * Add `IsStructViaReadRaw` and `IsUnionViaReadRaw` helper types for deriving
   `IsStruct` and `IsUnion` respectively via a `ReadRaw` (and `StaticSize`)
   instance. [issue #2121][is-2121] and [PR #2164][pr-2164].
+* Add new `setUnionPayloadBits` and `getUnionPayloadBits` functions for setting
+  and getting bit-fields in unions. See [issue #1253][is-1253].
 
 ### Minor changes
 
@@ -35,6 +37,7 @@
 
 None
 
+[is-1253]: https://github.com/well-typed/hs-bindgen/issues/1253
 [is-2060]: https://github.com/well-typed/hs-bindgen/issues/2060
 [is-2085]: https://github.com/well-typed/hs-bindgen/issues/2085
 [is-2121]: https://github.com/well-typed/hs-bindgen/issues/2121

--- a/hs-bindgen-runtime/CHANGELOG.md
+++ b/hs-bindgen-runtime/CHANGELOG.md
@@ -35,7 +35,9 @@
 
 ### Bug fixes
 
-None
+* Fix a missing conversion from bytes to bits in the internals of
+  `pokeBitOffWidth`. This would sometime cause the function to write more bytes
+  than necessary to a pointer. See [PR #2169][pr-2169].
 
 [is-1253]: https://github.com/well-typed/hs-bindgen/issues/1253
 [is-2060]: https://github.com/well-typed/hs-bindgen/issues/2060
@@ -45,6 +47,7 @@ None
 [pr-2091]: https://github.com/well-typed/hs-bindgen/pull/2091
 [pr-2164]: https://github.com/well-typed/hs-bindgen/pull/2164
 [pr-2168]: https://github.com/well-typed/hs-bindgen/pull/2168
+[pr-2169]: https://github.com/well-typed/hs-bindgen/pull/2169
 
 ## 0.1.0-alpha2 -- 2026-03-27
 

--- a/hs-bindgen-runtime/hs-bindgen-runtime.cabal
+++ b/hs-bindgen-runtime/hs-bindgen-runtime.cabal
@@ -137,6 +137,7 @@ test-suite test-hs-bindgen-runtime
     Test.HsBindgen.Runtime.SizedByteArray
     Test.HsBindgen.Runtime.Support.ByteArray
     Test.Util.Orphans
+    Test.Util.QC
     Test.Util.Show
     Test.Util.Tasty
 

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Support.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Support.hs
@@ -43,6 +43,8 @@ module HsBindgen.Runtime.Support (
   , StablePtr
   , getUnionPayload
   , setUnionPayload
+  , getUnionPayloadBits
+  , setUnionPayloadBits
   , with
   , allocaAndPeek
   , Generic
@@ -141,7 +143,10 @@ import System.IO.Unsafe (unsafePerformIO)
 import Text.Read (readListDefault, readListPrec, readListPrecDefault, readPrec)
 
 import HsBindgen.Runtime.Support.Bitfield (Bitfield)
-import HsBindgen.Runtime.Support.ByteArray (getUnionPayload, setUnionPayload)
+import HsBindgen.Runtime.Support.ByteArray (getUnionPayload,
+                                            getUnionPayloadBits,
+                                            setUnionPayload,
+                                            setUnionPayloadBits)
 import HsBindgen.Runtime.Support.CAPI (allocaAndPeek)
 import HsBindgen.Runtime.Support.FunPtr (FromFunPtr (fromFunPtr),
                                          ToFunPtr (toFunPtr))

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/Bitfield.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/Bitfield.hs
@@ -424,7 +424,7 @@ getAligned (ptrB, ptrBH) off width (ptrL, ptrH)
       -- 00000011 00000000 00000000 00011100 00000000 00000000 00000010 00000011
       | isLittleEndian =
           let r = off + 8 * (ptrB `minusPtr` ptrA)
-          in  (wSize - width - r, r)
+          in  (wSize * 8 - width - r, r)
 
       -- Big endian: bit-field offsets are from the most significant bit
       --
@@ -442,7 +442,7 @@ getAligned (ptrB, ptrBH) off width (ptrL, ptrH)
       -- 10000000 11000000 00000000 00000000 00110000 00000000 00000001 11000000
       | otherwise =
           let l = 8 * (ptrB `minusPtr` ptrA) + off
-          in  (l, wSize - width - l)
+          in  (l, wSize * 8 - width - l)
 
 -- | Get a bit-field value from a list of bytes (native byte order)
 getBitfield ::

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/Bitfield.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/Bitfield.hs
@@ -44,7 +44,7 @@ import HsBindgen.Runtime.Marshal qualified as Marshal
   Bitfield
 -------------------------------------------------------------------------------}
 
--- | Types which can be a bit-field in a C @struct@
+-- | Types which can be a bit-field in a C @struct@ or @union@
 --
 -- The members convert to/from 'Word64' to make the use in the implementation of
 -- bitfields in @hs-bindgen@ easier.  We could not convert or have a smallest
@@ -184,17 +184,17 @@ hiMask = complement . loMask
 -- architecture.
 --
 -- A bit-field is read using a single peek when possible, as determined by
--- alignment and the passed memory bounds.  This should always be the case with
--- normal @struct@s.
+-- alignment and the passed memory bounds. This should always be the case with
+-- normal @struct@s and @union@s.
 --
 -- When it is not possible to read a bit-field using a single peek, multiple
--- peeks are used to read the bytes of the bit-field.  This may happen with
--- (poorly-designed) packed @struct@s.
+-- peeks are used to read the bytes of the bit-field. This may happen with
+-- (poorly-designed) packed @struct@s\/@unions@.
 --
--- The memory bounds should generally be the bounds of the @struct@ object.  In
--- this case, concurrent access to different objects (in an array) is safe.
--- Concurrent access to bit-fields within a single @struct@ object is generally
--- unsafe.
+-- The memory bounds should generally be the bounds of the @struct@ or @union@
+-- object. In this case, concurrent access to different objects (in an array) is
+-- safe. Concurrent access to bit-fields within a single @struct@ or @union@
+-- object is generally unsafe.
 peekBitOffWidth :: forall a.
      Bitfield a
   => Ptr ()            -- ^ Pointer to the byte where the bit-field starts
@@ -263,18 +263,18 @@ peekBitOffWidth ptrB off width bounds@(ptrL, ptrH)
 --
 -- When a bit-field can be written using a single poke, as determined by
 -- alignment and the passed memory bounds, a single peek reads any extra bits
--- when necessary, and then a single poke writes the bit-field.  This should
--- always be the case with normal @struct@s.
+-- when necessary, and then a single poke writes the bit-field. This should
+-- always be the case with normal @struct@s and @union@s.
 --
 -- When it is not possible to write a bit-field using a single poke, the byte(s)
 -- containing any extra bits are read when necessary, and then multiple pokes
--- are used to write the bytes of the bit-field.  This may happen with
--- (poorly-designed) packed @struct@s.
+-- are used to write the bytes of the bit-field. This may happen with
+-- (poorly-designed) packed @struct@s\/@union@s.
 --
--- The memory bounds should generally be the bounds of the @struct@ object.  In
--- this case, concurrent access to different objects (in an array) is safe.
--- Concurrent access to bit-fields within a single @struct@ object is generally
--- unsafe.
+-- The memory bounds should generally be the bounds of the @struct@ or @union@
+-- object. In this case, concurrent access to different objects (in an array) is
+-- safe. Concurrent access to bit-fields within a single @struct@ or @union@
+-- object is generally unsafe.
 pokeBitOffWidth :: forall a.
      Bitfield a
   => Ptr ()            -- ^ Pointer to the byte where the bit-field starts
@@ -462,8 +462,8 @@ getBitfieldLE ::
   -> Either String Word64
 getBitfieldLE off width = auxFirst
   where
-    -- With little endian, @struct@s are stored in reverse byte order, and
-    -- bit-field offsets are from the least significant bit.
+    -- With little endian, @struct@s and @union@s are stored in reverse byte
+    -- order, and bit-field offsets are from the least significant bit.
     --
     -- * Single byte: @| loff? | numFieldBits | off? |@
     --
@@ -513,8 +513,8 @@ getBitfieldBE ::
   -> Either String Word64
 getBitfieldBE off width = auxFirst
   where
-    -- With big endian, @struct@s are stored in byte order, and bit-field
-    -- offsets are from the most significant bit.
+    -- With big endian, @struct@s and @union@s are stored in byte order, and
+    -- bit-field offsets are from the most significant bit.
     --
     -- * Single byte: @| off? | numFieldBits | roff? |@
     --

--- a/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/ByteArray.hs
+++ b/hs-bindgen-runtime/src/HsBindgen/Runtime/Support/ByteArray.hs
@@ -1,6 +1,6 @@
 {-# OPTIONS_HADDOCK hide #-}
 
--- | Utilities for dealing with 'ByteArray' and 'Storable'
+-- | Utilities for dealing with 'ByteArray', 'Storable', and 'Bitfield'.
 --
 -- The additional copying we have to do here is a bit annoying, but in the end
 -- an FFI implementation based on 'Storable' is never going to be /extremely/
@@ -19,6 +19,8 @@ module HsBindgen.Runtime.Support.ByteArray (
      -- * Support for defining setters and getters for union types
    , setUnionPayload
    , getUnionPayload
+   , setUnionPayloadBits
+   , getUnionPayloadBits
    ) where
 
 import Control.Exception
@@ -26,8 +28,11 @@ import Control.Monad.Primitive (RealWorld)
 import Data.Coerce (Coercible, coerce)
 import Data.Primitive.ByteArray (ByteArray, MutableByteArray)
 import Data.Primitive.ByteArray qualified as BA
-import Foreign (Ptr, Storable (peek, poke), castPtr, copyBytes, sizeOf)
+import Foreign (Ptr, Storable (peek, poke), castPtr, copyBytes, plusPtr, sizeOf)
 import System.IO.Unsafe (unsafePerformIO)
+
+import HsBindgen.Runtime.Support.Bitfield (Bitfield)
+import HsBindgen.Runtime.Support.Bitfield qualified as Bitfield
 
 {-------------------------------------------------------------------------------
   Support for defining 'Storable' instances for union types
@@ -65,6 +70,22 @@ getUnionPayload :: forall payload union.
      )
   => union -> payload
 getUnionPayload = peekFromByteArray . coerce
+
+setUnionPayloadBits :: forall payload union.
+     ( Bitfield payload
+     , Coercible union ByteArray
+     )
+  => Int -> Int -> payload -> union -> union
+setUnionPayloadBits bitOffset bitWidth x u =
+    coerce $ pokeBitsToByteArray bitOffset bitWidth x (coerce u)
+
+getUnionPayloadBits :: forall payload union.
+     ( Bitfield payload
+     , Coercible union ByteArray
+     )
+  => Int -> Int -> union -> payload
+getUnionPayloadBits bitOffset bitWidth =
+    peekBitsFromByteArray bitOffset bitWidth . coerce
 
 {-------------------------------------------------------------------------------
   Internal auxiliary
@@ -111,6 +132,79 @@ pokeToByteArray x bytes =
       BA.freezeByteArray pinnedCopy 0 bytesSize
   where
     bytesSize = BA.sizeofByteArray bytes
+
+-- | @'peekBitsFromByteArray' o w bs@ reads a range of bits of a 'Storable'
+-- value from a 'ByteArray'
+--
+-- Preconditions:
+--
+-- > o >= 0
+-- > w >= 1 && w <= 64
+-- > w <= 'sizeOf' (undefined :: a) * 8
+-- > o + w <= 'sizeofByteArray' bs * 8
+--
+-- It may well be the case that the ByteArray is /larger/ than the @union@ that
+-- it represents; see also 'peekFromByteArray'.
+peekBitsFromByteArray ::
+     forall a. Bitfield a
+     -- | Bit offset
+  => Int
+     -- | Bit width
+  -> Int
+  -> ByteArray
+  -> a
+peekBitsFromByteArray o w bs =
+    unsafePerformIO $ do
+      pinnedCopy <- thawToPinned bs
+      BA.withMutableByteArrayContents pinnedCopy $ \ptr -> do
+        let bounds = (ptrL, ptrR)
+            ptrL = castPtr ptr
+            ptrR = ptrL `plusPtr` BA.sizeofByteArray bs
+            -- peekBitOffWidth assumes that the bit offset is in the inclusive
+            -- range @\[0, 7\]@, so we move the pointer and update the bit
+            -- offset accordingly
+            ptr' = ptr `plusPtr` (o `div` 8)
+            o'   = o - ((o `div` 8) * 8)
+        Bitfield.peekBitOffWidth ptr' o' w bounds
+
+-- | @'pokeBitsToByteArray' o w v bs@ Write a range of bits from a 'Storable'
+-- value to a 'ByteArray'
+--
+-- Preconditions:
+--
+-- > o >= 0
+-- > w >= 1 && w <= 64
+-- > w <= 'sizeOf' v * 8
+-- > o + w <= 'sizeofByteArray' bs * 8
+--
+-- It may well be the case that the ByteArray is /larger/ than the @union@ that
+-- it represents; see also 'peekFromByteArray'.
+pokeBitsToByteArray ::
+     forall a. Bitfield a
+     -- | Bit offset
+  => Int
+     -- | Bit width
+  -> Int
+  -> a
+  -> ByteArray
+  -> ByteArray
+pokeBitsToByteArray o w v bs =
+    unsafePerformIO $ do
+      pinnedCopy <- thawToPinned bs
+      BA.withMutableByteArrayContents pinnedCopy $ \ptr -> do
+        let bounds = (ptrL, ptrR)
+            ptrL = castPtr ptr
+            ptrR = ptrL `plusPtr` bsSz
+            -- pokeBitOffWidth assumes that the bit offset is in the inclusive
+            -- range @\[0, 7\]@, so we move the pointer and update the bit
+            -- offset accordingly
+            ptr' = ptr `plusPtr` (o `div` 8)
+            o'   = o - ((o `div` 8) * 8)
+        Bitfield.pokeBitOffWidth ptr' o' w bounds v
+      -- The copy constructed by 'freezeByteArray' is /not/ pinned.
+      BA.freezeByteArray pinnedCopy 0 bsSz
+  where
+    bsSz = BA.sizeofByteArray bs
 
 -- | Like 'Data.Primiteve.ByteArray.thawByteArray', but the new
 -- | 'MutableByteArray' is pinned

--- a/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/Support/ByteArray.hs
+++ b/hs-bindgen-runtime/test/Test/HsBindgen/Runtime/Support/ByteArray.hs
@@ -20,8 +20,13 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 import Text.Printf (printf)
 
-import HsBindgen.Runtime.Support.ByteArray (getUnionPayload, setUnionPayload)
+import HsBindgen.Runtime.Support.Bitfield (Bitfield (narrow))
+import HsBindgen.Runtime.Support.ByteArray (getUnionPayload,
+                                            getUnionPayloadBits,
+                                            setUnionPayload,
+                                            setUnionPayloadBits)
 
+import Test.Util.QC (Arbitrary4 (liftShrink4))
 import Test.Util.Show (showRangesOf)
 
 {-------------------------------------------------------------------------------
@@ -43,6 +48,20 @@ tests = testGroup "Test.HsBindgen.Runtime.Support.ByteArray" [
     , testProperty "prop_getSet @Word32" $ prop_getSet (Proxy @Word32)
     , testProperty "prop_getSet @Word64" $ prop_getSet (Proxy @Word64)
     , testProperty "prop_getSet @Int"    $ prop_getSet (Proxy @Int)
+
+      -- prop_setGetBits
+    , testProperty "prop_setGetBits @Word8"  $ prop_setGetBits (Proxy @Word8)
+    , testProperty "prop_setGetBits @Word16" $ prop_setGetBits (Proxy @Word16)
+    , testProperty "prop_setGetBits @Word32" $ prop_setGetBits (Proxy @Word32)
+    , testProperty "prop_setGetBits @Word64" $ prop_setGetBits (Proxy @Word64)
+    , testProperty "prop_setGetBits @Int"    $ prop_setGetBits (Proxy @Int)
+
+      -- prop_getSetBits
+    , testProperty "prop_getSetBits @Word8"  $ prop_getSetBits (Proxy @Word8)
+    , testProperty "prop_getSetBits @Word16" $ prop_getSetBits (Proxy @Word16)
+    , testProperty "prop_getSetBits @Word32" $ prop_getSetBits (Proxy @Word32)
+    , testProperty "prop_getSetBits @Word64" $ prop_getSetBits (Proxy @Word64)
+    , testProperty "prop_getSetBits @Int"    $ prop_getSetBits (Proxy @Int)
     ]
 
 {-------------------------------------------------------------------------------
@@ -142,6 +161,122 @@ instance (Storable a, Arbitrary a, Show a) => Arbitrary (SetGetParams a) where
           ]
 
 {-------------------------------------------------------------------------------
+  Roundtrip: set bits and get bits
+-------------------------------------------------------------------------------}
+
+-- | Roundtrip: get bits after set bits should return the set value
+prop_setGetBits ::
+     forall a. Bitfield a
+  => Proxy a -> SetGetBitsParams a -> Property
+prop_setGetBits _ params =
+    tabulate "# of unused leading bits" [showRangesOf 64 o] $
+    tabulate "# of unused trailing bits" [showRangesOf 64 (bsSz * 8 - (o + w))] $
+    narrow v w === getUnionPayloadBits o w (setUnionPayloadBits o w v bs)
+  where
+    o = params.bitOffset
+    w = params.bitWidth
+    v = params.value
+    bs = params.bytes
+    bsSz = P.sizeofByteArray bs
+
+-- | Roundtrip: set after get should return the byte array to its original state
+--
+-- See als 'prop_getSet'.
+prop_getSetBits ::
+     forall a. Bitfield a
+  => Proxy a -> SetGetBitsParams a -> Property
+prop_getSetBits _ params =
+    tabulate "# of unused leading bits" [showRangesOf 64 o] $
+    tabulate "# of unused trailing bits" [showRangesOf 64 (bsSz * 8 - (o + w))] $
+    bs === setUnionPayloadBits @a o w (getUnionPayloadBits o w bs) bs
+  where
+    o = params.bitOffset
+    w = params.bitWidth
+    bs = params.bytes
+    bsSz = P.sizeofByteArray bs
+
+
+-- | Parameters for 'prop_setGetBits' and 'prop_getSetBits'
+--
+-- INVARIANT: see the 'CheckInvariant' instance
+data SetGetBitsParams a = SetGetBitsParams {
+    value :: a
+  , bitOffset :: Int
+  , bitWidth :: Int
+  , bytes :: ByteArray
+  }
+  deriving stock (Show, Eq)
+
+instance (Show a, Storable a) => CheckInvariant (SetGetBitsParams a) where
+  checkInvariant params = first (printf "For params (%s), " (show params) ++) go
+    where
+      go
+        | o < 0
+        = Left $ printf "A: %d < 0" o
+        | w < 1 || w > 64
+        = Left $ printf "B: %d < 1 || %d > 64" w w
+        | let vSz = sizeOf v
+        , w > vSz * 8
+        = Left $ printf "C: %d + %d > %d * 8" o w vSz
+        | let bsSz = P.sizeofByteArray bs
+        , o + w > bsSz * 8
+        = Left $ printf "D: %d + %d > %d * 8" o w bsSz
+        | otherwise
+        = Right params
+
+      o = params.bitOffset
+      w = params.bitWidth
+      v = params.value
+      bs = params.bytes
+
+mkSetGetBitsParams ::
+     forall a. (Storable a, Show a)
+  => a -> Int -> Int -> ByteArray -> Either String (SetGetBitsParams a)
+mkSetGetBitsParams value bitOffset bitWidth bytes =
+    checkInvariant $
+      SetGetBitsParams {
+          value = value, bitOffset = bitOffset, bitWidth = bitWidth, bytes = bytes
+        }
+
+mkSetGetBitsParams' ::
+     forall a. (HasCallStack, Storable a, Show a)
+  => a -> Int -> Int -> ByteArray ->  SetGetBitsParams a
+mkSetGetBitsParams' value bitOffset bitWidth bytes =
+    checkInvariant'
+      SetGetBitsParams {
+          value = value, bitOffset = bitOffset, bitWidth = bitWidth, bytes = bytes
+        }
+
+instance (Storable a, Show a, Arbitrary a) => Arbitrary (SetGetBitsParams a) where
+  arbitrary = do
+      bitWidth <- chooseInt (1, valueSz * 8 - 1)
+      let i = ceilDiv8 bitWidth
+      bytes <- genBytes i
+      bitOffset <- chooseInt (0, P.sizeofByteArray bytes * 8 - bitWidth)
+      value <- arbitrary
+      pure $ mkSetGetBitsParams' value bitOffset bitWidth bytes
+   where
+      valueSz = sizeOf (undefined :: a)
+
+      genBytes i = sized $ \n -> do
+        k <- chooseInt (i, max i n)
+        let genByte = getLarge <$> arbitrary
+        byteArrayOf k genByte
+
+  shrink params = snd $ partitionEithers [
+        mkSetGetBitsParams value' bitOffset' bitWidth' bytes'
+      | (value', bitOffset', bitWidth', bytes')
+          <- liftShrink4 shrink shrink shrink shrinkBytes
+              (params.value, params.bitOffset, params.bitWidth, params.bytes)
+      ]
+    where
+      shrinkBytes bytes = [
+            bytes'
+          | let shrinkByte = fmap getLarge . shrink . Large
+          , bytes' <- shrinkByteArray shrinkByte bytes
+          ]
+
+{-------------------------------------------------------------------------------
   Invariants
 -------------------------------------------------------------------------------}
 
@@ -172,3 +307,11 @@ shrinkByteArray shrinkByte bytes = [
       fromList bytes'
     | bytes' <- shrinkList shrinkByte (toList bytes)
     ]
+
+{-------------------------------------------------------------------------------
+  Numeric
+-------------------------------------------------------------------------------}
+
+-- | Divide by 8 and round up
+ceilDiv8 :: Int -> Int
+ceilDiv8 x = (x + 7) `div` 8

--- a/hs-bindgen-runtime/test/Test/Util/QC.hs
+++ b/hs-bindgen-runtime/test/Test/Util/QC.hs
@@ -1,0 +1,25 @@
+module Test.Util.QC (
+    Arbitrary4 (..)
+  ) where
+
+import Data.Kind
+import Test.QuickCheck
+
+{-------------------------------------------------------------------------------
+  Arbitrary4
+-------------------------------------------------------------------------------}
+
+class Arbitrary4 (f :: Type -> Type -> Type -> Type -> Type) where
+  {-# MINIMAL liftArbitrary4 #-}
+  liftArbitrary4 :: Gen a -> Gen b -> Gen c -> Gen d -> Gen (f a b c d)
+  liftShrink4 :: (a -> [a]) -> (b -> [b]) -> (c -> [c]) -> (d -> [d]) -> f a b c d -> [f a b c d]
+  liftShrink4 _ _ _ _ _ = []
+
+instance Arbitrary4 (,,,) where
+  liftArbitrary4 genA genB genC genD =
+      (,,,) <$> genA <*> genB <*> genC <*> genD
+
+  liftShrink4 shrA shrB shrC shrD (a, b, c, d) = do
+      (a', (b', (c', d'))) <-
+        liftShrink2 shrA (liftShrink2 shrB (liftShrink2 shrC shrD)) (a, (b, (c, d)))
+      pure (a', b', c', d')

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -192,6 +192,7 @@
   #2061][is-2061] and [PR #2136][pr-2136].
 * Generate `HsBindgen.Runtime.Structs.IsStruct` instances for structs. See
   [issue #2121][is-2121] and [PR #2164][pr-2164].
+* Support bit-fields in unions. See [issue #1253][is-1253].
 
 ### Minor changes
 
@@ -319,6 +320,7 @@
   and none outside of it. See [issue #2183][is-2183].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
+[is-1253]: https://github.com/well-typed/hs-bindgen/issues/1253
 [is-1382]: https://github.com/well-typed/hs-bindgen/issues/1382
 [is-1520]: https://github.com/well-typed/hs-bindgen/issues/1520
 [is-1685]: https://github.com/well-typed/hs-bindgen/issues/1685

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Global.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Global.hs
@@ -192,6 +192,8 @@ data BindgenGlobalTerm =
     -- Foreign function interface
   | ByteArray_setUnionPayload
   | ByteArray_getUnionPayload
+  | ByteArray_getUnionPayloadBits
+  | ByteArray_setUnionPayloadBits
   | Capi_with
   | Capi_allocaAndPeek
 
@@ -438,10 +440,12 @@ bindgenGlobalTerm = globalExpr . \case
     FromFunPtr_fromFunPtr -> (IRuntime Runtime.Support, GVar, 'BG.fromFunPtr)
 
     -- Foreign function interface
-    ByteArray_getUnionPayload -> (IRuntime Runtime.Support, GVar, 'BG.getUnionPayload)
-    ByteArray_setUnionPayload -> (IRuntime Runtime.Support, GVar, 'BG.setUnionPayload)
-    Capi_with                 -> (IRuntime Runtime.Support, GVar, 'BG.with)
-    Capi_allocaAndPeek        -> (IRuntime Runtime.Support, GVar, 'BG.allocaAndPeek)
+    ByteArray_getUnionPayload     -> (IRuntime Runtime.Support, GVar, 'BG.getUnionPayload)
+    ByteArray_setUnionPayload     -> (IRuntime Runtime.Support, GVar, 'BG.setUnionPayload)
+    ByteArray_getUnionPayloadBits -> (IRuntime Runtime.Support, GVar, 'BG.getUnionPayloadBits)
+    ByteArray_setUnionPayloadBits -> (IRuntime Runtime.Support, GVar, 'BG.setUnionPayloadBits)
+    Capi_with                     -> (IRuntime Runtime.Support, GVar, 'BG.with)
+    Capi_allocaAndPeek            -> (IRuntime Runtime.Support, GVar, 'BG.allocaAndPeek)
 
     -- StaticSize
     StaticSize_staticSizeOf    -> (IRuntime Runtime.Marshal, GVar, 'Marshal.staticSizeOf)

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -701,8 +701,13 @@ data HasFieldInstance = HasFieldInstance {
 
 -- | 'GHC.Records.HasField.getField' implementation
 data HasFieldImpl =
-    -- | unions
+    -- | union fields
     HasFieldImplUnion
+    -- | union bit-fields
+  | HasFieldImplUnionBits {
+        bitOffset :: Int
+      , bitWidth :: Int
+      }
     -- | indirect fields
   | HasFieldImplIndirect {
         -- | The name of the field to go from the current top-level struct/union
@@ -742,8 +747,13 @@ data HasFieldCompatImpl =
         -- | Fields that are unchanged
       , otherFields :: [Hs.Name Hs.NsVar]
       }
-    -- | unions
+    -- | union fields
   | HasFieldCompatImplUnion
+    -- | union bit-fields
+  | HasFieldCompatImplUnionBits {
+        bitOffset :: Int
+      , bitWidth :: Int
+      }
     -- | Indirect fields
   | HasFieldCompatImplIndirect {
         -- | The name of the field to go from the current top-level struct/union

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -281,9 +281,14 @@ getDecls supInsts env spec structName info struct insts =
 
     knownInsts :: Set Inst.TypeClass
     knownInsts = Set.fromList $ catMaybes [
+        -- A struct with only non-bit-fields trivially satisfies
+        -- 'Inst.HasCBitfield', but we omit such trivial instances as not to
+        -- confuse the user.
         if any (isJust . (.width)) struct.fields
           then Just Inst.HasCBitfield
           else Nothing
+        -- A struct with only bit-fields trivially satisfies 'Inst.HasCField',
+        -- but we omit such trivial instances as not to confuse the user.
       , if any (isNothing . (.width)) struct.fields
           then Just Inst.HasCField
           else Nothing

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
@@ -73,10 +73,18 @@ unionDecs info union spec = do
         knownInsts :: Set Inst.TypeClass
         knownInsts = Set.fromList $ catMaybes [
             Just Inst.Generic
-          -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
-          -- Should correctly detect 'Inst.HasCBitfield' and 'Inst.HasCField'
-          -- when bit-fields in unions are supported.
-          , if null union.fields then Nothing else Just Inst.HasCField
+            -- A union with only non-bit-fields trivially satisfies
+            -- 'Inst.HasCBitfield', but we omit such trivial instances as not to
+            -- confuse the user.
+          , if any (isJust . (.width)) union.fields
+              then Just Inst.HasCBitfield
+              else Nothing
+            -- A union with only bit-fields trivially satisfies
+            -- 'Inst.HasCField', but we omit such trivial instances as not to
+            -- confuse the user.
+          , if any (isNothing . (.width)) union.fields
+              then Just Inst.HasCField
+              else Nothing
           , if null union.fields then Nothing else Just Inst.HasField
           , if null union.fields then Nothing else Just Inst.HasFieldCompat
           , if null union.fields then Nothing else Just Inst.HasFieldPtr
@@ -215,7 +223,14 @@ hasFieldDecs st env info union field =
         -- instances
         IndirectField impField indField -> implIndirect impField indField
 
-    implUnion = Hs.HasFieldImplUnion
+    implUnion = case getFieldWidth field of
+      Nothing       -> Hs.HasFieldImplUnion
+      Just bitWidth ->
+        -- For non-bit-fields, the field offset is in terms of bytes. For
+        -- bit-fields, the field offset is in terms of bits. So, no need to do
+        -- any conversion.
+        let bitOffset = getFieldOffset field in
+        Hs.HasFieldImplUnionBits { bitOffset = bitOffset, bitWidth = bitWidth }
 
     implIndirect :: C.ImplicitField Final -> C.IndirectField Final -> Hs.HasFieldImpl
     implIndirect impField indField  = Hs.HasFieldImplIndirect {
@@ -281,7 +296,14 @@ hasFieldCompatDecs st env info union field =
         -- instances
         IndirectField impField indField -> implIndirect impField indField
 
-    implUnion = Hs.HasFieldCompatImplUnion
+    implUnion = case getFieldWidth field of
+      Nothing       -> Hs.HasFieldCompatImplUnion
+      Just bitWidth ->
+        -- For non-bit-fields, the field offset is in terms of bytes. For
+        -- bit-fields, the field offset is in terms of bits. So, no need to do
+        -- any conversion.
+        let bitOffset = getFieldOffset field in
+        Hs.HasFieldCompatImplUnionBits { bitOffset = bitOffset, bitWidth = bitWidth }
 
     implIndirect :: C.ImplicitField Final -> C.IndirectField Final -> Hs.HasFieldCompatImpl
     implIndirect impField indField  = Hs.HasFieldCompatImplIndirect {
@@ -300,12 +322,6 @@ hasFieldPtrDecs union field =
     | Inst.HasFieldPtr `elem` union.instances
     ]
   where
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
-    -- Should be changed to @getFieldWidth f@ when bit-fields in unions are
-    -- supported.
-    unionFieldWidth :: Field -> Maybe Int
-    unionFieldWidth _f = Nothing
-
     parentType :: Hs.Type
     parentType = Hs.TypRef union.name Nothing
 
@@ -321,14 +337,14 @@ hasFieldPtrDecs union field =
         , fieldName  = fieldName
         , fieldType  = fieldType
         , deriveVia  =
-            case unionFieldWidth field of
+            case getFieldWidth field of
               Nothing -> Hs.ViaHasCField
               Just _  -> Hs.ViaHasCBitfield
         }
 
 -- | Class instances for 'HsBindgen.Runtime.HasCField.HasCField'
 hasCFieldDecs :: Hs.Newtype -> Field -> [Hs.Decl l]
-hasCFieldDecs union field = case unionFieldWidth field of
+hasCFieldDecs union field = case getFieldWidth field of
     Just _w -> []
     Nothing ->
       [ Hs.DeclDefineInstance $
@@ -339,12 +355,6 @@ hasCFieldDecs union field = case unionFieldWidth field of
       | Inst.HasCField `elem` union.instances
       ]
   where
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
-    -- Should be changed to @getFieldWidth f@ when bit-fields in unions are
-    -- supported.
-    unionFieldWidth :: Field -> Maybe Int
-    unionFieldWidth _f = Nothing
-
     parentType :: Hs.Type
     parentType = Hs.TypRef union.name Nothing
 
@@ -364,7 +374,7 @@ hasCFieldDecs union field = case unionFieldWidth field of
 
 -- | Class instances for 'HsBindgen.Runtime.HasCBitfield.HasCBitfield'
 hasCBitfieldDecs :: Hs.Newtype -> Field -> [Hs.Decl l]
-hasCBitfieldDecs union field = case unionFieldWidth field of
+hasCBitfieldDecs union field = case getFieldWidth field of
     Nothing -> []
     Just w ->
       [ Hs.DeclDefineInstance $
@@ -375,12 +385,6 @@ hasCBitfieldDecs union field = case unionFieldWidth field of
       | Inst.HasCBitfield `elem` union.instances
       ]
   where
-    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1253>
-    -- Should be changed to @getFieldWidth f@ when bit-fields in unions are
-    -- supported.
-    unionFieldWidth :: Field -> Maybe Int
-    unionFieldWidth _f = Nothing
-
     parentType :: Hs.Type
     parentType = Hs.TypRef union.name Nothing
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/SHs/Translation.hs
@@ -606,6 +606,10 @@ translateHasFieldInstance inst mbComment = Instance{
     exprGetter :: SExpr Z
     exprGetter = case inst.impl of
       Hs.HasFieldImplUnion -> eBindgenGlobal ByteArray_getUnionPayload
+      Hs.HasFieldImplUnionBits {bitOffset, bitWidth} ->
+                 eBindgenGlobal ByteArray_getUnionPayloadBits
+          `EApp` EIntegral (fromIntegral bitOffset) Nothing
+          `EApp` EIntegral (fromIntegral bitWidth) Nothing
       Hs.HasFieldImplIndirect {nameTopToAnon, nameAnonToTarget} ->
         let strLitTopToAnon    = translateType (Hs.StrLit (Hs.nameToStr nameTopToAnon))
             strLitAnonToTarget = translateType (Hs.StrLit (Hs.nameToStr nameAnonToTarget)) in
@@ -665,8 +669,16 @@ translateHasFieldCompatInstance inst mbComment = Instance{
                 , map mkFBindIdentity otherFields
                 ]
           Hs.HasFieldCompatImplUnion ->
+              ELam (NameHint "y")
+                (      eBindgenGlobal ByteArray_setUnionPayload
+                `EApp` (EBound IZ)
+                `EApp` (EBound (IS IZ))
+                )
+          Hs.HasFieldCompatImplUnionBits {bitOffset, bitWidth} ->
             ELam (NameHint "y")
-              (      eBindgenGlobal ByteArray_setUnionPayload
+              (      eBindgenGlobal ByteArray_setUnionPayloadBits
+              `EApp` EIntegral (fromIntegral bitOffset) Nothing
+              `EApp` EIntegral (fromIntegral bitWidth) Nothing
               `EApp` (EBound IZ)
               `EApp` (EBound (IS IZ))
               )

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/Example.hs
@@ -1,0 +1,1938 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Foo_8(..)
+    , Example.Foo_16(..)
+    , Example.Foo_32(..)
+    , Example.Foo_64(..)
+    , Example.Foo_8_packed(..)
+    , Example.Foo_16_packed(..)
+    , Example.Foo_32_packed(..)
+    , Example.Foo_64_packed(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.BitfieldPtr as BitfieldPtr
+import qualified HsBindgen.Runtime.HasCBitfield as HasCBitfield
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+import qualified HsBindgen.Runtime.Union as Union
+
+{-| __C declaration:__ @union foo_8@
+
+    __defined at:__ @types\/unions\/bitfields.h 4:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_8 = Foo_8
+  { unwrapFoo_8 :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.StaticSize Foo_8
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.ReadRaw Foo_8
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.WriteRaw Foo_8
+
+deriving via Marshal.EquivStorable Foo_8 instance BG.Storable Foo_8
+
+deriving via BG.SizedByteArray 1 1 instance Union.IsUnion Foo_8
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 5:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_a" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 5:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_a" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_a" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_a")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_a" where
+
+  type CBitfieldType Foo_8 "foo_8_a" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 6:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_b" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 6:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_b" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_b" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_b" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_b")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_b" where
+
+  type CBitfieldType Foo_8 "foo_8_b" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 7:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_c" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 2
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 7:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_c" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 2 y1 x0, BG.getField @"foo_8_c" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_c" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_c")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_c" where
+
+  type CBitfieldType Foo_8 "foo_8_c" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 2
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 8:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_d" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 8:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_d" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_d" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_d" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_d")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_d" where
+
+  type CBitfieldType Foo_8 "foo_8_d" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 9:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_e" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 8
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 9:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_e" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 8 y1 x0, BG.getField @"foo_8_e" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_e" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_e")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_e" where
+
+  type CBitfieldType Foo_8 "foo_8_e" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 8
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 10:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_f" Foo_8 ty where
+
+  getField = BG.getUnionPayloadBits 0 5
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 10:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.CompatHasField.HasField "foo_8_f" Foo_8 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 5 y1 x0, BG.getField @"foo_8_f" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_f" (BG.Ptr Foo_8) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_8_f")
+
+instance HasCBitfield.HasCBitfield Foo_8 "foo_8_f" where
+
+  type CBitfieldType Foo_8 "foo_8_f" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 5
+
+{-| __C declaration:__ @union foo_16@
+
+    __defined at:__ @types\/unions\/bitfields.h 14:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_16 = Foo_16
+  { unwrapFoo_16 :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 4 4 instance Marshal.StaticSize Foo_16
+
+deriving via BG.SizedByteArray 4 4 instance Marshal.ReadRaw Foo_16
+
+deriving via BG.SizedByteArray 4 4 instance Marshal.WriteRaw Foo_16
+
+deriving via Marshal.EquivStorable Foo_16 instance BG.Storable Foo_16
+
+deriving via BG.SizedByteArray 4 4 instance Union.IsUnion Foo_16
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 15:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_16_a" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 15:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_16_a" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_16_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_16_a" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_a")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_a" where
+
+  type CBitfieldType Foo_16 "foo_16_a" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 16:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_b" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 10
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 16:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_16_b" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 10 y1 x0, BG.getField @"foo_16_b" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_b" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_b")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_b" where
+
+  type CBitfieldType Foo_16 "foo_16_b" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 10
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 17:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_c" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 16
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 17:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_16_c" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 16 y1 x0, BG.getField @"foo_16_c" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_c" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_c")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_c" where
+
+  type CBitfieldType Foo_16 "foo_16_c" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 16
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 18:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_d" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 16
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 18:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_16_d" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 16 y1 x0, BG.getField @"foo_16_d" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_d" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_d")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_d" where
+
+  type CBitfieldType Foo_16 "foo_16_d" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 16
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 19:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_e" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 19:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_16_e" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_16_e" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_e" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_e")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_e" where
+
+  type CBitfieldType Foo_16 "foo_16_e" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 20:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_f" Foo_16 ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 20:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_16_f" Foo_16 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_16_f" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_f" (BG.Ptr Foo_16) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_16_f")
+
+instance HasCBitfield.HasCBitfield Foo_16 "foo_16_f" where
+
+  type CBitfieldType Foo_16 "foo_16_f" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @union foo_32@
+
+    __defined at:__ @types\/unions\/bitfields.h 24:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_32 = Foo_32
+  { unwrapFoo_32 :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.StaticSize Foo_32
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.ReadRaw Foo_32
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.WriteRaw Foo_32
+
+deriving via Marshal.EquivStorable Foo_32 instance BG.Storable Foo_32
+
+deriving via BG.SizedByteArray 8 8 instance Union.IsUnion Foo_32
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 25:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_32_a" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 25:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_32_a" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_32_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_32_a" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_a")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_a" where
+
+  type CBitfieldType Foo_32 "foo_32_a" = BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 26:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_b" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 26:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_32_b" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_32_b" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_b" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_b")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_b" where
+
+  type CBitfieldType Foo_32 "foo_32_b" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 27:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_c" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 14
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 27:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_32_c" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 14 y1 x0, BG.getField @"foo_32_c" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_c" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_c")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_c" where
+
+  type CBitfieldType Foo_32 "foo_32_c" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 14
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 28:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_d" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 10
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 28:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_32_d" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 10 y1 x0, BG.getField @"foo_32_d" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_d" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_d")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_d" where
+
+  type CBitfieldType Foo_32 "foo_32_d" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 10
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 29:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_32_e" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 32
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 29:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_32_e" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 32 y1 x0, BG.getField @"foo_32_e" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_32_e" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_e")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_e" where
+
+  type CBitfieldType Foo_32 "foo_32_e" = BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 32
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 30:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_f" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 30:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "foo_32_f" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_32_f" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_f" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_f")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_f" where
+
+  type CBitfieldType Foo_32 "foo_32_f" = BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @g@
+
+    __defined at:__ @types\/unions\/bitfields.h 31:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_32_g" Foo_32 ty where
+
+  getField = BG.getUnionPayloadBits 0 24
+
+{-| __C declaration:__ @g@
+
+    __defined at:__ @types\/unions\/bitfields.h 31:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_32_g" Foo_32 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 24 y1 x0, BG.getField @"foo_32_g" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_32_g" (BG.Ptr Foo_32) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_32_g")
+
+instance HasCBitfield.HasCBitfield Foo_32 "foo_32_g" where
+
+  type CBitfieldType Foo_32 "foo_32_g" = BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 24
+
+{-| __C declaration:__ @union foo_64@
+
+    __defined at:__ @types\/unions\/bitfields.h 35:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_64 = Foo_64
+  { unwrapFoo_64 :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.StaticSize Foo_64
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.ReadRaw Foo_64
+
+deriving via BG.SizedByteArray 8 8 instance Marshal.WriteRaw Foo_64
+
+deriving via Marshal.EquivStorable Foo_64 instance BG.Storable Foo_64
+
+deriving via BG.SizedByteArray 8 8 instance Union.IsUnion Foo_64
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 36:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_64_a" Foo_64 ty where
+
+  getField = BG.getUnionPayloadBits 0 24
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 36:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_64_a" Foo_64 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 24 y1 x0, BG.getField @"foo_64_a" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_64_a" (BG.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_64_a")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_a" where
+
+  type CBitfieldType Foo_64 "foo_64_a" = BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 24
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 37:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLLong) => BG.HasField "foo_64_b" Foo_64 ty where
+
+  getField = BG.getUnionPayloadBits 0 40
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 37:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_b" Foo_64 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 40 y1 x0, BG.getField @"foo_64_b" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_b" (BG.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_64_b")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_b" where
+
+  type CBitfieldType Foo_64 "foo_64_b" = BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 40
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 38:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLLong) => BG.HasField "foo_64_c" Foo_64 ty where
+
+  getField = BG.getUnionPayloadBits 0 64
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 38:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_c" Foo_64 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 64 y1 x0, BG.getField @"foo_64_c" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_c" (BG.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_64_c")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_c" where
+
+  type CBitfieldType Foo_64 "foo_64_c" = BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 64
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 39:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLLong) => BG.HasField "foo_64_d" Foo_64 ty where
+
+  getField = BG.getUnionPayloadBits 0 36
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 39:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_d" Foo_64 ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 36 y1 x0, BG.getField @"foo_64_d" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_d" (BG.Ptr Foo_64) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField = HasCBitfield.toPtr (BG.Proxy @"foo_64_d")
+
+instance HasCBitfield.HasCBitfield Foo_64 "foo_64_d" where
+
+  type CBitfieldType Foo_64 "foo_64_d" = BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 36
+
+{-| __C declaration:__ @union foo_8_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 43:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_8_packed = Foo_8_packed
+  { unwrapFoo_8_packed :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.StaticSize Foo_8_packed
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.ReadRaw Foo_8_packed
+
+deriving via BG.SizedByteArray 1 1 instance Marshal.WriteRaw Foo_8_packed
+
+deriving via Marshal.EquivStorable Foo_8_packed instance BG.Storable Foo_8_packed
+
+deriving via BG.SizedByteArray 1 1 instance Union.IsUnion Foo_8_packed
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 44:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_a" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 44:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_a" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_packed_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_a" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_a")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_a" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_a" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 45:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_b" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 45:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_b" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_packed_b" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_b" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_b")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_b" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_b" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 46:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_c" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 2
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 46:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_c" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 2 y1 x0, BG.getField @"foo_8_packed_c" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_c" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_c")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_c" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_c" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 2
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 47:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_d" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 3
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 47:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_d" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 3 y1 x0, BG.getField @"foo_8_packed_d" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_d" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_d")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_d" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_d" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 3
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 48:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_e" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 8
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 48:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_e" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 8 y1 x0, BG.getField @"foo_8_packed_e" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_e" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_e")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_e" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_e" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 8
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 49:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CSChar) => BG.HasField "foo_8_packed_f" Foo_8_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 5
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 49:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_8_packed_f" Foo_8_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 5 y1 x0, BG.getField @"foo_8_packed_f" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_8_packed_f" (BG.Ptr Foo_8_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_8_packed_f")
+
+instance HasCBitfield.HasCBitfield Foo_8_packed "foo_8_packed_f" where
+
+  type CBitfieldType Foo_8_packed "foo_8_packed_f" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 5
+
+{-| __C declaration:__ @union foo_16_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 53:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_16_packed = Foo_16_packed
+  { unwrapFoo_16_packed :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 2 1 instance Marshal.StaticSize Foo_16_packed
+
+deriving via BG.SizedByteArray 2 1 instance Marshal.ReadRaw Foo_16_packed
+
+deriving via BG.SizedByteArray 2 1 instance Marshal.WriteRaw Foo_16_packed
+
+deriving via Marshal.EquivStorable Foo_16_packed instance BG.Storable Foo_16_packed
+
+deriving via BG.SizedByteArray 2 1 instance Union.IsUnion Foo_16_packed
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 54:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_16_packed_a" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 54:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_16_packed_a" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_16_packed_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_16_packed_a" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_a")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_a" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_a" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 55:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_packed_b" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 10
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 55:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_16_packed_b" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 10 y1 x0, BG.getField @"foo_16_packed_b" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_packed_b" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_b")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_b" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_b" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 10
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 56:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_packed_c" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 16
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 56:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_16_packed_c" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 16 y1 x0, BG.getField @"foo_16_packed_c" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_packed_c" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_c")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_c" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_c" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 16
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 57:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_packed_d" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 16
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 57:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_16_packed_d" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 16 y1 x0, BG.getField @"foo_16_packed_d" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_packed_d" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_d")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_d" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_d" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 16
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 58:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_packed_e" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 58:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_16_packed_e" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_16_packed_e" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_packed_e" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_e")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_e" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_e" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 59:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_16_packed_f" Foo_16_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 59:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_16_packed_f" Foo_16_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_16_packed_f" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_16_packed_f" (BG.Ptr Foo_16_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_16_packed_f")
+
+instance HasCBitfield.HasCBitfield Foo_16_packed "foo_16_packed_f" where
+
+  type CBitfieldType Foo_16_packed "foo_16_packed_f" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @union foo_32_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 63:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_32_packed = Foo_32_packed
+  { unwrapFoo_32_packed :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 4 1 instance Marshal.StaticSize Foo_32_packed
+
+deriving via BG.SizedByteArray 4 1 instance Marshal.ReadRaw Foo_32_packed
+
+deriving via BG.SizedByteArray 4 1 instance Marshal.WriteRaw Foo_32_packed
+
+deriving via Marshal.EquivStorable Foo_32_packed instance BG.Storable Foo_32_packed
+
+deriving via BG.SizedByteArray 4 1 instance Union.IsUnion Foo_32_packed
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 64:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_32_packed_a" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 64:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CSChar
+         ) => BG.CompatHasField.HasField "foo_32_packed_a" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_32_packed_a" x0)
+
+instance ( ty ~ BG.CSChar
+         ) => BG.HasField "foo_32_packed_a" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_a")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_a" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_a" =
+    BG.CSChar
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 65:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_packed_b" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 12
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 65:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_32_packed_b" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 12 y1 x0, BG.getField @"foo_32_packed_b" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_packed_b" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_b")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_b" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_b" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 12
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 66:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_packed_c" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 14
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 66:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_32_packed_c" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 14 y1 x0, BG.getField @"foo_32_packed_c" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_packed_c" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_c")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_c" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_c" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 14
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 67:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_packed_d" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 10
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 67:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_32_packed_d" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 10 y1 x0, BG.getField @"foo_32_packed_d" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_packed_d" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_d")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_d" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_d" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 10
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 68:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_32_packed_e" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 32
+
+{-| __C declaration:__ @e@
+
+    __defined at:__ @types\/unions\/bitfields.h 68:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_32_packed_e" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 32 y1 x0, BG.getField @"foo_32_packed_e" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_32_packed_e" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_e")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_e" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_e" =
+    BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 32
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 69:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CInt) => BG.HasField "foo_32_packed_f" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 6
+
+{-| __C declaration:__ @f@
+
+    __defined at:__ @types\/unions\/bitfields.h 69:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CInt
+         ) => BG.CompatHasField.HasField "foo_32_packed_f" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 6 y1 x0, BG.getField @"foo_32_packed_f" x0)
+
+instance ( ty ~ BG.CInt
+         ) => BG.HasField "foo_32_packed_f" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_f")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_f" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_f" =
+    BG.CInt
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 6
+
+{-| __C declaration:__ @g@
+
+    __defined at:__ @types\/unions\/bitfields.h 70:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_32_packed_g" Foo_32_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 24
+
+{-| __C declaration:__ @g@
+
+    __defined at:__ @types\/unions\/bitfields.h 70:15@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_32_packed_g" Foo_32_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 24 y1 x0, BG.getField @"foo_32_packed_g" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_32_packed_g" (BG.Ptr Foo_32_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_32_packed_g")
+
+instance HasCBitfield.HasCBitfield Foo_32_packed "foo_32_packed_g" where
+
+  type CBitfieldType Foo_32_packed "foo_32_packed_g" =
+    BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 24
+
+{-| __C declaration:__ @union foo_64_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 74:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_64_packed = Foo_64_packed
+  { unwrapFoo_64_packed :: BG.ByteArray
+  }
+  deriving stock (BG.Generic)
+
+deriving via BG.SizedByteArray 8 1 instance Marshal.StaticSize Foo_64_packed
+
+deriving via BG.SizedByteArray 8 1 instance Marshal.ReadRaw Foo_64_packed
+
+deriving via BG.SizedByteArray 8 1 instance Marshal.WriteRaw Foo_64_packed
+
+deriving via Marshal.EquivStorable Foo_64_packed instance BG.Storable Foo_64_packed
+
+deriving via BG.SizedByteArray 8 1 instance Union.IsUnion Foo_64_packed
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 75:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance (ty ~ BG.CLong) => BG.HasField "foo_64_packed_a" Foo_64_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 24
+
+{-| __C declaration:__ @a@
+
+    __defined at:__ @types\/unions\/bitfields.h 75:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLong
+         ) => BG.CompatHasField.HasField "foo_64_packed_a" Foo_64_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 24 y1 x0, BG.getField @"foo_64_packed_a" x0)
+
+instance ( ty ~ BG.CLong
+         ) => BG.HasField "foo_64_packed_a" (BG.Ptr Foo_64_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_64_packed_a")
+
+instance HasCBitfield.HasCBitfield Foo_64_packed "foo_64_packed_a" where
+
+  type CBitfieldType Foo_64_packed "foo_64_packed_a" =
+    BG.CLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 24
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 76:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_b" Foo_64_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 40
+
+{-| __C declaration:__ @b@
+
+    __defined at:__ @types\/unions\/bitfields.h 76:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_packed_b" Foo_64_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 40 y1 x0, BG.getField @"foo_64_packed_b" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_b" (BG.Ptr Foo_64_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_64_packed_b")
+
+instance HasCBitfield.HasCBitfield Foo_64_packed "foo_64_packed_b" where
+
+  type CBitfieldType Foo_64_packed "foo_64_packed_b" =
+    BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 40
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 77:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_c" Foo_64_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 64
+
+{-| __C declaration:__ @c@
+
+    __defined at:__ @types\/unions\/bitfields.h 77:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_packed_c" Foo_64_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 64 y1 x0, BG.getField @"foo_64_packed_c" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_c" (BG.Ptr Foo_64_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_64_packed_c")
+
+instance HasCBitfield.HasCBitfield Foo_64_packed "foo_64_packed_c" where
+
+  type CBitfieldType Foo_64_packed "foo_64_packed_c" =
+    BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 64
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 78:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_d" Foo_64_packed ty where
+
+  getField = BG.getUnionPayloadBits 0 36
+
+{-| __C declaration:__ @d@
+
+    __defined at:__ @types\/unions\/bitfields.h 78:20@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+instance ( ty ~ BG.CLLong
+         ) => BG.CompatHasField.HasField "foo_64_packed_d" Foo_64_packed ty where
+
+  hasField =
+    \x0 ->
+      (\y1 ->
+         BG.setUnionPayloadBits 0 36 y1 x0, BG.getField @"foo_64_packed_d" x0)
+
+instance ( ty ~ BG.CLLong
+         ) => BG.HasField "foo_64_packed_d" (BG.Ptr Foo_64_packed) (BitfieldPtr.BitfieldPtr ty) where
+
+  getField =
+    HasCBitfield.toPtr (BG.Proxy @"foo_64_packed_d")
+
+instance HasCBitfield.HasCBitfield Foo_64_packed "foo_64_packed_d" where
+
+  type CBitfieldType Foo_64_packed "foo_64_packed_d" =
+    BG.CLLong
+
+  bitfieldOffset# = \_ -> \_ -> 0
+
+  bitfieldWidth# = \_ -> \_ -> 36

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/bindingspec.yaml
@@ -1,0 +1,166 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: types/unions/bitfields.h
+  cname: union foo_8
+  hsname: Foo_8
+- headers: types/unions/bitfields.h
+  cname: union foo_16
+  hsname: Foo_16
+- headers: types/unions/bitfields.h
+  cname: union foo_32
+  hsname: Foo_32
+- headers: types/unions/bitfields.h
+  cname: union foo_64
+  hsname: Foo_64
+- headers: types/unions/bitfields.h
+  cname: union foo_8_packed
+  hsname: Foo_8_packed
+- headers: types/unions/bitfields.h
+  cname: union foo_16_packed
+  hsname: Foo_16_packed
+- headers: types/unions/bitfields.h
+  cname: union foo_32_packed
+  hsname: Foo_32_packed
+- headers: types/unions/bitfields.h
+  cname: union foo_64_packed
+  hsname: Foo_64_packed
+hstypes:
+- hsname: Foo_16
+  representation:
+    newtype:
+      constructor: Foo_16
+      fields:
+      - unwrapFoo_16
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_16_packed
+  representation:
+    newtype:
+      constructor: Foo_16_packed
+      fields:
+      - unwrapFoo_16_packed
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_32
+  representation:
+    newtype:
+      constructor: Foo_32
+      fields:
+      - unwrapFoo_32
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_32_packed
+  representation:
+    newtype:
+      constructor: Foo_32_packed
+      fields:
+      - unwrapFoo_32_packed
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_64
+  representation:
+    newtype:
+      constructor: Foo_64
+      fields:
+      - unwrapFoo_64
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_64_packed
+  representation:
+    newtype:
+      constructor: Foo_64_packed
+      fields:
+      - unwrapFoo_64_packed
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_8
+  representation:
+    newtype:
+      constructor: Foo_8
+      fields:
+      - unwrapFoo_8
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw
+- hsname: Foo_8_packed
+  representation:
+    newtype:
+      constructor: Foo_8_packed
+      fields:
+      - unwrapFoo_8_packed
+  instances:
+  - Generic
+  - HasCBitfield
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsUnion
+  - ReadRaw
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/unions/bitfields/th.txt
@@ -1,0 +1,681 @@
+-- addDependentFile test-artefacts/headers/golden/types/unions/bitfields.h
+{-| __C declaration:__ @union foo_8@
+
+    __defined at:__ @types\/unions\/bitfields.h 4:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_8
+    = Foo_8 {unwrapFoo_8 :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 1 1) instance StaticSize Foo_8
+deriving via (SizedByteArray 1 1) instance ReadRaw Foo_8
+deriving via (SizedByteArray 1 1) instance WriteRaw Foo_8
+deriving via (EquivStorable Foo_8) instance Storable Foo_8
+deriving via (SizedByteArray 1 1) instance IsUnion Foo_8
+instance (~) ty CSChar => HasField "foo_8_a" Foo_8 ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_a" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_a" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_a")
+instance HasCBitfield Foo_8 "foo_8_a"
+    where type CBitfieldType Foo_8 "foo_8_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_b" Foo_8 ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_b" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_b" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_b" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_b")
+instance HasCBitfield Foo_8 "foo_8_b"
+    where type CBitfieldType Foo_8 "foo_8_b" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_c" Foo_8 ty
+    where getField = getUnionPayloadBits 0 2
+instance (~) ty CSChar => HasField "foo_8_c" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 2 y_1 x_0,
+                              getField @"foo_8_c" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_c" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_c")
+instance HasCBitfield Foo_8 "foo_8_c"
+    where type CBitfieldType Foo_8 "foo_8_c" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 2
+instance (~) ty CSChar => HasField "foo_8_d" Foo_8 ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_d" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_d" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_d" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_d")
+instance HasCBitfield Foo_8 "foo_8_d"
+    where type CBitfieldType Foo_8 "foo_8_d" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_e" Foo_8 ty
+    where getField = getUnionPayloadBits 0 8
+instance (~) ty CSChar => HasField "foo_8_e" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 8 y_1 x_0,
+                              getField @"foo_8_e" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_e" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_e")
+instance HasCBitfield Foo_8 "foo_8_e"
+    where type CBitfieldType Foo_8 "foo_8_e" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 8
+instance (~) ty CSChar => HasField "foo_8_f" Foo_8 ty
+    where getField = getUnionPayloadBits 0 5
+instance (~) ty CSChar => HasField "foo_8_f" Foo_8 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 5 y_1 x_0,
+                              getField @"foo_8_f" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_f" (Ptr Foo_8) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_f")
+instance HasCBitfield Foo_8 "foo_8_f"
+    where type CBitfieldType Foo_8 "foo_8_f" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 5
+{-| __C declaration:__ @union foo_16@
+
+    __defined at:__ @types\/unions\/bitfields.h 14:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_16
+    = Foo_16 {unwrapFoo_16 :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 4) instance StaticSize Foo_16
+deriving via (SizedByteArray 4 4) instance ReadRaw Foo_16
+deriving via (SizedByteArray 4 4) instance WriteRaw Foo_16
+deriving via (EquivStorable Foo_16) instance Storable Foo_16
+deriving via (SizedByteArray 4 4) instance IsUnion Foo_16
+instance (~) ty CSChar => HasField "foo_16_a" Foo_16 ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CSChar => HasField "foo_16_a" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_16_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_16_a" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_a")
+instance HasCBitfield Foo_16 "foo_16_a"
+    where type CBitfieldType Foo_16 "foo_16_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CInt => HasField "foo_16_b" Foo_16 ty
+    where getField = getUnionPayloadBits 0 10
+instance (~) ty CInt => HasField "foo_16_b" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 10 y_1 x_0,
+                              getField @"foo_16_b" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_b" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_b")
+instance HasCBitfield Foo_16 "foo_16_b"
+    where type CBitfieldType Foo_16 "foo_16_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 10
+instance (~) ty CInt => HasField "foo_16_c" Foo_16 ty
+    where getField = getUnionPayloadBits 0 16
+instance (~) ty CInt => HasField "foo_16_c" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 16 y_1 x_0,
+                              getField @"foo_16_c" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_c" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_c")
+instance HasCBitfield Foo_16 "foo_16_c"
+    where type CBitfieldType Foo_16 "foo_16_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 16
+instance (~) ty CInt => HasField "foo_16_d" Foo_16 ty
+    where getField = getUnionPayloadBits 0 16
+instance (~) ty CInt => HasField "foo_16_d" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 16 y_1 x_0,
+                              getField @"foo_16_d" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_d" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_d")
+instance HasCBitfield Foo_16 "foo_16_d"
+    where type CBitfieldType Foo_16 "foo_16_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 16
+instance (~) ty CInt => HasField "foo_16_e" Foo_16 ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_16_e" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_16_e" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_e" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_e")
+instance HasCBitfield Foo_16 "foo_16_e"
+    where type CBitfieldType Foo_16 "foo_16_e" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+instance (~) ty CInt => HasField "foo_16_f" Foo_16 ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_16_f" Foo_16 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_16_f" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_f" (Ptr Foo_16) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_f")
+instance HasCBitfield Foo_16 "foo_16_f"
+    where type CBitfieldType Foo_16 "foo_16_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+{-| __C declaration:__ @union foo_32@
+
+    __defined at:__ @types\/unions\/bitfields.h 24:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_32
+    = Foo_32 {unwrapFoo_32 :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize Foo_32
+deriving via (SizedByteArray 8 8) instance ReadRaw Foo_32
+deriving via (SizedByteArray 8 8) instance WriteRaw Foo_32
+deriving via (EquivStorable Foo_32) instance Storable Foo_32
+deriving via (SizedByteArray 8 8) instance IsUnion Foo_32
+instance (~) ty CSChar => HasField "foo_32_a" Foo_32 ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CSChar => HasField "foo_32_a" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_32_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_32_a" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_a")
+instance HasCBitfield Foo_32 "foo_32_a"
+    where type CBitfieldType Foo_32 "foo_32_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CInt => HasField "foo_32_b" Foo_32 ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_32_b" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_32_b" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_b" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_b")
+instance HasCBitfield Foo_32 "foo_32_b"
+    where type CBitfieldType Foo_32 "foo_32_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+instance (~) ty CInt => HasField "foo_32_c" Foo_32 ty
+    where getField = getUnionPayloadBits 0 14
+instance (~) ty CInt => HasField "foo_32_c" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 14 y_1 x_0,
+                              getField @"foo_32_c" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_c" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_c")
+instance HasCBitfield Foo_32 "foo_32_c"
+    where type CBitfieldType Foo_32 "foo_32_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 14
+instance (~) ty CInt => HasField "foo_32_d" Foo_32 ty
+    where getField = getUnionPayloadBits 0 10
+instance (~) ty CInt => HasField "foo_32_d" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 10 y_1 x_0,
+                              getField @"foo_32_d" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_d" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_d")
+instance HasCBitfield Foo_32 "foo_32_d"
+    where type CBitfieldType Foo_32 "foo_32_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 10
+instance (~) ty CLong => HasField "foo_32_e" Foo_32 ty
+    where getField = getUnionPayloadBits 0 32
+instance (~) ty CLong => HasField "foo_32_e" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 32 y_1 x_0,
+                              getField @"foo_32_e" x_0)
+instance (~) ty CLong =>
+         HasField "foo_32_e" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_e")
+instance HasCBitfield Foo_32 "foo_32_e"
+    where type CBitfieldType Foo_32 "foo_32_e" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 32
+instance (~) ty CInt => HasField "foo_32_f" Foo_32 ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CInt => HasField "foo_32_f" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_32_f" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_f" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_f")
+instance HasCBitfield Foo_32 "foo_32_f"
+    where type CBitfieldType Foo_32 "foo_32_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CLong => HasField "foo_32_g" Foo_32 ty
+    where getField = getUnionPayloadBits 0 24
+instance (~) ty CLong => HasField "foo_32_g" Foo_32 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 24 y_1 x_0,
+                              getField @"foo_32_g" x_0)
+instance (~) ty CLong =>
+         HasField "foo_32_g" (Ptr Foo_32) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_g")
+instance HasCBitfield Foo_32 "foo_32_g"
+    where type CBitfieldType Foo_32 "foo_32_g" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
+{-| __C declaration:__ @union foo_64@
+
+    __defined at:__ @types\/unions\/bitfields.h 35:7@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_64
+    = Foo_64 {unwrapFoo_64 :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 8 8) instance StaticSize Foo_64
+deriving via (SizedByteArray 8 8) instance ReadRaw Foo_64
+deriving via (SizedByteArray 8 8) instance WriteRaw Foo_64
+deriving via (EquivStorable Foo_64) instance Storable Foo_64
+deriving via (SizedByteArray 8 8) instance IsUnion Foo_64
+instance (~) ty CLong => HasField "foo_64_a" Foo_64 ty
+    where getField = getUnionPayloadBits 0 24
+instance (~) ty CLong => HasField "foo_64_a" Foo_64 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 24 y_1 x_0,
+                              getField @"foo_64_a" x_0)
+instance (~) ty CLong =>
+         HasField "foo_64_a" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_a")
+instance HasCBitfield Foo_64 "foo_64_a"
+    where type CBitfieldType Foo_64 "foo_64_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
+instance (~) ty CLLong => HasField "foo_64_b" Foo_64 ty
+    where getField = getUnionPayloadBits 0 40
+instance (~) ty CLLong => HasField "foo_64_b" Foo_64 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 40 y_1 x_0,
+                              getField @"foo_64_b" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_b" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_b")
+instance HasCBitfield Foo_64 "foo_64_b"
+    where type CBitfieldType Foo_64 "foo_64_b" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 40
+instance (~) ty CLLong => HasField "foo_64_c" Foo_64 ty
+    where getField = getUnionPayloadBits 0 64
+instance (~) ty CLLong => HasField "foo_64_c" Foo_64 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 64 y_1 x_0,
+                              getField @"foo_64_c" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_c" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_c")
+instance HasCBitfield Foo_64 "foo_64_c"
+    where type CBitfieldType Foo_64 "foo_64_c" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 64
+instance (~) ty CLLong => HasField "foo_64_d" Foo_64 ty
+    where getField = getUnionPayloadBits 0 36
+instance (~) ty CLLong => HasField "foo_64_d" Foo_64 ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 36 y_1 x_0,
+                              getField @"foo_64_d" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_d" (Ptr Foo_64) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_d")
+instance HasCBitfield Foo_64 "foo_64_d"
+    where type CBitfieldType Foo_64 "foo_64_d" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 36
+{-| __C declaration:__ @union foo_8_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 43:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_8_packed
+    = Foo_8_packed {unwrapFoo_8_packed :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 1 1) instance StaticSize Foo_8_packed
+deriving via (SizedByteArray 1 1) instance ReadRaw Foo_8_packed
+deriving via (SizedByteArray 1 1) instance WriteRaw Foo_8_packed
+deriving via (EquivStorable Foo_8_packed) instance Storable Foo_8_packed
+deriving via (SizedByteArray 1 1) instance IsUnion Foo_8_packed
+instance (~) ty CSChar => HasField "foo_8_packed_a" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_packed_a" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_packed_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_a" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_a")
+instance HasCBitfield Foo_8_packed "foo_8_packed_a"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_packed_b" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_packed_b" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_packed_b" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_b" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_b")
+instance HasCBitfield Foo_8_packed "foo_8_packed_b"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_b" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_packed_c" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 2
+instance (~) ty CSChar => HasField "foo_8_packed_c" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 2 y_1 x_0,
+                              getField @"foo_8_packed_c" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_c" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_c")
+instance HasCBitfield Foo_8_packed "foo_8_packed_c"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_c" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 2
+instance (~) ty CSChar => HasField "foo_8_packed_d" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 3
+instance (~) ty CSChar => HasField "foo_8_packed_d" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 3 y_1 x_0,
+                              getField @"foo_8_packed_d" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_d" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_d")
+instance HasCBitfield Foo_8_packed "foo_8_packed_d"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_d" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 3
+instance (~) ty CSChar => HasField "foo_8_packed_e" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 8
+instance (~) ty CSChar => HasField "foo_8_packed_e" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 8 y_1 x_0,
+                              getField @"foo_8_packed_e" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_e" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_e")
+instance HasCBitfield Foo_8_packed "foo_8_packed_e"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_e" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 8
+instance (~) ty CSChar => HasField "foo_8_packed_f" Foo_8_packed ty
+    where getField = getUnionPayloadBits 0 5
+instance (~) ty CSChar => HasField "foo_8_packed_f" Foo_8_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 5 y_1 x_0,
+                              getField @"foo_8_packed_f" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_8_packed_f" (Ptr Foo_8_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_8_packed_f")
+instance HasCBitfield Foo_8_packed "foo_8_packed_f"
+    where type CBitfieldType Foo_8_packed "foo_8_packed_f" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 5
+{-| __C declaration:__ @union foo_16_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 53:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_16_packed
+    = Foo_16_packed {unwrapFoo_16_packed :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 2 1) instance StaticSize Foo_16_packed
+deriving via (SizedByteArray 2 1) instance ReadRaw Foo_16_packed
+deriving via (SizedByteArray 2 1) instance WriteRaw Foo_16_packed
+deriving via (EquivStorable Foo_16_packed) instance Storable Foo_16_packed
+deriving via (SizedByteArray 2 1) instance IsUnion Foo_16_packed
+instance (~) ty CSChar =>
+         HasField "foo_16_packed_a" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CSChar =>
+         HasField "foo_16_packed_a" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_16_packed_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_16_packed_a" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_a")
+instance HasCBitfield Foo_16_packed "foo_16_packed_a"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CInt => HasField "foo_16_packed_b" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 10
+instance (~) ty CInt => HasField "foo_16_packed_b" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 10 y_1 x_0,
+                              getField @"foo_16_packed_b" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_packed_b" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_b")
+instance HasCBitfield Foo_16_packed "foo_16_packed_b"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 10
+instance (~) ty CInt => HasField "foo_16_packed_c" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 16
+instance (~) ty CInt => HasField "foo_16_packed_c" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 16 y_1 x_0,
+                              getField @"foo_16_packed_c" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_packed_c" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_c")
+instance HasCBitfield Foo_16_packed "foo_16_packed_c"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 16
+instance (~) ty CInt => HasField "foo_16_packed_d" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 16
+instance (~) ty CInt => HasField "foo_16_packed_d" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 16 y_1 x_0,
+                              getField @"foo_16_packed_d" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_packed_d" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_d")
+instance HasCBitfield Foo_16_packed "foo_16_packed_d"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 16
+instance (~) ty CInt => HasField "foo_16_packed_e" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_16_packed_e" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_16_packed_e" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_packed_e" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_e")
+instance HasCBitfield Foo_16_packed "foo_16_packed_e"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_e" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+instance (~) ty CInt => HasField "foo_16_packed_f" Foo_16_packed ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_16_packed_f" Foo_16_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_16_packed_f" x_0)
+instance (~) ty CInt =>
+         HasField "foo_16_packed_f" (Ptr Foo_16_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_16_packed_f")
+instance HasCBitfield Foo_16_packed "foo_16_packed_f"
+    where type CBitfieldType Foo_16_packed "foo_16_packed_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+{-| __C declaration:__ @union foo_32_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 63:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_32_packed
+    = Foo_32_packed {unwrapFoo_32_packed :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 4 1) instance StaticSize Foo_32_packed
+deriving via (SizedByteArray 4 1) instance ReadRaw Foo_32_packed
+deriving via (SizedByteArray 4 1) instance WriteRaw Foo_32_packed
+deriving via (EquivStorable Foo_32_packed) instance Storable Foo_32_packed
+deriving via (SizedByteArray 4 1) instance IsUnion Foo_32_packed
+instance (~) ty CSChar =>
+         HasField "foo_32_packed_a" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CSChar =>
+         HasField "foo_32_packed_a" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_32_packed_a" x_0)
+instance (~) ty CSChar =>
+         HasField "foo_32_packed_a" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_a")
+instance HasCBitfield Foo_32_packed "foo_32_packed_a"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_a" = CSChar
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CInt => HasField "foo_32_packed_b" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 12
+instance (~) ty CInt => HasField "foo_32_packed_b" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 12 y_1 x_0,
+                              getField @"foo_32_packed_b" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_packed_b" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_b")
+instance HasCBitfield Foo_32_packed "foo_32_packed_b"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_b" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 12
+instance (~) ty CInt => HasField "foo_32_packed_c" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 14
+instance (~) ty CInt => HasField "foo_32_packed_c" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 14 y_1 x_0,
+                              getField @"foo_32_packed_c" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_packed_c" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_c")
+instance HasCBitfield Foo_32_packed "foo_32_packed_c"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_c" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 14
+instance (~) ty CInt => HasField "foo_32_packed_d" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 10
+instance (~) ty CInt => HasField "foo_32_packed_d" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 10 y_1 x_0,
+                              getField @"foo_32_packed_d" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_packed_d" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_d")
+instance HasCBitfield Foo_32_packed "foo_32_packed_d"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_d" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 10
+instance (~) ty CLong =>
+         HasField "foo_32_packed_e" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 32
+instance (~) ty CLong =>
+         HasField "foo_32_packed_e" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 32 y_1 x_0,
+                              getField @"foo_32_packed_e" x_0)
+instance (~) ty CLong =>
+         HasField "foo_32_packed_e" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_e")
+instance HasCBitfield Foo_32_packed "foo_32_packed_e"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_e" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 32
+instance (~) ty CInt => HasField "foo_32_packed_f" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 6
+instance (~) ty CInt => HasField "foo_32_packed_f" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 6 y_1 x_0,
+                              getField @"foo_32_packed_f" x_0)
+instance (~) ty CInt =>
+         HasField "foo_32_packed_f" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_f")
+instance HasCBitfield Foo_32_packed "foo_32_packed_f"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_f" = CInt
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 6
+instance (~) ty CLong =>
+         HasField "foo_32_packed_g" Foo_32_packed ty
+    where getField = getUnionPayloadBits 0 24
+instance (~) ty CLong =>
+         HasField "foo_32_packed_g" Foo_32_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 24 y_1 x_0,
+                              getField @"foo_32_packed_g" x_0)
+instance (~) ty CLong =>
+         HasField "foo_32_packed_g" (Ptr Foo_32_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_32_packed_g")
+instance HasCBitfield Foo_32_packed "foo_32_packed_g"
+    where type CBitfieldType Foo_32_packed "foo_32_packed_g" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
+{-| __C declaration:__ @union foo_64_packed@
+
+    __defined at:__ @types\/unions\/bitfields.h 74:31@
+
+    __exported by:__ @types\/unions\/bitfields.h@
+-}
+newtype Foo_64_packed
+    = Foo_64_packed {unwrapFoo_64_packed :: ByteArray}
+    deriving stock Generic
+deriving via (SizedByteArray 8 1) instance StaticSize Foo_64_packed
+deriving via (SizedByteArray 8 1) instance ReadRaw Foo_64_packed
+deriving via (SizedByteArray 8 1) instance WriteRaw Foo_64_packed
+deriving via (EquivStorable Foo_64_packed) instance Storable Foo_64_packed
+deriving via (SizedByteArray 8 1) instance IsUnion Foo_64_packed
+instance (~) ty CLong =>
+         HasField "foo_64_packed_a" Foo_64_packed ty
+    where getField = getUnionPayloadBits 0 24
+instance (~) ty CLong =>
+         HasField "foo_64_packed_a" Foo_64_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 24 y_1 x_0,
+                              getField @"foo_64_packed_a" x_0)
+instance (~) ty CLong =>
+         HasField "foo_64_packed_a" (Ptr Foo_64_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_packed_a")
+instance HasCBitfield Foo_64_packed "foo_64_packed_a"
+    where type CBitfieldType Foo_64_packed "foo_64_packed_a" = CLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 24
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_b" Foo_64_packed ty
+    where getField = getUnionPayloadBits 0 40
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_b" Foo_64_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 40 y_1 x_0,
+                              getField @"foo_64_packed_b" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_b" (Ptr Foo_64_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_packed_b")
+instance HasCBitfield Foo_64_packed "foo_64_packed_b"
+    where type CBitfieldType Foo_64_packed "foo_64_packed_b" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 40
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_c" Foo_64_packed ty
+    where getField = getUnionPayloadBits 0 64
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_c" Foo_64_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 64 y_1 x_0,
+                              getField @"foo_64_packed_c" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_c" (Ptr Foo_64_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_packed_c")
+instance HasCBitfield Foo_64_packed "foo_64_packed_c"
+    where type CBitfieldType Foo_64_packed "foo_64_packed_c" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 64
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_d" Foo_64_packed ty
+    where getField = getUnionPayloadBits 0 36
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_d" Foo_64_packed ty
+    where hasField = \x_0 -> (\y_1 -> setUnionPayloadBits 0 36 y_1 x_0,
+                              getField @"foo_64_packed_d" x_0)
+instance (~) ty CLLong =>
+         HasField "foo_64_packed_d" (Ptr Foo_64_packed) (BitfieldPtr ty)
+    where getField = toPtr (Proxy @"foo_64_packed_d")
+instance HasCBitfield Foo_64_packed "foo_64_packed_d"
+    where type CBitfieldType Foo_64_packed "foo_64_packed_d" = CLLong
+          bitfieldOffset# = \_ -> \_ -> 0
+          bitfieldWidth# = \_ -> \_ -> 36

--- a/hs-bindgen/test-artefacts/headers/golden/types/unions/bitfields.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/unions/bitfields.h
@@ -1,0 +1,80 @@
+#pragma once
+
+/* not packed, <=8-bit fields */
+union foo_8 {
+  signed char a : 3;
+  signed char b : 3;
+  signed char c : 2;
+  signed char d : 3;
+  signed char e : 8;
+  signed char f : 5;
+};
+
+/* not packed, <=16-bit fields */
+union foo_16 {
+  signed char a :  6;
+  signed int  b : 10;
+  signed int  c : 16;
+  signed int  d : 16;
+  signed int  e : 12;
+  signed int  f : 12;
+};
+
+/* not packed, <=32-bit fields */
+union foo_32 {
+  signed char a :  6;
+  signed int  b : 12;
+  signed int  c : 14;
+  signed int  d : 10;
+  signed long e : 32;
+  signed int  f :  6;
+  signed long g : 24;
+};
+
+/* not packed, <=64-bit fields */
+union foo_64 {
+  signed long      a : 24;
+  signed long long b : 40;
+  signed long long c : 64;
+  signed long long d : 36;
+};
+
+/* packed, <=8-bit fields */
+union __attribute__((packed)) foo_8_packed {
+  signed char a : 3;
+  signed char b : 3;
+  signed char c : 2;
+  signed char d : 3;
+  signed char e : 8;
+  signed char f : 5;
+};
+
+/* packed, <=16-bit fields */
+union __attribute__((packed)) foo_16_packed {
+  signed char a :  6;
+  signed int  b : 10;
+  signed int  c : 16;
+  signed int  d : 16;
+  signed int  e : 12;
+  signed int  f : 12;
+};
+
+/* packed, <=32-bit fields */
+union __attribute__((packed)) foo_32_packed {
+  signed char a :  6;
+  signed int  b : 12;
+  signed int  c : 14;
+  signed int  d : 10;
+  signed long e : 32;
+  signed int  f :  6;
+  signed long g : 24;
+};
+
+/* packed, <=64-bit fields */
+union __attribute__((packed)) foo_64_packed {
+  signed long      a : 24;
+  signed long long b : 40;
+  signed long long c : 64;
+  signed long long d : 36;
+};
+

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
@@ -62,6 +62,7 @@ testCases = [
     , defaultTest "types/typedefs/auxiliary/function-pointer/pointer"
     , defaultTest "types/typedefs/auxiliary/function-pointer/qual"
     , defaultTest "types/typedefs/typedef_vs_macro"
+    , defaultTest "types/unions/bitfields"
     , defaultTest "types/unions/nested_unions"
     , defaultTest "types/unions/unions"
       -- Bespoke tests

--- a/manual/c/structs.h
+++ b/manual/c/structs.h
@@ -19,7 +19,7 @@ void mk_triple(int a, int b, int c, triple *triple);
 // See structs/nesting.h
 
 /* -------------------------------------------------------------------------- */
-/* Bitfields. */
+/* Bit-fields. */
 
 struct aula_setup {
   char window_id;

--- a/manual/c/unions.h
+++ b/manual/c/unions.h
@@ -30,3 +30,32 @@ struct person {
 /* Nesting */
 
 // See unions/nesting.h
+
+/* -------------------------------------------------------------------------- */
+/* Bit-fields. */
+
+union colour {
+  // RGB (Red, Green, Blue)
+  struct {
+    unsigned R : 10;
+    unsigned G : 10;
+    unsigned B : 10;
+  };
+
+  // CYMK (Cyan, Yellow, Magenta, Black)
+  struct {
+    unsigned C : 8;
+    unsigned Y : 8;
+    unsigned M : 8;
+    unsigned K : 8;
+  };
+};
+
+union unforced_width {
+  char x;
+};
+
+union forced_width {
+  long long : 64;
+  char x;
+};

--- a/manual/low-level/translation/structs.md
+++ b/manual/low-level/translation/structs.md
@@ -58,10 +58,10 @@ Instances of `IsStruct` are generated automatically for generated struct types.
 
 See the [Structs/Nesting][manual:structs/nesting] manual section.
 
-## Bitfields
+## Bit-fields
 
-[_Bitfields_][wikipedia:bit-field] are structures or unions with elements of
-individual size. For example,
+[_Bit-fields_][wikipedia:bit-field] are fields of structs (or unions) with a
+field width defined in number of bits. For example,
 
 ```c
 struct aula_setup {
@@ -116,7 +116,7 @@ are used, provides some helper functions. For example,
 peek :: (HasCBitfield a field, ...) => Proxy field -> Ptr a -> IO (CBitfieldType a field)
 ```
 
-from `HsBindgen.Runtime.HasCBitfield` obtains the bitfield member `field`
+from `HsBindgen.Runtime.HasCBitfield` obtains the bit-field member `field`
 directly from its bit offset and width within `a`, without touching
 neighbouring fields.
 

--- a/manual/low-level/translation/unions.md
+++ b/manual/low-level/translation/unions.md
@@ -147,6 +147,63 @@ for `Person` either.
 
 See the [Unions/Nesting][manual:unions/nesting] manual section.
 
+## Bit-fields
+
+[_Bit-fields_][wikipedia:bit-field] are fields of unions (or stucts) with a
+field width defined in number of bits. See the [Bit-fields section of the
+Structs manual page][manual:structs-bit-fields] for an example of how bit-fields
+are supported for structs. The support for bit-fields in unions is largely the
+same as for structs, though there is a caveat. In structs, adjacent bit-field
+members may be packed to share and straddle the individual bytes. In unions,
+adjacent bit-field members share the same memory area, and are therefore not
+packed. This makes bit-fields in unions less useful than in structs. Still,
+there are a few cases where bit-fields in unions may still be useful.
+
+### Example 1: anonymous struct
+
+An anonymous struct's bit-fields can be accessed from the top-level union *as
+if* they were bit-fields of the union themselves. In the example below, we
+represent colours in two alternative formats: RGB and CYMK. If the two anonymous
+structs get nice packing behaviour, then the union size should stay within 32
+bits. The bit-fields can also be used from the top-level union.
+
+```c
+union colour {
+  // RGB (Red, Green, Blue)
+  struct {
+    unsigned R : 10;
+    unsigned G : 10;
+    unsigned B : 10;
+  };
+
+  // CYMK (Cyan, Yellow, Magenta, Black)
+  struct {
+    unsigned C : 8;
+    unsigned Y : 8;
+    unsigned M : 8;
+    unsigned K : 8;
+  };
+};
+```
+
+### Example 2: forced union width
+
+Bit-fields in unions can be used to force the union to be of a certain width. In
+the example below, the first union has a width of 1 bytes, while the second
+union has a width of 8 bytes, and this is also visible in the generated
+bindings.
+
+```c
+union unforced_width {
+  char x;
+};
+
+union forced_width {
+  long long : 64;
+  char x;
+};
+```
+
 
 
 <!-- footnotes -->
@@ -158,4 +215,5 @@ See the [Unions/Nesting][manual:unions/nesting] manual section.
 
 [hackage:base:ByteArray]: https://hackage.haskell.org/package/base/docs/Data-Array-Byte.html#t:ByteArray
 [manual:generated-names]: generated-names.md
+[manual:structs-bit-fields]: structs.md#bit-fields
 [manual:unions/nesting]: unions/nesting.md

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -410,7 +410,7 @@ Since the C code is compiled by Cabal, there is no need to update
 > compiler (typically GCC on Linux), while `hs-bindgen` uses `libclang` to
 > parse the headers and derive type layouts.  For simple types this is
 > unlikely to cause problems, but GCC and Clang can disagree on memory layout
-> for more exotic constructs (bitfields, packed structs, platform-specific
+> for more exotic constructs (bit-fields, packed structs, platform-specific
 > alignment).  See [Clang vs. GCC][manual:installation-clang-vs-gcc] for
 > details.
 


### PR DESCRIPTION
Resolves #1253

Now that we generate bindings for indirect fields, it's probably not too uncommon that someone would try to generate bindings for an *indirect* bit-field in a union. This PR adds support for bit-fields in unions, which turned out to be not too much work!

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.