### PR TITLE
`CI`: dedicated timeout for the `setup-llvm` action

### DIFF
--- a/.github/workflows/comprehensive-ci.yml
+++ b/.github/workflows/comprehensive-ci.yml
@@ -56,6 +56,7 @@ jobs:
 
     - name: 🛠️ Install LLVM/Clang
       uses: ./.github/actions/setup-llvm
+      timeout-minutes: 5
       with:
         version: ${{ matrix.llvm }}
 
@@ -269,6 +270,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
+        timeout-minutes: 5
         with:
           version: ${{ matrix.llvm }}
 
@@ -420,6 +422,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
+        timeout-minutes: 5
         with:
           version: ${{ matrix.llvm }}
 
@@ -509,6 +512,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
+        timeout-minutes: 5
         with:
           version: ${{ matrix.llvm }}
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -219,6 +219,7 @@ jobs:
     - name: 🛠️ Setup LLVM/Clang
       if: ${{ runner.os != 'Windows' }}
       uses: ./.github/actions/setup-llvm
+      timeout-minutes: 5
       with:
         version: ${{ matrix.llvm-version }}
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -176,6 +176,7 @@ jobs:
 
     - name: 🛠️ Install LLVM/Clang
       uses: ./.github/actions/setup-llvm
+      timeout-minutes: 5
       with:
         version: ${{ matrix.llvm }}
 


### PR DESCRIPTION
Currently the `setup-llvm` action sometimes hangs indefinitely until the CI job gets cancelled, which can take 30-60 minutes depending on the job. Now we set a dedicated timeout for the action (5 minutes). This should provide developers with feedback sooner, and runners (a limited resource) can be freed early.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.