### PR TITLE
Make `UnnamedId` unique

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -9,6 +9,19 @@ inputs:
 runs:
   using: composite
   steps:
+  # Some mirrors for the Ubuntu software repositories, like Microsoft
+  # Azure-hosted ones, are sometimes unstable. This is a known issue (see links
+  # below). This can cause apt-get commands to be prohibitively slow, causing CI
+  # jobs to time out. We use fast-apt-mirror to pick suitable alternative
+  # mirrors.
+  #
+  # <https://github.com/actions/runner-images/issues?q=is%3Aissue+azure.archive.ubuntu.com>
+  # <https://github.com/actions/runner-images/issues/12949>
+  # <https://github.com/actions/runner-images/issues/7048>
+  - name: Configure Fast APT Mirror (Linux)
+    if: ${{ runner.os == 'Linux' }}
+    uses: vegardit/fast-apt-mirror.sh@v1
+
   # Linux: install from apt. Ubuntu noble ships clang/llvm 14-19 in its own repos;
   # newer versions come from apt.llvm.org (its noble repo covers >= 17, used here
   # for >= 20). Both sources install to /usr/lib/llvm-N with an unversioned bin/

--- a/cabal.project.base
+++ b/cabal.project.base
@@ -41,3 +41,9 @@ if impl(ghc >= 9.14)
   allow-newer: fin-0.3.2:QuickCheck
   allow-newer: skew-list-0.1:QuickCheck
   allow-newer: vec-0.5.1:QuickCheck
