### PR TITLE
Rename DeclInfo.seqNr to sourceOrderIndex

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -645,13 +645,13 @@ typedefFunTypeIndirectionDecs origInfo (args, res, reconstruct) names origSpec =
 
     auxInfo :: C.DeclInfo Final
     auxInfo = C.DeclInfo {
-          loc          = origInfo.loc
-        , id           = auxDeclIdPair
-        , seqNr        = origInfo.seqNr
-        , headerInfo   = origInfo.headerInfo
-        , availability = C.Available
-        , comment      = Just auxComment
-        , enclosing    = []
+          loc              = origInfo.loc
+        , id               = auxDeclIdPair
+        , sourceOrderIndex = origInfo.sourceOrderIndex
+        , headerInfo       = origInfo.headerInfo
+        , availability     = C.Available
+        , comment          = Just auxComment
+        , enclosing        = []
         }
 
     auxComment :: C.Comment Final

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AssignAnonIds.hs
@@ -125,13 +125,13 @@ updateDeclInfo ::
 updateDeclInfo declId' info = do
     enclosing' <- mapM updateEnclosing info.enclosing
     pure C.DeclInfo{
-          loc          = info.loc
-        , id           = declId'
-        , seqNr        = info.seqNr
-        , headerInfo   = info.headerInfo
-        , availability = info.availability
-        , comment      = ()
-        , enclosing    = enclosing'
+          loc              = info.loc
+        , id               = declId'
+        , sourceOrderIndex = info.sourceOrderIndex
+        , headerInfo       = info.headerInfo
+        , availability     = info.availability
+        , comment          = ()
+        , enclosing        = enclosing'
         }
   where
     updateEnclosing ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
