### PR TITLE
Refactor golden test function names

### DIFF
--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Arrays.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Arrays.hs
@@ -15,25 +15,25 @@ import Test.HsBindgen.Golden.Infra.TestCase
 
 testCases :: [TestCase]
 testCases = [
-      test_arrays_array
-    , test_arrays_const_qualifier
-    , test_arrays_multi_dim
-    , test_arrays_failing_array_res_1
-    , test_arrays_failing_array_res_2
-    , test_arrays_failing_array_res_3
-    , test_arrays_failing_array_res_4
-    , test_arrays_failing_array_res_5
-    , test_arrays_failing_array_res_6
-    , test_arrays_failing_array_res_7
-    , test_arrays_failing_array_res_8
+      test_array
+    , test_const_qualifier
+    , test_multi_dim
+    , test_failing_array_res_1
+    , test_failing_array_res_2
+    , test_failing_array_res_3
+    , test_failing_array_res_4
+    , test_failing_array_res_5
+    , test_failing_array_res_6
+    , test_failing_array_res_7
+    , test_failing_array_res_8
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_arrays_array :: TestCase
-test_arrays_array =
+test_array :: TestCase
+test_array =
     defaultTest "arrays/array"
       & #clangVersion   .~ Just (>= (19, 0, 0))
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
@@ -58,14 +58,14 @@ test_arrays_array =
 
 -- | @const@ qualifiers applied to arrays (through typedefs) should be
 -- represented in the bindings.
-test_arrays_const_qualifier :: TestCase
-test_arrays_const_qualifier = defaultTest "arrays/const_qualifier"
+test_const_qualifier :: TestCase
+test_const_qualifier = defaultTest "arrays/const_qualifier"
 
-test_arrays_multi_dim :: TestCase
-test_arrays_multi_dim = defaultTest "arrays/multi_dim"
+test_multi_dim :: TestCase
+test_multi_dim = defaultTest "arrays/multi_dim"
 
-test_arrays_failing_array_res_1 :: TestCase
-test_arrays_failing_array_res_1 =
+test_failing_array_res_1 :: TestCase
+test_failing_array_res_1 =
     failingTestLibclangSimple "arrays/failing/array_res_1" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -76,8 +76,8 @@ test_arrays_failing_array_res_1 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_2 :: TestCase
-test_arrays_failing_array_res_2 =
+test_failing_array_res_2 :: TestCase
+test_failing_array_res_2 =
     failingTestLibclangSimple "arrays/failing/array_res_2" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -88,8 +88,8 @@ test_arrays_failing_array_res_2 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_3 :: TestCase
-test_arrays_failing_array_res_3 =
+test_failing_array_res_3 :: TestCase
+test_failing_array_res_3 =
     failingTestLibclangSimple "arrays/failing/array_res_3" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -100,8 +100,8 @@ test_arrays_failing_array_res_3 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_4 :: TestCase
-test_arrays_failing_array_res_4 =
+test_failing_array_res_4 :: TestCase
+test_failing_array_res_4 =
     failingTestLibclangSimple "arrays/failing/array_res_4" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -112,8 +112,8 @@ test_arrays_failing_array_res_4 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_5 :: TestCase
-test_arrays_failing_array_res_5 =
+test_failing_array_res_5 :: TestCase
+test_failing_array_res_5 =
     failingTestLibclangSimple "arrays/failing/array_res_5" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -124,8 +124,8 @@ test_arrays_failing_array_res_5 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_6 :: TestCase
-test_arrays_failing_array_res_6 =
+test_failing_array_res_6 :: TestCase
+test_failing_array_res_6 =
     failingTestLibclangSimple "arrays/failing/array_res_6" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -136,8 +136,8 @@ test_arrays_failing_array_res_6 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_7 :: TestCase
-test_arrays_failing_array_res_7 =
+test_failing_array_res_7 :: TestCase
+test_failing_array_res_7 =
     failingTestLibclangSimple "arrays/failing/array_res_7" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()
@@ -148,8 +148,8 @@ test_arrays_failing_array_res_7 =
       _otherwise ->
         Nothing
 
-test_arrays_failing_array_res_8 :: TestCase
-test_arrays_failing_array_res_8 =
+test_failing_array_res_8 :: TestCase
+test_failing_array_res_8 =
     failingTestLibclangSimple "arrays/failing/array_res_8" $ \case
       (matchDiagnosticSpelling "function cannot return array type" -> Just _diag) ->
         Just $ Expected ()

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Attributes.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Attributes.hs
@@ -21,31 +21,31 @@ testCases :: [TestCase]
 testCases = [
       defaultTest "attributes/visibility/edge-cases/nested_types"
     , defaultTest "attributes/visibility/types"
-    , test_attributes_asm
-    , test_attributes_attributes
-    , test_attributes_deprecated
-    , test_attributes_type_attributes
-    , test_attributes_visibility_functions
-    , test_attributes_visibility_variables
+    , test_asm
+    , test_attributes
+    , test_deprecated
+    , test_type_attributes
+    , test_visibility_functions
+    , test_visibility_variables
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_attributes_asm :: TestCase
-test_attributes_asm =
+test_asm :: TestCase
+test_asm =
     defaultTest "attributes/asm"
       & #clangVersion .~ Just (>= (18, 0, 0))
       & #cStandard    .~ gnu23
 
-test_attributes_attributes :: TestCase
-test_attributes_attributes =
+test_attributes :: TestCase
+test_attributes =
     testDiagnostic "attributes/attributes" $ \diag ->
       diagnosticCategoryText diag == "Nullability Issue"
 
-test_attributes_deprecated :: TestCase
-test_attributes_deprecated =
+test_deprecated :: TestCase
+test_deprecated =
   defaultTest "attributes/deprecated"
     & #onFrontend .~ ( #selectionPredicate .~
           BAnd
@@ -59,16 +59,16 @@ test_attributes_deprecated =
               Nothing
           )
 
-test_attributes_type_attributes :: TestCase
-test_attributes_type_attributes =
+test_type_attributes :: TestCase
+test_type_attributes =
     testTraceSimple "attributes/type_attributes" $ \case
       MatchSelect _name SelectDeprecated{} ->
         Just $ Expected ()
       _otherwise ->
         Nothing
 
-test_attributes_visibility_functions :: TestCase
-test_attributes_visibility_functions =
+test_visibility_functions :: TestCase
+test_visibility_functions =
     defaultTest "attributes/visibility/functions"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchDelayed name ParsePotentialDuplicateSymbol{} ->
@@ -92,8 +92,8 @@ test_attributes_visibility_functions =
         , "f15", "f16", "f17", "f18", "f19"
         ]
 
-test_attributes_visibility_variables :: TestCase
-test_attributes_visibility_variables =
+test_visibility_variables :: TestCase
+test_visibility_variables =
     defaultTest "attributes/visibility/variables"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchDelayed name ParsePotentialDuplicateSymbol{} ->

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/BindingSpecs.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/BindingSpecs.hs
@@ -20,50 +20,50 @@ import Test.HsBindgen.Resources
 
 testCases :: [TestCase]
 testCases = [
-      test_bindingSpecs_omit_type
+      test_omit_type
       -- * Bugs / regression tests
-    , test_bindingSpecs_trans_dep_macro_trans_dep_missing
-    , test_bindingSpecs_trans_dep_typedef_trans_dep_missing
+    , test_trans_dep_macro_trans_dep_missing
+    , test_trans_dep_typedef_trans_dep_missing
       -- * Naming types
-    , test_bindingSpecs_name_squash_both
-    , test_bindingSpecs_name_squash_struct
-    , test_bindingSpecs_name_squash_typedef
-    , test_bindingSpecs_name_type
+    , test_name_squash_both
+    , test_name_squash_struct
+    , test_name_squash_typedef
+    , test_name_type
       -- * C @enum@ specification
-    , test_bindingSpecs_enum_closed
-    , test_bindingSpecs_enum_open
-    , test_bindingSpecs_enum_mismatch
+    , test_enum_closed
+    , test_enum_open
+    , test_enum_mismatch
       -- * Representation: emptydata
-    , test_bindingSpecs_rep_emptydata_staticsize
+    , test_rep_emptydata_staticsize
       -- * Function arguments with typedefs
-    , test_bindingSpecs_fun_arg_typedef_array
-    , test_bindingSpecs_fun_arg_typedef_array_known_size
-    , test_bindingSpecs_fun_arg_typedef_enum
-    , test_bindingSpecs_fun_arg_typedef_function
-    , test_bindingSpecs_fun_arg_typedef_function_pointer
-    , test_bindingSpecs_fun_arg_typedef_struct
-    , test_bindingSpecs_fun_arg_typedef_union
+    , test_fun_arg_typedef_array
+    , test_fun_arg_typedef_array_known_size
+    , test_fun_arg_typedef_enum
+    , test_fun_arg_typedef_function
+    , test_fun_arg_typedef_function_pointer
+    , test_fun_arg_typedef_struct
+    , test_fun_arg_typedef_union
       -- * Function arguments with macros
-    , test_bindingSpecs_fun_arg_macro_array
-    , test_bindingSpecs_fun_arg_macro_array_known_size
-    , test_bindingSpecs_fun_arg_macro_enum
-    , test_bindingSpecs_fun_arg_macro_function
-    , test_bindingSpecs_fun_arg_macro_function_pointer
-    , test_bindingSpecs_fun_arg_macro_struct
-    , test_bindingSpecs_fun_arg_macro_union
+    , test_fun_arg_macro_array
+    , test_fun_arg_macro_array_known_size
+    , test_fun_arg_macro_enum
+    , test_fun_arg_macro_function
+    , test_fun_arg_macro_function_pointer
+    , test_fun_arg_macro_struct
+    , test_fun_arg_macro_union
       -- * Standard library
-    , test_bindingSpecs_stdlib_instances_c11
-    , test_bindingSpecs_stdlib_instances_c23
-    , test_bindingSpecs_stdlib_bool_c23
-    , test_bindingSpecs_stdlib_return_values
+    , test_stdlib_instances_c11
+    , test_stdlib_instances_c23
+    , test_stdlib_bool_c23
+    , test_stdlib_return_values
     ]
 
 {-------------------------------------------------------------------------------
   Omit type
 -------------------------------------------------------------------------------}
 