+
+source-repository-package
+   type:     git
+   location: https://github.com/well-typed/libclang-bindings
+   tag:      c1340ddbd9b26cd59f143f7625beb48187a863bf
+   subdir:   libclang-bindings

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -339,6 +339,9 @@
 * Fix a bug where bindings for indirect fields could cause "conflicting use
   sites for unnamed IDs" panics if the indirect fields referenced untagged
   structs/unions/enums. See [issue #2194][is-2194].
+* Make `UnnamedId`s unique by including a hash of the unnamed declaration's AST.
+  This prevents accidental `UnnamedId` collisions on all supported `llvm`
+  versions, even on `llvm < 19.1.0`. See [issue #2210][is-2210].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
 [is-1253]: https://github.com/well-typed/hs-bindgen/issues/1253
@@ -365,6 +368,7 @@
 [is-2185]: https://github.com/well-typed/hs-bindgen/issues/2185
 [is-2194]: https://github.com/well-typed/hs-bindgen/issues/2194
 [is-2198]: https://github.com/well-typed/hs-bindgen/issues/2198
+[is-2210]: https://github.com/well-typed/hs-bindgen/issues/2210
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
 [pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Naming.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Naming.hs
@@ -40,6 +40,7 @@ module HsBindgen.IR.C.Naming (
   ) where
 
 import Data.Text qualified as Text
+import Foreign.C.Types (CUInt)
 import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel (ShowFile (..))
@@ -196,10 +197,10 @@ parseScopedName t = case Text.words t of
 
 -- | Unnamed declaration identifier
 --
--- A single macro expansion can produce multiple unnamed declarations,
--- and libclang reports the /same/ expansion location for all of them
--- (the macro call site). Without further information they would share an
--- 'UnnamedId'.  Example:
+-- A single macro expansion can produce multiple unnamed declarations, and
+-- libclang reports the /same/ expansion location for all of them (the macro
+-- call site). Without further information they would share an 'UnnamedId'.
+-- Example:
 --
 -- > #define TwoUntaggedStructs \
 -- >     struct { int a; } x; \
@@ -207,19 +208,21 @@ parseScopedName t = case Text.words t of
 -- >
 -- > TwoUntaggedStructs   // both 'struct {}'s share the expansion location
 --
--- The /spelling/ location points back to where each token was originally
--- written -- for macro-expanded code, an offset inside the macro body rather
--- than the call site.  The two structs above have distinct spelling locations
--- (one per @struct@ token in the macro), so keying on it disambiguates them.
+-- To make sure that each unnamed ID is unique, we include a 'hash' of the
+-- cursor pointing to the associated unnamed declaration. With 'hash' in hand,
+-- we can also properly compare unnamed IDs via 'Eq' and 'Ord'. There is a
+-- possilibity that hashes collide accidentally, but the probability of this
+-- happening is very small.
 --
--- 'loc' (expansion) is what we surface in traces and Haddock, so it stays the
--- human-facing identifier; 'spelling' exists only to make the derived 'Eq' and
--- 'Ord' fine-grained enough.  For non-macro code 'spelling' equals 'loc' and
--- 'UnnamedId' behaves as before.
+-- For human convenience, we also include the /spelling/ location of a
+-- declaration in the unnamed ID. The spelling location points back to where
+-- each token was originally written. For macro-expanded code, this an offset
+-- inside the macro body rather than the call site. The two structs above have
+-- distinct spelling locations (one per @struct@ token in the macro).
 --
--- The spelling location is only populated correctly on @llvm >= 19.1.0@; on
--- older toolchains it equals the expansion location and the collision
--- returns.
+-- NOTE: The spelling location is only populated correctly on @llvm >= 19.1.0@;
+-- on older toolchains, the spelling location is the same as the expansion
+-- location.
 data UnnamedId = UnnamedId {
       -- | Macro expansion site, or the source location for non-macro decls.
       -- Used for tracing and Haddock comments.
@@ -228,6 +231,10 @@ data UnnamedId = UnnamedId {
       -- (inside the macro definition, for macro-expanded decls).
     , spelling :: SingleLoc
     , kind     :: NameKind
+      -- | Hash of the cursor pointing to the associated unnamed declaration
+      --
+      -- The hash uniquely keys each unnamed declaration.
+    , hash     :: CUInt
     }
   deriving stock (Eq, Generic, Ord, Show)
 
@@ -249,6 +256,8 @@ instance PrettyForTrace UnnamedId where
         ++ HighLevel.prettySingleLoc ShowFile unnamedId.spelling
         ++ ">"
     | unnamedId.spelling /= unnamedId.loc
+    ] ++ [
+      PP.string $ "<Hash=" ++ show unnamedId.hash ++ ">"
     ]
 
 --------------------------------------------------------------------------------
@@ -320,8 +329,9 @@ prelimDeclIdAtCursor curr kind = do
       cxLoc    <- clang_getCursorLocation curr
       loc      <- HighLevel.clang_getExpansionLocation cxLoc
       spelling <- HighLevel.clang_getSpellingLocation  cxLoc
+      hash     <- clang_hashCursor curr
       return $
-        PrelimDeclIdUnnamed UnnamedId{loc = loc, spelling = spelling, kind = kind}
+        PrelimDeclIdUnnamed UnnamedId{loc = loc, spelling = spelling, kind = kind, hash = hash}
 
 {-------------------------------------------------------------------------------
   DeclId

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/Example.hs
@@ -33,7 +33,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @enum T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -126,7 +126,7 @@ instance HasCField.HasCField T "unwrapT" where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:16@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -135,7 +135,7 @@ pattern A = T 0
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -143,7 +143,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
     -}
@@ -178,7 +178,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -207,7 +207,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -215,7 +215,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
     -}
@@ -250,7 +250,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -278,7 +278,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -290,7 +290,7 @@ instance (ty ~ T) => BG.HasField "s_anon'anon'x_x" S_anon'anon'x ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -319,7 +319,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -327,7 +327,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
     -}
@@ -362,7 +362,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -388,7 +388,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -400,7 +400,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/bindingspec.yaml
@@ -4,8 +4,9 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
-  cname: struct S
-  hsname: S
+  cname: enum T
+  hsname: T
+  enum: open
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
@@ -13,9 +14,8 @@ ctypes:
   cname: struct @S_anon'anon'x_anon'x
   hsname: S_anon'anon'x_anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
-  cname: enum T
-  hsname: T
-  enum: open
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
 {-| __C declaration:__ @enum T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -48,7 +48,7 @@ instance HasCField T "unwrapT"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:16@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -56,7 +56,7 @@ pattern A :: T
 pattern A = T 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -64,7 +64,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: T
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 12:20@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
                             -}}
