### PR TITLE
`Manual`: one shared object instead of many

### DIFF
--- a/manual/c/Makefile
+++ b/manual/c/Makefile
@@ -27,84 +27,73 @@ ifeq ($(OS),Windows_NT)
 endif
 
 default: \
-	libexample${TARGET_EXT} \
-	libmacro${TARGET_EXT} \
+	libmanual${TARGET_EXT} \
 	libvector${TARGET_EXT} \
 	libgame${TARGET_EXT} \
-	libglobals${TARGET_EXT} \
-	libarrays${TARGET_EXT} \
-	libfunctionpointers${TARGET_EXT} \
-	libhsb_complex_test${TARGET_EXT} \
-	libcallbacks${TARGET_EXT} \
-	libpointermanipulation${TARGET_EXT} \
-	libstructs${TARGET_EXT} \
-	libunions${TARGET_EXT}
 
 .PHONY: clean
 clean:
 	rm -f *.so *.dll *.o */*.o
 
-# Basic examples
+# Manual
 
-libexample${TARGET_EXT}: manual_examples.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libexample${TARGET_EXT} manual_examples.o
+libmanual${TARGET_EXT}: \
+		manual_examples.o \
+		macro.o \
+		globals.o \
+		arrays.o \
+		function_pointers.o \
+		hsb_complex_test.o \
+		callbacks.o \
+		pointer_manipulation.o \
+		structs.o \
+		structs/nesting.o \
+		unions.o \
+		unions/nesting.o \
+		omit_field_prefixes.o
+
+	clang ${EXTRAFLAGS} -Wall -shared -o libmanual${TARGET_EXT} \
+		manual_examples.o \
+		macro.o \
+		globals.o \
+		arrays.o \
+		function_pointers.o \
+		hsb_complex_test.o \
+		callbacks.o \
+		pointer_manipulation.o \
+		structs.o \
+		structs/nesting.o \
+		unions.o \
+		unions/nesting.o \
+		omit_field_prefixes.o
 
 manual_examples.o: manual_examples.c manual_examples.h
 	clang ${EXTRAFLAGS} -Wall -o manual_examples.o -c -fPIC manual_examples.c -I${PROJECT_ROOT}/hs-bindgen/manual/c
 
-libmacro${TARGET_EXT}: macro.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libmacro${TARGET_EXT} macro.o
-
 macro.o: macro.c macro.h
 	clang ${EXTRAFLAGS} -Wall -o macro.o -c -fPIC macro.c
-
-
-libglobals${TARGET_EXT}: globals.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libglobals${TARGET_EXT} globals.o
 
 globals.o: globals.c globals.h
 	clang ${EXTRAFLAGS} -Wall -o globals.o -c -fPIC globals.c
 
-libarrays${TARGET_EXT}: arrays.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libarrays${TARGET_EXT} arrays.o
-
 arrays.o: arrays.c arrays.h
 	clang ${EXTRAFLAGS} -Wall -o arrays.o -c -fPIC arrays.c
-
-libfunctionpointers${TARGET_EXT}: function_pointers.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libfunctionpointers${TARGET_EXT} function_pointers.o
 
 function_pointers.o: function_pointers.c function_pointers.h
 	clang ${EXTRAFLAGS} -Wall -o function_pointers.o -c -fPIC function_pointers.c
 
-libhsb_complex_test${TARGET_EXT}: hsb_complex_test.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libhsb_complex_test${TARGET_EXT} hsb_complex_test.o
-
 hsb_complex_test.o: hsb_complex_test.c hsb_complex_test.h
 	clang ${EXTRAFLAGS} -Wall -o hsb_complex_test.o -c -fPIC hsb_complex_test.c
-
-libcallbacks${TARGET_EXT}: callbacks.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libcallbacks${TARGET_EXT} callbacks.o
 
 callbacks.o: callbacks.c callbacks.h
 	clang ${EXTRAFLAGS} -Wall -o callbacks.o -c -fPIC callbacks.c
 
 ## Pointer manipulation API
 
-libpointermanipulation${TARGET_EXT}: pointer_manipulation.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libpointermanipulation${TARGET_EXT} pointer_manipulation.o
-
 pointer_manipulation.o: pointer_manipulation.c pointer_manipulation.h
 	clang ${EXTRAFLAGS} -Wall -o pointer_manipulation.o -c -fPIC pointer_manipulation.c
 
 ## Structs
-
-libstructs${TARGET_EXT}: \
-		structs.o \
-		structs/nesting.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libstructs${TARGET_EXT} \
-		structs.o \
-		structs/nesting.o
 
 structs.o: structs.c structs.h
 	clang ${EXTRAFLAGS} -Wall -o structs.o -c -fPIC structs.c
@@ -114,20 +103,18 @@ structs/nesting.o: structs/nesting.c structs/nesting.h
 
 ## Unions
 
-libunions${TARGET_EXT}: \
-		unions.o \
-		unions/nesting.o
-	clang ${EXTRAFLAGS} -Wall -shared -o libunions${TARGET_EXT} \
-		unions.o \
-		unions/nesting.o
-
 unions.o: unions.c unions.h
 	clang ${EXTRAFLAGS} -Wall -o unions.o -c -fPIC unions.c
 
 unions/nesting.o: unions/nesting.c unions/nesting.h
 	clang ${EXTRAFLAGS} -Wall -Wno-missing-declarations -o unions/nesting.o -c -fPIC unions/nesting.c
 
-# Example for external bindings
+## Unprefixed field names
+
+omit_field_prefixes.o: omit_field_prefixes.c omit_field_prefixes.h
+	clang ${EXTRAFLAGS} -Wall -o omit_field_prefixes.o -c -fPIC omit_field_prefixes.c
+
+# External bindings: vector example
 
 libvector${TARGET_EXT}: vector.o vector_length.o vector_rotate.o
 	clang ${EXTRAFLAGS} -Wall -shared -o libvector${TARGET_EXT} vector.o vector_length.o vector_rotate.o -lm
@@ -140,6 +127,8 @@ vector_length.o: vector_length.c vector_length.h
 
 vector_rotate.o: vector_rotate.c vector_rotate.h
 	clang ${EXTRAFLAGS} -Wall -o vector_rotate.o -c -fPIC vector_rotate.c
+
+# External bindings: vector example
 
 libgame${TARGET_EXT}: game_world.o game_player.o
 	clang ${EXTRAFLAGS} -Wall -shared -o libgame${TARGET_EXT} game_world.o game_player.o

--- a/manual/c/function_pointers.c
+++ b/manual/c/function_pointers.c
@@ -1,7 +1,6 @@
 #include "function_pointers.h"
-#include <stdio.h>
 
-int square (int x) {
+int square2 (int x) {
   return (x * x);
 }
 

--- a/manual/c/function_pointers.h
+++ b/manual/c/function_pointers.h
@@ -2,7 +2,7 @@
  * Function pointers
  */
 