-test_bindingSpecs_omit_type :: TestCase
-test_bindingSpecs_omit_type =
+test_omit_type :: TestCase
+test_omit_type =
     defaultTest "binding-specs/omit_type"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/omit_type_p.yaml"
@@ -74,8 +74,8 @@ test_bindingSpecs_omit_type =
 
 -- | External binding specifications for non-selected macro types should not
 --   lead to warnings/errors
-test_bindingSpecs_trans_dep_macro_trans_dep_missing :: TestCase
-test_bindingSpecs_trans_dep_macro_trans_dep_missing =
+test_trans_dep_macro_trans_dep_missing :: TestCase
+test_trans_dep_macro_trans_dep_missing =
     defaultTest "binding-specs/trans_dep/macro_trans_dep_missing"
       & #specExternal .~
           [ "test-artefacts/headers/golden/binding-specs/trans_dep/macro_trans_dep_missing.yaml"
@@ -89,8 +89,8 @@ test_bindingSpecs_trans_dep_macro_trans_dep_missing =
 
 -- | External binding specifications for non-selected typedef types should not
 --   lead to warnings/errors
-test_bindingSpecs_trans_dep_typedef_trans_dep_missing :: TestCase
-test_bindingSpecs_trans_dep_typedef_trans_dep_missing =
+test_trans_dep_typedef_trans_dep_missing :: TestCase
+test_trans_dep_typedef_trans_dep_missing =
     defaultTest "binding-specs/trans_dep/typedef_trans_dep_missing"
       & #specExternal .~
           [ "test-artefacts/headers/golden/binding-specs/trans_dep/typedef_trans_dep_missing.yaml"
@@ -103,29 +103,29 @@ test_bindingSpecs_trans_dep_typedef_trans_dep_missing =
 -------------------------------------------------------------------------------}
 
 -- | Naming a squashed type, specifying the name for both the struct and typedef
-test_bindingSpecs_name_squash_both :: TestCase
-test_bindingSpecs_name_squash_both =
+test_name_squash_both :: TestCase
+test_name_squash_both =
     defaultTest "binding-specs/name/squash_both"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/name/squash_both_p.yaml"
 
 -- | Naming a squashed type, specifying the name for the struct
-test_bindingSpecs_name_squash_struct :: TestCase
-test_bindingSpecs_name_squash_struct =
+test_name_squash_struct :: TestCase
+test_name_squash_struct =
     defaultTest "binding-specs/name/squash_struct"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/name/squash_struct_p.yaml"
 
 -- | Naming a squashed type, specifying the name for the typedef
-test_bindingSpecs_name_squash_typedef :: TestCase
-test_bindingSpecs_name_squash_typedef =
+test_name_squash_typedef :: TestCase
+test_name_squash_typedef =
     defaultTest "binding-specs/name/squash_typedef"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/name/squash_typedef_p.yaml"
 
 -- | Naming a type
-test_bindingSpecs_name_type :: TestCase
-test_bindingSpecs_name_type =
+test_name_type :: TestCase
+test_name_type =
     defaultTest "binding-specs/name/type"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/name/type_p.yaml"
@@ -134,20 +134,20 @@ test_bindingSpecs_name_type =
   C @enum@ specification
 -------------------------------------------------------------------------------}
 
-test_bindingSpecs_enum_closed :: TestCase
-test_bindingSpecs_enum_closed =
+test_enum_closed :: TestCase
+test_enum_closed =
     defaultTest "binding-specs/enum/closed"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/enum/closed_p.yaml"
 
-test_bindingSpecs_enum_open :: TestCase
-test_bindingSpecs_enum_open =
+test_enum_open :: TestCase
+test_enum_open =
     defaultTest "binding-specs/enum/open"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/enum/open_p.yaml"
 
-test_bindingSpecs_enum_mismatch :: TestCase
-test_bindingSpecs_enum_mismatch =
+test_enum_mismatch :: TestCase
+test_enum_mismatch =
     testTraceSimple "binding-specs/enum/mismatch" auxTrace
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/enum/mismatch_p.yaml"
@@ -176,8 +176,8 @@ test_bindingSpecs_enum_mismatch =
 --
 -- The typedefs' underlying types live in an included header; program slicing
 -- keeps them out of the generated output.
-test_bindingSpecs_rep_emptydata_staticsize :: TestCase
-test_bindingSpecs_rep_emptydata_staticsize =
+test_rep_emptydata_staticsize :: TestCase
+test_rep_emptydata_staticsize =
     defaultTest "binding-specs/rep/emptydata/staticsize"
       & #specPrescriptive .~
           Just "test-artefacts/headers/golden/binding-specs/rep/emptydata/staticsize_p.yaml"
@@ -195,75 +195,75 @@ test_bindingSpecs_rep_emptydata_staticsize =
 -- unknown size).
 --
 -- Arrays are passed by 'Ptr' to the first element of the array.
-test_bindingSpecs_fun_arg_typedef_array :: TestCase
-test_bindingSpecs_fun_arg_typedef_array =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/array"
+test_fun_arg_typedef_array :: TestCase
+test_fun_arg_typedef_array =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/array"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying array type of
 -- known size.
 --
 -- Arrays of known size are passed by 'Ptr' to the first element of the array.
-test_bindingSpecs_fun_arg_typedef_array_known_size :: TestCase
-test_bindingSpecs_fun_arg_typedef_array_known_size =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/array_known_size"
+test_fun_arg_typedef_array_known_size :: TestCase
+test_fun_arg_typedef_array_known_size =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/array_known_size"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying enum type.
 --
 -- Enums can be passed by value rather than by 'Ptr'.
-test_bindingSpecs_fun_arg_typedef_enum :: TestCase
-test_bindingSpecs_fun_arg_typedef_enum =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/enum"
+test_fun_arg_typedef_enum :: TestCase
+test_fun_arg_typedef_enum =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/enum"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying function type.
 --
 -- Functions should be passed by 'FunPtr' rather than by 'Ptr'. Previously we
 -- had a bug where we doing the latter, see issue #1363.
-test_bindingSpecs_fun_arg_typedef_function :: TestCase
-test_bindingSpecs_fun_arg_typedef_function =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/function"
+test_fun_arg_typedef_function :: TestCase
+test_fun_arg_typedef_function =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/function"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying function pointer
 -- type.
 --
 -- Functions should be passed by 'FunPtr' rather than by 'Ptr'.
-test_bindingSpecs_fun_arg_typedef_function_pointer :: TestCase
-test_bindingSpecs_fun_arg_typedef_function_pointer =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/function_pointer"
+test_fun_arg_typedef_function_pointer :: TestCase
+test_fun_arg_typedef_function_pointer =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/function_pointer"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying struct type.
 --
 -- Structs should be passed by 'Ptr' rather than by value.
-test_bindingSpecs_fun_arg_typedef_struct :: TestCase
-test_bindingSpecs_fun_arg_typedef_struct =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/struct"
+test_fun_arg_typedef_struct :: TestCase
+test_fun_arg_typedef_struct =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/struct"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef with an underlying union type.
 --
 -- Union should be passed by 'Ptr' rather than by value.
-test_bindingSpecs_fun_arg_typedef_union :: TestCase
-test_bindingSpecs_fun_arg_typedef_union =
-    test_bindingSpecs_fun_arg_typedef "binding-specs/fun_arg/typedef/union"
+test_fun_arg_typedef_union :: TestCase
+test_fun_arg_typedef_union =
+    test_fun_arg_typedef "binding-specs/fun_arg/typedef/union"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a typedef.
-test_bindingSpecs_fun_arg_typedef :: FilePath -> TestCase
-test_bindingSpecs_fun_arg_typedef path =
+test_fun_arg_typedef :: FilePath -> TestCase
+test_fun_arg_typedef path =
   defaultTest path
       & #specExternal .~
           [ "test-artefacts" </> "headers" </> "golden" </> path <.> "yaml"
           ]
       & #onFrontend .~
-          #selectionPredicate .~ test_bindingSpecs_fun_arg_typedef_selectionPredicate
+          #selectionPredicate .~ test_fun_arg_typedef_selectionPredicate
 
--- | Selection predicate for 'test_bindingSpecs_fun_arg_typedef' tests
-test_bindingSpecs_fun_arg_typedef_selectionPredicate :: Boolean SelectionPredicate
-test_bindingSpecs_fun_arg_typedef_selectionPredicate =
+-- | Selection predicate for 'test_fun_arg_typedef' tests
+test_fun_arg_typedef_selectionPredicate :: Boolean SelectionPredicate
+test_fun_arg_typedef_selectionPredicate =
     BOr (BIf $ SelectDecl (DeclNameMatches "A|B|C|D|E|(My.*)"))
         (BIf $ SelectDecl (DeclNameMatches "(foo.*)|(bar.*)"))
 
@@ -276,79 +276,79 @@ test_bindingSpecs_fun_arg_typedef_selectionPredicate =
 -- unknown size).
 --
 -- Arrays are passed by 'Ptr' to the first element of the array.
-test_bindingSpecs_fun_arg_macro_array :: TestCase
-test_bindingSpecs_fun_arg_macro_array =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/array"
+test_fun_arg_macro_array :: TestCase
+test_fun_arg_macro_array =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/array"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying array type of
 -- known size.
 --
 -- Arrays of known size are passed by 'Ptr' to the first element of the array.
-test_bindingSpecs_fun_arg_macro_array_known_size :: TestCase
-test_bindingSpecs_fun_arg_macro_array_known_size =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/array_known_size"
+test_fun_arg_macro_array_known_size :: TestCase
+test_fun_arg_macro_array_known_size =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/array_known_size"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying enum type.
 --
 -- Enums can be passed by value rather than by 'Ptr'.
-test_bindingSpecs_fun_arg_macro_enum :: TestCase
-test_bindingSpecs_fun_arg_macro_enum =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/enum"
+test_fun_arg_macro_enum :: TestCase
+test_fun_arg_macro_enum =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/enum"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying function type.
 --
 -- Functions should be passed by 'FunPtr' rather than by 'Ptr'. Previously we
 -- had a bug where we doing the latter, see issue #1363.
-test_bindingSpecs_fun_arg_macro_function :: TestCase
-test_bindingSpecs_fun_arg_macro_function =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/function"
+test_fun_arg_macro_function :: TestCase
+test_fun_arg_macro_function =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/function"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying function
 -- pointer type.
 --
 -- Functions should be passed by 'FunPtr' rather than by 'Ptr'.