@@ -94,7 +94,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -102,7 +102,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
                      -}}
@@ -141,7 +141,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
 -}
@@ -149,7 +149,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/Example.hs
@@ -33,7 +33,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @enum \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -135,7 +135,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x_x "unwrapS_anon'anon'x_anon'x_
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -144,7 +144,7 @@ pattern A = S_anon'anon'x_anon'x_x 0
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -152,7 +152,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
     -}
@@ -187,7 +187,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -216,7 +216,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -224,7 +224,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
     -}
@@ -259,7 +259,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -287,7 +287,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -300,7 +300,7 @@ instance ( ty ~ S_anon'anon'x_anon'x_x
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -330,7 +330,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -338,7 +338,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
     -}
@@ -373,7 +373,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -399,7 +399,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -411,7 +411,7 @@ instance (ty ~ S_anon'anon'x_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/bindingspec.yaml
@@ -4,8 +4,9 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
-  cname: struct S
-  hsname: S
+  cname: enum @S_anon'anon'x_anon'x_x
+  hsname: S_anon'anon'x_anon'x_x
+  enum: open
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
@@ -13,9 +14,8 @@ ctypes:
   cname: struct @S_anon'anon'x_anon'x
   hsname: S_anon'anon'x_anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
-  cname: enum @S_anon'anon'x_anon'x_x
-  hsname: S_anon'anon'x_anon'x_x
-  enum: open
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_enum_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
 {-| __C declaration:__ @enum \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -54,7 +54,7 @@ instance HasCField S_anon'anon'x_anon'x_x
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -62,7 +62,7 @@ pattern A :: S_anon'anon'x_anon'x_x
 pattern A = S_anon'anon'x_anon'x_x 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -70,7 +70,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 12:18@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
                             -}}
@@ -100,7 +100,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -108,7 +108,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
                      -}}
@@ -150,7 +150,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
 -}
@@ -158,7 +158,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_enum_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/Example.hs
@@ -28,7 +28,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @struct T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 12:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -36,7 +36,7 @@ data T = T
   { t_a :: BG.CInt
     {- ^ __C declaration:__ @a@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 13:13@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
     -}
@@ -71,7 +71,7 @@ deriving via Struct.IsStructViaReadRaw T instance Struct.IsStruct T
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -92,7 +92,7 @@ instance HasCField.HasCField T "t_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -100,7 +100,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
     -}
@@ -135,7 +135,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -164,7 +164,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -172,7 +172,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
     -}
@@ -207,7 +207,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -235,7 +235,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -247,7 +247,7 @@ instance (ty ~ T) => BG.HasField "s_anon'anon'x_x" S_anon'anon'x ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -276,7 +276,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -284,7 +284,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
     -}
@@ -319,7 +319,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -345,7 +345,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -357,7 +357,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/bindingspec.yaml
@@ -4,14 +4,14 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
   cname: struct @S_anon'anon'x_anon'x
   hsname: S_anon'anon'x_anon'x
+- headers: types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
   cname: struct T
   hsname: T

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
 {-| __C declaration:__ @struct T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 12:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -10,7 +10,7 @@ data T
     = T {t_a :: CInt
          {- ^ __C declaration:__ @a@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 13:13@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
          -}}
@@ -35,7 +35,7 @@ instance HasCField T "t_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -43,7 +43,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: T
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 14:9@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
                             -}}
@@ -73,7 +73,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -81,7 +81,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
                      -}}
@@ -120,7 +120,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
 -}