@@ -87,16 +87,16 @@ resolveDeclInfo nsProxy info = do
     comment'   <- traverse (resolve info) info.comment
     enclosing' <- mapM resolveEnclosingRef info.enclosing
     pure C.DeclInfo{
-        loc          = info.loc
-      , id           = DeclIdPair{
+        loc              = info.loc
+      , id               = DeclIdPair{
             cName  = info.id
           , hsName = Hs.demoteNs hsName
           }
-      , seqNr        = info.seqNr
-      , headerInfo   = info.headerInfo
-      , availability = info.availability
-      , comment      = comment'
-      , enclosing    = enclosing'
+      , sourceOrderIndex = info.sourceOrderIndex
+      , headerInfo       = info.headerInfo
+      , availability     = info.availability
+      , comment          = comment'
+      , enclosing        = enclosing'
       }
 
 resolveFieldInfo ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse.hs
@@ -38,35 +38,62 @@ parseDecls macroLang parseEnv = do
       let resultsOriginalOrder :: [ParseResult l Parse]
           resultsOriginalOrder = concatMap snd resultsWithLocs
       macroDefinitions <- ParseDecl.getMacroDefinitions
-      -- If the version of Clang is >= 20.1, we can obtain sequence order by
-      -- sorting declarations by source position.
+      -- 'resultsOriginalOrder' is in sequence order (the order in which
+      -- libclang visits the declarations). We additionally record the source
+      -- order of each declaration in its 'sourceOrderIndex', obtained by
+      -- sorting the declarations by source position.
       --
-      -- However, for older versions of Clang, the required API function is
-      -- unavailable. Hence, we refrain from sorting declarations, and only
-      -- populate the sequence order into 'DeclInfo'.
+      -- Comparing source positions across the translation unit requires
+      -- 'clang_isBeforeInTranslationUnit', available only with Clang >= 20.1.
+      -- On older versions we leave 'sourceOrderIndex' as 'Nothing' and return
+      -- the declarations in sequence order, unchanged.
       (,macroDefinitions) <$> case clang_isBeforeInTranslationUnit of
         Just isBeforeInUnit -> do
           let isBefore (a, _) (b, _) = isBeforeInUnit a b
-          resultsSequenceOrder :: [ParseResult l Parse] <-
+          resultsSourceOrder :: [ParseResult l Parse] <-
             liftIO $ concatMap snd <$> sortByM isBefore resultsWithLocs
           let -- The map is keyed on @('Id' 'Parse', 'SingleLoc')@ rather than
               -- just @'Id' 'Parse'@ to handle forward declarations at different
               -- locations with the same name.
-              seqNrMap :: Map (Id Parse, SingleLoc) Natural
-              seqNrMap = Map.fromList
+              sourceOrderMap :: Map (Id Parse, SingleLoc) Natural
+              sourceOrderMap = Map.fromList
                 [ ((r.id, r.loc), i)
-                | (i, r) <- zip [0..] resultsSequenceOrder
+                | (i, r) <- zip [0..] resultsSourceOrder
                 ]
-          ParseDecl.traceImmediateGlobal ParseSeqNrPopulated
-          -- We only add sequence numbers to successful parses here. We /could/
-          -- also populate the sequence numbers to non-successful parses.
-          pure $ map (setSeqNr seqNrMap) resultsOriginalOrder
+          ParseDecl.traceImmediateGlobal ParseSourceOrderPopulated
+          -- We only add source-order indices to successful parses here. We
+          -- /could/ also populate them for non-successful parses.
+          pure $ map (setSourceOrderIndex sourceOrderMap) resultsOriginalOrder
         Nothing -> do
-          ParseDecl.traceImmediateGlobal ParseSeqNrUnavailable
+          ParseDecl.traceImmediateGlobal ParseSourceOrderUnavailable
           pure resultsOriginalOrder
 
 {-------------------------------------------------------------------------------
-  Sequence order
+  Orderings
+
+  We distinguish a few orderings of declarations (see issue #1580). These
+  definitions live here for now; they should eventually move to wherever the
+  orderings are defined and used centrally.
+
+  * Sequence order: the order in which libclang presents the declarations to
+    our parser (the order in which the cursor visits them). libclang visits
+    macros first and the remaining declarations in source order, so sequence
+    order is /not/ source order. This is the order of 'resultsOriginalOrder',
+    and the order in which 'parseDecls' returns its results.
+
+  * Source order: roughly, how the declarations appear in the C source. We
+    record it per declaration in 'DeclInfo.sourceOrderIndex', computed above by
+    sorting on source position via 'clang_isBeforeInTranslationUnit' (accurate,
+    but requires Clang >= 20.1). Note that @annSortKey@ (in
+    "HsBindgen.Frontend.Analysis.DeclUseGraph.Construction") computes a
+    /best-effort/ source order without that API, used only as a tiebreak when
+    ordering the output; it can be inaccurate, e.g. when a header includes
+    another header part-way through its own declarations.
+
+  * Dependency order: the order according to the use-decl graph; if @A@ has a
+    by-value use of @B@ then @B@ comes before @A@. This is the order the rest of
+    the frontend works in (established by @toDecls@ in
+    "HsBindgen.Frontend.Analysis.DeclUseGraph.Query").
 -------------------------------------------------------------------------------}
 
 -- | Stable merge sort using a monadic strict-less-than predicate.
@@ -97,13 +124,13 @@ sortByM isBefore = go
   Internal helpers
 -------------------------------------------------------------------------------}
 
--- | Populate the sequence number in the 'DeclInfo' of a successful
+-- | Populate the source-order index in the 'DeclInfo' of a successful
 --   'ParseResult'
-setSeqNr ::
+setSourceOrderIndex ::
      Map (Id Parse, SingleLoc) Natural
   -> ParseResult l Parse
   -> ParseResult l Parse
-setSeqNr seqNrMap result =
+setSourceOrderIndex sourceOrderMap result =
     result
-      &  #classification % #_ParseResultSuccess % #decl % #info % #seqNr
-      .~ Map.lookup (result.id, result.loc) seqNrMap
+      &  #classification % #_ParseResultSuccess % #decl % #info % #sourceOrderIndex
+      .~ Map.lookup (result.id, result.loc) sourceOrderMap

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -934,16 +934,16 @@ withDeclInfo enclosing ctx k = \curr -> do
       withAvailability ctx declId declLoc $ \availability curr' -> do
         let info :: C.DeclInfo Parse
             info = C.DeclInfo{
-                  loc          = declLoc
-                , id           = declId
-                  -- We initialize the sequence number to 'Nothing', and
+                  loc              = declLoc
+                , id               = declId
+                  -- We initialize the source-order index to 'Nothing', and
                   -- populate it when consolidating macros with non-macros in
                   -- "HsBindgen.Frontend.Pass.Parse".
-                , seqNr        = Nothing
-                , headerInfo   = headerInfo
-                , availability = availability
-                , comment      = ()
-                , enclosing    = enclosing
+                , sourceOrderIndex = Nothing
+                , headerInfo       = headerInfo
+                , availability     = availability
+                , comment          = ()
+                , enclosing        = enclosing
                 }
         k info curr') curr
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -48,17 +48,18 @@ data ImmediateParseMsg =
     -- | We failed to parse a declaration that is required for scoping.
   | ParseOfDeclarationRequiredForScopingFailed
 
-    -- | Sequence numbers were populated, using 'clang_isBeforeInTranslationUnit'
+    -- | Source-order indices were populated, using
+    -- 'clang_isBeforeInTranslationUnit'
     --
-    -- Sequence numbers record the order in which declarations appear in the
-    -- translation unit.  Populating them requires Clang >= 20.1.
-  | ParseSeqNrPopulated
+    -- Source-order indices record the order in which declarations appear in the
+    -- C source.  Populating them requires Clang >= 20.1.
+  | ParseSourceOrderPopulated
 
-    -- | Sequence numbers could not be populated
+    -- | Source-order indices could not be populated
     --
     -- 'clang_isBeforeInTranslationUnit' is not available; this requires
     -- Clang >= 20.1.
-  | ParseSeqNrUnavailable
+  | ParseSourceOrderUnavailable
 
   deriving stock (Show, Eq, Ord, Generic)
 
@@ -76,12 +77,12 @@ instance PrettyForTrace ImmediateParseMsg where
         , "the failed declaration may be required when parsing"
         , "other declarations containing macro replacements"
         ]