-test_bindingSpecs_fun_arg_macro_function_pointer :: TestCase
-test_bindingSpecs_fun_arg_macro_function_pointer =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/function_pointer"
+test_fun_arg_macro_function_pointer :: TestCase
+test_fun_arg_macro_function_pointer =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/function_pointer"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying struct type.
 --
 -- Structs should be passed by 'Ptr' rather than by value.
-test_bindingSpecs_fun_arg_macro_struct :: TestCase
-test_bindingSpecs_fun_arg_macro_struct =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/struct"
+test_fun_arg_macro_struct :: TestCase
+test_fun_arg_macro_struct =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/struct"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type with an underlying union type.
 --
 -- Union should be passed by 'Ptr' rather than by value.
-test_bindingSpecs_fun_arg_macro_union :: TestCase
-test_bindingSpecs_fun_arg_macro_union =
-    test_bindingSpecs_fun_arg_macro "binding-specs/fun_arg/macro/union"
+test_fun_arg_macro_union :: TestCase
+test_fun_arg_macro_union =
+    test_fun_arg_macro "binding-specs/fun_arg/macro/union"
 
 -- | Test that @hs-bindgen@ can detect whether an external binding reference in
 -- a function argument references a macro type.
-test_bindingSpecs_fun_arg_macro :: FilePath -> TestCase
-test_bindingSpecs_fun_arg_macro path =
+test_fun_arg_macro :: FilePath -> TestCase
+test_fun_arg_macro path =
   defaultTest path
       & #specExternal .~
           [ "test-artefacts" </> "headers" </> "golden" </> path <.> "yaml"
           ]
       & #onFrontend .~
-          #selectionPredicate .~ test_bindingSpecs_fun_arg_macro_selectionPredicate
+          #selectionPredicate .~ test_fun_arg_macro_selectionPredicate
       -- Macros should not fail to parse.
       & #tracePredicate .~
           multiTracePredicateCustomLogLevel @()
             (getCustomLogLevel [EnableMacroWarnings]) [] (const Nothing)
 
--- | Selection predicate for 'test_bindingSpecs_fun_arg_macro' tests
-test_bindingSpecs_fun_arg_macro_selectionPredicate :: Boolean SelectionPredicate
-test_bindingSpecs_fun_arg_macro_selectionPredicate =
+-- | Selection predicate for 'test_fun_arg_macro' tests
+test_fun_arg_macro_selectionPredicate :: Boolean SelectionPredicate
+test_fun_arg_macro_selectionPredicate =
     BOr (BIf $ SelectDecl (DeclNameMatches "A|B|C|D|E|(My.*)"))
         (BIf $ SelectDecl (DeclNameMatches "(foo.*)|(bar.*)"))
 
@@ -390,8 +390,8 @@ test_bindingSpecs_fun_arg_macro_selectionPredicate =
 -- correctly recognizes @bool@ as an external reference, which gets matched
 -- against the external binding spec. We translate to
 -- 'HsBindgen.Runtime.LibC.CBool'.
-test_bindingSpecs_stdlib_instances_c11 :: TestCase
-test_bindingSpecs_stdlib_instances_c11 =
+test_stdlib_instances_c11 :: TestCase
+test_stdlib_instances_c11 =
     testVariant "binding-specs/stdlib/instances" (Just 1) "c11-parse-all"
       & #cStandard  .~ c11
 
@@ -401,19 +401,19 @@ test_bindingSpecs_stdlib_instances_c11 =
 -- environment; reparsing correctly recognizes @bool@ as an external reference,
 -- which gets matched against the external binding spec. We translate to
 -- 'HsBindgen.Runtime.LibC.CBool'.
-test_bindingSpecs_stdlib_instances_c23 :: TestCase
-test_bindingSpecs_stdlib_instances_c23 =
+test_stdlib_instances_c23 :: TestCase
+test_stdlib_instances_c23 =
     testVariant "binding-specs/stdlib/instances" (Just 1) "c23-parse-all"
       & #clangVersion .~ Just (>= (18, 0, 0))
       & #cStandard    .~ c23
 
 -- **Case 3: C23 without including @stdbool.h@**
-test_bindingSpecs_stdlib_bool_c23 :: TestCase
-test_bindingSpecs_stdlib_bool_c23 =
+test_stdlib_bool_c23 :: TestCase
+test_stdlib_bool_c23 =
     defaultTest "binding-specs/stdlib/bool"
       & #clangVersion .~ Just (>= (18, 0, 0))
       & #cStandard    .~ c23
 
-test_bindingSpecs_stdlib_return_values :: TestCase
-test_bindingSpecs_stdlib_return_values =
+test_stdlib_return_values :: TestCase
+test_stdlib_return_values =
     defaultTest "binding-specs/stdlib/return_values"

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Comprehensive.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Comprehensive.hs
@@ -25,8 +25,8 @@ import Test.HsBindgen.Resources
 
 testCases :: [TestCase]
 testCases = map omitFieldPrefixes [
-      test_comprehensive_c2hsc
-    , test_comprehensive_smoke
+      test_c2hsc
+    , test_smoke
     ]
   where
     omitFieldPrefixes :: TestCase -> TestCase