@@ -128,7 +128,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/Example.hs
@@ -28,7 +28,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -36,7 +36,7 @@ data S_anon'anon'x_anon'x_x = S_anon'anon'x_anon'x_x
   { s_anon'anon'x_anon'x_x_a :: BG.CInt
     {- ^ __C declaration:__ @a@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 13:13@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
     -}
@@ -71,7 +71,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x_x instance Struct.Is
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -100,7 +100,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x_x "s_anon'anon'x_anon'x_x_a" w
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -108,7 +108,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
     -}
@@ -143,7 +143,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -172,7 +172,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -180,7 +180,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
     -}
@@ -215,7 +215,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -243,7 +243,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -256,7 +256,7 @@ instance ( ty ~ S_anon'anon'x_anon'x_x
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -286,7 +286,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -294,7 +294,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
     -}
@@ -329,7 +329,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -355,7 +355,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -367,7 +367,7 @@ instance (ty ~ S_anon'anon'x_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/bindingspec.yaml
@@ -4,9 +4,6 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
@@ -15,6 +12,9 @@ ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
   cname: struct @S_anon'anon'x_anon'x_x
   hsname: S_anon'anon'x_anon'x_x
+- headers: types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_struct_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -10,7 +10,7 @@ data S_anon'anon'x_anon'x_x
     = S_anon'anon'x_anon'x_x {s_anon'anon'x_anon'x_x_a :: CInt
                               {- ^ __C declaration:__ @a@
 
-                                   __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 13:13@
+                                   __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
                                    __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
                               -}}
@@ -41,7 +41,7 @@ instance HasCField S_anon'anon'x_anon'x_x
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -49,7 +49,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 14:9@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
                             -}}
@@ -79,7 +79,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -87,7 +87,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
                      -}}
@@ -129,7 +129,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
 -}
@@ -137,7 +137,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_struct_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/Example.hs
@@ -29,7 +29,7 @@ import qualified HsBindgen.Runtime.Union as Union
 
 {-| __C declaration:__ @union T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 12:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -50,7 +50,7 @@ deriving via BG.SizedByteArray 4 4 instance Union.IsUnion T
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -60,7 +60,7 @@ instance (ty ~ BG.CInt) => BG.HasField "t_a" T ty where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -83,7 +83,7 @@ instance HasCField.HasCField T "t_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -91,7 +91,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
     -}
@@ -126,7 +126,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -155,7 +155,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -163,7 +163,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
     -}
@@ -198,7 +198,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -226,7 +226,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -238,7 +238,7 @@ instance (ty ~ T) => BG.HasField "s_anon'anon'x_x" S_anon'anon'x ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -267,7 +267,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -275,7 +275,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
     -}
@@ -310,7 +310,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -336,7 +336,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -348,7 +348,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/bindingspec.yaml
@@ -4,14 +4,14 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_union_tagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/multi_nesting_union_tagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_union_tagged.h
   cname: struct @S_anon'anon'x_anon'x
   hsname: S_anon'anon'x_anon'x
+- headers: types/anonymous/indirect-fields/multi_nesting_union_tagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/multi_nesting_union_tagged.h
   cname: union T
   hsname: T

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_tagged.h
 {-| __C declaration:__ @union T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 12:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -24,7 +24,7 @@ instance HasCField T "t_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -32,7 +32,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: T
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 14:9@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
                             -}}
@@ -62,7 +62,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -70,7 +70,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
                      -}}
@@ -109,7 +109,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
 -}
