### PR TITLE
`CI`: increase `setup-llvm` timeout to 10 minutes

### DIFF
--- a/.github/workflows/comprehensive-ci.yml
+++ b/.github/workflows/comprehensive-ci.yml
@@ -56,7 +56,7 @@ jobs:
 
     - name: 🛠️ Install LLVM/Clang
       uses: ./.github/actions/setup-llvm
-      timeout-minutes: 5
+      timeout-minutes: 10
       with:
         version: ${{ matrix.llvm }}
 
@@ -270,7 +270,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ matrix.llvm }}
 
@@ -422,7 +422,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ matrix.llvm }}
 
@@ -512,7 +512,7 @@ jobs:
 
       - name: 🛠️ Setup LLVM/Clang
         uses: ./.github/actions/setup-llvm
-        timeout-minutes: 5
+        timeout-minutes: 10
         with:
           version: ${{ matrix.llvm }}
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -219,7 +219,7 @@ jobs:
     - name: 🛠️ Setup LLVM/Clang
       if: ${{ runner.os != 'Windows' }}
       uses: ./.github/actions/setup-llvm
-      timeout-minutes: 5
+      timeout-minutes: 10
       with:
         version: ${{ matrix.llvm-version }}
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -176,7 +176,7 @@ jobs:
 
     - name: 🛠️ Install LLVM/Clang
       uses: ./.github/actions/setup-llvm
-      timeout-minutes: 5
+      timeout-minutes: 10
       with:
         version: ${{ matrix.llvm }}
 


### PR DESCRIPTION
It *feels* like jobs time out more often since #2180. So maybe let's try 10 minutes instead of 5.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.