@@ -37,8 +37,8 @@ testCases = map omitFieldPrefixes [
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_comprehensive_c2hsc :: TestCase
-test_comprehensive_c2hsc =
+test_c2hsc :: TestCase
+test_c2hsc =
     defaultTest "comprehensive/c2hsc"
       & #tracePredicate .~ multiTracePredicate expected trace
   where
@@ -63,7 +63,7 @@ test_comprehensive_c2hsc =
       _otherwise ->
         Nothing
 
-test_comprehensive_smoke :: TestCase
-test_comprehensive_smoke =
+test_smoke :: TestCase
+test_smoke =
     defaultTest "comprehensive/smoke"
       & #cStandard .~ c99

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Declarations.hs
@@ -26,26 +26,26 @@ testCases = [
     , defaultTest "declarations/forward_declaration"
     , defaultTest "declarations/opaque_declaration"
       -- Bespoke tests
-    , test_declarations_declaration_unselected_b
-    , test_declarations_definitions
-    , test_declarations_duplicate_field_name_omit
-    , test_declarations_failing_tentative_definitions_linkage
-    , test_declarations_field_name_reuse_omit
-    , test_declarations_name_collision
-    , test_declarations_name_collision_aux
-    , test_declarations_redeclaration
-    , test_declarations_redeclaration_different
-    , test_declarations_redeclaration_identical
-    , test_declarations_select_scoping
-    , test_declarations_tentative_definitions
+    , test_declaration_unselected_b
+    , test_definitions
+    , test_duplicate_field_name_omit
+    , test_failing_tentative_definitions_linkage
+    , test_field_name_reuse_omit
+    , test_name_collision
+    , test_name_collision_aux
+    , test_redeclaration
+    , test_redeclaration_different
+    , test_redeclaration_identical
+    , test_select_scoping
+    , test_tentative_definitions
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_declarations_declaration_unselected_b :: TestCase
-test_declarations_declaration_unselected_b =
+test_declaration_unselected_b :: TestCase
+test_declaration_unselected_b =
     testTraceMulti "declarations/declaration_unselected_b" declsWithMsgs $ \case
       MatchSelect name (MatchTransMissing [MatchTransNotSelected]) ->
         Just $ Expected name
@@ -55,8 +55,8 @@ test_declarations_declaration_unselected_b =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["f"]
 
-test_declarations_definitions :: TestCase
-test_declarations_definitions =
+test_definitions :: TestCase
+test_definitions =
     testTraceMulti "declarations/definitions" declsWithMsgs $ \case
       MatchDelayed name ParsePotentialDuplicateSymbol{} ->
         Just $ Expected name
@@ -66,8 +66,8 @@ test_declarations_definitions =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["foo", "n"]
 
-test_declarations_duplicate_field_name_omit :: TestCase
-test_declarations_duplicate_field_name_omit =
+test_duplicate_field_name_omit :: TestCase
+test_duplicate_field_name_omit =
     defaultTest "declarations/duplicate_field_name_omit"
       & #onFrontend      .~ (\cfg -> cfg
             & #fieldNamingStrategy .~ OmitFieldPrefixes
@@ -82,8 +82,8 @@ test_declarations_duplicate_field_name_omit =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct S"]
 
-test_declarations_failing_tentative_definitions_linkage :: TestCase
-test_declarations_failing_tentative_definitions_linkage =
+test_failing_tentative_definitions_linkage :: TestCase
+test_failing_tentative_definitions_linkage =
     failingTestLibclangMulti "declarations/failing/tentative_definitions_linkage" [(), ()] $ \case
       (matchDiagnosticSpelling "non-static declaration of" -> Just _diag) ->
         Just $ Expected ()
@@ -97,8 +97,8 @@ test_declarations_failing_tentative_definitions_linkage =
 -- coincide with a non-field declaration of the same name. Here @struct S@'s
 -- field @foo@ shares a name with a global @foo@, and @struct T@'s field @bar@
 -- with a function @bar@; none collide and all are generated and compile.
-test_declarations_field_name_reuse_omit :: TestCase
-test_declarations_field_name_reuse_omit =
+test_field_name_reuse_omit :: TestCase
+test_field_name_reuse_omit =
     defaultTest "declarations/field_name_reuse_omit"
       & #onFrontend .~ (\cfg -> cfg
             & #fieldNamingStrategy .~ OmitFieldPrefixes
@@ -111,8 +111,8 @@ test_declarations_field_name_reuse_omit =
 -- intra-declaration collisions: @enum Color { Color }@, whose tag and
 -- enumerator share the C name; and @enum A { a }@ (issue #2020), where the tag
 -- and the case-mangled enumerator both produce the Haskell name @A@.
-test_declarations_name_collision :: TestCase
-test_declarations_name_collision =
+test_name_collision :: TestCase
+test_name_collision =
     testTraceMulti "declarations/name_collision" declsWithMsgs $ \case
       MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name
@@ -130,8 +130,8 @@ test_declarations_name_collision =
 --
 -- * A function-pointer typedef generates @Bar_Aux@ (the function-pointer
 --   auxiliary type), which clashes with a top-level @bar_Aux@ declaration.
-test_declarations_name_collision_aux :: TestCase
-test_declarations_name_collision_aux =
+test_name_collision_aux :: TestCase
+test_name_collision_aux =
     testTraceMulti "declarations/name_collision_aux" declsWithMsgs $ \case
       MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name
@@ -141,8 +141,8 @@ test_declarations_name_collision_aux =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct foo", "foo_Aux", "bar", "bar_Aux"]
 
-test_declarations_redeclaration :: TestCase
-test_declarations_redeclaration =
+test_redeclaration :: TestCase
+test_redeclaration =
     defaultTest "declarations/redeclaration"
       & #cStandard      .~ c11
       & #tracePredicate .~ multiTracePredicate expected trace
@@ -157,8 +157,8 @@ test_declarations_redeclaration =
       _otherwise ->
         Nothing
 
-test_declarations_redeclaration_different :: TestCase
-test_declarations_redeclaration_different =
+test_redeclaration_different :: TestCase
+test_redeclaration_different =
     testTraceSimple "declarations/redeclaration_different" $ \case
       MatchSelect _name SelectConflict{} ->
         Just $ Expected ()
@@ -169,8 +169,8 @@ test_declarations_redeclaration_different =
       _otherwise ->
         Nothing
 
-test_declarations_redeclaration_identical :: TestCase
-test_declarations_redeclaration_identical =
+test_redeclaration_identical :: TestCase
+test_redeclaration_identical =
     defaultTest "declarations/redeclaration_identical"
       & #cStandard      .~ c11
       & #tracePredicate .~ multiTracePredicate expected trace
@@ -185,8 +185,8 @@ test_declarations_redeclaration_identical =
       _otherwise ->
         Nothing
 
-test_declarations_select_scoping :: TestCase
-test_declarations_select_scoping =
+test_select_scoping :: TestCase
+test_select_scoping =
     defaultTest "declarations/select_scoping"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BIf (SelectHeader FromMainHeaders)
@@ -204,8 +204,8 @@ test_declarations_select_scoping =
         , "ParsedAndSelected3"
         ]
 
-test_declarations_tentative_definitions :: TestCase
-test_declarations_tentative_definitions =
+test_tentative_definitions :: TestCase
+test_tentative_definitions =
     testTraceMulti "declarations/tentative_definitions" declsWithMsgs $ \case
       MatchDelayed name ParsePotentialDuplicateSymbol{} ->
         Just $ Expected name

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Documentation.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Documentation.hs
@@ -17,7 +17,7 @@ import Test.HsBindgen.Resources
 testCases :: [TestCase]
 testCases = [
       defaultTest "documentation/data_kind_pragma"
-    , test_documentation_doxygen_docs
+    , test_doxygen_docs
     , defaultTest "documentation/javadoc_banner"
     ]
 
@@ -25,8 +25,8 @@ testCases = [
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_documentation_doxygen_docs :: TestCase
-test_documentation_doxygen_docs =
+test_doxygen_docs :: TestCase
+test_doxygen_docs =
     testTrace "documentation/doxygen_docs"
       (multiTracePredicate @Text [] $ \case
         MatchDoxygen (DoxygenUnsupported _) -> Just Tolerated

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/EdgeCases.hs
@@ -37,30 +37,30 @@ testCases = [
     , defaultTest "edge-cases/unnamed_type_multiple_typedefs"
     , defaultTest "edge-cases/uses_utf8"
       -- Bespoke tests
-    , test_edgeCases_adios
-    , test_edgeCases_clang_generated_collision
-    , test_edgeCases_duplicate
-    , test_edgeCases_duplicate_record_field
-    , test_edgeCases_headers
-    , test_edgeCases_include_macro
-    , test_edgeCases_iterator
-    , test_edgeCases_ordinary_unnamed_decl
-    , test_edgeCases_select_no_match
-    , test_edgeCases_thread_local
-    , test_edgeCases_unsupported_builtin
+    , test_adios
+    , test_clang_generated_collision
+    , test_duplicate
+    , test_duplicate_record_field
+    , test_headers
+    , test_include_macro
+    , test_iterator
+    , test_ordinary_unnamed_decl
+    , test_select_no_match
+    , test_thread_local
+    , test_unsupported_builtin
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_edgeCases_adios :: TestCase
-test_edgeCases_adios =
+test_adios :: TestCase
+test_adios =
     defaultTest "edge-cases/adios"
       & #cStandard .~ c11
 
-test_edgeCases_clang_generated_collision :: TestCase
-test_edgeCases_clang_generated_collision =
+test_clang_generated_collision :: TestCase
+test_clang_generated_collision =
     defaultTest "edge-cases/clang_generated_collision"
       & #clangVersion   .~ Just (>= (16, 0, 0))
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
@@ -75,8 +75,8 @@ test_edgeCases_clang_generated_collision =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct foo"]
 
-test_edgeCases_duplicate :: TestCase
-test_edgeCases_duplicate =
+test_duplicate :: TestCase
+test_duplicate =
     defaultTest "edge-cases/duplicate"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BOr
@@ -103,40 +103,40 @@ test_edgeCases_duplicate =
         , ("function",        "mangle")
         ]
 
-test_edgeCases_duplicate_record_field :: TestCase
-test_edgeCases_duplicate_record_field =
+test_duplicate_record_field :: TestCase
+test_duplicate_record_field =
     defaultTest "edge-cases/duplicate_record_field"
       & #onFrontend .~ (\cfg -> cfg
             & #fieldNamingStrategy .~ OmitFieldPrefixes
           )
 
-test_edgeCases_headers :: TestCase
-test_edgeCases_headers =
+test_headers :: TestCase
+test_headers =
     testTraceSimple "edge-cases/headers" $ \case
       MatchNoDeclarations ->
         Just $ Expected ()
       _otherwise ->
         Nothing
 
-test_edgeCases_include_macro :: TestCase
-test_edgeCases_include_macro =
+test_include_macro :: TestCase
+test_include_macro =
     defaultTest "edge-cases/include_macro_parent"
       & #onFrontend .~ ( #selectionPredicate .~ BTrue )
 
-test_edgeCases_iterator :: TestCase
-test_edgeCases_iterator =
+test_iterator :: TestCase
+test_iterator =
     defaultTest "edge-cases/iterator"
       & #clangVersion .~ Just (>= (15, 0, 0))
       & #cStandard    .~ c23
       & #onBoot       .~ ( #clangArgs % #enableBlocks .~ True )
 
-test_edgeCases_ordinary_unnamed_decl :: TestCase
-test_edgeCases_ordinary_unnamed_decl =
+test_ordinary_unnamed_decl :: TestCase
+test_ordinary_unnamed_decl =
     defaultTest "edge-cases/ordinary_unnamed_decl_parent"
       & #onFrontend .~ ( #selectionPredicate .~ BTrue )
 
-test_edgeCases_select_no_match :: TestCase
-test_edgeCases_select_no_match =
+test_select_no_match :: TestCase
+test_select_no_match =
     defaultTest "edge-cases/select_no_match"
       & #onFrontend .~ ( #selectionPredicate .~
             BIf (SelectDecl (DeclNameMatches "this_pattern_will_never_match"))
@@ -148,8 +148,8 @@ test_edgeCases_select_no_match =
               Nothing
           )
 
-test_edgeCases_thread_local :: TestCase
-test_edgeCases_thread_local =
+test_thread_local :: TestCase
+test_thread_local =
     defaultTest "edge-cases/thread_local"
       & #clangVersion   .~ Just (>= (16, 0, 0))
       & #cStandard    .~ c23
@@ -160,8 +160,8 @@ test_edgeCases_thread_local =
               Nothing
           )
 
-test_edgeCases_unsupported_builtin :: TestCase
-test_edgeCases_unsupported_builtin =
+test_unsupported_builtin :: TestCase
+test_unsupported_builtin =
     testTraceMulti "edge-cases/unsupported_builtin" declsWithMsgs $ \case
       MatchDelayed name (ParseUnsupportedBuiltin "__builtin_va_list") ->
         Just $ Expected name

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
@@ -34,23 +34,23 @@ testCases = [
     , defaultTest "functions/heap_types/union"
     , defaultTest "functions/typedef_funptr"
       -- Bespoke tests
-    , test_functions_decls_in_signature
-    , test_functions_fun_attributes
-    , test_functions_fun_attributes_conflict
-    , test_functions_hash_defines
-    , test_functions_hash_defines_select_all
-    , test_functions_not_visible_decl
-    , test_functions_simple_func
-    , test_functions_simple_func_rename
-    , test_functions_varargs
+    , test_decls_in_signature
+    , test_fun_attributes
+    , test_fun_attributes_conflict
+    , test_hash_defines
+    , test_hash_defines_select_all
+    , test_not_visible_decl
+    , test_simple_func
+    , test_simple_func_rename
+    , test_varargs
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_functions_decls_in_signature :: TestCase
-test_functions_decls_in_signature =
+test_decls_in_signature :: TestCase
+test_decls_in_signature =
     testTraceMulti "functions/decls_in_signature" declsWithMsgs $ \case
       MatchDelayed name ParseDeclarationNotVisible{} ->
         Just $ Expected name
@@ -64,8 +64,8 @@ test_functions_decls_in_signature =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["f1", "f2", "f3", "f4", "f5"]
 
-test_functions_fun_attributes :: TestCase
-test_functions_fun_attributes =
+test_fun_attributes :: TestCase
+test_fun_attributes =
     defaultTest "functions/fun_attributes"
       & #clangVersion   .~ Just (>= (15, 0, 0))
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
@@ -92,8 +92,8 @@ test_functions_fun_attributes =
         , "old_fn_unavailable"
         ]
 
-test_functions_fun_attributes_conflict :: TestCase
-test_functions_fun_attributes_conflict =
+test_fun_attributes_conflict :: TestCase
+test_fun_attributes_conflict =
     testTraceMulti "functions/fun_attributes_conflict" declsWithMsgs $ \case
       MatchDiagnosticOption "-Wno-ignored-attributes" ->
         Just Tolerated
@@ -108,8 +108,8 @@ test_functions_fun_attributes_conflict =
 -- The header does not preprocess without @MY_SIZE@, so PP\/TH fixture
 -- compilation only succeeds if the directives are forwarded to the wrapper
 -- source.
-test_functions_hash_defines :: TestCase
-test_functions_hash_defines =
+test_hash_defines :: TestCase
+test_hash_defines =
     defaultTest "functions/hash_defines"
       & #hashDefines .~ hashDefines
 
@@ -118,8 +118,8 @@ test_functions_hash_defines =
 -- They live in the synthetic root header, which is not a main header of
 -- anything, so they are not attempted at all — no macro bindings, and no
 -- traces.
-test_functions_hash_defines_select_all :: TestCase
-test_functions_hash_defines_select_all =
+test_hash_defines_select_all :: TestCase
+test_hash_defines_select_all =
     testVariant "functions/hash_defines" (Just 1) "select_all"
       & #hashDefines .~ hashDefines
       & #onFrontend  .~ ( #selectionPredicate .~ BTrue)
@@ -131,8 +131,8 @@ hashDefines = [
     , C.HashDefine "MY_EMPTY"   ""
     ]
 
-test_functions_not_visible_decl :: TestCase
-test_functions_not_visible_decl =
+test_not_visible_decl :: TestCase
+test_not_visible_decl =
     testTraceMulti "functions/not_visible_decl" declsWithMsgs $ \case
       MatchDelayed name ParseDeclarationNotVisible{} ->
         Just $ Expected name
@@ -146,13 +146,13 @@ test_functions_not_visible_decl =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["f", "g", "h"]
 
-test_functions_simple_func :: TestCase
-test_functions_simple_func =
+test_simple_func :: TestCase
+test_simple_func =
     defaultTest "functions/simple_func"
       & #cStandard .~ c99
 
-test_functions_simple_func_rename :: TestCase
-test_functions_simple_func_rename =
+test_simple_func_rename :: TestCase
+test_simple_func_rename =
     testVariant "functions/simple_func" (Just 1) "rename"
       & #cStandard .~ c99
       & #onBackend .~ ( #categoryChoice .~ ByCategory {
@@ -163,8 +163,8 @@ test_functions_simple_func_rename =
           , cGlobal = ExcludeCategory
           })
 