@@ -117,7 +117,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/Example.hs
@@ -29,7 +29,7 @@ import qualified HsBindgen.Runtime.Union as Union
 
 {-| __C declaration:__ @union \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -50,7 +50,7 @@ deriving via BG.SizedByteArray 4 4 instance Union.IsUnion S_anon'anon'x_anon'x_x
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -61,7 +61,7 @@ instance ( ty ~ BG.CInt
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 13:13@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -88,7 +88,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x_x "s_anon'anon'x_anon'x_x_a" w
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -96,7 +96,7 @@ data S_anon'anon'x_anon'x = S_anon'anon'x_anon'x
   { s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
     -}
@@ -131,7 +131,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x_anon'x instance Struct.IsSt
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -160,7 +160,7 @@ instance HasCField.HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x" where
 
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -168,7 +168,7 @@ data S_anon'anon'x = S_anon'anon'x
   { s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 11:5@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
     -}
@@ -203,7 +203,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'anon'x instance Struct.IsStruct S_
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -231,7 +231,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -244,7 +244,7 @@ instance ( ty ~ S_anon'anon'x_anon'x_x
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -274,7 +274,7 @@ instance HasCField.HasCField S_anon'anon'x "s_anon'anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -282,7 +282,7 @@ data S = S
   { s_anon'anon'x :: S_anon'anon'x
     {- ^ __C declaration:__ @anon\'anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
     -}
@@ -317,7 +317,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -343,7 +343,7 @@ instance HasCField.HasCField S "s_anon'anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -355,7 +355,7 @@ instance (ty ~ S_anon'anon'x_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/bindingspec.yaml
@@ -4,14 +4,14 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/multi_nesting_union_untagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/multi_nesting_union_untagged.h
   cname: struct @S_anon'anon'x
   hsname: S_anon'anon'x
 - headers: types/anonymous/indirect-fields/multi_nesting_union_untagged.h
   cname: struct @S_anon'anon'x_anon'x
   hsname: S_anon'anon'x_anon'x
+- headers: types/anonymous/indirect-fields/multi_nesting_union_untagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/multi_nesting_union_untagged.h
   cname: union @S_anon'anon'x_anon'x_x
   hsname: S_anon'anon'x_anon'x_x

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/multi_nesting_union_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_untagged.h
 {-| __C declaration:__ @union \@S_anon\'anon\'x_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 12:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -37,7 +37,7 @@ instance HasCField S_anon'anon'x_anon'x_x
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -45,7 +45,7 @@ data S_anon'anon'x_anon'x
     = S_anon'anon'x_anon'x {s_anon'anon'x_anon'x_x :: S_anon'anon'x_anon'x_x
                             {- ^ __C declaration:__ @x@
 
-                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 14:9@
+                                 __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
                                  __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
                             -}}
@@ -75,7 +75,7 @@ instance HasCField S_anon'anon'x_anon'x "s_anon'anon'x_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -83,7 +83,7 @@ data S_anon'anon'x
     = S_anon'anon'x {s_anon'anon'x_anon'x :: S_anon'anon'x_anon'x
                      {- ^ __C declaration:__ @anon\'x@
 
-                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 11:5@
+                          __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
                           __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
                      -}}
@@ -125,7 +125,7 @@ instance HasCField S_anon'anon'x "s_anon'anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
 -}
@@ -133,7 +133,7 @@ data S
     = S {s_anon'anon'x :: S_anon'anon'x
          {- ^ __C declaration:__ @anon\'anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/multi_nesting_union_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/Example.hs
@@ -32,7 +32,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @enum T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:10@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -125,7 +125,7 @@ instance HasCField.HasCField T "unwrapT" where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -134,7 +134,7 @@ pattern A = T 0
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -142,7 +142,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:18@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
     -}
@@ -177,7 +177,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -201,7 +201,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -209,7 +209,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
     -}
@@ -244,7 +244,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -267,7 +267,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -279,7 +279,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:18@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/bindingspec.yaml
@@ -4,15 +4,15 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_enum_tagged.h
-  cname: struct S
-  hsname: S
+  cname: enum T
+  hsname: T
+  enum: open
 - headers: types/anonymous/indirect-fields/single_nesting_enum_tagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
 - headers: types/anonymous/indirect-fields/single_nesting_enum_tagged.h
-  cname: enum T
-  hsname: T
-  enum: open
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_tagged.h
 {-| __C declaration:__ @enum T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:10@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -48,7 +48,7 @@ instance HasCField T "unwrapT"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:14@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -56,7 +56,7 @@ pattern A :: T
 pattern A = T 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -64,7 +64,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: T
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 11:18@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
                 -}}
@@ -89,7 +89,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
 -}
@@ -97,7 +97,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/Example.hs
@@ -32,7 +32,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @enum \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -132,7 +132,7 @@ instance HasCField.HasCField S_anon'x_x "unwrapS_anon'x_x" where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -141,7 +141,7 @@ pattern A = S_anon'x_x 0
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -149,7 +149,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: S_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:16@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
     -}