-extern int square(int);
+extern int square2(int);
 
 extern int plus(int, int);
 

--- a/manual/c/omit_field_prefixes.c
+++ b/manual/c/omit_field_prefixes.c
@@ -1,0 +1,1 @@
+#include "omit_field_prefixes.h"

--- a/manual/generate-and-run.sh
+++ b/manual/generate-and-run.sh
@@ -26,7 +26,7 @@ echo "# "
 mkdir -p binding-specs
 
 echo "# "
-echo "# Basic examples"
+echo "# Manual"
 echo "# "
 
 mkdir -p hs/manual/generated
@@ -102,7 +102,7 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     callbacks.h
 
 echo "# "
-echo "# Pointer manipulation API"
+echo "## Pointer manipulation API"
 echo "# "
 
 cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
@@ -116,7 +116,7 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     pointer_manipulation.h
 
 echo "# "
-echo "# Structs"
+echo "## Structs"
 echo "# "
 
 cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
@@ -140,7 +140,7 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     structs/nesting.h
 
 echo "# "
-echo "# Unions"
+echo "## Unions"
 echo "# "
 
 cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
@@ -164,7 +164,7 @@ cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \
     unions/nesting.h
 
 echo "# "
-echo "# Unprefixed field names"
+echo "## Unprefixed field names"
 echo "# "
 
 cabal run --project-dir="${PROJECT_ROOT}" -- hs-bindgen-cli \