-test_functions_varargs :: TestCase
-test_functions_varargs =
+test_varargs :: TestCase
+test_varargs =
     testTraceMulti "functions/varargs" declsWithMsgs $ \case
       MatchDelayed name ParseUnsupportedVariadicFunction ->
         Just $ Expected name

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Globals.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Globals.hs
@@ -14,16 +14,16 @@ import Test.HsBindgen.Golden.Infra.TestCase
 
 testCases :: [TestCase]
 testCases = [
-      test_globals_globals
-    , test_globals_untagged
+      test_globals
+    , test_untagged
     ]
 
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
 
-test_globals_globals :: TestCase
-test_globals_globals =
+test_globals :: TestCase
+test_globals =
     testTraceMulti "globals/globals" declsWithMsgs $ \case
       MatchDelayed name ParsePotentialDuplicateSymbol{} ->
         Just $ Expected name
@@ -52,5 +52,5 @@ test_globals_globals =
         , "streamBinary"
         ]
 
-test_globals_untagged :: TestCase
-test_globals_untagged = defaultTest "globals/untagged"
+test_untagged :: TestCase
+test_untagged = defaultTest "globals/untagged"

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -34,21 +34,21 @@ testCases = [
     , defaultTest "macros/parse/macro_typedef_scope"
     , defaultTest "macros/undef"
       -- Bespoke tests
-    , test_macros_macro_comma
-    , test_macros_macro_ext_binding_dep
-    , test_macros_macro_resolution_log_level_default
-    , test_macros_macro_resolution_log_level_warnings
-    , test_macros_macro_type_unresolved_tagged
-    , test_macros_macro_in_fundecl
-    , test_macros_macro_in_fundecl_vs_typedef
-    , test_macros_macro_redefines_global
-    , test_macros_macros
-    , test_macros_parse_simple
-    , test_macros_parse_elaborate
-    , test_macros_parse_intermittent_include
-    , test_macros_parse_intermittent_include_conditional
-    , test_macros_parse_macro_typedef_scope_multiple
-    , test_macros_wrong_source_location
+    , test_macro_comma
+    , test_macro_ext_binding_dep
+    , test_macro_resolution_log_level_default
+    , test_macro_resolution_log_level_warnings
+    , test_macro_type_unresolved_tagged
+    , test_macro_in_fundecl
+    , test_macro_in_fundecl_vs_typedef
+    , test_macro_redefines_global
+    , test_macros
+    , test_parse_simple
+    , test_parse_elaborate
+    , test_parse_intermittent_include
+    , test_parse_intermittent_include_conditional
+    , test_parse_macro_typedef_scope_multiple
+    , test_wrong_source_location
     ]
 
 {-------------------------------------------------------------------------------
@@ -61,16 +61,16 @@ testCases = [
 -- bodies no meaning of their own, and tuples support the argument-list idiom
 -- (@#define ARGS 1, 2@ used as @f(ARGS)@). Consequently, a comma expression
 -- does not compose with arithmetic; @ARITH@ is dropped with a parse failure.
-test_macros_macro_comma :: TestCase
-test_macros_macro_comma =
+test_macro_comma :: TestCase
+test_macro_comma =
     testTraceMulti "macros/macro_comma" ["macro ARITH"] $ \case
       MatchUnusable name@"macro ARITH" (UnusableParseFailure ParseMacroErrorParse{}) ->
         Just $ Expected name
       _otherwise ->
         Nothing
 
-test_macros_macro_ext_binding_dep :: TestCase
-test_macros_macro_ext_binding_dep =
+test_macro_ext_binding_dep :: TestCase
+test_macro_ext_binding_dep =
     defaultTest "macros/macro_ext_binding_dep"
       & #specExternal .~
           [ "test-artefacts/headers/golden/macros/macro_ext_binding_dep.yaml"
@@ -81,8 +81,8 @@ test_macros_macro_ext_binding_dep =
 -- Regression test for <https://github.com/well-typed/hs-bindgen/issues/2147>:
 -- such failures are common in real headers (e.g. preprocessor-only operators),
 -- so they must not be warnings by default.
-test_macros_macro_resolution_log_level_default :: TestCase
-test_macros_macro_resolution_log_level_default =
+test_macro_resolution_log_level_default :: TestCase
+test_macro_resolution_log_level_default =
     testVariant "macros/macro_resolution_log_level" Nothing "default"
       & #tracePredicate .~ multiTracePredicate expected (\trace -> case trace of
             MatchUnusable name (UnusableMacroResolutionFailure{})
@@ -95,10 +95,10 @@ test_macros_macro_resolution_log_level_default =
 
 -- | 'EnableMacroWarnings' raises macro name-resolution failures to 'Warning'.
 --
--- Companion to 'test_macros_macro_resolution_log_level_default'; the predicate
+-- Companion to 'test_macro_resolution_log_level_default'; the predicate
 -- insists the (custom) log level is 'Warning'.
-test_macros_macro_resolution_log_level_warnings :: TestCase
-test_macros_macro_resolution_log_level_warnings =
+test_macro_resolution_log_level_warnings :: TestCase
+test_macro_resolution_log_level_warnings =
     testVariant "macros/macro_resolution_log_level" Nothing "enable_macro_warnings"
       & #tracePredicate .~ multiTracePredicateCustomLogLevel customLogLevel
           expected (\trace -> case trace of
@@ -114,8 +114,8 @@ test_macros_macro_resolution_log_level_warnings =
     expected :: [C.DeclName]
     expected = ["macro UNRESOLVED_MACRO"]
 
-test_macros_macro_type_unresolved_tagged :: TestCase
-test_macros_macro_type_unresolved_tagged =
+test_macro_type_unresolved_tagged :: TestCase
+test_macro_type_unresolved_tagged =
     testTraceMulti "macros/macro_type_unresolved_tagged" declsWithMsgs $ \case
       MatchUnusable name@"struct Unparsable"
         (UnusableParseFailure (ParseUnsupportedFloatType UnsupportedLongDouble)) ->
@@ -142,8 +142,8 @@ test_macros_macro_type_unresolved_tagged =
       , ("macro DOES_NOT_EXIST",     "macro-unresolved-tagged-type")
       ]
 
-test_macros_macro_in_fundecl :: TestCase
-test_macros_macro_in_fundecl =
+test_macro_in_fundecl :: TestCase
+test_macro_in_fundecl =
     testTraceMulti "macros/macro_in_fundecl" declsWithMsgs $ \case
       MatchDelayed name ParsePotentialDuplicateSymbol{} ->
         Just $ Expected name
@@ -160,8 +160,8 @@ test_macros_macro_in_fundecl =
         , "wam"
         ]
 
-test_macros_macro_in_fundecl_vs_typedef :: TestCase
-test_macros_macro_in_fundecl_vs_typedef =
+test_macro_in_fundecl_vs_typedef :: TestCase
+test_macro_in_fundecl_vs_typedef =
     testTraceMulti "macros/macro_in_fundecl_vs_typedef" declsWithMsgs $ \case
       MatchDelayed name ParsePotentialDuplicateSymbol{} ->
         Just $ Expected name
@@ -171,8 +171,8 @@ test_macros_macro_in_fundecl_vs_typedef =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["quux1", "quux2", "wam1", "wam2"]
 
-test_macros_macro_redefines_global :: TestCase
-test_macros_macro_redefines_global =
+test_macro_redefines_global :: TestCase
+test_macro_redefines_global =
     testTraceMulti "macros/macro_redefines_global" declsWithMsgs $ \case
       MatchSelect name SelectConflict{} ->
         Just $ Expected name
@@ -189,34 +189,34 @@ test_macros_macro_redefines_global =
       , "macro stderr"
       ]
 
-test_macros_macros :: TestCase
-test_macros_macros =
+test_macros :: TestCase
+test_macros =
     defaultTest "macros/macros"
       & #cStandard .~ c23
 
-test_macros_parse_simple :: TestCase
-test_macros_parse_simple =
+test_parse_simple :: TestCase
+test_parse_simple =
     defaultTest "macros/parse/simple"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BTrue
           )
 
-test_macros_parse_elaborate :: TestCase
-test_macros_parse_elaborate =
+test_parse_elaborate :: TestCase
+test_parse_elaborate =
     defaultTest "macros/parse/elaborate"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BTrue
           )
 
-test_macros_parse_intermittent_include :: TestCase
-test_macros_parse_intermittent_include =
+test_parse_intermittent_include :: TestCase
+test_parse_intermittent_include =
     defaultTest "macros/parse/intermittent_include"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BTrue
           )
 