@@ -184,7 +184,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:16@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -209,7 +209,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -217,7 +217,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
     -}
@@ -252,7 +252,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -275,7 +275,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:16@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -287,7 +287,7 @@ instance (ty ~ S_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:16@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/bindingspec.yaml
@@ -4,15 +4,15 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_enum_untagged.h
-  cname: struct S
-  hsname: S
+  cname: enum @S_anon'x_x
+  hsname: S_anon'x_x
+  enum: open
 - headers: types/anonymous/indirect-fields/single_nesting_enum_untagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
 - headers: types/anonymous/indirect-fields/single_nesting_enum_untagged.h
-  cname: enum @S_anon'x_x
-  hsname: S_anon'x_x
-  enum: open
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_enum_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_untagged.h
 {-| __C declaration:__ @enum \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -49,7 +49,7 @@ instance HasCField S_anon'x_x "unwrapS_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -57,7 +57,7 @@ pattern A :: S_anon'x_x
 pattern A = S_anon'x_x 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -65,7 +65,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: S_anon'x_x
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 11:16@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
                 -}}
@@ -91,7 +91,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
 -}
@@ -99,7 +99,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_enum_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/Example.hs
@@ -27,7 +27,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @struct T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 11:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -35,7 +35,7 @@ data T = T
   { t_a :: BG.CInt
     {- ^ __C declaration:__ @a@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 12:11@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
     -}
@@ -70,7 +70,7 @@ deriving via Struct.IsStructViaReadRaw T instance Struct.IsStruct T
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -91,7 +91,7 @@ instance HasCField.HasCField T "t_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -99,7 +99,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 13:7@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
     -}
@@ -134,7 +134,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -158,7 +158,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -166,7 +166,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
     -}
@@ -201,7 +201,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -224,7 +224,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -236,7 +236,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/bindingspec.yaml
@@ -4,11 +4,11 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_struct_tagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/single_nesting_struct_tagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
+- headers: types/anonymous/indirect-fields/single_nesting_struct_tagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/single_nesting_struct_tagged.h
   cname: struct T
   hsname: T

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_tagged.h
 {-| __C declaration:__ @struct T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 11:12@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -10,7 +10,7 @@ data T
     = T {t_a :: CInt
          {- ^ __C declaration:__ @a@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 12:11@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
          -}}
@@ -35,7 +35,7 @@ instance HasCField T "t_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -43,7 +43,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: T
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 13:7@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
                 -}}
@@ -68,7 +68,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
 -}
@@ -76,7 +76,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/Example.hs
@@ -27,7 +27,7 @@ import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
 
 {-| __C declaration:__ @struct \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -35,7 +35,7 @@ data S_anon'x_x = S_anon'x_x
   { s_anon'x_x_a :: BG.CInt
     {- ^ __C declaration:__ @a@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 12:11@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
     -}
@@ -70,7 +70,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x_x instance Struct.IsStruct S_ano
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -96,7 +96,7 @@ instance HasCField.HasCField S_anon'x_x "s_anon'x_x_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -104,7 +104,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: S_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 13:7@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
     -}
@@ -139,7 +139,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -164,7 +164,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -172,7 +172,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
     -}
