### PR TITLE
Do not count empty macros

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -557,7 +557,7 @@ isDroppedMacro = \case
     isMacroParseFailure :: DelayedParseMsg -> Bool
     isMacroParseFailure = \case
       ParseMacroDefinitionNoMacroName{} -> True
-      ParseMacroEmpty{}                 -> True
+      ParseMacroEmpty{}                 -> False
       ParseMacroErrorParse{}            -> True
       _otherwise                        -> False
 


### PR DESCRIPTION
I do not think that any changes to the CHANGELOG are necessary, as the existing description is still valid (and we have yet to release).