-test_macros_parse_intermittent_include_conditional :: TestCase
-test_macros_parse_intermittent_include_conditional =
+test_parse_intermittent_include_conditional :: TestCase
+test_parse_intermittent_include_conditional =
     defaultTest "macros/parse/intermittent_include_conditional"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BTrue
@@ -236,15 +236,15 @@ test_macros_parse_intermittent_include_conditional =
       , ("macro FOO", "conflict")
       ]
 
-test_macros_parse_macro_typedef_scope_multiple :: TestCase
-test_macros_parse_macro_typedef_scope_multiple =
+test_parse_macro_typedef_scope_multiple :: TestCase
+test_parse_macro_typedef_scope_multiple =
     defaultTest "macros/parse/macro_typedef_scope_multiple"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BTrue
           )
 
-test_macros_wrong_source_location :: TestCase
-test_macros_wrong_source_location =
+test_wrong_source_location :: TestCase
+test_wrong_source_location =
     defaultTest "macros/wrong_source_location"
       -- Spelling location is only populated correctly on llvm >= 19.1.0;
       -- older toolchains cannot disambiguate unnamed declarations

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
@@ -23,44 +23,44 @@ import Test.HsBindgen.Golden.Infra.TestCase
 
 testCases :: [TestCase]
 testCases = [
-      test_programAnalysis_delay_traces
+      test_delay_traces
       -- * Circular programs
-    , test_programAnalysis_circular_includes
-    , test_programAnalysis_circular_macro
+    , test_circular_includes
+    , test_circular_macro
       -- * Program slicing
-    , test_programAnalysis_program_slicing_macro_selected
-    , test_programAnalysis_program_slicing_macro_unselected
-    , test_programAnalysis_program_slicing_typedef_selected
-    , test_programAnalysis_program_slicing_typedef_unselected
-    , test_programAnalysis_program_slicing_selection
-    , test_programAnalysis_program_slicing_simple
+    , test_program_slicing_macro_selected
+    , test_program_slicing_macro_unselected
+    , test_program_slicing_typedef_selected
+    , test_program_slicing_typedef_unselected
+    , test_program_slicing_selection
+    , test_program_slicing_simple
       -- * Selection
-    , test_programAnalysis_selection_bad
-    , test_programAnalysis_selection_fail
-    , test_programAnalysis_selection_fail_variant_1
-    , test_programAnalysis_selection_fail_variant_2
-    , test_programAnalysis_selection_fail_variant_3
-    , test_programAnalysis_selection_foo
-    , test_programAnalysis_selection_matches_c_names_1
-    , test_programAnalysis_selection_matches_c_names_2
-    , test_programAnalysis_selection_merge_traces
-    , test_programAnalysis_selection_omit_external_a
-    , test_programAnalysis_selection_omit_external_b
-    , test_programAnalysis_selection_omit_prescriptive
-    , test_programAnalysis_selection_squash
+    , test_selection_bad
+    , test_selection_fail
+    , test_selection_fail_variant_1
+    , test_selection_fail_variant_2
+    , test_selection_fail_variant_3
+    , test_selection_foo
+    , test_selection_matches_c_names_1
+    , test_selection_matches_c_names_2
+    , test_selection_merge_traces
+    , test_selection_omit_external_a
+    , test_selection_omit_external_b
+    , test_selection_omit_prescriptive
+    , test_selection_squash
       -- * Typedef analysis
-    , test_programAnalysis_typedef_analysis
-    , test_programAnalysis_typedef_block
-    , test_programAnalysis_typedef_name_clash
-    , test_programAnalysis_typedef_suffix_clash
+    , test_typedef_analysis
+    , test_typedef_block
+    , test_typedef_name_clash
+    , test_typedef_suffix_clash
     ]
 
 {-------------------------------------------------------------------------------
   Delay traces
 -------------------------------------------------------------------------------}
 
-test_programAnalysis_delay_traces :: TestCase
-test_programAnalysis_delay_traces =
+test_delay_traces :: TestCase
+test_delay_traces =
     defaultTest "program-analysis/delay_traces"
       & #onFrontend .~ ( #selectionPredicate .~
             -- NOTE: Matching for name kind is not good practice, but we want to
@@ -100,12 +100,12 @@ test_programAnalysis_delay_traces =
   Circularities
 -------------------------------------------------------------------------------}
 
-test_programAnalysis_circular_includes :: TestCase
-test_programAnalysis_circular_includes =
+test_circular_includes :: TestCase
+test_circular_includes =
     defaultTest "program-analysis/circular_includes"
 
-test_programAnalysis_circular_macro :: TestCase
-test_programAnalysis_circular_macro =
+test_circular_macro :: TestCase
+test_circular_macro =
     defaultTest "program-analysis/circular_macro"
       & #tracePredicate .~
           multiTracePredicateCustomLogLevel
@@ -133,15 +133,15 @@ test_programAnalysis_circular_macro =
   Program slicing
 -------------------------------------------------------------------------------}
 
-test_programAnalysis_program_slicing_macro_selected :: TestCase
-test_programAnalysis_program_slicing_macro_selected =
+test_program_slicing_macro_selected :: TestCase
+test_program_slicing_macro_selected =
     defaultTest "program-analysis/program-slicing/macro_selected"
       & #onFrontend .~ (\cfg -> cfg
             & #programSlicing .~ EnableProgramSlicing
           )
 
-test_programAnalysis_program_slicing_macro_unselected :: TestCase
-test_programAnalysis_program_slicing_macro_unselected =
+test_program_slicing_macro_unselected :: TestCase
+test_program_slicing_macro_unselected =
     defaultTest "program-analysis/program-slicing/macro_unselected"
       & #onFrontend .~ (\cfg -> cfg
             & #programSlicing .~ DisableProgramSlicing
@@ -156,15 +156,15 @@ test_programAnalysis_program_slicing_macro_unselected =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["foo"]
 
-test_programAnalysis_program_slicing_typedef_selected :: TestCase
-test_programAnalysis_program_slicing_typedef_selected =
+test_program_slicing_typedef_selected :: TestCase
+test_program_slicing_typedef_selected =
     defaultTest "program-analysis/program-slicing/typedef_selected"
       & #onFrontend .~ (\cfg -> cfg
             & #programSlicing .~ EnableProgramSlicing
           )
 
-test_programAnalysis_program_slicing_typedef_unselected :: TestCase
-test_programAnalysis_program_slicing_typedef_unselected =
+test_program_slicing_typedef_unselected :: TestCase
+test_program_slicing_typedef_unselected =
     defaultTest "program-analysis/program-slicing/typedef_unselected"
       & #onFrontend .~ (\cfg -> cfg
             & #programSlicing .~ DisableProgramSlicing
@@ -179,8 +179,8 @@ test_programAnalysis_program_slicing_typedef_unselected =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["foo"]
 
-test_programAnalysis_program_slicing_selection :: TestCase
-test_programAnalysis_program_slicing_selection =
+test_program_slicing_selection :: TestCase
+test_program_slicing_selection =
     defaultTest "program-analysis/program_slicing_selection"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BOr
@@ -206,8 +206,8 @@ test_programAnalysis_program_slicing_selection =
 
 -- Check that program slicing generates bindings for uint32_t and uint64_t if we
 -- only provide external binding specifications for uint64_t.
-test_programAnalysis_program_slicing_simple :: TestCase
-test_programAnalysis_program_slicing_simple =
+test_program_slicing_simple :: TestCase
+test_program_slicing_simple =
     defaultTest "program-analysis/program_slicing_simple"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BIf (SelectHeader FromMainHeaders)
@@ -235,8 +235,8 @@ test_programAnalysis_program_slicing_simple =
   Selection
 -------------------------------------------------------------------------------}
 
-test_programAnalysis_selection_bad :: TestCase
-test_programAnalysis_selection_bad =
+test_selection_bad :: TestCase
+test_selection_bad =
     testTraceMulti "program-analysis/selection_bad" declsWithMsgs $ \case
       MatchSelect name MatchTransMissing{} ->
         Just $ Expected name
@@ -247,8 +247,8 @@ test_programAnalysis_selection_bad =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["f"]
 
-test_programAnalysis_selection_fail :: TestCase
-test_programAnalysis_selection_fail =
+test_selection_fail :: TestCase
+test_selection_fail =
     testTraceMulti "program-analysis/selection_fail" declsWithMsgs $ \case
       MatchUnusable name UnusableParseFailure{} ->
         Just $ Expected name
@@ -273,8 +273,8 @@ test_programAnalysis_selection_fail =
         , "struct OkAfter"
         ]
 
-test_programAnalysis_selection_fail_variant_1 :: TestCase
-test_programAnalysis_selection_fail_variant_1 =
+test_selection_fail_variant_1 :: TestCase
+test_selection_fail_variant_1 =
     testVariant "program-analysis/selection_fail" (Just 1) "deselect_failed"
       & #onFrontend .~ ( #selectionPredicate .~  BAnd
             (       BIf $ SelectHeader   FromMainHeaders)
@@ -301,8 +301,8 @@ test_programAnalysis_selection_fail_variant_1 =
         , "struct OkAfter"
         ]
 
-test_programAnalysis_selection_fail_variant_2 :: TestCase
-test_programAnalysis_selection_fail_variant_2 =
+test_selection_fail_variant_2 :: TestCase
+test_selection_fail_variant_2 =
     testVariant "program-analysis/selection_fail" (Just 2) "program_slicing"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BAnd
@@ -331,8 +331,8 @@ test_programAnalysis_selection_fail_variant_2 =
         , "struct OkAfter"
         ]
 
-test_programAnalysis_selection_fail_variant_3 :: TestCase
-test_programAnalysis_selection_fail_variant_3 =
+test_selection_fail_variant_3 :: TestCase
+test_selection_fail_variant_3 =
     testVariant "program-analysis/selection_fail" (Just 3) "select_ok"
       & #onFrontend .~ (\cfg -> cfg
           & #selectionPredicate .~ BAnd
@@ -350,8 +350,8 @@ test_programAnalysis_selection_fail_variant_3 =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct OkBefore"]
 
-test_programAnalysis_selection_foo :: TestCase
-test_programAnalysis_selection_foo =
+test_selection_foo :: TestCase
+test_selection_foo =
     testTraceMulti "program-analysis/selection_foo" declsWithMsgs $ \case
       MatchSelect _name (MatchTransMissing [_]) ->
         Just $ Expected ("macro A", "foo_t not selected")