--- a/manual/hs/manual/app/Manual/Functions/FirstOrder.hs
+++ b/manual/hs/manual/app/Manual/Functions/FirstOrder.hs
@@ -38,9 +38,9 @@ examples = do
 
     section "Function pointers"
 
-    print =<< Fun.apply1 FunPtr.square 4
-    print =<< Fun.apply1 FunPtr.square 5
-    print =<< Fun.apply1 FunPtr.square 6
+    print =<< Fun.apply1 FunPtr.square2 4
+    print =<< Fun.apply1 FunPtr.square2 5
+    print =<< Fun.apply1 FunPtr.square2 6
 
     print =<< Fun.apply2 FunPtr.plus 7 8
     print =<< Fun.apply2 FunPtr.plus 9 10
@@ -49,29 +49,29 @@ examples = do
     subsection "Implicit function to pointer conversion"
     do
       -- function pointer type in function parameter
-      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square) 4
-      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square) 5
-      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square) 6
+      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square2) 4
+      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square2) 5
+      print =<< Fun.apply1_pointer_arg (safeCastFunPtr FunPtr.square2) 6
 
       -- function type in function parameter
-      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square) 4
-      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square) 5
-      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square) 6
+      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square2) 4
+      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square2) 5
+      print =<< Fun.apply1_nopointer_arg (safeCastFunPtr FunPtr.square2) 6
 
       subsubsection "Parameters of function type can occur almost anywhere!"
       do -- function type in function result
         apply1FunPtr <- Fun.apply1_nopointer_res
         let apply1Fun = fromFunPtr apply1FunPtr
-        print =<< apply1Fun (safeCastFunPtr FunPtr.square) 4
+        print =<< apply1Fun (safeCastFunPtr FunPtr.square2) 4
       do -- function type in global
         let apply1FunPtr = Fun.apply1_nopointer_var
             apply1Fun = fromFunPtr apply1FunPtr
-        print =<< apply1Fun (safeCastFunPtr FunPtr.square) 5
+        print =<< apply1Fun (safeCastFunPtr FunPtr.square2) 5
       do -- function type in struct field
         let apply1FunPtr = Fun.apply1Struct_apply1_nopointer_struct_field Fun.apply1_struct
             apply1Fun = fromFunPtr apply1FunPtr
-        print =<< apply1Fun (safeCastFunPtr FunPtr.square) 6
+        print =<< apply1Fun (safeCastFunPtr FunPtr.square2) 6
       do -- function type in union field
         let apply1FunPtr = Fun.apply1_union.apply1Union_apply1_nopointer_union_field
             apply1Fun = fromFunPtr apply1FunPtr
-        print =<< apply1Fun (safeCastFunPtr FunPtr.square) 7
+        print =<< apply1Fun (safeCastFunPtr FunPtr.square2) 7

--- a/manual/hs/manual/manual.cabal
+++ b/manual/hs/manual/manual.cabal
@@ -59,17 +59,7 @@ library generated
   import:          lang
   visibility:      private
   hs-source-dirs:  generated
-  extra-libraries:
-    arrays
-    callbacks
-    example
-    functionpointers
-    globals
-    hsb_complex_test
-    macro
-    pointermanipulation
-    structs
-    unions
+  extra-libraries: manual
 
   -- External
   build-depends:


### PR DESCRIPTION
This makes the code slightly simpler, but the main goal is that we can no longer get "ELF interposition". For example, we have two definitions of the `square` C function that were previously defined in different shared objects. When we used them in the manual executable, one definition would get picked silently over the other. Not so harmful now since the two `square` functions are largely identical, but it can be a source of bugs. Now we have to come up with unique names for C functions in the manual, which can be a little inconvenient.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.