### PR TITLE
Commas in macros are tuples, not the C comma operator

### DIFF
--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.1.empty/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.1.empty/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.1.empty/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.1.empty/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile test-artefacts/headers/golden/macros/macro_comma.h

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/Example.hs
@@ -1,0 +1,75 @@
+module Example
+    ( Example.oBJ
+    , Example.oBJ_NO_PARENS
+    , Example.fUN
+    , Example.fUN_THREE
+    , Example.aRITH
+    )
+  where
+
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ :: [String]
+oBJ = ["(", "1", ",", "2", ")"]
+
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS :: [String]
+oBJ_NO_PARENS = ["1", ",", "2"]
+
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN :: [String]
+fUN =
+  ["(", "x", ",", "y", ")", "(", "x", ",", "y", ")"]
+
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE :: [String]
+fUN_THREE =
+  [ "("
+  , "x"
+  , ","
+  , "y"
+  , ","
+  , "z"
+  , ")"
+  , "("
+  , "("
+  , "x"
+  , ")"
+  , ","
+  , "("
+  , "y"
+  , ")"
+  , ","
+  , "("
+  , "z"
+  , ")"
+  , ")"
+  ]
+
+{-| __C declaration:__ @macro ARITH@
+
+    __defined at:__ @macros\/macro_comma.h 15:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+aRITH :: [String]
+aRITH = ["(", "(", "1", ",", "2", ")", "+", "3", ")"]

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma.2.raw/th.txt
@@ -1,0 +1,90 @@
+-- addDependentFile test-artefacts/headers/golden/macros/macro_comma.h
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ :: [String]
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ = ["(", "1", ",", "2", ")"]
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS :: [String]
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS = ["1", ",", "2"]
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN :: [String]
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN = ["(", "x", ",", "y", ")", "(", "x", ",", "y", ")"]
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE :: [String]
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE = ["(",
+             "x",
+             ",",
+             "y",
+             ",",
+             "z",
+             ")",
+             "(",
+             "(",
+             "x",
+             ")",
+             ",",
+             "(",
+             "y",
+             ")",
+             ",",
+             "(",
+             "z",
+             ")",
+             ")"]
+{-| __C declaration:__ @macro ARITH@
+
+    __defined at:__ @macros\/macro_comma.h 15:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+aRITH :: [String]
+{-| __C declaration:__ @macro ARITH@
+
+    __defined at:__ @macros\/macro_comma.h 15:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+aRITH = ["(", "(", "1", ",", "2", ")", "+", "3", ")"]

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/Example.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE ExplicitForAll #-}
+
+module Example
+    ( Example.oBJ
+    , Example.oBJ_NO_PARENS
+    , Example.fUN
+    , Example.fUN_THREE
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ :: (BG.CInt, BG.CInt)
+oBJ = ((1 :: BG.CInt), (2 :: BG.CInt))
+
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS :: (BG.CInt, BG.CInt)
+oBJ_NO_PARENS = ((1 :: BG.CInt), (2 :: BG.CInt))
+
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN :: forall a0 b1. a0 -> b1 -> (a0, b1)
+fUN = \x0 -> \y1 -> (x0, y1)
+
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE :: forall a0 b1 c2. a0 -> b1 -> c2 -> (a0, b1, c2)
+fUN_THREE = \x0 -> \y1 -> \z2 -> (x0, y1, z2)

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/macro_comma/th.txt
@@ -1,0 +1,58 @@
+-- addDependentFile test-artefacts/headers/golden/macros/macro_comma.h
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ :: (CInt, CInt)
+{-| __C declaration:__ @macro OBJ@
+
+    __defined at:__ @macros\/macro_comma.h 8:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ = (1 :: CInt, 2 :: CInt)
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS :: (CInt, CInt)
+{-| __C declaration:__ @macro OBJ_NO_PARENS@
+
+    __defined at:__ @macros\/macro_comma.h 9:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+oBJ_NO_PARENS = (1 :: CInt, 2 :: CInt)
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN :: forall a_0 b_1 . a_0 -> b_1 -> (a_0, b_1)
+{-| __C declaration:__ @macro FUN@
+
+    __defined at:__ @macros\/macro_comma.h 10:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN = \x_0 -> \y_1 -> (x_0, y_1)
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE :: forall a_0 b_1 c_2 .
+             a_0 -> b_1 -> c_2 -> (a_0, b_1, c_2)
+{-| __C declaration:__ @macro FUN_THREE@
+
+    __defined at:__ @macros\/macro_comma.h 11:9@
+
+    __exported by:__ @macros\/macro_comma.h@
+-}
+fUN_THREE = \x_0 -> \y_1 -> \z_2 -> (x_0, y_1, z_2)

--- a/hs-bindgen/test-artefacts/headers/golden/macros/macro_comma.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/macro_comma.h
@@ -1,0 +1,15 @@
+// A comma in a macro body denotes a tuple, not the C comma operator.
+//
+// C assigns no meaning to macro bodies, so we are free to pick the most useful
+// interpretation. Tuples support the argument-list idiom (`#define ARGS 1, 2`
+// used as `f(ARGS)`); the comma operator is pointless here, since the
+// expressions we can express have no side effects. See issue 2182.
+
+#define OBJ            (1, 2)
+#define OBJ_NO_PARENS  1, 2
+#define FUN(x, y)      (x, y)
+#define FUN_THREE(x, y, z) ((x), (y), (z))
+
+// Consequence of the tuple interpretation: a comma expression does not compose
+// with arithmetic, so this macro fails to parse.
+#define ARITH          ((1, 2) + 3)

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -34,6 +34,7 @@ testCases = [
     , defaultTest "macros/parse/macro_typedef_scope"
     , defaultTest "macros/undef"
       -- Bespoke tests
+    , test_macros_macro_comma
     , test_macros_macro_ext_binding_dep
     , test_macros_macro_resolution_log_level_default
     , test_macros_macro_resolution_log_level_warnings
@@ -53,6 +54,20 @@ testCases = [
 {-------------------------------------------------------------------------------
   Individual test definitions
 -------------------------------------------------------------------------------}
+
+-- | A comma in a macro body denotes a tuple, not the C comma operator.
+--
+-- See <https://github.com/well-typed/hs-bindgen/issues/2182>: C gives macro
+-- bodies no meaning of their own, and tuples support the argument-list idiom
+-- (@#define ARGS 1, 2@ used as @f(ARGS)@). Consequently, a comma expression
+-- does not compose with arithmetic; @ARITH@ is dropped with a parse failure.
+test_macros_macro_comma :: TestCase
+test_macros_macro_comma =
+    testTraceMulti "macros/macro_comma" ["macro ARITH"] $ \case
+      MatchUnusable name@"macro ARITH" (UnusableParseFailure ParseMacroErrorParse{}) ->
+        Just $ Expected name
+      _otherwise ->
+        Nothing
 
 test_macros_macro_ext_binding_dep :: TestCase
 test_macros_macro_ext_binding_dep =


### PR DESCRIPTION
Add a golden test that asserts this expectation.

See issue #2182.

The corresponding `c-expr` PR: https://github.com/well-typed/c-expr/pull/37.