@@ -372,8 +372,8 @@ test_programAnalysis_selection_foo =
       , ("f", "unsupported underlying type")
       ]
 
-test_programAnalysis_selection_matches_c_names_1 :: TestCase
-test_programAnalysis_selection_matches_c_names_1 =
+test_selection_matches_c_names_1 :: TestCase
+test_selection_matches_c_names_1 =
     testVariant "program-analysis/selection_matches_c_names" (Just 1) "positive_case"
       & #specPrescriptive .~ Just "test-artefacts/headers/golden/program-analysis/selection_matches_c_names.yaml"
       & #onFrontend .~ ( #selectionPredicate .~ predicate )
@@ -384,8 +384,8 @@ test_programAnalysis_selection_matches_c_names_1 =
               (BIf (SelectDecl $ DeclNameMatches "FunctionWithAssignedHaskellNameByNameMangler"))
               (BIf (SelectDecl $ DeclNameMatches "struct StructWithAssignedHaskellNameByPrescriptiveBindingSpecs"))
 
-test_programAnalysis_selection_matches_c_names_2 :: TestCase
-test_programAnalysis_selection_matches_c_names_2 =
+test_selection_matches_c_names_2 :: TestCase
+test_selection_matches_c_names_2 =
     testVariant "program-analysis/selection_matches_c_names" (Just 2) "negative_case"
       & #specPrescriptive .~ Just "test-artefacts/headers/golden/program-analysis/selection_matches_c_names.yaml"
       & #onFrontend .~ ( #selectionPredicate .~ predicate )
@@ -402,8 +402,8 @@ test_programAnalysis_selection_matches_c_names_2 =
               (BIf (SelectDecl $ DeclNameMatches "functionWithAssignedHaskellNameByNameMangler"))
               (BIf (SelectDecl $ DeclNameMatches "NewName"))
 
-test_programAnalysis_selection_merge_traces :: TestCase
-test_programAnalysis_selection_merge_traces =
+test_selection_merge_traces :: TestCase
+test_selection_merge_traces =
     defaultTest "program-analysis/selection_merge_traces"
       & #onFrontend .~ ( #selectionPredicate .~ predicate )
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
@@ -423,8 +423,8 @@ test_programAnalysis_selection_merge_traces =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["dependsOnXAndY"]
 
-test_programAnalysis_selection_omit_external_a :: TestCase
-test_programAnalysis_selection_omit_external_a =
+test_selection_omit_external_a :: TestCase
+test_selection_omit_external_a =
     defaultTest "program-analysis/selection_omit_external_a"
       & #specExternal .~ ["test-artefacts/headers/golden/program-analysis/selection_omit_external.yaml"]
       & #onFrontend .~ ( #programSlicing .~ EnableProgramSlicing )
@@ -441,14 +441,14 @@ test_programAnalysis_selection_omit_external_a =
 -- TODO <https://github.com/well-typed/hs-bindgen/issues/1361>
 -- We should warn when we create bindings for a declaration omitted by an
 -- /external/ binding specification.
-test_programAnalysis_selection_omit_external_b :: TestCase
-test_programAnalysis_selection_omit_external_b =
+test_selection_omit_external_b :: TestCase
+test_selection_omit_external_b =
     defaultTest "program-analysis/selection_omit_external_b"
       & #specExternal .~ ["test-artefacts/headers/golden/program-analysis/selection_omit_external.yaml"]
       & #onFrontend   .~ ( #programSlicing .~  EnableProgramSlicing )
 
-test_programAnalysis_selection_omit_prescriptive :: TestCase
-test_programAnalysis_selection_omit_prescriptive =
+test_selection_omit_prescriptive :: TestCase
+test_selection_omit_prescriptive =
     defaultTest "program-analysis/selection_omit_prescriptive"
       & #specPrescriptive .~ Just "test-artefacts/headers/golden/program-analysis/selection_omit_prescriptive.yaml"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
@@ -467,8 +467,8 @@ test_programAnalysis_selection_omit_prescriptive =
         , ("struct IndirectlyDependsOnOmitted", "select")
         ]
 
-test_programAnalysis_selection_squash :: TestCase
-test_programAnalysis_selection_squash =
+test_selection_squash :: TestCase
+test_selection_squash =
     defaultTest "program-analysis/selection_squash_typedef"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
             MatchSelect name (MatchTransMissing [MatchTransNotSelected]) ->
@@ -486,11 +486,11 @@ test_programAnalysis_selection_squash =
 
 -- | Locally resolvable typedef/tag clashes: squashing and suffixing.
 --