@@ -207,7 +207,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -230,7 +230,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -242,7 +242,7 @@ instance (ty ~ S_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/bindingspec.yaml
@@ -4,14 +4,14 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_struct_untagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/single_nesting_struct_untagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
 - headers: types/anonymous/indirect-fields/single_nesting_struct_untagged.h
   cname: struct @S_anon'x_x
   hsname: S_anon'x_x
+- headers: types/anonymous/indirect-fields/single_nesting_struct_untagged.h
+  cname: struct S
+  hsname: S
 hstypes:
 - hsname: S
   representation:

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_struct_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_untagged.h
 {-| __C declaration:__ @struct \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -10,7 +10,7 @@ data S_anon'x_x
     = S_anon'x_x {s_anon'x_x_a :: CInt
                   {- ^ __C declaration:__ @a@
 
-                       __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 12:11@
+                       __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
                        __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
                   -}}
@@ -36,7 +36,7 @@ instance HasCField S_anon'x_x "s_anon'x_x_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -44,7 +44,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: S_anon'x_x
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 13:7@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
                 -}}
@@ -70,7 +70,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
 -}
@@ -78,7 +78,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_struct_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/Example.hs
@@ -28,7 +28,7 @@ import qualified HsBindgen.Runtime.Union as Union
 
 {-| __C declaration:__ @union T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 11:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -49,7 +49,7 @@ deriving via BG.SizedByteArray 4 4 instance Union.IsUnion T
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -59,7 +59,7 @@ instance (ty ~ BG.CInt) => BG.HasField "t_a" T ty where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -82,7 +82,7 @@ instance HasCField.HasCField T "t_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -90,7 +90,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: T
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 13:7@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
     -}
@@ -125,7 +125,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -149,7 +149,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -157,7 +157,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
     -}
@@ -192,7 +192,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -215,7 +215,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -227,7 +227,7 @@ instance (ty ~ T) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/bindingspec.yaml
@@ -4,11 +4,11 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_union_tagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/single_nesting_union_tagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
+- headers: types/anonymous/indirect-fields/single_nesting_union_tagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/single_nesting_union_tagged.h
   cname: union T
   hsname: T

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_tagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_tagged.h
 {-| __C declaration:__ @union T@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 11:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -24,7 +24,7 @@ instance HasCField T "t_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -32,7 +32,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: T
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 13:7@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
                 -}}
@@ -57,7 +57,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
 -}
