### PR TITLE
Reflect `emptydata` instances in binding specifications

### DIFF
--- a/hs-bindgen/app/HsBindgen/Cli/Info/Instances.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/Instances.hs
@@ -34,10 +34,11 @@ exec = mapM_ putStrLn (aux def)
   where
     aux :: Inst.SupportedInstances -> [String]
     aux supportedInstances =
-         auxKind "struct"  supportedInstances.struct
-      ++ auxKind "union"   supportedInstances.union
-      ++ auxKind "enum"    supportedInstances.enum
-      ++ auxKind "typedef" supportedInstances.typedef
+         auxKind "struct"    supportedInstances.struct
+      ++ auxKind "union"     supportedInstances.union
+      ++ auxKind "enum"      supportedInstances.enum
+      ++ auxKind "typedef"   supportedInstances.typedef
+      ++ auxKind "emptydata" supportedInstances.emptydata
 
     auxKind :: String -> Map Inst.TypeClass Inst.SupportedStrategies -> [String]
     auxKind kind classMap =

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/AST.hs
@@ -140,9 +140,10 @@ data Struct = Struct{
   deriving stock (Generic, Show)
 
 data EmptyData = EmptyData{
-      name    :: Hs.Name Hs.NsTypeConstr
-    , origin  :: Origin.Decl Origin.EmptyData
-    , comment :: Maybe HsDoc.Comment
+      name      :: Hs.Name Hs.NsTypeConstr
+    , origin    :: Origin.Decl Origin.EmptyData
+    , instances :: Set Inst.TypeClass
+    , comment   :: Maybe HsDoc.Comment
     }
   deriving stock (Generic, Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -246,19 +246,25 @@ opaqueDecs info spec mSize = do
 
     mkDecl :: HsM.Env -> Hs.Decl l
     mkDecl env = Hs.DeclEmpty Hs.EmptyData {
-          name   = name
-        , comment = mkHaddocks env.haddockConfig info
-        , origin = Origin.Decl{
+          name      = name
+        , origin    = Origin.Decl{
               info = info
             , kind = Origin.Opaque info.id.cName.name.kind
             , spec = spec
             }
+        , instances = insts
+        , comment   = mkHaddocks env.haddockConfig info
         }
 
-    -- We generate a 'StaticSize' instance when the (otherwise opaque) C type
-    -- has a known size and alignment, that is, when a /complete/ C type was
-    -- given the @emptydata@ representation.  Its methods use proxies, so the
-    -- field-less data type can have the instance.
+    -- TODO: <https://github.com/well-typed/hs-bindgen/issues/1528>
+    -- Do not generate a 'StaticSize' instance if it is omitted in a
+    -- prescriptive binding specification.
+
+    -- We generate a 'StaticSize' instance for C types with known size and
+    -- alignment that are made /opaque/ in Haskell bindings by prescribing an
+    -- @emptydata@ representation.  This makes it possible to allocate memory
+    -- for such a type, necessary to support APIs that require users to manage
+    -- the memory.
     (insts, staticSizeDecls)
       | Just (C.OpaqueSize sz al) <- mSize =
           ( Set.singleton Inst.StaticSize

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -231,7 +231,10 @@ genBindingSpec' hsModuleName getMainHeaders omitTypes squashedTypes =
             }
           hsTypeSpec = BindingSpec.HsTypeSpec {
               hsRep     = Just BindingSpec.HsTypeRepEmptyData
-            , instances = Map.empty
+            , instances =
+                mkInstSpecs
+                  (maybe Map.empty (.instances) $ originDecl.spec.hsSpec)
+                  edata.instances
             }
       in  ( (originDecl.info, cTypeSpec)
           , (edata.name, hsTypeSpec)

--- a/hs-bindgen/src-internal/HsBindgen/Instances.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Instances.hs
@@ -154,13 +154,15 @@ data Instance = Instance {
 -- binding specifications.
 data SupportedInstances = SupportedInstances {
       -- | Supported instances for @struct@ types
-      struct  :: Map TypeClass SupportedStrategies
+      struct    :: Map TypeClass SupportedStrategies
     , -- | Supported instances for @union@ types
-      union   :: Map TypeClass SupportedStrategies
+      union     :: Map TypeClass SupportedStrategies
     , -- | Supported instances for @enum@ types
-      enum    :: Map TypeClass SupportedStrategies
+      enum      :: Map TypeClass SupportedStrategies
     , -- | Supported instances for @typedef@ types
-      typedef :: Map TypeClass SupportedStrategies
+      typedef   :: Map TypeClass SupportedStrategies
+    , -- | Supported instances for types with Haskell @emptydata@ representation
+      emptydata :: Map TypeClass SupportedStrategies
     }
   deriving stock (Show)
 
@@ -274,6 +276,9 @@ instance Default SupportedInstances where
           , mkDef Storable        Dependent   Newtype   []
           , mkDef ToFunPtr        Independent HsBindgen []
           , mkDef WriteRaw        Dependent   Newtype   []
+          ]
+      , emptydata = Map.fromList [
+            mkDef StaticSize      Independent HsBindgen []
           ]
       }
     where

--- a/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/staticsize/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/binding-specs/rep/emptydata/staticsize/bindingspec.yaml
@@ -33,6 +33,8 @@ ctypes:
 hstypes:
 - hsname: Color
   representation: emptydata
+  instances:
+  - StaticSize
 - hsname: Counter
   representation: emptydata
 - hsname: MacroPtr
@@ -41,11 +43,21 @@ hstypes:
   representation: emptydata
 - hsname: Point2d
   representation: emptydata
+  instances:
+  - StaticSize
 - hsname: TdChain
   representation: emptydata
+  instances:
+  - StaticSize
 - hsname: TdStruct
   representation: emptydata
+  instances:
+  - StaticSize
 - hsname: TdUnion
   representation: emptydata
+  instances:
+  - StaticSize
 - hsname: Value
   representation: emptydata
+  instances:
+  - StaticSize


### PR DESCRIPTION
Instances for `emptydata` are added to the (WIP) instance resolution code.  The `StaticSize` instance is now reflected in generated binding specifications.  A new `TODO` is added, referencing #1528, about adding `omit` support.

The comment is updated to (briefly) explain *why* we generate `StaticSize` instances.