--- See also 'test_programAnalysis_typedef_block' (the @-fblocks@ path) and
--- 'test_programAnalysis_typedef_name_clash' (clashes that are /not/ locally
+-- See also 'test_typedef_block' (the @-fblocks@ path) and
+-- 'test_typedef_name_clash' (clashes that are /not/ locally
 -- resolvable and are reported as failures).
-test_programAnalysis_typedef_analysis :: TestCase
-test_programAnalysis_typedef_analysis =
+test_typedef_analysis :: TestCase
+test_typedef_analysis =
     testTraceMulti "program-analysis/typedef_analysis" declsWithMsgs $ \case
       MatchSelect name SelectMangleNamesSquashed{} ->
         Just $ Expected (name, Nothing)
@@ -535,10 +535,10 @@ test_programAnalysis_typedef_analysis =
 
 -- | Exercise the 'C.TypeBlock' path in 'taggedPayloads'.
 --
--- Kept separate from 'test_programAnalysis_typedef_analysis' because this
+-- Kept separate from 'test_typedef_analysis' because this
 -- header requires @-fblocks@.
-test_programAnalysis_typedef_block :: TestCase
-test_programAnalysis_typedef_block =
+test_typedef_block :: TestCase
+test_typedef_block =
     testTraceMulti "program-analysis/typedef_block" declsWithMsgs (\case
           MatchMangle name (MangleNamesAssignedName new) ->
             Just $ Expected (name, new.text)
@@ -556,10 +556,10 @@ test_programAnalysis_typedef_block =
 -- | Clash cases that the typedef analysis deliberately does NOT resolve
 -- locally; both colliding declarations are deselected via 'DetectClashesCollision'.
 --
--- Complements 'test_programAnalysis_typedef_analysis', which covers the cases
+-- Complements 'test_typedef_analysis', which covers the cases
 -- that /are/ locally resolvable.
-test_programAnalysis_typedef_name_clash :: TestCase
-test_programAnalysis_typedef_name_clash =
+test_typedef_name_clash :: TestCase
+test_typedef_name_clash =
     testTraceMulti "program-analysis/typedef_name_clash" declsWithMsgs $ \case
       MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected (name, "collision")
@@ -585,11 +585,11 @@ test_programAnalysis_typedef_name_clash =
 -- check deselects /both/ colliding declarations (it does not invent a
 -- @_struct2@); the eponymous typedef then loses its dropped dependency.
 --
--- Complements 'test_programAnalysis_typedef_analysis' (the suffix in isolation)
--- and 'test_programAnalysis_typedef_name_clash' (clashes with no suffix
+-- Complements 'test_typedef_analysis' (the suffix in isolation)
+-- and 'test_typedef_name_clash' (clashes with no suffix
 -- involved).
-test_programAnalysis_typedef_suffix_clash :: TestCase
-test_programAnalysis_typedef_suffix_clash =
+test_typedef_suffix_clash :: TestCase
+test_typedef_suffix_clash =
     testTraceMulti "program-analysis/typedef_suffix_clash" declsWithMsgs $ \case
       MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected (name, "collision")

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
@@ -70,30 +70,30 @@ testCases = [
     ++ test_indirect_fields
     ++ [
       -- Bespoke tests
-      test_types_anonymous_edge_cases_drop_indirect_fields_1
-    , test_types_anonymous_edge_cases_drop_indirect_fields_2
-    , test_types_anonymous_edge_cases_empty_anon
-    , test_types_anonymous_edge_cases_multi_nesting
-    , test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes
-    , test_types_anonymous_edge_cases_reparse
-    , test_types_long_double
-    , test_types_primitives_bool_c23
-    , test_types_primitives_bool_macro_override
-    , test_types_primitives_bool_typedef_override
-    , test_types_primitives_least_fast
-    , test_types_scoping_deep_nesting
-    , test_types_scoping_nesting
-    , test_types_scoping_wide_nesting
-    , test_types_small_floats
-    , test_types_special_parse_failure_long_double
-    , test_types_structs_bitfields
-    , test_types_structs_omit_field_prefixes
-    , test_types_structs_post_qualified
-    , test_types_structs_tagged_vs_untagged
-    , test_types_structs_untagged_struct
-    , test_types_typedefs_auxiliary_function_pointer_block
-    , test_types_typedefs_typedefs
-    , test_types_typedefs_typenames
+      test_anonymous_edge_cases_drop_indirect_fields_1
+    , test_anonymous_edge_cases_drop_indirect_fields_2
+    , test_anonymous_edge_cases_empty_anon
+    , test_anonymous_edge_cases_multi_nesting
+    , test_anonymous_edge_cases_multi_nesting_omit_field_prefixes
+    , test_anonymous_edge_cases_reparse
+    , test_long_double
+    , test_primitives_bool_c23
+    , test_primitives_bool_macro_override
+    , test_primitives_bool_typedef_override
+    , test_primitives_least_fast
+    , test_scoping_deep_nesting
+    , test_scoping_nesting
+    , test_scoping_wide_nesting
+    , test_small_floats
+    , test_special_parse_failure_long_double
+    , test_structs_bitfields
+    , test_structs_omit_field_prefixes
+    , test_structs_post_qualified
+    , test_structs_tagged_vs_untagged
+    , test_structs_untagged_struct
+    , test_typedefs_auxiliary_function_pointer_block
+    , test_typedefs_typedefs
+    , test_typedefs_typenames
     ]
 
 {-------------------------------------------------------------------------------
@@ -127,8 +127,8 @@ test_indirect_fields = [
 
 -- | Test that indirect fields are dropped if they would cross an external
 -- binding spec abstraction boundary
-test_types_anonymous_edge_cases_drop_indirect_fields_1 :: TestCase
-test_types_anonymous_edge_cases_drop_indirect_fields_1 =
+test_anonymous_edge_cases_drop_indirect_fields_1 :: TestCase
+test_anonymous_edge_cases_drop_indirect_fields_1 =
     defaultTest "types/anonymous/edge-cases/drop_indirect_fields"
       & #name %~ (++ "_1")
       & #outputDir %~ (++ "_1")
@@ -156,8 +156,8 @@ test_types_anonymous_edge_cases_drop_indirect_fields_1 =
 
 -- | Test that indirect fields are dropped if they would cross an external
 -- binding spec abstraction boundary
-test_types_anonymous_edge_cases_drop_indirect_fields_2 :: TestCase
-test_types_anonymous_edge_cases_drop_indirect_fields_2 =
+test_anonymous_edge_cases_drop_indirect_fields_2 :: TestCase
+test_anonymous_edge_cases_drop_indirect_fields_2 =
     defaultTest "types/anonymous/edge-cases/drop_indirect_fields"
       & #name %~ (++ "_2")
       & #outputDir %~ (++ "_2")
@@ -182,8 +182,8 @@ test_types_anonymous_edge_cases_drop_indirect_fields_2 =
       _otherwise ->
         Nothing
 
-test_types_anonymous_edge_cases_empty_anon :: TestCase
-test_types_anonymous_edge_cases_empty_anon =
+test_anonymous_edge_cases_empty_anon :: TestCase
+test_anonymous_edge_cases_empty_anon =
     testTraceMulti "types/anonymous/edge-cases/empty_anon" declsWithMsgs $ \case
       MatchDelayedImplicitField "struct S1" UnsupportedEmptyAnon ->
         Just $ Expected "struct S1"
@@ -195,55 +195,55 @@ test_types_anonymous_edge_cases_empty_anon =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct S1", "struct S2"]
 
-test_types_anonymous_edge_cases_multi_nesting :: TestCase
-test_types_anonymous_edge_cases_multi_nesting =
+test_anonymous_edge_cases_multi_nesting :: TestCase
+test_anonymous_edge_cases_multi_nesting =
     defaultTest "types/anonymous/edge-cases/multi_nesting"
 
-test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes :: TestCase
-test_types_anonymous_edge_cases_multi_nesting_omit_field_prefixes =
+test_anonymous_edge_cases_multi_nesting_omit_field_prefixes :: TestCase
+test_anonymous_edge_cases_multi_nesting_omit_field_prefixes =
     testVariant "types/anonymous/edge-cases/multi_nesting" Nothing "omit_field_prefixes"
       & #onFrontend .~ ( #fieldNamingStrategy .~ OmitFieldPrefixes )
 
 -- | Test that indirect fields are reparsed
-test_types_anonymous_edge_cases_reparse :: TestCase
-test_types_anonymous_edge_cases_reparse =
+test_anonymous_edge_cases_reparse :: TestCase
+test_anonymous_edge_cases_reparse =
     defaultTest "types/anonymous/edge-cases/reparse"
 
-test_types_long_double :: TestCase
-test_types_long_double =
+test_long_double :: TestCase
+test_long_double =
     testTraceSimple "types/special/long_double" $ \case
       MatchDelayed _name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected ()
       _otherwise ->
         Nothing
 
-test_types_primitives_bool_c23 :: TestCase
-test_types_primitives_bool_c23 =
+test_primitives_bool_c23 :: TestCase
+test_primitives_bool_c23 =
     defaultTest "types/primitives/bool_c23"
       & #clangVersion .~ Just (>= (15, 0, 0))
       & #cStandard    .~ c23
 
 -- | Test that when @bool@ is given a definition (via @#define@), it is /not/
 -- parsed as @PrimBool@ by @language-c@.
-test_types_primitives_bool_macro_override :: TestCase
-test_types_primitives_bool_macro_override =
+test_primitives_bool_macro_override :: TestCase
+test_primitives_bool_macro_override =
     defaultTest "types/primitives/bool_macro_override"
       & #clangVersion .~ Just (>= (15, 0, 0))
       & #cStandard    .~ c23
 
 -- | Test that when @bool@ is given a definition (via @typedef@), it is /not/
 -- parsed as @PrimBool@ by @language-c@.
-test_types_primitives_bool_typedef_override :: TestCase
-test_types_primitives_bool_typedef_override =
+test_primitives_bool_typedef_override :: TestCase
+test_primitives_bool_typedef_override =
     defaultTest "types/primitives/bool_typedef_override"
 
-test_types_primitives_least_fast :: TestCase
-test_types_primitives_least_fast =
+test_primitives_least_fast :: TestCase
+test_primitives_least_fast =
     defaultTest "types/primitives/least_fast"
       & #onFrontend .~ ( #programSlicing .~ EnableProgramSlicing )
 
-test_types_scoping_deep_nesting :: TestCase
-test_types_scoping_deep_nesting =
+test_scoping_deep_nesting :: TestCase
+test_scoping_deep_nesting =
     testTraceMulti "types/scoping/deep_nesting" declsWithMsgs $ \case
       MatchDelayed name@"struct foo" ParseNestedDeclsFailed ->
         Just $ Expected name
@@ -256,8 +256,8 @@ test_types_scoping_deep_nesting =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct foo", "struct bar"]
 
-test_types_scoping_nesting :: TestCase
-test_types_scoping_nesting =
+test_scoping_nesting :: TestCase
+test_scoping_nesting =
     testTraceMulti "types/scoping/nesting" declsWithMsgs $ \case
       MatchDelayed name@"struct foo"
         (ParseUnsupportedFloatType UnsupportedLongDouble) ->
@@ -268,8 +268,8 @@ test_types_scoping_nesting =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct foo"]
 
-test_types_scoping_wide_nesting :: TestCase
-test_types_scoping_wide_nesting =
+test_scoping_wide_nesting :: TestCase
+test_scoping_wide_nesting =
     testTraceMulti "types/scoping/wide_nesting" declsWithMsgs $ \case
       MatchDelayed name@"struct foo" ParseNestedDeclsFailed ->
         Just $ Expected name
@@ -285,8 +285,8 @@ test_types_scoping_wide_nesting =
 -- | Test that small floating-point types are unsupported, but do not crash us
 --
 -- Clang only supports @_Float16@ on x86 since version 15.
-test_types_small_floats :: TestCase
-test_types_small_floats =
+test_small_floats :: TestCase
+test_small_floats =
     testTraceMulti "types/special/small_floats" declsWithMsgs (\case
       MatchDelayed name (ParseUnsupportedFloatType UnsupportedFloat16) ->
         Just $ Expected name
@@ -299,8 +299,8 @@ test_types_small_floats =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["float16_t", "fp16_t", "struct small_floats", "fun"]
 
-test_types_special_parse_failure_long_double :: TestCase
-test_types_special_parse_failure_long_double =
+test_special_parse_failure_long_double :: TestCase
+test_special_parse_failure_long_double =
     testTraceMulti "types/special/parse_failure_long_double" declsWithMsgs $ \case
       MatchDelayed name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
@@ -310,28 +310,28 @@ test_types_special_parse_failure_long_double =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["fun1", "struct struct1"]
 
-test_types_structs_tagged_vs_untagged :: TestCase
-test_types_structs_tagged_vs_untagged =
+test_structs_tagged_vs_untagged :: TestCase
+test_structs_tagged_vs_untagged =
     defaultTest "types/structs/tagged_vs_untagged"
       & #clangVersion .~ Just (>= (19, 1, 0))
 
-test_types_structs_bitfields :: TestCase
-test_types_structs_bitfields =
+test_structs_bitfields :: TestCase
+test_structs_bitfields =
     defaultTest "types/structs/bitfields"
       & #cStandard .~ c99  -- C99 required for inline functions
 
-test_types_structs_omit_field_prefixes :: TestCase
-test_types_structs_omit_field_prefixes =
+test_structs_omit_field_prefixes :: TestCase
+test_structs_omit_field_prefixes =
     testVariant "types/structs/simple_structs" Nothing "omit_field_prefixes"
       & #onFrontend .~ ( #fieldNamingStrategy .~ OmitFieldPrefixes )
 
-test_types_structs_post_qualified :: TestCase
-test_types_structs_post_qualified =
+test_structs_post_qualified :: TestCase
+test_structs_post_qualified =
     testVariant "types/structs/simple_structs" Nothing "post_qualified"
       & #qualifiedStyle .~ PostQualified
 
-test_types_structs_untagged_struct :: TestCase
-test_types_structs_untagged_struct =
+test_structs_untagged_struct :: TestCase
+test_structs_untagged_struct =
     testTraceSimple "types/structs/untagged_struct" $ \case
       MatchDiagnosticCategory "Semantic Issue" ->
         Just $ Expected ()
@@ -340,15 +340,15 @@ test_types_structs_untagged_struct =
       _otherwise ->
         Nothing
 
-test_types_typedefs_auxiliary_function_pointer_block :: TestCase
-test_types_typedefs_auxiliary_function_pointer_block =
+test_typedefs_auxiliary_function_pointer_block :: TestCase
+test_typedefs_auxiliary_function_pointer_block =
     defaultTest "types/typedefs/auxiliary/function-pointer/block"
       & #clangVersion .~ Just (>= (15, 0, 0))
       & #cStandard    .~ c23
       & #onBoot       .~ ( #clangArgs % #enableBlocks .~ True )
 
-test_types_typedefs_typedefs :: TestCase
-test_types_typedefs_typedefs =
+test_typedefs_typedefs :: TestCase
+test_typedefs_typedefs =
     testTraceMulti "types/typedefs/typedefs" declsWithMsgs $ \case
       MatchDelayed name ParseFunctionOfTypeTypedef ->
         Just $ Expected name
@@ -359,8 +359,8 @@ test_types_typedefs_typedefs =
     declsWithMsgs = ["foo"]
 
 -- This tests https://github.com/well-typed/hs-bindgen/issues/1389.
-test_types_typedefs_typenames :: TestCase
-test_types_typedefs_typenames =
+test_typedefs_typenames :: TestCase
+test_typedefs_typenames =
     testTraceMulti "types/typedefs/typenames" declsWithMsgs $ \case
       MatchUnusable name (UnusableMangleNamesFailure (MangleNamesCollisionError DetectClashesCollision{})) ->
         Just $ Expected name


### PR DESCRIPTION
Each golden test function specified the category of test when they were all defined in single module.  For example, all binding specifications test functions began with `test_bindingSpecs_`.  This is no longer needed now that we define tests for different categories in separate modules.  Indeed, `Macros` sub-modules do not unnecessarily specify the category.  This commit refactors the names of the other golden test functions.