@@ -65,7 +65,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_tagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/Example.hs
@@ -28,7 +28,7 @@ import qualified HsBindgen.Runtime.Union as Union
 
 {-| __C declaration:__ @union \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -49,7 +49,7 @@ deriving via BG.SizedByteArray 4 4 instance Union.IsUnion S_anon'x_x
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -59,7 +59,7 @@ instance (ty ~ BG.CInt) => BG.HasField "s_anon'x_x_a" S_anon'x_x ty where
 
 {-| __C declaration:__ @a@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 12:11@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -85,7 +85,7 @@ instance HasCField.HasCField S_anon'x_x "s_anon'x_x_a" where
 
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -93,7 +93,7 @@ data S_anon'x = S_anon'x
   { s_anon'x_x :: S_anon'x_x
     {- ^ __C declaration:__ @x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 13:7@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
     -}
@@ -128,7 +128,7 @@ deriving via Struct.IsStructViaReadRaw S_anon'x instance Struct.IsStruct S_anon'
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -153,7 +153,7 @@ instance HasCField.HasCField S_anon'x "s_anon'x_x" where
 
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -161,7 +161,7 @@ data S = S
   { s_anon'x :: S_anon'x
     {- ^ __C declaration:__ @anon\'x@
 
-         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 10:3@
+         __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
          __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
     -}
@@ -196,7 +196,7 @@ deriving via Struct.IsStructViaReadRaw S instance Struct.IsStruct S
 
 {-| __C declaration:__ @anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -219,7 +219,7 @@ instance HasCField.HasCField S "s_anon'x" where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -231,7 +231,7 @@ instance (ty ~ S_anon'x_x) => BG.HasField "s_x" S ty where
 
 {-| __C declaration:__ @x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 13:7@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/bindingspec.yaml
@@ -4,11 +4,11 @@ version:
 hsmodule: Example
 ctypes:
 - headers: types/anonymous/indirect-fields/single_nesting_union_untagged.h
-  cname: struct S
-  hsname: S
-- headers: types/anonymous/indirect-fields/single_nesting_union_untagged.h
   cname: struct @S_anon'x
   hsname: S_anon'x
+- headers: types/anonymous/indirect-fields/single_nesting_union_untagged.h
+  cname: struct S
+  hsname: S
 - headers: types/anonymous/indirect-fields/single_nesting_union_untagged.h
   cname: union @S_anon'x_x
   hsname: S_anon'x_x

--- a/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/anonymous/indirect-fields/single_nesting_union_untagged/th.txt
@@ -2,7 +2,7 @@
 -- addDependentFile test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_untagged.h
 {-| __C declaration:__ @union \@S_anon\'x_x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 11:5@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -27,7 +27,7 @@ instance HasCField S_anon'x_x "s_anon'x_x_a"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct \@S_anon\'x@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 10:3@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -35,7 +35,7 @@ data S_anon'x
     = S_anon'x {s_anon'x_x :: S_anon'x_x
                 {- ^ __C declaration:__ @x@
 
-                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 13:7@
+                     __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
                      __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
                 -}}
@@ -61,7 +61,7 @@ instance HasCField S_anon'x "s_anon'x_x"
           offset# = \_ -> \_ -> 0
 {-| __C declaration:__ @struct S@
 
-    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 9:8@
+    __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
     __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
 -}
@@ -69,7 +69,7 @@ data S
     = S {s_anon'x :: S_anon'x
          {- ^ __C declaration:__ @anon\'x@
 
-              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 10:3@
+              __defined at:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h 3:1@
 
               __exported by:__ @types\/anonymous\/indirect-fields\/single_nesting_union_untagged.h@
          -}}

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_tagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(enum T { a } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      enum T { a } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_enum_untagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(enum { a } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      enum { a } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_tagged.h
@@ -1,17 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(struct T { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      struct T {
-        int a;
-      } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_struct_untagged.h
@@ -1,17 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(struct { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      struct {
-        int a;
-      } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_tagged.h
@@ -1,17 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(union T { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      union T {
-        int a;
-      } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/multi_nesting_union_untagged.h
@@ -1,17 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkMultiNestedS(union { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      union {
-        int a;
-      } x;
-    };
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_tagged.h
@@ -1,13 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(enum T { a } x)
-*/
-
-struct S {
-  struct {
-    enum T { a } x;
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_enum_untagged.h
@@ -1,13 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(enum { a } x)
-*/
-
-struct S {
-  struct {
-    enum { a } x;
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_tagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(struct T { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct T {
-      int a;
-    } x;
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_struct_untagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(struct { int a; } x)
-*/
-
-struct S {
-  struct {
-    struct {
-      int a;
-    } x;
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_tagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_tagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(union T { int a; } x)
-*/
-
-struct S {
-  struct {
-    union T {
-      int a;
-    } x;
-  };
-};

--- a/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_untagged.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/anonymous/indirect-fields/single_nesting_union_untagged.h
@@ -1,15 +1,3 @@
 #include "_internal_macros.h"
 
-// TODO <https://github.com/well-typed/hs-bindgen/issues/2210>:
-// replace the code below with:
-/*
 MkSingleNestedS(union { int a; } x)
-*/
-
-struct S {
-  struct {
-    union {
-      int a;
-    } x;
-  };
-};


### PR DESCRIPTION
Resolves #2210

We make `UnnamedId`s (technically) unique by including a hash of the cursor pointing at the declaration that we are trying to name. It will be rare for two hashes to match accidentally.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.