-      ParseSeqNrPopulated -> PP.hsep [
-          "Sequence order of declarations populated"
+      ParseSourceOrderPopulated -> PP.hsep [
+          "Source order of declarations populated"
         , "(requires Clang >= 20.1)"
         ]
-      ParseSeqNrUnavailable -> PP.hsep [
-          "Sequence order of declarations unavailable:"
+      ParseSourceOrderUnavailable -> PP.hsep [
+          "Source order of declarations unavailable:"
         , "clang_isBeforeInTranslationUnit requires Clang >= 20.1"
         ]
 
@@ -90,8 +91,8 @@ instance IsTrace Level ImmediateParseMsg where
       ParseGetMacroExpansionsMultipleFiles{}       -> Warning
       ParseMacroExpansionNoMacroName{}             -> Bug
       ParseOfDeclarationRequiredForScopingFailed{} -> Info
-      ParseSeqNrPopulated{}                        -> Info
-      ParseSeqNrUnavailable{}                      -> Info
+      ParseSourceOrderPopulated{}                  -> Info
+      ParseSourceOrderUnavailable{}                -> Info
   getSource  = const HsBindgen
   getTraceId = \case
     ParseMacroExpansionNoMacroName -> "parse-immediate-macro"

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
@@ -104,12 +104,14 @@ deriving stock instance (Show (Id p)) => Show (EnclosingRef p)
 data DeclInfo (p :: Pass) = DeclInfo{
       loc           :: SingleLoc
     , id            :: Id p
-    -- | Sequence number
+    -- | Source order index
     --
-    -- Declarations with lower sequence numbers come before declarations with
-    -- higher sequence numbers in the translation unit. We can populate sequence
-    -- numbers only with Clang version 20.1 or newer.
-    , seqNr         :: Maybe Natural
+    -- The position of this declaration in /source order/ (roughly, how
+    -- declarations appear in the C source; see the ordering definitions in
+    -- "HsBindgen.Frontend.Pass.Parse"), starting at 0. Declarations with a
+    -- lower index come before those with a higher index. Populated only with
+    -- Clang version 20.1 or newer; 'Nothing' otherwise.
+    , sourceOrderIndex :: Maybe Natural
     , headerInfo    :: HeaderInfo
     , availability  :: Availability
     , comment       :: CommentDecl p
@@ -604,13 +606,13 @@ instance (
     , CoercePassCommentDecl p p'
     ) => CoercePass DeclInfo p p' where
   coercePass info = DeclInfo{
-        loc          = info.loc
-      , id           = coercePassId (Proxy @'(p, p')) info.id
-      , seqNr        = info.seqNr
-      , headerInfo   = info.headerInfo
-      , availability = info.availability
-      , comment      = coercePassCommentDecl (Proxy @'(p, p')) info.comment
-      , enclosing    = map coercePass info.enclosing
+        loc              = info.loc
+      , id               = coercePassId (Proxy @'(p, p')) info.id
+      , sourceOrderIndex = info.sourceOrderIndex
+      , headerInfo       = info.headerInfo
+      , availability     = info.availability
+      , comment          = coercePassCommentDecl (Proxy @'(p, p')) info.comment
+      , enclosing        = map coercePass info.enclosing
       }
 
 instance (

--- a/hs-bindgen/test-artefacts/headers/golden/macros/parse/intermittent_include.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/parse/intermittent_include.h
@@ -1,4 +1,4 @@
-// Test that we sort macros into sequence order even with intermittent includes.
+// Test that we sort macros into source order even with intermittent includes.
 
 // (At the moment, we do not perform any output sorting, and the generated
 // bindings are in dependency order, with inner includes sorted before other

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
@@ -31,7 +31,7 @@ import Test.HsBindgen.Resources
 tests :: IO TestResources -> TestTree
 tests getTestResources = testGroup "Test.HsBindgen.Unit.Frontend" [
       testGroup "Parse" [
-          testParseSequenceNumber getTestResources
+          testParseSourceOrder getTestResources
         ]
     ]
 
@@ -39,9 +39,9 @@ tests getTestResources = testGroup "Test.HsBindgen.Unit.Frontend" [
   Parse pass tests
 -------------------------------------------------------------------------------}
 
-testParseSequenceNumber :: IO TestResources -> TestTree
-testParseSequenceNumber getTestResources =
-  testWhenClangVersion (>= (20, 1, 0)) "ParseSequenceNumber" $ do
+testParseSourceOrder :: IO TestResources -> TestTree
+testParseSourceOrder getTestResources =
+  testWhenClangVersion (>= (20, 1, 0)) "ParseSourceOrder" $ do
     results <-
       execFrontend
         getTestResources
@@ -49,20 +49,22 @@ testParseSequenceNumber getTestResources =
         ["test-artefacts" </> "headers" </> "golden" </> "macros" </> "parse"]
         "elaborate.h"
         getParseResults
-    declNamesWithSeqNrs <- forM results $ \result ->
+    declNamesWithSourceOrderIndex <- forM results $ \result ->
       case getParseResultMaybeDecl result of
         Nothing   -> assertFailure $ "parse failed: " ++ show result
         Just decl -> do
-          case decl.info.seqNr of
+          case decl.info.sourceOrderIndex of
             Nothing ->
               panicPure $
-                "no sequence number for declaration " ++ show decl.info.id
-            Just seqNr ->
-              pure (show $ prettyForTrace decl.info.id, seqNr)
-    let declNamesDependencyOrderActual :: [String]
-        declNamesDependencyOrderActual = map fst declNamesWithSeqNrs
-        declNamesDependencyOrderExpected :: [String]
-        declNamesDependencyOrderExpected = [
+                "no source-order index for declaration " ++ show decl.info.id
+            Just idx ->
+              pure (show $ prettyForTrace decl.info.id, idx)
+    -- 'getParseResults' returns declarations in sequence order (libclang's
+    -- visitation order: macros first, then the rest).
+    let declNamesSequenceOrderActual :: [String]
+        declNamesSequenceOrderActual = map fst declNamesWithSourceOrderIndex
+        declNamesSequenceOrderExpected :: [String]
+        declNamesSequenceOrderExpected = [
              "'macro OUTER_A'"
            , "'macro INNER_A'"
            , "'macro INNER_B'"
@@ -71,13 +73,15 @@ testParseSequenceNumber getTestResources =
            , "'outer_int'"
            , "'inner_int'"
            ]
-    assertEqual "dependency order"
-      declNamesDependencyOrderExpected
-      declNamesDependencyOrderActual
-    let declNamesSequenceOrderActual :: [String]
-        declNamesSequenceOrderActual = map fst $ sortOn snd declNamesWithSeqNrs
-        declNamesSequenceOrderExpected :: [String]
-        declNamesSequenceOrderExpected = [
+    assertEqual "sequence order"
+      declNamesSequenceOrderExpected
+      declNamesSequenceOrderActual
+    -- Sorting by the source-order index recovers source order.
+    let declNamesSourceOrderActual :: [String]
+        declNamesSourceOrderActual =
+          map fst $ sortOn snd declNamesWithSourceOrderIndex
+        declNamesSourceOrderExpected :: [String]
+        declNamesSourceOrderExpected = [
             "'macro OUTER_A'"
           , "'outer_int'"
           , "'macro INNER_A'"
@@ -86,9 +90,9 @@ testParseSequenceNumber getTestResources =
           , "'macro OUTER_B'"
           , "'macro OUTER_C'"
           ]
-    assertEqual "sequence order"
-      declNamesSequenceOrderExpected
-      declNamesSequenceOrderActual
+    assertEqual "source order"
+      declNamesSourceOrderExpected
+      declNamesSourceOrderActual
 
 {-------------------------------------------------------------------------------
   Auxiliary functions


### PR DESCRIPTION
Internal bugfix PR.

The value always stored source order (from clang_isBeforeInTranslationUnit), not sequence order (libclang's macro-first visit order).

Rename the field, the traces (ParseSeqNr* -> ParseSourceOrder*) and the ParseSourceOrder unit test, and add ordering definitions to Parse.hs.
