### PR TITLE
Emit TH string literals without relying on `-O`

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/TH/Translation.hs
@@ -90,7 +90,10 @@ mkRolledExpr env expr = case expr of
         )
         (mkType EmptyEnv t)
     ECChar (CChar i) -> [| CChar $(TH.lift i) |]
-    EString s -> [| s |]
+    -- Not @[| s |]@: cross-stage lifting of a 'String' yields a list of 'Char'
+    -- literals unless the @TH:liftString@ rewrite rule fires, which needs @-O@.
+    -- This is problematic during development.
+    EString s -> TH.litE (TH.StringL s)
     ECString bs ->
       TH.appE
         (mkGlobalExpr (bindgenGlobalTerm ByteString_pack))


### PR DESCRIPTION
`[| s |]` for `s :: String` only produces `StringL` together with the `TH:liftString` rewrite rule. At `-O0` it corresponds to a lit of `Char` literals, which leads to differences in golden tests in TH mode.
