### PR TITLE
Make macro definitions root directives

### DIFF
--- a/dev/building-manual.md
+++ b/dev/building-manual.md
@@ -35,14 +35,18 @@ package hs-vector
 ```
 
 On Linux, since it supports Unicode characters, also add the following to the
-file:
+file, which enables the Haskell CPP branch that calls the Unicode-named
+functions:
 
 ```cabal
-package *
+package manual
   ghc-options:
-    -optc-DSUPPORTS_UNICODE
     -DSUPPORTS_UNICODE
 ```
+
+The C stages get `SUPPORTS_UNICODE` from a `#define` root directive
+(`--hash-define SUPPORTS_UNICODE 1`) that `generate-and-run.sh` passes when
+generating the `GeneratedNames` bindings.
 
 Change directory to the [`c/`](../manual/c/) folder and compile the binaries
 using the Makefile.
@@ -65,7 +69,7 @@ all in one step:
 
 ### Unicode Support
 
-- Linux: Full Unicode support available with `SUPPORTS_UNICODE=1`
+- Linux: Full Unicode support available with `SUPPORTS_UNICODE` defined
 - macOS: No Unicode support (Apple assembler limitation), disabled by default.
 - Windows: No Unicode support (Windows assembler limitation), disabled by default.
 - LLVM Backend: No Unicode support (LLVM IR limitation), disabled by default.

--- a/dev/troubleshooting.md
+++ b/dev/troubleshooting.md
@@ -58,6 +58,26 @@ Solution:
 - Ensure `extra-include-dirs` points to the correct directory
 - Check that header files exist in the specified location
 
+### `cc-options` Do Not Reach the Generated C Source
+
+Error: the generated C wrapper source fails to compile, or compiles against a
+different view of the header than the bindings were generated from, even though
+the `.cabal` file sets the required flags in `cc-options`.
+
+Cause: `hs-bindgen` attaches the generated C source via Template Haskell
+(`addForeignSource`). GHC compiles it itself, and Cabal's `cc-options` are *not*
+passed to that compilation; only `-optc-...` flags in `ghc-options` are.
+
+Solution:
+
+- Macro definitions belong in a `#define` root directive (`--hash-define NAME
+  VALUE` on the command line, `hashDefine` in Template Haskell). Those are
+  emitted into the generated C source itself, so they reach both, the code
+  generation stage and the binding compilation stage. See the [C
+  stages](../manual/low-level/usage/c-stages.md) manual page.
+- For anything not expressible as a root directive, use `ghc-options:
+  -optc-<flag>` rather than `cc-options: <flag>`.
+
 ### Linking Issues (Bindings for c-example)
 
 Error:

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -78,6 +78,36 @@
 * The `--log-show-time` CLI flag has been removed, along with the
   `ShowTimeStamp` type and the `showTimeStamp` field of `TracerConfig`.
   Trace output no longer includes timestamps.
+  * Macro definitions are no longer a Clang argument but a *root directive*: an
+    entry of an ordered list containing `#include` and `#define` statements. The
+    root header is rendered from that list, and the very same rendering is
+    prepended to the generated CAPI wrapper source, so both, binding generation
+    stage and binding compilation stage agree by construction. Previously a `-D
+    FOO` had to be stated twice, once for `hs-bindgen` and once as `ghc-options:
+    -optc-DFOO` in the `.cabal` file. See [issue #2214][is-2214] and the [C
+    stages](../manual/low-level/usage/c-stages.md) manual page. Concretely:
+      * `ClangArgsConfig.defineMacros` is **removed**. Use a `#define` root
+        directive instead. Raw `-D` passed via
+        `argsBefore`/`argsInner`/`argsAfter` or `BINDGEN_EXTRA_CLANG_ARGS` still
+        reaches the binding generation stage only.
+      * The CLI option `-D`/`--define-macro` is **removed**, replaced by
+        `--hash-define NAME VALUE`. It is an *input* directive: its position
+        relative to the `HEADER` arguments matters, and it takes *two* arguments.
+        `-DFOO` becomes `--hash-define FOO 1`; an empty replacement list is
+        `--hash-define FOO ''`.
+      * Template Haskell gains `hashDefine :: String -> String -> BindgenM ()`,
+        next to `hashInclude`. This is `#define` syntax, *not* `-D` syntax:
+        `hashDefine "FOO" ""` is `#define FOO`, `hashDefine "FOO" "1"` is
+        `#define FOO 1`.
+      * The `HashIncludeArgs` artefact is renamed `RootDirectives` and carries the
+        `#define`s too; `runBoot` takes `[C.UncheckedRootDirective]`.
+        `CWrapper.hashIncludeArg` is removed, and `RootHeader.fromMainFiles`
+        becomes `RootHeader.fromRootDirectives`.
+      * Behaviour: the generated C wrapper source now starts with the whole root
+        header rather than the includes its own wrappers reference, so a module's
+        wrapper translation unit includes every main header.
+      * Declarations in the root header (i.e., the `#define`s) are not parsed: a
+        root directive is configuration.
 
 ### New features
 
@@ -369,6 +399,7 @@
 [is-2194]: https://github.com/well-typed/hs-bindgen/issues/2194
 [is-2198]: https://github.com/well-typed/hs-bindgen/issues/2198
 [is-2210]: https://github.com/well-typed/hs-bindgen/issues/2210
+[is-2214]: https://github.com/well-typed/hs-bindgen/issues/2214
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
 [pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917

--- a/hs-bindgen/app/HsBindgen/App.hs
+++ b/hs-bindgen/app/HsBindgen/App.hs
@@ -61,7 +61,7 @@ hsBindgen ::
      TracerConfig Level     TraceMsg
   -> TracerConfig SafeLevel SafeTraceMsg
   -> BindgenConfig
-  -> [C.UncheckedHashIncludeArg]
+  -> [C.UncheckedRootDirective]
   -> Artefact CExpr a
   -> IO a
 hsBindgen = hsBindgenMacroLang (pure . Macro.cExpr)
@@ -318,7 +318,6 @@ parseClangArgsConfig = do
     enableBlocks     <- parseEnableBlocks
     builtinIncDir    <- parseBuiltinIncDirConfig
     extraIncludeDirs <- many parseIncludeDir
-    defineMacros     <- many parseDefineMacro
     argsBefore       <- many parseClangOptionBefore
     argsInner        <- many parseClangOptionInner
     argsAfter        <- many parseClangOptionAfter
@@ -326,7 +325,6 @@ parseClangArgsConfig = do
         enableBlocks     = enableBlocks
       , builtinIncDir    = builtinIncDir
       , extraIncludeDirs = extraIncludeDirs
-      , defineMacros     = defineMacros
       , argsBefore       = argsBefore
       , argsInner        = argsInner
       , argsAfter        = argsAfter
@@ -343,14 +341,6 @@ parseIncludeDir = strOption $ mconcat [
       short 'I'
     , metavar "DIR"
     , help "Include search path directory"
-    ]
-
-parseDefineMacro :: Parser String
-parseDefineMacro = strOption $ mconcat [
-      short 'D'
-    , long "define-macro"
-    , metavar "<macro>=<value>"
-    , help "Define <macro> to <value> (or 1 if <value> omitted)"
     ]
 
 parseClangOptionBefore :: Parser String
@@ -539,15 +529,43 @@ parseGenTestsOutput = strOption $ mconcat [
   Input arguments
 -------------------------------------------------------------------------------}
 
--- | Parse one or more input header arguments
+-- | Parse one or more input root directives
 --
--- This uses standard syntax for one or more arguments, which
--- @optparse-applicative@ does not get right when just using 'Control.Applicative.some'.
-parseInputs :: Parser [C.UncheckedHashIncludeArg]
-parseInputs = some . strArgument $ mconcat [
-      metavar "HEADER..."
-    , help "Input C header(s), relative to an include path directory"
+-- @#include@s and @#define@s form a single ordered list: a @#define@ only
+-- affects the headers listed after it.
+--
+-- We check that at least one directive is of type @#include@ when the root
+-- header is constructed ('HsBindgen.Frontend.RootHeader.fromRootDirectives').
+-- This ensures that CLI and TH mode have the same behavior. Also,
+-- @optparse-applicative@ can only reject the parsed list with monadic
+-- sequencing, but its usage renderer does not distinguish monadic sequencing
+-- from repetition, so every bind picks up the @multiSuffix@ marker.
+parseInputs :: Parser [C.UncheckedRootDirective]
+parseInputs = some . asum $ [
+      C.DirectiveHashInclude <$> parseHashInclude
+    , C.DirectiveHashDefine  <$> parseHashDefine
     ]
+  where
+    parseHashInclude :: Parser C.UncheckedHashIncludeArg
+    parseHashInclude = strArgument $ mconcat [
+        metavar "HEADER"
+      , help "Input C header(s), relative to an include path directory"
+      ]
+
+    parseHashDefine :: Parser C.HashDefine
+    parseHashDefine =
+        C.HashDefine
+          -- The metavar covers both arguments, so that @--help@ shows the
+          -- @#define@ shape; the value argument itself renders nothing.
+          <$> strOption   (long "hash-define" <> metavar "NAME VALUE" <> help hashDefineHelp)
+          <*> strArgument mempty
+
+    hashDefineHelp :: String
+    hashDefineHelp = unwords [
+        "Emit '#define NAME VALUE' before the following headers."
+      , "See 'Root directives' in the manual"
+      , "(manual/low-level/usage/c-stages.md)."
+      ]
 
 {-------------------------------------------------------------------------------
   Haddock options

--- a/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/GenTests.hs
@@ -39,7 +39,7 @@ data Opts = Opts {
     , uniqueId       :: UniqueId
     , baseModuleName :: BaseModuleName
     , output         :: FilePath
-    , inputs         :: [C.UncheckedHashIncludeArg]
+    , inputs         :: [C.UncheckedRootDirective]
     }
 
 parseOpts :: Parser Opts

--- a/hs-bindgen/app/HsBindgen/Cli/Info/Doxygen.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/Doxygen.hs
@@ -39,7 +39,7 @@ info = progDesc "Output the parsed doxygen state"
 data Opts = Opts {
       config     :: Config
     , output     :: Maybe FilePath
-    , inputs     :: [C.UncheckedHashIncludeArg]
+    , inputs     :: [C.UncheckedRootDirective]
     , filePolicy :: FilePolicy
     , dirPolicy  :: DirPolicy
     }

--- a/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/IncludeGraph.hs
@@ -46,7 +46,7 @@ data Opts = Opts {
     , labelStyle     :: HeaderLabelStyle
     , format         :: IncludeGraphFormat
     , output         :: Maybe FilePath
-    , inputs         :: [C.UncheckedHashIncludeArg]
+    , inputs         :: [C.UncheckedRootDirective]
     , filePolicy     :: FilePolicy
     , dirPolicy      :: DirPolicy
     }

--- a/hs-bindgen/app/HsBindgen/Cli/Info/ResolveHeader.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/ResolveHeader.hs
@@ -41,7 +41,7 @@ info = progDesc "Resolve C headers to source paths"
 
 data Opts = Opts {
       clangArgsConfig :: ClangArgsConfig FilePath
-    , inputs          :: [C.UncheckedHashIncludeArg]
+    , inputs          :: [C.UncheckedRootDirective]
     }
 
 parseOpts :: Parser Opts
@@ -57,7 +57,8 @@ parseOpts =
 exec :: GlobalOpts -> Opts -> IO ()
 exec global opts = do
     eErr <- withTracer tracerConfig' $ \tracer -> do
-      hashIncludeArgs <- checkInputs tracer opts.inputs
+      -- This command only resolves headers; #define directives play no role.
+      hashIncludeArgs <- checkInputs tracer (C.hashIncludeArgsOf opts.inputs)
       checkMacosEnv (contramap (TraceBoot . BootMacos) tracer)
       clangArgs <- (.clangArgs) <$>
         getClangArtefacts (contramap TraceBoot tracer) opts.clangArgsConfig

--- a/hs-bindgen/app/HsBindgen/Cli/Info/UseDeclGraph.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Info/UseDeclGraph.hs
@@ -40,7 +40,7 @@ data Opts = Opts {
     , uniqueId       :: UniqueId
     , baseModuleName :: BaseModuleName
     , output         :: Maybe FilePath
-    , inputs         :: [C.UncheckedHashIncludeArg]
+    , inputs         :: [C.UncheckedRootDirective]
     , filePolicy     :: FilePolicy
     , dirPolicy      :: DirPolicy
     }

--- a/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Internal/Frontend.hs
@@ -96,7 +96,7 @@ data Opts = Opts {
     , uniqueId       :: UniqueId
     , baseModuleName :: BaseModuleName
     , dirPolicy      :: DirPolicy
-    , inputs         :: [C.UncheckedHashIncludeArg]
+    , inputs         :: [C.UncheckedRootDirective]
     , filePolicy     :: FilePolicy
     }
 

--- a/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/Preprocess.hs
@@ -61,7 +61,7 @@ data ConfigCLI = ConfigCLI {
     , dirPolicy         :: DirPolicy
     , filePolicy        :: FilePolicy
     -- NOTE: Inputs (arguments) must be last, options must go before it.
-    , inputs            :: [C.UncheckedHashIncludeArg]
+    , inputs            :: [C.UncheckedRootDirective]
     }
   deriving (Generic)
 

--- a/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
+++ b/hs-bindgen/app/HsBindgen/Cli/ToolSupport/Literate.hs
@@ -88,7 +88,7 @@ data Lit = Lit {
     , baseModuleName :: BaseModuleName
     , qualifiedStyle :: QualifiedStyle
     , outputOptions  :: OutputOptions
-    , inputs         :: [C.UncheckedHashIncludeArg]
+    , inputs         :: [C.UncheckedRootDirective]
     }
 
 parseLit :: Parser Lit

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -38,7 +38,10 @@ execCliParser :: IO Cli
 execCliParser = customExecParser prefs' opts
   where
     prefs' :: ParserPrefs
-    prefs' = prefs $ helpShowGlobals <> subparserInline
+    -- 'multiSuffix' marks repeatable options and arguments in the usage
+    -- synopsis; without it, @(HEADER | --hash-define NAME VALUE)@ reads as an
+    -- exclusive choice of one.
+    prefs' = prefs $ multiSuffix "..." <> helpShowGlobals <> subparserInline
 
     opts :: ParserInfo Cli
     opts = info (parseCli <**> simpleVersioner vers <**> helper) $

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -259,10 +259,12 @@ library internal
     HsBindgen.IR.C
     HsBindgen.IR.C.Conflict
     HsBindgen.IR.C.Decl
+    HsBindgen.IR.C.HashDefine
     HsBindgen.IR.C.HashIncludeArg
     HsBindgen.IR.C.LocationInfo
     HsBindgen.IR.C.Naming
     HsBindgen.IR.C.PrettyPrinter
+    HsBindgen.IR.C.RootDirective
     HsBindgen.IR.C.Type
     HsBindgen.IR.Hs
     HsBindgen.IR.Hs.Type
@@ -341,7 +343,6 @@ library internal
     , transformers        >=0.5        && <0.7
     , unliftio-core       >=0.2.1      && <0.3
     , vec                 >=0.5        && <0.6
-    , witherable          >=0.4.2      && <0.6
     , yaml                >=0.11.11.1  && <0.12
 
   if impl(ghc <9.4)
@@ -551,6 +552,7 @@ test-suite test-hs-bindgen
     Test.HsBindgen.Unit.Digraph
     Test.HsBindgen.Unit.Frontend
     Test.HsBindgen.Unit.Pretty
+    Test.HsBindgen.Unit.RootDirective
     Test.HsBindgen.Unit.Runtime
     Test.HsBindgen.Unit.Tracer
 

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -97,7 +97,7 @@ hsBindgenMacroLang ::
   -> TracerConfig Level     TraceMsg
   -> TracerConfig SafeLevel SafeTraceMsg
   -> BindgenConfig
-  -> [C.UncheckedHashIncludeArg]
+  -> [C.UncheckedRootDirective]
   -> Artefact l a
   -> IO a
 hsBindgenMacroLang mkMacroLang tu ts b i a = do
@@ -124,7 +124,7 @@ hsBindgenEMacroLang ::
   -> TracerConfig Level     TraceMsg
   -> TracerConfig SafeLevel SafeTraceMsg
   -> BindgenConfig
-  -> [C.UncheckedHashIncludeArg]
+  -> [C.UncheckedRootDirective]
   -> Artefact l a
   -> IO (Either BindgenError a)
 hsBindgenEMacroLang
@@ -132,14 +132,14 @@ hsBindgenEMacroLang
   tracerConfigUnsafe
   tracerConfigSafe
   config
-  uncheckedHashIncludeArgs
+  uncheckedRootDirectives
   artefacts = do
     eRes <- withTracer tracerConfigUnsafe $ \tracerUnsafe -> do
       -- 1. Boot.
       let tracerBoot :: Tracer BootMsg
           tracerBoot = contramap TraceBoot tracerUnsafe
       bootArtefact <-
-        runBoot tracerBoot mkMacroLang config uncheckedHashIncludeArgs
+        runBoot tracerBoot mkMacroLang config uncheckedRootDirectives
       -- 2. Frontend.
       let tracerFrontend :: Tracer FrontendMsg
           tracerFrontend = contramap TraceFrontend tracerUnsafe
@@ -232,13 +232,14 @@ writeDoxygen filePolicy dirPolicy mPath = do
 getBindings :: ModuleRenderConfig -> Artefact l String
 getBindings mrc = do
     name   <- ModuleBaseName
+    dirs   <- RootDirectives
     decls  <- FinalDecls
     tags   <- getExportTags
     when (all nullDecls decls) $ EmitTrace $ NoBindingsSingleModule name
     config <- getConfig
     let fns = config.frontend.fieldNamingStrategy
     pure $ render $
-      translateModuleSingle fns mrc name (resolveExports tags) decls
+      translateModuleSingle fns mrc dirs name (resolveExports tags) decls
 
 -- | Write bindings to file.
 writeBindings ::
@@ -281,6 +282,7 @@ writeBindingsSingle mrc filePolicy dirPolicy hsOutputDir = do
 getBindingsMultiple :: ModuleRenderConfig -> Artefact l (ByCategory_ (Maybe String))
 getBindingsMultiple mrc = do
     name   <- ModuleBaseName
+    dirs   <- RootDirectives
     decls  <- FinalDecls
     tags   <- getExportTags
     when (all nullDecls decls) $
@@ -288,7 +290,7 @@ getBindingsMultiple mrc = do
     config <- getConfig
     let fns = config.frontend.fieldNamingStrategy
     pure $ fmap render <$>
-      translateModuleMultiple fns mrc name (resolveExports tags) decls
+      translateModuleMultiple fns mrc dirs name (resolveExports tags) decls
 
 -- | Write bindings to files in provided output directory.
 --
@@ -350,11 +352,11 @@ writeBindingSpec filePolicy dirPolicy path = do
 writeTests :: FilePath -> Artefact l ()
 writeTests _testDir = do
     -- moduleBaseName  <- ModuleBaseName
-    -- hashIncludeArgs <- HashIncludeArgs
+    -- rootDirectives  <- RootDirectives
     -- hsDecls         <- HsDecls
     -- liftIO $
     --   genTests
-    --     hashIncludeArgs
+    --     rootDirectives
     --     hsDecls
     --     moduleBaseName
     --     testDir

--- a/hs-bindgen/src-internal/HsBindgen/Artefact.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Artefact.hs
@@ -83,7 +83,7 @@ data FrontendPass (l :: Star) (result :: Star) where
 -- | Build artefact.
 data Artefact l (a :: Star) where
   -- * Boot
-  HashIncludeArgs :: Artefact l [C.HashIncludeArg]
+  RootDirectives  :: Artefact l [C.RootDirective C.HashIncludeArg]
   ModuleBaseName  :: Artefact l BaseModuleName
   -- * Frontend
   ParseInfoA      :: Artefact l ParseInfo
@@ -134,7 +134,7 @@ runArtefacts tracer config boot frontend backend artefact =
     runArtefact :: forall x. Artefact l x -> ArtefactM x
     runArtefact = \case
         --Boot.
-        HashIncludeArgs -> runCached boot.hashIncludeArgs
+        RootDirectives  -> runCached boot.rootDirectives
         ModuleBaseName  -> pure boot.baseModule
         -- Frontend.
         ParseInfoA      -> runCached frontend.parseMeta

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/CallConv.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/CallConv.hs
@@ -15,31 +15,34 @@ import HsBindgen.Backend.Runtime qualified as Runtime
 import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 
-import Witherable (ordNub)
-
 {-------------------------------------------------------------------------------
   Definition
 -------------------------------------------------------------------------------}
 
 -- | The 'CallConvUserlandCapi' requires a wrapper on the C side with a
 -- corresponding import.
-data CWrapper = CWrapper {
-      definition     :: String
-    , hashIncludeArg :: C.HashIncludeArg
+newtype CWrapper = CWrapper {
+      definition :: String
     }
   deriving (Show, Generic)
 
-getCWrappersSource :: [CWrapper] -> String
-getCWrappersSource wrappers = concat headers ++ concat bodies
-    where
-      getImport :: CWrapper -> String
-      getImport wrapper = "#include <" ++ wrapper.hashIncludeArg.path ++ ">" ++ "\n"
-
-      headers, bodies :: [String]
-      -- It is important that we don't include the same header more than once,
-      -- /especially/ for non-extern non-static globals.
-      headers = ordNub $ map getImport wrappers
-      bodies = map (.definition) wrappers
+-- | Source of the C translation unit containing the wrappers
+--
+-- The wrappers are preceded by the /whole/ root header, verbatim and in order,
+-- reproducing the environment in which the declarations were parsed, including
+-- the interleaving of @#define@s and @#include@s.
+--
+-- Duplicate @#include@s are preserved deliberately: re-inclusion at a different
+-- point in the sequence is meaningful (X-macro headers). A header that cannot
+-- tolerate double inclusion fails the root header parse in the binding
+-- generation stage.
+--
+-- We emit nothing when there are no wrappers, so that a module without wrappers
+-- does not gain a C translation unit.
+getCWrappersSource :: [C.RootDirective C.HashIncludeArg] -> [CWrapper] -> String
+getCWrappersSource _         [] = ""
+getCWrappersSource directives wrappers =
+    C.renderRootDirectives directives ++ concatMap (.definition) wrappers
 
 data CallConv =
     -- | Our default calling convention: userland CAPI

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -1004,8 +1004,7 @@ addressStubDecs info ty runnerNameSpec _spec = do
 
         cWrapper :: CWrapper
         cWrapper = CWrapper {
-              definition     = prettyStub
-            , hashIncludeArg = getMainHashIncludeArg info
+              definition = prettyStub
             }
 
         foreignImport :: [Hs.Decl l]

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -1,11 +1,9 @@
 module HsBindgen.Backend.Hs.Translation.Function (
     functionDecs
-  , getMainHashIncludeArg
   ) where
 
 import Control.Monad.Reader qualified as Reader
 import Data.Kind (Type)
-import Data.List.NonEmpty qualified as NonEmpty
 import Data.Text qualified as T
 import Data.Type.Equality ((:~:) (Refl))
 import DeBruijn (Add, Ctx, Env (..), Idx (..), lzeroAdd, sizeEnv, swapAdd,
@@ -139,8 +137,7 @@ functionDecs safety info origCFun _spec = do
 
             cWrapper :: CWrapper
             cWrapper = CWrapper {
-                  definition     = PC.prettyFunDefn cWrapperDecl ""
-                , hashIncludeArg = getMainHashIncludeArg info
+                  definition = PC.prettyFunDefn cWrapperDecl ""
                 }
 
         foreignImportParams :: [Hs.ForeignImport.FunParam]
@@ -223,9 +220,6 @@ functionDecs safety info origCFun _spec = do
 
         mbIoComment :: Maybe HsDoc.Comment
         mbIoComment = ioComment origCFun.attrs.purity
-
-getMainHashIncludeArg :: C.DeclInfo Final -> C.HashIncludeArg
-getMainHashIncludeArg info = NonEmpty.head info.headerInfo.mainHeaders
 
 {-------------------------------------------------------------------------------
   Purity

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty.hs
@@ -26,7 +26,7 @@ instance Pretty HsModule where
       PP.vcat (map pretty hsModule.pragmas)
     : prettyModuleHeader hsModule.name hsModule.exports
     : PP.vcat (map (prettyImport hsModule.qualifiedStyle) hsModule.imports)
-    : (prettyCapiWrappers hsModule.cWrappers)
+    : (prettyCapiWrappers hsModule.rootDirectives hsModule.cWrappers)
     : map pretty hsModule.decls
 
 -- | Render the module header with an explicit export list

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/CAPI.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Pretty/CAPI.hs
@@ -12,16 +12,19 @@ import Text.SimplePrettyPrint qualified as PP
 
 import HsBindgen.Backend.Hs.CallConv
 import HsBindgen.Imports
+import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 
 -- | Pretty print the CAPI 'HsBindgen.Config.Internal.addCSource' code fragment.
-prettyCapiWrappers :: [CWrapper] -> CtxDoc
-prettyCapiWrappers wrappers
-  | null src  = PP.empty
-  | otherwise = prettyCapiWrappers' src
+prettyCapiWrappers ::
+     [C.RootDirective C.HashIncludeArg]
+  -> [CWrapper]
+  -> CtxDoc
+prettyCapiWrappers directives wrappers
+    | null src  = PP.empty
+    | otherwise = prettyCapiWrappers' src
   where
-    src :: String
-    src = getCWrappersSource wrappers
+    src = getCWrappersSource directives wrappers
 
 prettyCapiWrappers' :: String -> CtxDoc
 prettyCapiWrappers' src = PP.vcat [

--- a/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/HsModule/Translation.hs
@@ -31,6 +31,7 @@ import HsBindgen.Backend.SHs.AST.Expr (FBind (FBind))
 import HsBindgen.Config.Prelims
 import HsBindgen.Imports
 import HsBindgen.Instances qualified as Inst
+import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
@@ -102,6 +103,8 @@ data HsModule = HsModule {
     , exports        :: [ExportEntry]
     , imports        :: [ImportListItem]
     , qualifiedStyle :: QualifiedStyle
+      -- | Root directives, prepended to the CAPI wrapper source
+    , rootDirectives :: [C.RootDirective C.HashIncludeArg]
     , cWrappers      :: [CWrapper]
     , decls          :: [SDecl]
     }
@@ -113,44 +116,48 @@ data HsModule = HsModule {
 translateModuleMultiple ::
      FieldNamingStrategy
   -> ModuleRenderConfig
+  -> [C.RootDirective C.HashIncludeArg]
   -> BaseModuleName
   -> ([SDecl] -> [ExportEntry])
   -> ByCategory_ ([CWrapper], [SDecl])
   -> ByCategory_ (Maybe HsModule)
-translateModuleMultiple fns mrc moduleBaseName resolveExports declsByCat =
+translateModuleMultiple fns mrc dirs moduleBaseName resolveExports declsByCat =
     mapWithCategory_ go declsByCat
   where
     go :: Category -> ([CWrapper], [SDecl]) -> Maybe HsModule
     go _ ([], []) = Nothing
     go cat xs     = Just $
-      translateModule' fns mrc (Just cat) moduleBaseName resolveExports xs
+      translateModule' fns mrc dirs (Just cat) moduleBaseName resolveExports xs
 
 translateModuleSingle ::
      FieldNamingStrategy
   -> ModuleRenderConfig
+  -> [C.RootDirective C.HashIncludeArg]
   -> BaseModuleName
   -> ([SDecl] -> [ExportEntry])
   -> ByCategory_ ([CWrapper], [SDecl])
   -> HsModule
-translateModuleSingle fns mrc name resolveExports declsByCat =
-    translateModule' fns mrc Nothing name resolveExports $
+translateModuleSingle fns mrc dirs name resolveExports declsByCat =
+    translateModule' fns mrc dirs Nothing name resolveExports $
       Foldable.fold declsByCat
 
 translateModule' ::
      FieldNamingStrategy
   -> ModuleRenderConfig
+  -> [C.RootDirective C.HashIncludeArg]
   -> Maybe Category
   -> BaseModuleName
   -> ([SDecl] -> [ExportEntry])
   -> ([CWrapper], [SDecl])
   -> HsModule
-translateModule' fns mrc mcat moduleBaseName resolveExports (cWrappers, decs) =
+translateModule' fns mrc dirs mcat moduleBaseName resolveExports (cWrappers, decs) =
     HsModule{
         pragmas        = resolvePragmas fns mrc.qualifiedStyle cWrappers decs
       , exports        = resolveExports decs
       , imports        = resolveImports moduleBaseName mcat cWrappers decs
       , name           = fromBaseModuleName moduleBaseName mcat
       , qualifiedStyle = mrc.qualifiedStyle
+      , rootDirectives = dirs
       , cWrappers      = cWrappers
       , decls          = decs
       }

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec/Gen.hs
@@ -65,7 +65,7 @@ genBindingSpec
     compareCDeclId :: C.DeclId -> C.DeclId -> Ordering
     compareCDeclId cDeclIdL cDeclIdR = Ord.comparing aux cDeclIdL cDeclIdR
 
-    aux :: C.DeclId -> (Int, Int, Int, Text)
+    aux :: C.DeclId -> (IncludeGraph.IncludeOrderIx, Int, Int, Text)
     aux cDeclId =
       case DeclIndex.lookupLoc cDeclId declIndex of
         Just locs ->
@@ -74,15 +74,20 @@ genBindingSpec
           -- colliding definitions). This is OK, since we only use the location
           -- to sort the binding specifications before generating them.
           let loc = C.declLocsMin locs
-          in  ( fromMaybe maxBound (Map.lookup loc.singleLocPath orderMap)
+          in  ( IncludeGraph.lookupIncludeOrder order loc.singleLocPath
               , loc.singleLocLine
               , loc.singleLocColumn
               , C.renderDeclId cDeclId
               )
-        Nothing -> (maxBound, maxBound, maxBound, C.renderDeclId cDeclId)
+        Nothing -> (
+            IncludeGraph.NotInIncludeGraph
+          , maxBound
+          , maxBound
+          , C.renderDeclId cDeclId
+          )
 
-    orderMap :: Map SourcePath Int
-    orderMap = IncludeGraph.toOrderMap includeGraph
+    order :: IncludeGraph.IncludeOrder
+    order = IncludeGraph.toIncludeOrder includeGraph
 
 {-------------------------------------------------------------------------------
   Auxiliary functions

--- a/hs-bindgen/src-internal/HsBindgen/Boot.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Boot.hs
@@ -43,19 +43,20 @@ runBoot ::
      Tracer BootMsg
   -> (ClangCStandard -> IO (Macro.Lang l))
   -> BindgenConfig
-  -> [C.UncheckedHashIncludeArg]
+  -> [C.UncheckedRootDirective]
   -> IO (BootArtefact l)
-runBoot tracer mkMacroLang config uncheckedHashIncludeArgs = do
+runBoot tracer mkMacroLang config uncheckedRootDirectives = do
     traceStatus $ BootStatusStart config
 
     checkBackendConfig (contramap BootBackendConfig tracer) config.backend
 
     checkMacosEnv (contramap BootMacos tracer)
 
-    getHashIncludeArgs <- cache "hashIncludeArgs" $ Cached $ do
+    getRootDirectives <- cache "rootDirectives" $ Cached $ do
       let tracer' = contramap BootHashIncludeArg tracer
-      withTrace BootStatusHashIncludeArgs $
-        mapM (C.hashIncludeArgWithTrace tracer') uncheckedHashIncludeArgs
+      withTrace BootStatusRootDirectives $
+        traverse (traverse (C.hashIncludeArgWithTrace tracer'))
+          uncheckedRootDirectives
 
     getClangArtefacts' <- cache "clangArtefacts" $ Cached $
       getClangArtefacts tracer config.boot.clangArgs
@@ -99,7 +100,7 @@ runBoot tracer mkMacroLang config uncheckedHashIncludeArgs = do
         , clangExe                = getClangExe
         , clangArgs               = getClangArgs
         , macroLang               = getMacroLang
-        , hashIncludeArgs         = getHashIncludeArgs
+        , rootDirectives          = getRootDirectives
         , externalBindingSpecs    = getExternalBindingSpecs
         , prescriptiveBindingSpec = getPrescriptiveBindingSpec
         , sizeofs                 = sizeofs
@@ -189,7 +190,7 @@ data BootArtefact l = BootArtefact {
     , clangExe                :: Cached (Maybe ClangExe)
     , clangArgs               :: Cached ClangArgs
     , macroLang               :: Cached (Macro.Lang l)
-    , hashIncludeArgs         :: Cached [C.HashIncludeArg]
+    , rootDirectives          :: Cached [C.RootDirective C.HashIncludeArg]
     , externalBindingSpecs    :: Cached MergedBindingSpecs
     , prescriptiveBindingSpec :: Cached PrescriptiveBindingSpec
     , sizeofs                 :: Cached Sizeofs
@@ -204,7 +205,7 @@ data BootStatusMsg =
   | BootStatusCStandard               ClangCStandard
   | BootStatusClangExe                (Maybe ClangExe)
   | BootStatusClangArgs               ClangArgs
-  | BootStatusHashIncludeArgs         [C.HashIncludeArg]
+  | BootStatusRootDirectives          [C.RootDirective C.HashIncludeArg]
   | BootStatusExternalBindingSpecs    MergedBindingSpecs
   | BootStatusPrescriptiveBindingSpec PrescriptiveBindingSpec
   deriving stock (Show, Generic)
@@ -219,7 +220,7 @@ instance PrettyForTrace BootStatusMsg where
     BootStatusCStandard               x -> bootStatus "ClangCStandard"          x
     BootStatusClangExe                x -> bootStatus "ClangExe"                x
     BootStatusClangArgs               x -> bootStatus "ClangArgs"               x
-    BootStatusHashIncludeArgs         x -> bootStatus "HashIncludeArgs"         x
+    BootStatusRootDirectives          x -> bootStatus "RootDirectives"          x
     BootStatusExternalBindingSpecs    x -> bootStatus "ExternalBindingSpecs"    x
     BootStatusPrescriptiveBindingSpec x -> bootStatus "PrescriptiveBindingSpec" x
 

--- a/hs-bindgen/src-internal/HsBindgen/Config/ClangArgs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Config/ClangArgs.hs
@@ -36,16 +36,6 @@ data ClangArgsConfig path = ClangArgsConfig {
       -- argument](https://clang.llvm.org/docs/ClangCommandLineReference.html#include-path-management).
     , extraIncludeDirs :: [path]
 
-      -- | Preprocessor macro definitions
-      --
-      -- A definition of form @<macro>=<value>@ defines a macro with the
-      -- specified value. A definition of form @<macro>@ defines a macro with
-      -- value @1@.
-      --
-      -- This corresponds to the [@-D@ Clang
-      -- argument](https://clang.llvm.org/docs/ClangCommandLineReference.html#preprocessor-options).
-    , defineMacros :: [String]
-
       -- | Enable block support
       --
       -- Running code that uses blocks will need the blocks runtime. This is not
@@ -89,7 +79,6 @@ instance Default (ClangArgsConfig path) where
  def = ClangArgsConfig {
       builtinIncDir    = BuiltinIncDirClang
     , extraIncludeDirs = []
-    , defineMacros     = []
     , enableBlocks     = False
     , argsBefore       = []
     , argsInner        = []
@@ -113,10 +102,6 @@ clangArgsConfigToClangArgs config = ClangArgs $ concat [
         concat [
             ["-I", path]
           | path <- config.extraIncludeDirs
-          ]
-      , concat [
-            ["-D" ++ defn]
-          | defn <- config.defineMacros
           ]
       , [ "-fblocks" | config.enableBlocks ]
       ]

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -54,7 +54,7 @@ import HsBindgen.Frontend.Pass.TypecheckMacros
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Frontend.ProcessIncludes
-import HsBindgen.Frontend.RootHeader (RootHeader)
+import HsBindgen.Frontend.RootHeader (RootHeader, RootHeaderMsg)
 import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports
@@ -240,8 +240,13 @@ runFrontend ::
   -> BootArtefact l
   -> IO (FrontendArtefact l)
 runFrontend tracer config boot = do
+    rootHeaderC <- cache "rootHeader" $ do
+      (msgs, rootHeader) <- RootHeader.fromRootDirectives <$> boot.rootDirectives
+      liftIO $ mapM_ (traceWith tracerRootHeader . withCallStack) msgs
+      pure rootHeader
+
     parsePass <- cache "parse" $ do
-      setup     <- getSetup
+      setup     <- getSetup =<< rootHeaderC
       macroLang <- boot.macroLang
       liftIO $ withClang (contramap FrontendClang tracer) setup $ \unit -> do
         (includeGraph, isMainHeader, isInMainHeaderDir, getMainHeadersAndInclude, mainHeaderPaths) <-
@@ -335,8 +340,8 @@ runFrontend tracer config boot = do
       afterParse <- parsePass
       (afterTypecheckMacros, _, _) <- typecheckMacrosPass
       clangExe <- boot.clangExe
-      setup <- getSetup
-      rootHeader <- getRootHeader
+      rootHeader <- rootHeaderC
+      setup <- getSetup rootHeader
       liftIO $ prepareReparse
                   (contramap FrontendPrepareReparse tracer)
                   clangExe
@@ -403,14 +408,11 @@ runFrontend tracer config boot = do
       , final                    = finalPass
       }
   where
-    getRootHeader :: Cached RootHeader
-    getRootHeader = RootHeader.fromMainFiles <$> boot.hashIncludeArgs
-
-    getSetup :: Cached ClangSetup
-    getSetup = do
+    getSetup :: RootHeader -> Cached ClangSetup
+    getSetup rootHeader = do
       clangArgs <- boot.clangArgs
-      hContent <- RootHeader.content <$> getRootHeader
-      let setup = defaultClangSetup clangArgs $ ClangInputMemory hFilePath hContent
+      let hContent = RootHeader.content rootHeader
+          setup = defaultClangSetup clangArgs $ ClangInputMemory hFilePath hContent
       pure $ setup {
           flags = bitfieldEnum [
               CXTranslationUnit_DetailedPreprocessingRecord
@@ -430,6 +432,9 @@ runFrontend tracer config boot = do
 
     cache :: String -> Cached a -> IO (Cached a)
     cache = cacheWith (contramap (FrontendCache . SafeTrace) tracer) . Just
+
+    tracerRootHeader :: Tracer RootHeaderMsg
+    tracerRootHeader = contramap FrontendRootHeader tracer
 
 {-------------------------------------------------------------------------------
   Artefact
@@ -471,6 +476,7 @@ data FrontendMsg =
   | FrontendSelect                   (Msg Select)
   | FrontendCache                    (SafeTrace CacheMsg)
   | FrontendDoxygen                   DoxygenMsg
+  | FrontendRootHeader                RootHeaderMsg
   deriving stock    (Show, Generic)
   deriving anyclass (PrettyForTrace, IsTrace Level)
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/DeclUseGraph/Construction.hs
@@ -10,11 +10,9 @@ module HsBindgen.Frontend.Analysis.DeclUseGraph.Construction (
 import Data.Digraph (Digraph)
 import Data.Digraph qualified as Digraph
 import Data.List qualified as List
-import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
 import Clang.HighLevel.Types
-import Clang.Paths
 
 import HsBindgen.Errors
 import HsBindgen.Frontend.Analysis
@@ -42,13 +40,13 @@ construct includeGraph declIndex = declUseGraph
   where
     -- The include graph informs us about the order of declarations which is
     -- key.
-    orderMap :: Map SourcePath Int
-    orderMap = IncludeGraph.toOrderMap includeGraph
+    order :: IncludeGraph.IncludeOrder
+    order = IncludeGraph.toIncludeOrder includeGraph
     -- The declaration index contains declarations that we cannot use. Macros
     -- have already been resolved while constructing the declaration index.
     successfulDecls, sortedSuccessfulDecls :: [C.Decl l ConstructTranslationUnit]
     successfulDecls       = DeclIndex.getDecls declIndex
-    sortedSuccessfulDecls = List.sortOn (annSortKey orderMap) successfulDecls
+    sortedSuccessfulDecls = List.sortOn (annSortKey order) successfulDecls
 
     allDeclIds, successfulDeclIds, failedDeclIds :: Set C.DeclId
     allDeclIds        = DeclIndex.keysSet declIndex
@@ -137,20 +135,23 @@ deleteRevDeps depIds declUseGraph = DeclUseGraph{
 -------------------------------------------------------------------------------}
 
 data SortKey = SortKey{
-      sortPathIx :: Int
+      sortPathIx :: IncludeGraph.IncludeOrderIx
     , sortLineNo :: Int
     , sortColNo  :: Int
     }
   deriving (Eq, Ord, Show)
 
-annSortKey :: Map SourcePath Int -> C.Decl l p -> SortKey
-annSortKey sourceMap decl = SortKey{
+annSortKey :: HasCallStack => IncludeGraph.IncludeOrder -> C.Decl l p -> SortKey
+annSortKey order decl = SortKey{
       sortPathIx = sortPathIx
     , sortLineNo = singleLocLine   decl.info.loc
     , sortColNo  = singleLocColumn decl.info.loc
     }
   where
-    key        = singleLocPath decl.info.loc
-    sortPathIx = fromMaybe
-      (panicPure $ "Source of declaration " <> show key <> " not in source map")
-      (Map.lookup key sourceMap)
+    path = singleLocPath decl.info.loc
+    -- Unlike a trace message, a declaration whose source is not in the include
+    -- graph means the frontend is broken; there is nothing to salvage.
+    sortPathIx = case IncludeGraph.lookupIncludeOrder order path of
+      IncludeGraph.NotInIncludeGraph ->
+        panicPure $ "Source of declaration " <> show path <> " not in include graph"
+      ix -> ix

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/IncludeGraph.hs
@@ -17,8 +17,12 @@ module HsBindgen.Frontend.Analysis.IncludeGraph (
     -- * Query
   , reaches
   , toSortedList
-  , toOrderMap
   , getIncludes
+    -- * Include order
+  , IncludeOrder -- opaque
+  , IncludeOrderIx(..)
+  , toIncludeOrder
+  , lookupIncludeOrder
     -- * Visualization
   , Predicate
   , HeaderLabelStyle(..)
@@ -134,14 +138,46 @@ toSortedList :: IncludeGraph -> [SourcePath]
 toSortedList includeGraph =
     List.delete RootHeader.name (Digraph.sort includeGraph.graph)
 
-toOrderMap :: IncludeGraph -> Map SourcePath Int
-toOrderMap graph = Map.fromList (zip (toSortedList graph) [0..])
-
 getIncludes ::
      IncludeGraph
   -> SourcePath
   -> Digraph.FindEdgesResult Include
 getIncludes includeGraph path = Digraph.findEdges path includeGraph.graph
+
+{-------------------------------------------------------------------------------
+  Include order
+-------------------------------------------------------------------------------}
+
+-- | Position of a source in the include order
+--
+-- The constructor order /is/ the specification: the root header precedes every
+-- real source, and an unknown path sorts last. Do not reorder.
+data IncludeOrderIx =
+    -- | The root header
+    --
+    -- The root header is synthetic and not a source file, so it is not part of
+    -- the include order proper. Anything located in it comes from a root
+    -- directive, i.e. directly from the user, and hence comes first.
+    InRootHeader
+    -- | Position in the topologically sorted include graph
+  | InIncludeGraph Int
+    -- | Path unknown to the include graph
+    --
+    -- Reaching this is a bug; see
+    -- 'HsBindgen.Frontend.Pass.Select.IsPass.SelectSourceNotInIncludeGraph'.
+  | NotInIncludeGraph
+  deriving stock (Show, Eq, Ord)
+
+-- | The include order of a t'IncludeGraph', for repeated lookup
+newtype IncludeOrder = IncludeOrder (Map SourcePath Int)
+
+toIncludeOrder :: IncludeGraph -> IncludeOrder
+toIncludeOrder graph = IncludeOrder $ Map.fromList (zip (toSortedList graph) [0..])
+
+lookupIncludeOrder :: IncludeOrder -> SourcePath -> IncludeOrderIx
+lookupIncludeOrder (IncludeOrder order) path
+  | RootHeader.isRootHeaderPath path = InRootHeader
+  | otherwise = maybe NotInIncludeGraph InIncludeGraph (Map.lookup path order)
 
 {-------------------------------------------------------------------------------
   Visualization

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -25,6 +25,7 @@ import HsBindgen.Frontend.Pass.Parse.Monad.Decl
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Parse.Result
 import HsBindgen.Frontend.Pass.Parse.Type
+import HsBindgen.Frontend.RootHeader qualified as RootHeader
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
@@ -81,14 +82,20 @@ parseDeclTopLevel macroLang curr = do
     -- potentially get the location twice. We could store the 'CXSourceLocation'
     -- next to all parse results and use it to retrieve the single location
     -- stored in the 'DeclInfo'.
-    loc       <- clang_getCursorLocation curr
-    nextDecls <- parseDecl' macroLang [] Nothing curr
-    -- Note the subtle difference between `foldContinue` and
-    -- `foldContinueWith []`: the 'Functor' instance of 'Next' drops values on
-    -- `Continue Nothing`, so a parser using `foldContinue` contributes no entry
-    -- to the result list here, whereas `foldContinueWith []` contributes an
-    -- empty entry (with location attached).
-    pure $ (loc,) <$> nextDecls
+    loc     <- clang_getCursorLocation curr
+    declLoc <- HighLevel.clang_getCursorLocation' curr
+    -- The root header is a synthetic in-memory file, so a @#define@ root
+    -- directive in it has no main header and 'withHeaderInfo' would fail the
+    -- parse (and it shouldn't have one). We consider root directives
+    -- configuration, not API. Do not attempt to parse it.
+    if RootHeader.isRootHeaderPath (singleLocPath declLoc) then foldContinue else do
+      nextDecls <- parseDecl' macroLang [] Nothing curr
+      -- Note the subtle difference between `foldContinue` and
+      -- `foldContinueWith []`: the 'Functor' instance of 'Next' drops values on
+      -- `Continue Nothing`, so a parser using `foldContinue` contributes no
+      -- entry to the result list here, whereas `foldContinueWith []`
+      -- contributes an empty entry (with location attached).
+      pure $ (loc,) <$> nextDecls
 
 -- | Auxiliary function; use 'parseDeclNested' or 'parseDeclTopLevel'
 parseDecl' ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -3,12 +3,10 @@ module HsBindgen.Frontend.Pass.Select (
   ) where
 
 import Data.Foldable qualified as Foldable
-import Data.List (sortBy)
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict qualified as Map
-import Data.Maybe (maybeToList)
-import Data.Ord (comparing)
+import Data.Maybe (listToMaybe, maybeToList)
 import Data.Set ((\\))
 import Data.Set qualified as Set
 
@@ -565,40 +563,64 @@ isDroppedMacro = \case
   Sort traces
 -------------------------------------------------------------------------------}
 
-compareByOrder :: Map SourcePath Int -> SourcePath -> SourcePath -> Ordering
-compareByOrder xs x y =
-  let ix = lookupUnsafe x
-      iy = lookupUnsafe y
-  in  compare ix iy
-  where
-    lookupUnsafe z = case Map.lookup z xs of
-      Nothing -> panicPure $ "Unknown source path: " <> show z
-      Just v  -> v
+-- | Location a trace message is sorted by
+--
+-- Only conflicting declarations carry more than one location; we sort by the
+-- first.
+msgLoc :: AnnMsg Select -> Maybe SingleLoc
+msgLoc msg = listToMaybe $ C.locationInfoLocs msg.traceMsg.loc
 
-compareSingleLocs :: Map SourcePath Int -> SingleLoc -> SingleLoc -> Ordering
-compareSingleLocs xs x y =
-    case compareByOrder xs (singleLocPath x) (singleLocPath y) of
-      LT -> LT
-      EQ -> comparing getLineCol x y
-      GT -> GT
-  where
-    getLineCol :: SingleLoc -> (Int, Int)
-    getLineCol z = (singleLocLine z, singleLocColumn z)
+-- | Sort key of a trace message
+--
+-- The constructor order /is/ the specification: messages not attached to a
+-- declaration sort to the back. Do not reorder.
+data MsgSortKey =
+    MsgAt {
+        msgSource :: IncludeGraph.IncludeOrderIx
+      , msgLine   :: Int
+      , msgColumn :: Int
+      }
+  | MsgNoLocation
+  deriving stock (Eq, Ord)
 
-compareMsgs :: Map SourcePath Int -> AnnMsg Select -> AnnMsg Select -> Ordering
-compareMsgs orderMap x y =
-  case (C.locationInfoLocs x.traceMsg.loc, C.locationInfoLocs y.traceMsg.loc) of
-    (lx : __, ly : _) -> compareSingleLocs orderMap lx ly
-    -- Sort messages not attached to a declaration to the back.
-    ([] , _ ) -> GT
-    (_  , []) -> LT
+msgSortKey :: IncludeGraph.IncludeOrder -> AnnMsg Select -> MsgSortKey
+msgSortKey order msg = case msgLoc msg of
+    Nothing  -> MsgNoLocation
+    Just loc -> MsgAt {
+        msgSource = IncludeGraph.lookupIncludeOrder order (singleLocPath loc)
+      , msgLine   = singleLocLine   loc
+      , msgColumn = singleLocColumn loc
+      }
 
 sortSelectMsgs :: IncludeGraph -> [AnnMsg Select] -> [AnnMsg Select]
-sortSelectMsgs includeGraph = sortBy (compareMsgs orderMap)
+sortSelectMsgs includeGraph msgs =
+    bugMsgs ++ List.sortOn (msgSortKey order) msgs
   where
-    -- Compute the order map once.
-    orderMap :: Map SourcePath Int
-    orderMap = IncludeGraph.toOrderMap includeGraph
+    -- Compute the include order once.
+    order :: IncludeGraph.IncludeOrder
+    order = IncludeGraph.toIncludeOrder includeGraph
+
+    -- We do not know where to sort a message whose source is not in the include
+    -- graph, but a mis-sorted message is no reason to abort: report the bug and
+    -- sort the message to the back.
+    bugMsgs :: [AnnMsg Select]
+    bugMsgs = [
+        withCallStack C.WithLocationInfo{
+            loc = C.LocationUnavailable
+          , msg = SelectSourceNotInIncludeGraph path
+          }
+      | path <- Set.toList unknownPaths
+      ]
+
+    unknownPaths :: Set SourcePath
+    unknownPaths = Set.fromList [
+        path
+      | msg <- msgs
+      , Just loc <- [msgLoc msg]
+      , let path = singleLocPath loc
+      , IncludeGraph.lookupIncludeOrder order path
+          == IncludeGraph.NotInIncludeGraph
+      ]
 
 {-------------------------------------------------------------------------------
   Apply the selection predicate

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -15,6 +15,7 @@ import Text.SimplePrettyPrint (CtxDoc, (<+>), (><))
 import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
+import Clang.Paths
 
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Frontend.Analysis.DeclIndex (Squashed (..), UnusableEntry,
@@ -178,6 +179,9 @@ data SelectMsg =
     -- | Summary of the number of selected macros that hs-bindgen failed to
     -- translate.
   | SelectMacrosDropped Int
+    -- | The source of a trace message is not part of the include graph, so we
+    -- do not know where to sort it.
+  | SelectSourceNotInIncludeGraph SourcePath
   deriving stock (Show)
 
 instance PrettyForTrace SelectMsg where
@@ -226,6 +230,10 @@ instance PrettyForTrace SelectMsg where
             <> (if n == 1 then " macro failed to translate; "
                           else " macros failed to translate; ")
             <> "use --log-enable-macro-warnings for details"
+      SelectSourceNotInIncludeGraph path -> PP.hsep [
+          "Source not in include graph:"
+        , PP.string $ getSourcePath path
+        ]
     where
       during :: IsTrace l e => e -> CtxDoc -> CtxDoc
       during x = PP.hang (PP.string ("During " <> (getTraceId x).id <> ":")) 2
@@ -263,6 +271,7 @@ instance IsTrace Level SelectMsg where
     SelectDelayedReparseMacroExpansionsMsg x -> getDefaultLogLevel x
     SelectNoDeclarationsMatched              -> Warning
     SelectMacrosDropped{}                    -> Notice
+    SelectSourceNotInIncludeGraph{}          -> Bug
   getSource  = const HsBindgen
   getTraceId = \case
     SelectStatusInfo{}                       -> "select"
@@ -282,6 +291,7 @@ instance IsTrace Level SelectMsg where
     SelectDelayedReparseMacroExpansionsMsg x -> "select-" <> getTraceId x
     SelectNoDeclarationsMatched              -> "select"
     SelectMacrosDropped{}                    -> "select-dropped-macros"
+    SelectSourceNotInIncludeGraph{}          -> "select-source-not-in-include-graph"
 
 {-------------------------------------------------------------------------------
   CoercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/RootHeader.hs
@@ -7,20 +7,26 @@
 module HsBindgen.Frontend.RootHeader (
     -- * RootHeader
     RootHeader -- opaque
-  , fromMainFiles
+  , fromRootDirectives
     -- ** Generation
   , name
   , content
     -- ** Query
+  , isRootHeaderPath
   , isInRootHeader
+    -- ** Trace message
+  , RootHeaderMsg(..)
   ) where
 
 import Prelude hiding (lookup)
+
+import Text.SimplePrettyPrint qualified as PP
 
 import Clang.HighLevel.Types
 import Clang.Paths
 
 import HsBindgen.IR.C qualified as C
+import HsBindgen.Util.Tracer
 
 {-------------------------------------------------------------------------------
   RootHeader
@@ -28,12 +34,19 @@ import HsBindgen.IR.C qualified as C
 
 -- | Abstract representation of the root header
 --
--- This is /precisely/ the set of main files as specified by the user.
-newtype RootHeader = RootHeader [C.HashIncludeArg]
+-- This is /precisely/ the list of root directives as specified by the user.
+newtype RootHeader = RootHeader [C.RootDirective C.HashIncludeArg]
 
--- | Construct a t'RootHeader'
-fromMainFiles :: [C.HashIncludeArg] -> RootHeader
-fromMainFiles = RootHeader
+-- | Construct a t'RootHeader', returning trace messages
+fromRootDirectives ::
+     [C.RootDirective C.HashIncludeArg]
+  -> ([RootHeaderMsg], RootHeader)
+fromRootDirectives directives = (msgs, RootHeader directives)
+  where
+    -- Without a header there is nothing to generate bindings for. This is the
+    -- single check: every way of using @hs-bindgen@ builds the root header here.
+    msgs :: [RootHeaderMsg]
+    msgs = [RootHeaderNoHashInclude | null (C.hashIncludeArgsOf directives)]
 
 {-------------------------------------------------------------------------------
   Generation
@@ -45,19 +58,41 @@ name = SourcePath "hs-bindgen-root.h"
 
 -- | Root header content
 --
--- The content contains one include per line, in order, with no extra lines.
--- Functions @at@ and 'Prelude.lookup' rely on this.
+-- The content contains one directive per line, in order, with no extra lines.
+-- The very same rendering is prepended to the generated CAPI wrapper source and
+-- to the generated C test source, so that all C stages agree.
 content :: RootHeader -> String
-content (RootHeader headers) =
-    unlines $ map toLine headers
-  where
-    toLine :: C.HashIncludeArg -> String
-    toLine arg = "#include <"  ++ arg.path ++ ">"
+content (RootHeader directives) = C.renderRootDirectives directives
 
 {-------------------------------------------------------------------------------
   Query
 -------------------------------------------------------------------------------}
 
+-- | Check if the specified path is the root header
+isRootHeaderPath :: SourcePath -> Bool
+isRootHeaderPath = (== name)
+
 -- | Check if the specified location is in the root header
 isInRootHeader :: MultiLoc -> Bool
-isInRootHeader = (== name) . singleLocPath . multiLocExpansion
+isInRootHeader = isRootHeaderPath . singleLocPath . multiLocExpansion
+
+{-------------------------------------------------------------------------------
+  Trace messages
+-------------------------------------------------------------------------------}
+
+-- | Root header trace message
+data RootHeaderMsg =
+    RootHeaderNoHashInclude
+  deriving stock (Show)
+
+instance PrettyForTrace RootHeaderMsg where
+  prettyForTrace = \case
+    RootHeaderNoHashInclude ->
+      PP.string "no #include root directive: nothing to generate bindings for"
+
+instance IsTrace Level RootHeaderMsg where
+  -- A warning, not an error: hs-bindgen runs to completion, and no declarations
+  -- is the correct result for a root header with no @#include@.
+  getDefaultLogLevel = const Warning
+  getSource          = const HsBindgen
+  getTraceId         = const "root-header"

--- a/hs-bindgen/src-internal/HsBindgen/IR/C.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C.hs
@@ -10,17 +10,21 @@
 module HsBindgen.IR.C (
     module HsBindgen.IR.C.Conflict
   , module HsBindgen.IR.C.Decl
+  , module HsBindgen.IR.C.HashDefine
   , module HsBindgen.IR.C.HashIncludeArg
   , module HsBindgen.IR.C.LocationInfo
   , module HsBindgen.IR.C.Naming
   , module HsBindgen.IR.C.PrettyPrinter
+  , module HsBindgen.IR.C.RootDirective
   , module HsBindgen.IR.C.Type
   ) where
 
 import HsBindgen.IR.C.Conflict
 import HsBindgen.IR.C.Decl
+import HsBindgen.IR.C.HashDefine
 import HsBindgen.IR.C.HashIncludeArg
 import HsBindgen.IR.C.LocationInfo
 import HsBindgen.IR.C.Naming
 import HsBindgen.IR.C.PrettyPrinter
+import HsBindgen.IR.C.RootDirective
 import HsBindgen.IR.C.Type

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/HashDefine.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/HashDefine.hs
@@ -1,0 +1,63 @@
+-- | @#define@ directive
+--
+-- This module should only be used within the @HsBindgen.IR@ hierarchy.  From
+-- outside the @HsBindgen.IR@ hierarchy, "HsBindgen.IR.C" should be used.
+--
+-- Within @HsBindgen.IR@, all modules aside from "HsBindgen.IR.C" should import
+-- this module qualified for consistency.
+--
+-- > import HsBindgen.IR.C.HashDefine qualified as C
+module HsBindgen.IR.C.HashDefine (
+    -- * HashDefine
+    HashDefine(..)
+  , hashDefineToDirective
+  ) where
+
+import HsBindgen.Imports
+
+{-------------------------------------------------------------------------------
+  HashDefine
+-------------------------------------------------------------------------------}
+
+-- | A @#define@ directive
+--
+-- This is @#define@ syntax, /not/ C compiler @-D@ syntax; the translation
+-- between the two is not the identity:
+--
+-- * The @=@ of @-DFOO=BAR@ is not @#define@ syntax. @#define FOO=BAR@ is valid
+--   C, but defines a macro @FOO@ whose replacement list is @= BAR@. * @-DFOO@
+--   is not @#define FOO@. Clang and GCC define a bare @-D@ macro as @1@, so
+--   @-DFOO@ and @-DFOO=@ define /different/ macros. Both are @#ifdef@-true, but
+--   @#if FOO@ is true for the former and an error for the latter.
+--
+-- The correspondence is therefore:
+--
+-- +--------------------+--------------------------------+--------------------+
+-- | @-D@ argument      | t'HashDefine'                  | emitted directive  |
+-- +====================+================================+====================+
+-- | @-D FOO@           | @name = "FOO", value = "1"@    | @#define FOO 1@    |
+-- +--------------------+--------------------------------+--------------------+
+-- | @-D FOO=BAR@       | @name = "FOO", value = "BAR"@  | @#define FOO BAR@  |
+-- +--------------------+--------------------------------+--------------------+
+-- | @-D FOO=@          | @name = "FOO", value = ""@     | @#define FOO@      |
+-- +--------------------+--------------------------------+--------------------+
+-- | @-D \'FOO(x)=x\'@  | @name = "FOO(x)", value = "x"@ | @#define FOO(x) x@ |
+-- +--------------------+--------------------------------+--------------------+
+--
+-- Neither field is parsed or validated: a malformed definition is reported by
+-- Clang as a diagnostic in the root header, the same treatment an unresolvable
+-- @#include@ gets.
+data HashDefine = HashDefine {
+      -- | Macro name; may be function-like, e.g. @FOO(x)@
+      name :: String
+
+      -- | Replacement list; @""@ for @#define FOO@
+    , value :: String
+    }
+  deriving stock (Show, Eq, Generic)
+
+-- | Render a t'HashDefine' as a @#define@ directive (no trailing newline)
+hashDefineToDirective :: HashDefine -> String
+hashDefineToDirective hashDefine
+  | null hashDefine.value = "#define " ++ hashDefine.name
+  | otherwise             = "#define " ++ hashDefine.name ++ " " ++ hashDefine.value

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/RootDirective.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/RootDirective.hs
@@ -1,0 +1,64 @@
+-- | Root header directives
+--
+-- This module should only be used within the @HsBindgen.IR@ hierarchy.  From
+-- outside the @HsBindgen.IR@ hierarchy, "HsBindgen.IR.C" should be used.
+--
+-- Within @HsBindgen.IR@, all modules aside from "HsBindgen.IR.C" should import
+-- this module qualified for consistency.
+--
+-- > import HsBindgen.IR.C.RootDirective qualified as C
+module HsBindgen.IR.C.RootDirective (
+    -- * RootDirective
+    RootDirective(..)
+  , UncheckedRootDirective
+  , hashIncludeArgsOf
+    -- * Rendering
+  , renderRootDirectives
+  ) where
+
+import HsBindgen.Imports
+import HsBindgen.IR.C.HashDefine (HashDefine, hashDefineToDirective)
+import HsBindgen.IR.C.HashIncludeArg (HashIncludeArg (..),
+                                      UncheckedHashIncludeArg)
+
+{-------------------------------------------------------------------------------
+  RootDirective
+-------------------------------------------------------------------------------}
+
+-- | A directive of the root header
+--
+-- The user states @#include@s and @#define@s as a single ordered list, because
+-- the order matters: a @#define@ only affects the headers included after it.
+--
+-- The parameter is the @#include@ argument, which has an unchecked (as given by
+-- the user) and a checked form; @#define@s need no checking.
+data RootDirective arg =
+    DirectiveHashInclude arg
+  | DirectiveHashDefine  HashDefine
+  deriving stock (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+-- | Root directive with an unchecked @#include@ argument
+type UncheckedRootDirective = RootDirective UncheckedHashIncludeArg
+
+-- | The @#include@ arguments, in order, discarding the @#define@s
+--
+-- For consumers that genuinely only care about the headers.
+hashIncludeArgsOf :: [RootDirective arg] -> [arg]
+hashIncludeArgsOf = concatMap toList
+
+{-------------------------------------------------------------------------------
+  Rendering
+-------------------------------------------------------------------------------}
+
+-- | Render root directives, one per line, in order
+--
+-- This is the single source of truth for the C source seen by /all/ C stages:
+-- the root header parsed by @libclang@, the generated CAPI wrapper source
+-- compiled by GHC, and the generated C test source.
+renderRootDirectives :: [RootDirective HashIncludeArg] -> String
+renderRootDirectives = unlines . map render
+  where
+    render :: RootDirective HashIncludeArg -> String
+    render = \case
+      DirectiveHashInclude arg -> "#include <" ++ arg.path ++ ">"
+      DirectiveHashDefine  d   -> hashDefineToDirective d

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -4,6 +4,7 @@ module HsBindgen.TH.Internal (
   , IncludeDir(..)
   , withHsBindgenMacroLang
   , hashInclude
+  , hashDefine
   , BindgenM
 
    -- * Internal artefacts
@@ -69,6 +70,7 @@ toFilePath _    (Dir x) = x
 -- For example,
 --
 -- > withHsBindgenMacroLang myMacroLang def def $ do
+-- >   hashDefine "FOO_FEATURE" "1"
 -- >   hashInclude "foo.h"
 -- >   hashInclude "bar.h"
 withHsBindgenMacroLang ::
@@ -95,26 +97,32 @@ withHsBindgenMacroLang mkMacroLang config configTH hashIncludes = do
           tracerConfigDefTH
             & #verbosity .~ configTH.verbosity
 
-        -- Traverse #include directives.
+        -- Traverse root directives.
         bindgenState :: BindgenState
         bindgenState = execBindgenM hashIncludes (BindgenState [])
 
-        -- Restore original order of include directives.
-        uncheckedHashIncludeArgs :: [C.UncheckedHashIncludeArg]
-        uncheckedHashIncludeArgs = reverse bindgenState.hashIncludeArgs
+        -- Restore original order of the directives.
+        uncheckedRootDirectives :: [C.UncheckedRootDirective]
+        uncheckedRootDirectives = reverse bindgenState.rootDirectives
 
-        artefact :: Artefact l ([SourcePath], ([CWrapper], [SHs.SDecl]))
+        artefact ::
+          Artefact l
+            ( [SourcePath]
+            , ( [C.RootDirective C.HashIncludeArg]
+              , ([CWrapper], [SHs.SDecl])
+              )
+            )
         artefact = (,)
           <$> getDependencies
-          <*> (Foldable.fold <$> FinalDecls)
+          <*> ((,) <$> RootDirectives <*> (Foldable.fold <$> FinalDecls))
 
-    (deps, decls) <- liftIO $ do
+    (deps, (rootDirectives, decls)) <- liftIO $ do
         hsBindgenMacroLang
           mkMacroLang
           tracerConfigUnsafe
           tracerConfigSafe
           bindgenConfig
-          uncheckedHashIncludeArgs
+          uncheckedRootDirectives
           artefact
 
     let fns  = bindgenConfig.frontend.fieldNamingStrategy
@@ -123,7 +131,7 @@ withHsBindgenMacroLang mkMacroLang config configTH hashIncludes = do
     -- Reverse SDecl order to counteract GHC reversing TH type/class
     -- declarations during dependency analysis, which causes Haddock to show
     -- declarations in reverse order.
-    uncurry (getThDecls fns deps) (second reverse decls)
+    uncurry (getThDecls fns deps rootDirectives) (second reverse decls)
 
 -- | @#include@ (i.e., generate bindings for) a C header
 --
@@ -138,8 +146,29 @@ withHsBindgenMacroLang mkMacroLang config configTH hashIncludes = do
 -- See 'withHsBindgen'.
 hashInclude :: FilePath -> BindgenM ()
 hashInclude arg = do
-    -- Prepend the C header to the list (the order will be reversed)
-    modify $ #hashIncludeArgs %~ (arg:)
+    -- Prepend the directive to the list (the order will be reversed)
+    modify $ #rootDirectives %~ (C.DirectiveHashInclude arg:)
+
+-- | @#define@ a macro, in effect for all subsequent 'hashInclude's
+--
+-- > hashDefine "FOO" "1"    -- #define FOO 1
+-- > hashDefine "FOO" ""     -- #define FOO      (empty replacement list)
+-- > hashDefine "FOO(x)" "x" -- #define FOO(x) x
+--
+-- The directive applies to /all/ C stages: it is emitted both into the header
+-- @libclang@ parses and into the generated C wrapper source GHC compiles.
+--
+-- Neither argument is validated; see t'C.HashDefine'.
+--
+-- This is @#define@ syntax, /not/ C ompiler @-D@ syntax. For example, @-D FOO@
+-- corresponds to @--hash-define FOO 1@, translating to @#define FOO 1@.
+hashDefine ::
+     String -- ^ Macro name; may be function-like, e.g. @FOO(x)@
+  -> String -- ^ Replacement list; @""@ for @#define FOO@
+  -> BindgenM ()
+hashDefine name value = do
+    -- Prepend the directive to the list (the order will be reversed)
+    modify $ #rootDirectives %~ (C.DirectiveHashDefine (C.HashDefine name value):)
 
 {-------------------------------------------------------------------------------
   Internal artefacts
@@ -163,15 +192,16 @@ getThDecls
     :: Guasi q
     => FieldNamingStrategy
     -> [SourcePath]
+    -> [C.RootDirective C.HashIncludeArg]
     -> [CWrapper]
     -> [SHs.SDecl]
     -> q [TH.Dec]
-getThDecls fns deps wrappers decls = do
+getThDecls fns deps rootDirectives wrappers decls = do
     -- Record dependencies, including transitively included headers.
     mapM_ (addDependentFile . getSourcePath) deps
 
     -- Add userland-CAPI wrappers source code.
-    addCSource wrapperSrc
+    unless (null wrapperSrc) $ addCSource wrapperSrc
 
     -- Generate TH declarations.
     xs <- fmap concat $ traverse (mkDecl fns) decls
@@ -182,7 +212,7 @@ getThDecls fns deps wrappers decls = do
     pure xs
   where
     wrapperSrc :: String
-    wrapperSrc = getCWrappersSource wrappers
+    wrapperSrc = getCWrappersSource rootDirectives wrappers
 
     reportMissingModules :: Guasi q => q ()
     reportMissingModules = do
@@ -211,11 +241,11 @@ newtype BindgenM a = BindgenM { unwrap :: State BindgenState a }
 execBindgenM :: BindgenM a -> BindgenState -> BindgenState
 execBindgenM = execState . (.unwrap)
 
--- | State manipulated by 'hashInclude'
+-- | State manipulated by 'hashInclude' and 'hashDefine'
 --
 -- Internal!
 data BindgenState = BindgenState {
-      hashIncludeArgs :: [C.UncheckedHashIncludeArg]
+      rootDirectives :: [C.UncheckedRootDirective]
     }
   deriving stock (Generic)
 

--- a/hs-bindgen/src-internal/HsBindgen/Test.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Test.hs
@@ -23,12 +23,12 @@ import HsBindgen.Test.Readme (genTestsReadme)
 
 -- | Generate test suite
 genTests ::
-     [C.HashIncludeArg]
+     [C.RootDirective C.HashIncludeArg]
   -> ByCategory_ [Hs.Decl l]
   -> BaseModuleName -- ^ Generated Haskell module name
   -> FilePath       -- ^ Test suite directory path
   -> IO ()
-genTests hashIncludeArgs decls baseModule testSuitePath = do
+genTests rootDirectives decls baseModule testSuitePath = do
     -- fails when testSuitePath already exists
     mapM_ Dir.createDirectory $
       testSuitePath : cbitsPath : srcPath : modulePaths
@@ -41,7 +41,7 @@ genTests hashIncludeArgs decls baseModule testSuitePath = do
     genTestsC
       cTestHeaderPath
       cTestSourcePath
-      hashIncludeArgs
+      rootDirectives
       decls
     genTestsHs
       hsTestPath

--- a/hs-bindgen/src-internal/HsBindgen/Test/C.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Test/C.hs
@@ -15,7 +15,8 @@ import HsBindgen.IR.C qualified as C
 genTestsC ::
      FilePath                -- ^ C test header file path
   -> FilePath                -- ^ C test source file path
-  -> [C.HashIncludeArg]      -- ^ C header paths
+  -> [C.RootDirective C.HashIncludeArg]
+                             -- ^ Root directives (rendered verbatim)
   -> ByCategory_ [Hs.Decl l] -- ^ Declarations
   -> IO ()
 genTestsC = throwPure_TODO 22 "generate test suite"

--- a/hs-bindgen/src/HsBindgen/TH.hs
+++ b/hs-bindgen/src/HsBindgen/TH.hs
@@ -8,6 +8,7 @@ module HsBindgen.TH (
     withHsBindgen
   , TH.withHsBindgenMacroLang
   , TH.hashInclude
+  , TH.hashDefine
   , TH.BindgenM -- opaque, used in type signatures
 
     -- * Configuration

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Hash_defines_buffer(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.ConstantArray as CA
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Struct as Struct
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+
+{-| __C declaration:__ @struct hash_defines_buffer@
+
+    __defined at:__ @functions\/hash_defines.h 14:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+data Hash_defines_buffer = Hash_defines_buffer
+  { hash_defines_buffer_data :: CA.ConstantArray 8 BG.CChar
+    {- ^ __C declaration:__ @data@
+
+         __defined at:__ @functions\/hash_defines.h 15:8@
+
+         __exported by:__ @functions\/hash_defines.h@
+    -}
+  }
+  deriving stock (Eq, BG.Generic, Show)
+
+instance Marshal.StaticSize Hash_defines_buffer where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (1 :: Int)
+
+instance Marshal.ReadRaw Hash_defines_buffer where
+
+  readRaw =
+    \ptr0 ->
+          pure Hash_defines_buffer
+      <*> HasCField.readRaw (BG.Proxy @"hash_defines_buffer_data") ptr0
+
+instance Marshal.WriteRaw Hash_defines_buffer where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Hash_defines_buffer hash_defines_buffer_data2 ->
+            HasCField.writeRaw (BG.Proxy @"hash_defines_buffer_data") ptr0 hash_defines_buffer_data2
+
+deriving via Marshal.EquivStorable Hash_defines_buffer instance BG.Storable Hash_defines_buffer
+
+deriving via Struct.IsStructViaReadRaw Hash_defines_buffer instance Struct.IsStruct Hash_defines_buffer
+
+{-| __C declaration:__ @data@
+
+    __defined at:__ @functions\/hash_defines.h 15:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+instance ( ty ~ CA.ConstantArray 8 BG.CChar
+         ) => BG.CompatHasField.HasField "hash_defines_buffer_data" Hash_defines_buffer ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Hash_defines_buffer {hash_defines_buffer_data = y1}
+      , BG.getField @"hash_defines_buffer_data" x0
+      )
+
+instance ( ty ~ CA.ConstantArray 8 BG.CChar
+         ) => BG.HasField "hash_defines_buffer_data" (BG.Ptr Hash_defines_buffer) (BG.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (BG.Proxy @"hash_defines_buffer_data")
+
+instance HasCField.HasCField Hash_defines_buffer "hash_defines_buffer_data" where
+
+  type CFieldType Hash_defines_buffer "hash_defines_buffer_data" =
+    CA.ConstantArray 8 BG.CChar
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/FunPtr.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/FunPtr.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.FunPtr
+    ( Example.FunPtr.hash_defines_feature
+    , Example.FunPtr.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "/* test_functionshash_defines_1_selec_Example_get_hash_defines_feature */"
+  , "__attribute__ ((const))"
+  , "signed int (*hs_bindgen_50e4783814da01a4 (void)) ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return &hash_defines_feature;"
+  , "}"
+  , "/* test_functionshash_defines_1_selec_Example_get_hash_defines_empty */"
+  , "__attribute__ ((const))"
+  , "signed int (*hs_bindgen_b21d3bcdf79e0d85 (void)) (void)"
+  , "{"
+  , "  return &hash_defines_empty;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_50e4783814da01a4" hs_bindgen_50e4783814da01a4_base ::
+     IO (BG.FunPtr BG.Void)
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_feature@
+hs_bindgen_50e4783814da01a4 :: IO (BG.FunPtr (BG.CInt -> IO BG.CInt))
+hs_bindgen_50e4783814da01a4 =
+  BG.fromFFIType hs_bindgen_50e4783814da01a4_base
+
+{-# NOINLINE hash_defines_feature #-}
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature :: BG.FunPtr (BG.CInt -> IO BG.CInt)
+hash_defines_feature =
+  BG.unsafePerformIO hs_bindgen_50e4783814da01a4
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_b21d3bcdf79e0d85" hs_bindgen_b21d3bcdf79e0d85_base ::
+     IO (BG.FunPtr BG.Void)
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_empty@
+hs_bindgen_b21d3bcdf79e0d85 :: IO (BG.FunPtr (IO BG.CInt))
+hs_bindgen_b21d3bcdf79e0d85 =
+  BG.fromFFIType hs_bindgen_b21d3bcdf79e0d85_base
+
+{-# NOINLINE hash_defines_empty #-}
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: BG.FunPtr (IO BG.CInt)
+hash_defines_empty =
+  BG.unsafePerformIO hs_bindgen_b21d3bcdf79e0d85

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/Safe.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/Safe.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Safe
+    ( Example.Safe.hash_defines_feature
+    , Example.Safe.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "signed int hs_bindgen_6aab0c8e3c921393 ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return (hash_defines_feature)(arg1);"
+  , "}"
+  , "signed int hs_bindgen_af6bf91e93f5ed0c (void)"
+  , "{"
+  , "  return (hash_defines_empty)();"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_feature@
+foreign import ccall safe "hs_bindgen_6aab0c8e3c921393" hs_bindgen_6aab0c8e3c921393_base ::
+     BG.Int32
+  -> IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_feature@
+hs_bindgen_6aab0c8e3c921393 ::
+     BG.CInt
+  -> IO BG.CInt
+hs_bindgen_6aab0c8e3c921393 =
+  BG.fromFFIType hs_bindgen_6aab0c8e3c921393_base
+
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature ::
+     BG.CInt
+     -- ^ __C declaration:__ @x@
+  -> IO BG.CInt
+hash_defines_feature = hs_bindgen_6aab0c8e3c921393
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_empty@
+foreign import ccall safe "hs_bindgen_af6bf91e93f5ed0c" hs_bindgen_af6bf91e93f5ed0c_base ::
+     IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_empty@
+hs_bindgen_af6bf91e93f5ed0c :: IO BG.CInt
+hs_bindgen_af6bf91e93f5ed0c =
+  BG.fromFFIType hs_bindgen_af6bf91e93f5ed0c_base
+
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: IO BG.CInt
+hash_defines_empty = hs_bindgen_af6bf91e93f5ed0c

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/Unsafe.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/Example/Unsafe.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Unsafe
+    ( Example.Unsafe.hash_defines_feature
+    , Example.Unsafe.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "signed int hs_bindgen_9c64b65744839a8b ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return (hash_defines_feature)(arg1);"
+  , "}"
+  , "signed int hs_bindgen_f811fa46f514d285 (void)"
+  , "{"
+  , "  return (hash_defines_empty)();"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_9c64b65744839a8b" hs_bindgen_9c64b65744839a8b_base ::
+     BG.Int32
+  -> IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_feature@
+hs_bindgen_9c64b65744839a8b ::
+     BG.CInt
+  -> IO BG.CInt
+hs_bindgen_9c64b65744839a8b =
+  BG.fromFFIType hs_bindgen_9c64b65744839a8b_base
+
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature ::
+     BG.CInt
+     -- ^ __C declaration:__ @x@
+  -> IO BG.CInt
+hash_defines_feature = hs_bindgen_9c64b65744839a8b
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_f811fa46f514d285" hs_bindgen_f811fa46f514d285_base ::
+     IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_empty@
+hs_bindgen_f811fa46f514d285 :: IO BG.CInt
+hs_bindgen_f811fa46f514d285 =
+  BG.fromFFIType hs_bindgen_f811fa46f514d285_base
+
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: IO BG.CInt
+hash_defines_empty = hs_bindgen_f811fa46f514d285

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/bindingspec.yaml
@@ -1,0 +1,28 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: functions/hash_defines.h
+  cname: struct hash_defines_buffer
+  hsname: Hash_defines_buffer
+hstypes:
+- hsname: Hash_defines_buffer
+  representation:
+    record:
+      constructor: Hash_defines_buffer
+      fields:
+      - hash_defines_buffer_data
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsStruct
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines.1.select_all/th.txt
@@ -1,0 +1,208 @@
+-- addDependentFile test-artefacts/headers/golden/functions/hash_defines.h
+-- #define MY_FEATURE 1
+-- #define MY_SIZE 8
+-- #define MY_EMPTY
+-- #include <functions/hash_defines.h>
+-- signed int hs_bindgen_6aab0c8e3c921393 (
+--   signed int arg1
+-- )
+-- {
+--   return (hash_defines_feature)(arg1);
+-- }
+-- signed int hs_bindgen_af6bf91e93f5ed0c (void)
+-- {
+--   return (hash_defines_empty)();
+-- }
+-- signed int hs_bindgen_9c64b65744839a8b (
+--   signed int arg1
+-- )
+-- {
+--   return (hash_defines_feature)(arg1);
+-- }
+-- signed int hs_bindgen_f811fa46f514d285 (void)
+-- {
+--   return (hash_defines_empty)();
+-- }
+-- /* test_functionshash_defines_1_selec_Example_get_hash_defines_feature */
+-- __attribute__ ((const))
+-- signed int (*hs_bindgen_50e4783814da01a4 (void)) (
+--   signed int arg1
+-- )
+-- {
+--   return &hash_defines_feature;
+-- }
+-- /* test_functionshash_defines_1_selec_Example_get_hash_defines_empty */
+-- __attribute__ ((const))
+-- signed int (*hs_bindgen_b21d3bcdf79e0d85 (void)) (void)
+-- {
+--   return &hash_defines_empty;
+-- }
+{-| __C declaration:__ @struct hash_defines_buffer@
+
+    __defined at:__ @functions\/hash_defines.h 14:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+data Hash_defines_buffer
+    = Hash_defines_buffer {hash_defines_buffer_data :: (ConstantArray 8
+                                                                      CChar)
+                           {- ^ __C declaration:__ @data@
+
+                                __defined at:__ @functions\/hash_defines.h 15:8@
+
+                                __exported by:__ @functions\/hash_defines.h@
+                           -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Hash_defines_buffer
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 1 :: Int
+instance ReadRaw Hash_defines_buffer
+    where readRaw = \ptr_0 -> pure Hash_defines_buffer <*> readRaw (Proxy @"hash_defines_buffer_data") ptr_0
+instance WriteRaw Hash_defines_buffer
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Hash_defines_buffer hash_defines_buffer_data_2 -> writeRaw (Proxy @"hash_defines_buffer_data") ptr_0 hash_defines_buffer_data_2
+deriving via (EquivStorable Hash_defines_buffer) instance Storable Hash_defines_buffer
+deriving via (IsStructViaReadRaw Hash_defines_buffer) instance IsStruct Hash_defines_buffer
+instance (~) ty (ConstantArray 8 CChar) =>
+         HasField "hash_defines_buffer_data" Hash_defines_buffer ty
+    where hasField = \x_0 -> (\y_1 -> Hash_defines_buffer{hash_defines_buffer_data = y_1},
+                              getField @"hash_defines_buffer_data" x_0)
+instance (~) ty (ConstantArray 8 CChar) =>
+         HasField "hash_defines_buffer_data"
+                  (Ptr Hash_defines_buffer)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"hash_defines_buffer_data")
+instance HasCField Hash_defines_buffer "hash_defines_buffer_data"
+    where type CFieldType Hash_defines_buffer
+                          "hash_defines_buffer_data" = ConstantArray 8 CChar
+          offset# = \_ -> \_ -> 0
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_feature@
+foreign import ccall safe "hs_bindgen_6aab0c8e3c921393" hs_bindgen_6aab0c8e3c921393_base ::
+    Int32
+ -> IO Int32
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_feature@
+hs_bindgen_6aab0c8e3c921393 :: CInt -> IO CInt
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_feature@
+hs_bindgen_6aab0c8e3c921393 = fromFFIType hs_bindgen_6aab0c8e3c921393_base
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_safe :: CInt -> IO CInt
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_safe = hs_bindgen_6aab0c8e3c921393
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_empty@
+foreign import ccall safe "hs_bindgen_af6bf91e93f5ed0c" hs_bindgen_af6bf91e93f5ed0c_base ::
+    IO Int32
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_empty@
+hs_bindgen_af6bf91e93f5ed0c :: IO CInt
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Safe_hash_defines_empty@
+hs_bindgen_af6bf91e93f5ed0c = fromFFIType hs_bindgen_af6bf91e93f5ed0c_base
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_safe :: IO CInt
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_safe = hs_bindgen_af6bf91e93f5ed0c
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_9c64b65744839a8b" hs_bindgen_9c64b65744839a8b_base ::
+    Int32
+ -> IO Int32
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_feature@
+hs_bindgen_9c64b65744839a8b :: CInt -> IO CInt
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_feature@
+hs_bindgen_9c64b65744839a8b = fromFFIType hs_bindgen_9c64b65744839a8b_base
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_unsafe :: CInt -> IO CInt
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_unsafe = hs_bindgen_9c64b65744839a8b
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_f811fa46f514d285" hs_bindgen_f811fa46f514d285_base ::
+    IO Int32
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_empty@
+hs_bindgen_f811fa46f514d285 :: IO CInt
+-- __unique:__ @test_functionshash_defines_1_selec_Example_Unsafe_hash_defines_empty@
+hs_bindgen_f811fa46f514d285 = fromFFIType hs_bindgen_f811fa46f514d285_base
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_unsafe :: IO CInt
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_unsafe = hs_bindgen_f811fa46f514d285
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_50e4783814da01a4" hs_bindgen_50e4783814da01a4_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_feature@
+hs_bindgen_50e4783814da01a4 :: IO (FunPtr (CInt -> IO CInt))
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_feature@
+hs_bindgen_50e4783814da01a4 = fromFFIType hs_bindgen_50e4783814da01a4_base
+{-# NOINLINE hash_defines_feature_funptr #-}
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_funptr :: FunPtr (CInt -> IO CInt)
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_funptr = unsafePerformIO hs_bindgen_50e4783814da01a4
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_b21d3bcdf79e0d85" hs_bindgen_b21d3bcdf79e0d85_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_empty@
+hs_bindgen_b21d3bcdf79e0d85 :: IO (FunPtr (IO CInt))
+-- __unique:__ @test_functionshash_defines_1_selec_Example_get_hash_defines_empty@
+hs_bindgen_b21d3bcdf79e0d85 = fromFFIType hs_bindgen_b21d3bcdf79e0d85_base
+{-# NOINLINE hash_defines_empty_funptr #-}
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_funptr :: FunPtr (IO CInt)
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_funptr = unsafePerformIO hs_bindgen_b21d3bcdf79e0d85

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.Hash_defines_buffer(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.ConstantArray as CA
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Struct as Struct
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+
+{-| __C declaration:__ @struct hash_defines_buffer@
+
+    __defined at:__ @functions\/hash_defines.h 14:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+data Hash_defines_buffer = Hash_defines_buffer
+  { hash_defines_buffer_data :: CA.ConstantArray 8 BG.CChar
+    {- ^ __C declaration:__ @data@
+
+         __defined at:__ @functions\/hash_defines.h 15:8@
+
+         __exported by:__ @functions\/hash_defines.h@
+    -}
+  }
+  deriving stock (Eq, BG.Generic, Show)
+
+instance Marshal.StaticSize Hash_defines_buffer where
+
+  staticSizeOf = \_ -> (8 :: Int)
+
+  staticAlignment = \_ -> (1 :: Int)
+
+instance Marshal.ReadRaw Hash_defines_buffer where
+
+  readRaw =
+    \ptr0 ->
+          pure Hash_defines_buffer
+      <*> HasCField.readRaw (BG.Proxy @"hash_defines_buffer_data") ptr0
+
+instance Marshal.WriteRaw Hash_defines_buffer where
+
+  writeRaw =
+    \ptr0 ->
+      \s1 ->
+        case s1 of
+          Hash_defines_buffer hash_defines_buffer_data2 ->
+            HasCField.writeRaw (BG.Proxy @"hash_defines_buffer_data") ptr0 hash_defines_buffer_data2
+
+deriving via Marshal.EquivStorable Hash_defines_buffer instance BG.Storable Hash_defines_buffer
+
+deriving via Struct.IsStructViaReadRaw Hash_defines_buffer instance Struct.IsStruct Hash_defines_buffer
+
+{-| __C declaration:__ @data@
+
+    __defined at:__ @functions\/hash_defines.h 15:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+instance ( ty ~ CA.ConstantArray 8 BG.CChar
+         ) => BG.CompatHasField.HasField "hash_defines_buffer_data" Hash_defines_buffer ty where
+
+  hasField =
+    \x0 ->
+      ( \y1 ->
+          Hash_defines_buffer {hash_defines_buffer_data = y1}
+      , BG.getField @"hash_defines_buffer_data" x0
+      )
+
+instance ( ty ~ CA.ConstantArray 8 BG.CChar
+         ) => BG.HasField "hash_defines_buffer_data" (BG.Ptr Hash_defines_buffer) (BG.Ptr ty) where
+
+  getField =
+    HasCField.fromPtr (BG.Proxy @"hash_defines_buffer_data")
+
+instance HasCField.HasCField Hash_defines_buffer "hash_defines_buffer_data" where
+
+  type CFieldType Hash_defines_buffer "hash_defines_buffer_data" =
+    CA.ConstantArray 8 BG.CChar
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/FunPtr.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/FunPtr.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.FunPtr
+    ( Example.FunPtr.hash_defines_feature
+    , Example.FunPtr.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "/* test_functionshash_defines_Example_get_hash_defines_feature */"
+  , "__attribute__ ((const))"
+  , "signed int (*hs_bindgen_ebc7bd37f43918fa (void)) ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return &hash_defines_feature;"
+  , "}"
+  , "/* test_functionshash_defines_Example_get_hash_defines_empty */"
+  , "__attribute__ ((const))"
+  , "signed int (*hs_bindgen_11624d9d43a105dc (void)) (void)"
+  , "{"
+  , "  return &hash_defines_empty;"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_ebc7bd37f43918fa" hs_bindgen_ebc7bd37f43918fa_base ::
+     IO (BG.FunPtr BG.Void)
+
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_feature@
+hs_bindgen_ebc7bd37f43918fa :: IO (BG.FunPtr (BG.CInt -> IO BG.CInt))
+hs_bindgen_ebc7bd37f43918fa =
+  BG.fromFFIType hs_bindgen_ebc7bd37f43918fa_base
+
+{-# NOINLINE hash_defines_feature #-}
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature :: BG.FunPtr (BG.CInt -> IO BG.CInt)
+hash_defines_feature =
+  BG.unsafePerformIO hs_bindgen_ebc7bd37f43918fa
+
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_11624d9d43a105dc" hs_bindgen_11624d9d43a105dc_base ::
+     IO (BG.FunPtr BG.Void)
+
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_empty@
+hs_bindgen_11624d9d43a105dc :: IO (BG.FunPtr (IO BG.CInt))
+hs_bindgen_11624d9d43a105dc =
+  BG.fromFFIType hs_bindgen_11624d9d43a105dc_base
+
+{-# NOINLINE hash_defines_empty #-}
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: BG.FunPtr (IO BG.CInt)
+hash_defines_empty =
+  BG.unsafePerformIO hs_bindgen_11624d9d43a105dc

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/Safe.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/Safe.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Safe
+    ( Example.Safe.hash_defines_feature
+    , Example.Safe.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "signed int hs_bindgen_8b3d8c537a5a6361 ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return (hash_defines_feature)(arg1);"
+  , "}"
+  , "signed int hs_bindgen_60d52d7fed356c54 (void)"
+  , "{"
+  , "  return (hash_defines_empty)();"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_feature@
+foreign import ccall safe "hs_bindgen_8b3d8c537a5a6361" hs_bindgen_8b3d8c537a5a6361_base ::
+     BG.Int32
+  -> IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_feature@
+hs_bindgen_8b3d8c537a5a6361 ::
+     BG.CInt
+  -> IO BG.CInt
+hs_bindgen_8b3d8c537a5a6361 =
+  BG.fromFFIType hs_bindgen_8b3d8c537a5a6361_base
+
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature ::
+     BG.CInt
+     -- ^ __C declaration:__ @x@
+  -> IO BG.CInt
+hash_defines_feature = hs_bindgen_8b3d8c537a5a6361
+
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_empty@
+foreign import ccall safe "hs_bindgen_60d52d7fed356c54" hs_bindgen_60d52d7fed356c54_base ::
+     IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_empty@
+hs_bindgen_60d52d7fed356c54 :: IO BG.CInt
+hs_bindgen_60d52d7fed356c54 =
+  BG.fromFFIType hs_bindgen_60d52d7fed356c54_base
+
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: IO BG.CInt
+hash_defines_empty = hs_bindgen_60d52d7fed356c54

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/Unsafe.hs
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/Example/Unsafe.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_HADDOCK prune #-}
+
+module Example.Unsafe
+    ( Example.Unsafe.hash_defines_feature
+    , Example.Unsafe.hash_defines_empty
+    )
+  where
+
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CAPI
+
+$(HsBindgen.Runtime.Support.CAPI.addCSource (HsBindgen.Runtime.Support.CAPI.unlines
+  [ "#define MY_FEATURE 1"
+  , "#define MY_SIZE 8"
+  , "#define MY_EMPTY"
+  , "#include <functions/hash_defines.h>"
+  , "signed int hs_bindgen_2d6dbb74d32d186a ("
+  , "  signed int arg1"
+  , ")"
+  , "{"
+  , "  return (hash_defines_feature)(arg1);"
+  , "}"
+  , "signed int hs_bindgen_ba61b6fc716692e4 (void)"
+  , "{"
+  , "  return (hash_defines_empty)();"
+  , "}"
+  ]))
+
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_2d6dbb74d32d186a" hs_bindgen_2d6dbb74d32d186a_base ::
+     BG.Int32
+  -> IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_feature@
+hs_bindgen_2d6dbb74d32d186a ::
+     BG.CInt
+  -> IO BG.CInt
+hs_bindgen_2d6dbb74d32d186a =
+  BG.fromFFIType hs_bindgen_2d6dbb74d32d186a_base
+
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature ::
+     BG.CInt
+     -- ^ __C declaration:__ @x@
+  -> IO BG.CInt
+hash_defines_feature = hs_bindgen_2d6dbb74d32d186a
+
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_ba61b6fc716692e4" hs_bindgen_ba61b6fc716692e4_base ::
+     IO BG.Int32
+
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_empty@
+hs_bindgen_ba61b6fc716692e4 :: IO BG.CInt
+hs_bindgen_ba61b6fc716692e4 =
+  BG.fromFFIType hs_bindgen_ba61b6fc716692e4_base
+
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty :: IO BG.CInt
+hash_defines_empty = hs_bindgen_ba61b6fc716692e4

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/bindingspec.yaml
@@ -1,0 +1,28 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: functions/hash_defines.h
+  cname: struct hash_defines_buffer
+  hsname: Hash_defines_buffer
+hstypes:
+- hsname: Hash_defines_buffer
+  representation:
+    record:
+      constructor: Hash_defines_buffer
+      fields:
+      - hash_defines_buffer_data
+  instances:
+  - Eq
+  - Generic
+  - HasCField
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - IsStruct
+  - ReadRaw
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/functions/hash_defines/th.txt
@@ -1,0 +1,208 @@
+-- addDependentFile test-artefacts/headers/golden/functions/hash_defines.h
+-- #define MY_FEATURE 1
+-- #define MY_SIZE 8
+-- #define MY_EMPTY
+-- #include <functions/hash_defines.h>
+-- signed int hs_bindgen_8b3d8c537a5a6361 (
+--   signed int arg1
+-- )
+-- {
+--   return (hash_defines_feature)(arg1);
+-- }
+-- signed int hs_bindgen_60d52d7fed356c54 (void)
+-- {
+--   return (hash_defines_empty)();
+-- }
+-- signed int hs_bindgen_2d6dbb74d32d186a (
+--   signed int arg1
+-- )
+-- {
+--   return (hash_defines_feature)(arg1);
+-- }
+-- signed int hs_bindgen_ba61b6fc716692e4 (void)
+-- {
+--   return (hash_defines_empty)();
+-- }
+-- /* test_functionshash_defines_Example_get_hash_defines_feature */
+-- __attribute__ ((const))
+-- signed int (*hs_bindgen_ebc7bd37f43918fa (void)) (
+--   signed int arg1
+-- )
+-- {
+--   return &hash_defines_feature;
+-- }
+-- /* test_functionshash_defines_Example_get_hash_defines_empty */
+-- __attribute__ ((const))
+-- signed int (*hs_bindgen_11624d9d43a105dc (void)) (void)
+-- {
+--   return &hash_defines_empty;
+-- }
+{-| __C declaration:__ @struct hash_defines_buffer@
+
+    __defined at:__ @functions\/hash_defines.h 14:8@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+data Hash_defines_buffer
+    = Hash_defines_buffer {hash_defines_buffer_data :: (ConstantArray 8
+                                                                      CChar)
+                           {- ^ __C declaration:__ @data@
+
+                                __defined at:__ @functions\/hash_defines.h 15:8@
+
+                                __exported by:__ @functions\/hash_defines.h@
+                           -}}
+    deriving stock (Eq, Generic, Show)
+instance StaticSize Hash_defines_buffer
+    where staticSizeOf = \_ -> 8 :: Int
+          staticAlignment = \_ -> 1 :: Int
+instance ReadRaw Hash_defines_buffer
+    where readRaw = \ptr_0 -> pure Hash_defines_buffer <*> readRaw (Proxy @"hash_defines_buffer_data") ptr_0
+instance WriteRaw Hash_defines_buffer
+    where writeRaw = \ptr_0 -> \s_1 -> case s_1 of
+                                       Hash_defines_buffer hash_defines_buffer_data_2 -> writeRaw (Proxy @"hash_defines_buffer_data") ptr_0 hash_defines_buffer_data_2
+deriving via (EquivStorable Hash_defines_buffer) instance Storable Hash_defines_buffer
+deriving via (IsStructViaReadRaw Hash_defines_buffer) instance IsStruct Hash_defines_buffer
+instance (~) ty (ConstantArray 8 CChar) =>
+         HasField "hash_defines_buffer_data" Hash_defines_buffer ty
+    where hasField = \x_0 -> (\y_1 -> Hash_defines_buffer{hash_defines_buffer_data = y_1},
+                              getField @"hash_defines_buffer_data" x_0)
+instance (~) ty (ConstantArray 8 CChar) =>
+         HasField "hash_defines_buffer_data"
+                  (Ptr Hash_defines_buffer)
+                  (Ptr ty)
+    where getField = fromPtr (Proxy @"hash_defines_buffer_data")
+instance HasCField Hash_defines_buffer "hash_defines_buffer_data"
+    where type CFieldType Hash_defines_buffer
+                          "hash_defines_buffer_data" = ConstantArray 8 CChar
+          offset# = \_ -> \_ -> 0
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_feature@
+foreign import ccall safe "hs_bindgen_8b3d8c537a5a6361" hs_bindgen_8b3d8c537a5a6361_base ::
+    Int32
+ -> IO Int32
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_feature@
+hs_bindgen_8b3d8c537a5a6361 :: CInt -> IO CInt
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_feature@
+hs_bindgen_8b3d8c537a5a6361 = fromFFIType hs_bindgen_8b3d8c537a5a6361_base
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_safe :: CInt -> IO CInt
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_safe = hs_bindgen_8b3d8c537a5a6361
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_empty@
+foreign import ccall safe "hs_bindgen_60d52d7fed356c54" hs_bindgen_60d52d7fed356c54_base ::
+    IO Int32
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_empty@
+hs_bindgen_60d52d7fed356c54 :: IO CInt
+-- __unique:__ @test_functionshash_defines_Example_Safe_hash_defines_empty@
+hs_bindgen_60d52d7fed356c54 = fromFFIType hs_bindgen_60d52d7fed356c54_base
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_safe :: IO CInt
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_safe = hs_bindgen_60d52d7fed356c54
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_2d6dbb74d32d186a" hs_bindgen_2d6dbb74d32d186a_base ::
+    Int32
+ -> IO Int32
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_feature@
+hs_bindgen_2d6dbb74d32d186a :: CInt -> IO CInt
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_feature@
+hs_bindgen_2d6dbb74d32d186a = fromFFIType hs_bindgen_2d6dbb74d32d186a_base
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_unsafe :: CInt -> IO CInt
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_unsafe = hs_bindgen_2d6dbb74d32d186a
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_ba61b6fc716692e4" hs_bindgen_ba61b6fc716692e4_base ::
+    IO Int32
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_empty@
+hs_bindgen_ba61b6fc716692e4 :: IO CInt
+-- __unique:__ @test_functionshash_defines_Example_Unsafe_hash_defines_empty@
+hs_bindgen_ba61b6fc716692e4 = fromFFIType hs_bindgen_ba61b6fc716692e4_base
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_unsafe :: IO CInt
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_unsafe = hs_bindgen_ba61b6fc716692e4
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_feature@
+foreign import ccall unsafe "hs_bindgen_ebc7bd37f43918fa" hs_bindgen_ebc7bd37f43918fa_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_feature@
+hs_bindgen_ebc7bd37f43918fa :: IO (FunPtr (CInt -> IO CInt))
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_feature@
+hs_bindgen_ebc7bd37f43918fa = fromFFIType hs_bindgen_ebc7bd37f43918fa_base
+{-# NOINLINE hash_defines_feature_funptr #-}
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_funptr :: FunPtr (CInt -> IO CInt)
+{-| __C declaration:__ @hash_defines_feature@
+
+    __defined at:__ @functions\/hash_defines.h 9:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_feature_funptr = unsafePerformIO hs_bindgen_ebc7bd37f43918fa
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_empty@
+foreign import ccall unsafe "hs_bindgen_11624d9d43a105dc" hs_bindgen_11624d9d43a105dc_base ::
+    IO (FunPtr Void)
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_empty@
+hs_bindgen_11624d9d43a105dc :: IO (FunPtr (IO CInt))
+-- __unique:__ @test_functionshash_defines_Example_get_hash_defines_empty@
+hs_bindgen_11624d9d43a105dc = fromFFIType hs_bindgen_11624d9d43a105dc_base
+{-# NOINLINE hash_defines_empty_funptr #-}
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_funptr :: FunPtr (IO CInt)
+{-| __C declaration:__ @hash_defines_empty@
+
+    __defined at:__ @functions\/hash_defines.h 20:5@
+
+    __exported by:__ @functions\/hash_defines.h@
+-}
+hash_defines_empty_funptr = unsafePerformIO hs_bindgen_11624d9d43a105dc

--- a/hs-bindgen/test-artefacts/headers/golden/functions/hash_defines.h
+++ b/hs-bindgen/test-artefacts/headers/golden/functions/hash_defines.h
@@ -1,0 +1,21 @@
+/* Root '#define' directives must reach binding generation stage and binding
+   compilation stage: the header `libclang` parses at generation time, and the
+   CAPI wrapper source GHC compiles. */
+
+#if MY_FEATURE
+/* Needs the replacement list to be '1', not empty: '#if' on a macro with an
+   empty replacement list is an error.  Without the define reaching the
+   compilation stage, the wrapper body calls an undeclared function. */
+int hash_defines_feature(int x);
+#endif
+
+/* Without the define reaching the compilation stage, the header itself does not
+   preprocess there. */
+struct hash_defines_buffer {
+  char data[MY_SIZE];
+};
+
+/* Pins the '#define MY_EMPTY' (empty replacement list) rendering. */
+#ifdef MY_EMPTY
+int hash_defines_empty(void);
+#endif

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Functions.hs
@@ -5,6 +5,7 @@ import HsBindgen.Backend.Category
 import HsBindgen.Config.Internal
 import HsBindgen.Frontend.Analysis.DeclIndex (UnusableReason (..))
 import HsBindgen.Frontend.Pass.Select.IsPass
+import HsBindgen.Frontend.Predicate (Boolean (..))
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.TraceMsg
@@ -36,6 +37,8 @@ testCases = [
     , test_functions_decls_in_signature
     , test_functions_fun_attributes
     , test_functions_fun_attributes_conflict
+    , test_functions_hash_defines
+    , test_functions_hash_defines_select_all
     , test_functions_not_visible_decl
     , test_functions_simple_func
     , test_functions_simple_func_rename
@@ -99,6 +102,34 @@ test_functions_fun_attributes_conflict =
   where
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = []
+
+-- | @#define@ root directives reach the generation /and/ compilation stage
+--
+-- The header does not preprocess without @MY_SIZE@, so PP\/TH fixture
+-- compilation only succeeds if the directives are forwarded to the wrapper
+-- source.
+test_functions_hash_defines :: TestCase
+test_functions_hash_defines =
+    defaultTest "functions/hash_defines"
+      & #hashDefines .~ hashDefines
+
+-- | Root-header @#define@s produce no bindings, not even under @--select-all@
+--
+-- They live in the synthetic root header, which is not a main header of
+-- anything, so they are not attempted at all — no macro bindings, and no
+-- traces.
+test_functions_hash_defines_select_all :: TestCase
+test_functions_hash_defines_select_all =
+    testVariant "functions/hash_defines" (Just 1) "select_all"
+      & #hashDefines .~ hashDefines
+      & #onFrontend  .~ ( #selectionPredicate .~ BTrue)
+
+hashDefines :: [C.HashDefine]
+hashDefines = [
+      C.HashDefine "MY_FEATURE" "1"
+    , C.HashDefine "MY_SIZE"    "8"
+    , C.HashDefine "MY_EMPTY"   ""
+    ]
 
 test_functions_not_visible_decl :: TestCase
 test_functions_not_visible_decl =

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/Check/TH.hs
@@ -49,14 +49,14 @@ check getTestResources test =
         pkgroot <- (.packageRoot) <$> getTestResources
         -- We do not have access to 'Q', and so have to compute the 'getThDecls'
         -- artefact manually.
-        (deps, decls) <-
+        (deps, (dirs, decls)) <-
           runTestHsBindgenSuccess report getTestResources testTh
-            ((,) <$> getDependencies <*> FinalDecls)
+            ((,) <$> getDependencies <*> ((,) <$> RootDirectives <*> FinalDecls))
 
         let fns :: FieldNamingStrategy
             fns = (.fieldNamingStrategy) $ getTestFrontendConfig test
             thDecls :: Qu [TH.Dec]
-            thDecls = uncurry (getThDecls fns deps) $ Foldable.fold decls
+            thDecls = uncurry (getThDecls fns deps dirs) $ Foldable.fold decls
 
             (st, thdecs) = runQu thDecls
 

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCase.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Infra/TestCase.hs
@@ -9,7 +9,7 @@ module Test.HsBindgen.Golden.Infra.TestCase (
   , macroLangCExpr
   , macroLangEmpty
   , macroLangRaw
-  , testInputInclude
+  , testInputDirectives
     -- * Construction
   , defaultTest
   , defaultFailingTest
@@ -150,6 +150,9 @@ data TestCase = TestCase {
       -- | In imports, put "qualified" before or after the module name
     , qualifiedStyle :: QualifiedStyle
 
+      -- | @#define@s emitted before the input header
+    , hashDefines :: [C.HashDefine]
+
       -- | The macro language to run this test with
     , macroLang :: SomeMacroLang
     }
@@ -159,8 +162,11 @@ data TestCase = TestCase {
   Derived
 -------------------------------------------------------------------------------}
 
-testInputInclude :: TestCase -> C.UncheckedHashIncludeArg
-testInputInclude test = test.inputHeader
+-- | The root directives of a test: the @#define@s, then the input header
+testInputDirectives :: TestCase -> [C.UncheckedRootDirective]
+testInputDirectives test =
+    map C.DirectiveHashDefine test.hashDefines
+      ++ [C.DirectiveHashInclude test.inputHeader]
 
 {-------------------------------------------------------------------------------
   Construction
@@ -186,6 +192,7 @@ defaultTest fp = TestCase{
     , specPrescriptive = Nothing
     , pathStyle        = Short
     , qualifiedStyle   = def
+    , hashDefines      = []
     , macroLang        = macroLangCExpr
     }
 
@@ -356,7 +363,7 @@ runTestHsBindgen report getTestResources test artefacts = do
             traceConfigUnsafe
             quietTracerConfig
             bindgenConfig
-            [testInputInclude test]
+            (testInputDirectives test)
             artefacts
 
 runTestHsBindgenSuccess ::

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Generate.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Generate.hs
@@ -13,8 +13,10 @@ import Data.List qualified as List
 import HsBindgen.BindingSpec
 import HsBindgen.Config.ClangArgs (ClangArgsConfig (..))
 import HsBindgen.Config.Internal
+import HsBindgen.IR.C qualified as C
 
-import Test.HsBindgen.Golden.Infra.TestCase (TestCase (..), getTestBootConfig)
+import Test.HsBindgen.Golden.Infra.TestCase (TestCase (..), getTestBootConfig,
+                                             testInputDirectives)
 import Test.HsBindgen.Resources
 
 {-------------------------------------------------------------------------------
@@ -27,7 +29,7 @@ generateModule testResources tc = unlines $ List.intercalate [""] [
       languagePragmas
     , moduleHeader bootConfig
     , imports
-    , letBlock bootConfig tc.inputHeader
+    , letBlock bootConfig (testInputDirectives tc)
     ]
   where
     bootConfig :: BootConfig
@@ -76,13 +78,12 @@ imports = [
     , "import Optics ((%), (&), (.~))"
     ]
 
-letBlock :: BootConfig -> FilePath -> [String]
-letBlock bootConfig inputHeader = [
+letBlock :: BootConfig -> [C.UncheckedRootDirective] -> [String]
+letBlock bootConfig directives = [
       "let cfg :: Config"
     , "    cfg = def"
     , "      & #clang % #builtinIncDir                 .~ " ++ builtinIncDir'
     , "      & #clang % #extraIncludeDirs              .~ " ++ extraIncludeDirs'
-    , "      & #clang % #defineMacros                  .~ " ++ defineMacros'
     , "      & #clang % #enableBlocks                  .~ " ++ enableBlocks'
     , "      & #clang % #argsBefore                    .~ " ++ argsBefore'
     , "      & #clang % #argsInner                     .~ " ++ argsInner'
@@ -100,17 +101,25 @@ letBlock bootConfig inputHeader = [
     , "    cfgTh :: ConfigTH"
     , "    cfgTh = def"
     , "      & #categoryChoice .~ thCategoryChoice"
-    , " in withHsBindgen cfg cfgTh $"
-    , "      hashInclude " ++ show inputHeader
-    ]
+    , " in withHsBindgen cfg cfgTh $ do"
+    ] ++ map (("      " ++) . renderDirective) directives
   where
+    renderDirective :: C.UncheckedRootDirective -> String
+    renderDirective = \case
+      C.DirectiveHashInclude arg ->
+        "hashInclude " ++ show arg
+      C.DirectiveHashDefine hashDefine -> unwords [
+          "hashDefine"
+        , show hashDefine.name
+        , show hashDefine.value
+        ]
+
     -- All type 'String':
     builtinIncDir' = show bootConfig.clangArgs.builtinIncDir
     extraIncludeDirs' = ("[" ++) . (++ "]") $ List.intercalate ", " [
         "Dir " ++ show includeDir
       | includeDir <- bootConfig.clangArgs.extraIncludeDirs
       ]
-    defineMacros' = show bootConfig.clangArgs.defineMacros
     enableBlocks' = show bootConfig.clangArgs.enableBlocks
     argsBefore' = show bootConfig.clangArgs.argsBefore
     argsInner' = show bootConfig.clangArgs.argsInner

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Frontend.hs
@@ -128,7 +128,8 @@ execFrontend getTestResources cStdStr incDirs header k =
           config         = BindgenConfig bootConfig frontendConfig backendConfig
           bootTracer     = contramap TraceBoot tracer
           frontendTracer = contramap TraceFrontend tracer
-      bootArtefact     <- runBoot bootTracer (pure . Macro.cExpr) config [header]
+      bootArtefact     <- runBoot bootTracer (pure . Macro.cExpr) config
+                            [C.DirectiveHashInclude header]
       frontendArtefact <- runFrontend frontendTracer frontendConfig bootArtefact
       k frontendArtefact
   where

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/RootDirective.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/RootDirective.hs
@@ -1,0 +1,54 @@
+module Test.HsBindgen.Unit.RootDirective (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import HsBindgen.IR.C qualified as C
+
+{-------------------------------------------------------------------------------
+  List of tests
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.HsBindgen.Unit.RootDirective" [
+      hashDefineToDirectiveTests
+    , renderRootDirectivesTests
+    ]
+
+{-------------------------------------------------------------------------------
+  HashDefine
+-------------------------------------------------------------------------------}
+
+-- | The rows of the correspondence table in t'C.HashDefine's haddock
+hashDefineToDirectiveTests :: TestTree
+hashDefineToDirectiveTests = testGroup "hashDefineToDirective" [
+      testCase "-D FOO"        $ render "FOO"    "1"   @?= "#define FOO 1"
+    , testCase "-D FOO=BAR"    $ render "FOO"    "BAR" @?= "#define FOO BAR"
+    , testCase "-D FOO="       $ render "FOO"    ""    @?= "#define FOO"
+    , testCase "-D 'FOO(x)=x'" $ render "FOO(x)" "x"   @?= "#define FOO(x) x"
+    ]
+  where
+    render :: String -> String -> String
+    render name value = C.hashDefineToDirective (C.HashDefine name value)
+
+{-------------------------------------------------------------------------------
+  RootDirective
+-------------------------------------------------------------------------------}
+
+renderRootDirectivesTests :: TestTree
+renderRootDirectivesTests = testGroup "renderRootDirectives" [
+      testCase "empty" $ C.renderRootDirectives [] @?= ""
+    , testCase "order preserved" $
+        C.renderRootDirectives [
+            C.DirectiveHashDefine  (C.HashDefine "A" "1")
+          , C.DirectiveHashInclude "a.h"
+          , C.DirectiveHashDefine  (C.HashDefine "B" "")
+          , C.DirectiveHashInclude "b.h"
+          ]
+          @?= unlines [
+              "#define A 1"
+            , "#include <a.h>"
+            , "#define B"
+            , "#include <b.h>"
+            ]
+    ]

--- a/hs-bindgen/test/hs-bindgen/test-hs-bindgen.hs
+++ b/hs-bindgen/test/hs-bindgen/test-hs-bindgen.hs
@@ -17,6 +17,7 @@ import Test.HsBindgen.Unit.ClangArgs qualified as Unit.ClangArgs
 import Test.HsBindgen.Unit.Digraph qualified as Unit.Digraph
 import Test.HsBindgen.Unit.Frontend qualified as Unit.Frontend
 import Test.HsBindgen.Unit.Pretty qualified as Unit.Pretty
+import Test.HsBindgen.Unit.RootDirective qualified as Unit.RootDirective
 import Test.HsBindgen.Unit.Runtime qualified as Unit.Runtime
 import Test.HsBindgen.Unit.Tracer qualified as Unit.Tracer
 
@@ -37,6 +38,7 @@ main = defaultMain $
           , Unit.Frontend.tests testResources
           , Unit.Tracer.tests
           , Unit.Pretty.tests
+          , Unit.RootDirective.tests
           , Unit.Runtime.tests
           ]
       , testGroup "integration tests" [

--- a/manual/README.md
+++ b/manual/README.md
@@ -14,6 +14,7 @@
 * [Invocation](low-level/usage/invocation.md)
 * [Tracing](low-level/usage/tracing.md)
 * [Clang options](low-level/usage/clang-options.md)
+* [C stages](low-level/usage/c-stages.md)
 * [Includes](low-level/usage/includes.md)
 * [Selecting and program slicing](low-level/usage/selecting-and-program-slicing.md)
 * [Binding specifications](low-level/usage/binding-specifications.md)

--- a/manual/c/header_only.h
+++ b/manual/c/header_only.h
@@ -1,0 +1,23 @@
+/* A header-only library.
+ *
+ * The declarations are always visible. The definitions are compiled only into
+ * the one translation unit that defines HEADER_ONLY_IMPLEMENTATION -- here,
+ * hs/manual/cbits/header_only.c. Defining it in more than one translation unit
+ * results in duplicate symbols at link time.
+ */
+
+#ifndef HEADER_ONLY_H
+#define HEADER_ONLY_H
+
+/**
+ * The number of horns of a unicorn.
+ */
+int header_only_horns(void);
+
+#ifdef HEADER_ONLY_IMPLEMENTATION
+
+int header_only_horns(void) { return 1; }
+
+#endif
+
+#endif

--- a/manual/configure.sh
+++ b/manual/configure.sh
@@ -71,18 +71,25 @@ fi
 
 
 
-### BINDGEN_EXTRA_CLANG_ARGS ###
+### SUPPORTS_UNICODE ###
 
 # There's a quirk with Apple and Windows assembler and LLVM IR that do not
 # accept Unicode characters. There's SUPPORTS_UNICODE flag that allows Unicode
 # characters and we only enable that for non-MacOS and non-LLVM backend
 # compilation
 #
-# Check inside manual_examples.{c,h} for where this macro flag is used.
+# Check inside generated_names.{c,h} for where this macro flag is used.
 #
+# The root directive is stated once and reaches every C stage: the headers
+# libclang parses and the generated C wrapper source GHC compiles.  Sourcing
+# this file makes the array available to generate-and-run.sh.
+#
+# shellcheck disable=SC2034  # used by generate-and-run.sh, which sources this file
+SUPPORTS_UNICODE_ARGS=()
+# shellcheck disable=SC2034
 if is_linux && [[ "${LLVM_BACKEND}" != "1" ]]; then
-    echo "Setting SUPPORTS_UNICODE in BINDGEN_EXTRA_CLANG_ARGS"
-    export BINDGEN_EXTRA_CLANG_ARGS="-DSUPPORTS_UNICODE ${BINDGEN_EXTRA_CLANG_ARGS:-}"
+    echo "Setting SUPPORTS_UNICODE root directive"
+    SUPPORTS_UNICODE_ARGS=(--hash-define SUPPORTS_UNICODE 1)
 else
     echo "Not setting SUPPORTS_UNICODE (not Linux or LLVM backend enabled)"
 fi
@@ -128,12 +135,12 @@ EOF
 }
 
 generate_cabal_project_local_unix () {
+  # Haskell CPP only; the C stages get SUPPORTS_UNICODE as a root directive.
   local SUPPORTS_UNICODE_STANZA
   SUPPORTS_UNICODE_STANZA=""
   if [[ "$(uname -s)" == "Linux" && "${LLVM_BACKEND}" != "1" ]]; then
       SUPPORTS_UNICODE_STANZA="package manual
   ghc-options:
-    -optc-DSUPPORTS_UNICODE
     -DSUPPORTS_UNICODE
 
 "

--- a/manual/generate-and-run.sh
+++ b/manual/generate-and-run.sh
@@ -124,6 +124,7 @@ cabal run --project-dir="${PROJECT_ROOT}" hs-bindgen-cli -- \
     --hs-output-dir "$GENERATED_DIR" \
     --module GeneratedNames \
     --omit-field-prefixes \
+    "${SUPPORTS_UNICODE_ARGS[@]}" \
     generated_names.h
 
 cabal run --project-dir="${PROJECT_ROOT}" hs-bindgen-cli -- \
@@ -150,6 +151,22 @@ cabal run --project-dir="${PROJECT_ROOT}" hs-bindgen-cli -- \
     --hs-output-dir "$GENERATED_DIR" \
     --module PointerManipulation \
     pointer_manipulation.h
+
+echo "# "
+echo "## Header-only library"
+echo "# "
+
+# No --hash-define HEADER_ONLY_IMPLEMENTATION: the definitions are compiled
+# once, by hs/manual/cbits/header_only.c.
+cabal run --project-dir="${PROJECT_ROOT}" hs-bindgen-cli -- \
+    preprocess \
+    -I c \
+    --create-output-dirs \
+    --overwrite-files \
+    --unique-id com.hs-bindgen.manual.header-only \
+    --hs-output-dir "$GENERATED_DIR" \
+    --module HeaderOnly \
+    header_only.h
 
 echo "# "
 echo "## Structs"

--- a/manual/hs/manual/app/Manual.hs
+++ b/manual/hs/manual/app/Manual.hs
@@ -24,6 +24,7 @@ into separate modules corresponding to the manual's structure:
 * 'Manual.GeneratedNames.UnprefixedFieldNames' - Examples for unprefixed field names
 * 'Manual.BindingSpecifications' - Examples for external binding specifications
 * 'Manual.Globals' - Examples for global variables and constants
+* 'Manual.HeaderOnly' - Example for the header-only library recipe
 * 'Manual.PointerManipulation' - Examples for the pointer manipulation API
 -}
 module Manual (main) where
@@ -39,6 +40,7 @@ import Manual.Functions.HigherOrder qualified
 import Manual.GeneratedNames qualified
 import Manual.GeneratedNames.UnprefixedFieldNames qualified
 import Manual.Globals qualified
+import Manual.HeaderOnly qualified
 import Manual.Macros qualified
 import Manual.PointerManipulation qualified
 import Manual.Types.Arrays qualified
@@ -72,6 +74,7 @@ main = do
     Manual.Types.Complex.examples
     Manual.Functions.HigherOrder.examples
     Manual.PointerManipulation.examples
+    Manual.HeaderOnly.examples
 
 {-------------------------------------------------------------------------------
   Helper - shared across modules

--- a/manual/hs/manual/app/Manual/HeaderOnly.hs
+++ b/manual/hs/manual/app/Manual/HeaderOnly.hs
@@ -1,0 +1,19 @@
+module Manual.HeaderOnly (examples) where
+
+import Text.Printf
+
+import HeaderOnly.Unsafe
+import Manual.Tools
+
+{-------------------------------------------------------------------------------
+  Examples
+-------------------------------------------------------------------------------}
+
+-- | The bindings are generated without @HEADER_ONLY_IMPLEMENTATION@, so this
+-- call resolves to the symbol in @cbits/header_only.c@.
+examples :: IO ()
+examples = do
+    section "Header-only library"
+
+    horns <- header_only_horns
+    printf "header_only_horns() = %d\n" (toInteger horns)

--- a/manual/hs/manual/cbits/header_only.c
+++ b/manual/hs/manual/cbits/header_only.c
@@ -1,0 +1,8 @@
+/* The single translation unit holding the implementation of the header-only
+ * library. The bindings are generated *without* HEADER_ONLY_IMPLEMENTATION, so
+ * the generated C wrapper sees the declarations only and the symbols come from
+ * this object at link time.
+ */
+
+#define HEADER_ONLY_IMPLEMENTATION
+#include <header_only.h>

--- a/manual/hs/manual/manual.cabal
+++ b/manual/hs/manual/manual.cabal
@@ -28,6 +28,7 @@ executable run-manual
     Manual.GeneratedNames
     Manual.GeneratedNames.UnprefixedFieldNames
     Manual.Globals
+    Manual.HeaderOnly
     Manual.Macros
     Manual.PointerManipulation
     Manual.Tools
@@ -88,6 +89,7 @@ library generated
     GeneratedNames.Unsafe
     Globals
     Globals.Global
+    HeaderOnly.Unsafe
     Macro
     Macro.Unsafe
     PointerManipulation
@@ -99,6 +101,10 @@ library generated
     Unions.Nesting
     Unions.Safe
     Unions.Unsafe
+
+  -- The implementation of the header-only library; see cbits/header_only.c and
+  -- the manual page on the C stages.
+  c-sources:       cbits/header_only.c
 
   -- Avoid gcc warnings about non-NFC characters
   -- See <https://github.com/well-typed/hs-bindgen/issues/918>

--- a/manual/low-level/usage/c-stages.md
+++ b/manual/low-level/usage/c-stages.md
@@ -1,0 +1,180 @@
+# C stages
+
+Generating bindings and building them are two different C toolchains, running at
+different times. Knowing which is which explains why some options belong on the
+`hs-bindgen` command line, some in the `.cabal` file, and some in both.
+
+## The stages
+
+* __Generation stage__: `libclang` parses the headers you specify, and
+  `hs-bindgen` translates the declarations it finds into Haskell.
+
+* __Compilation stage__: the generated Haskell modules embed C source (i.e., the
+  userland CAPI wrappers). When GHC compiles a generated module, it hands that C
+  source to the C compiler GHC is configured to use, which generally defaults to
+  GCC on Linux and Clang on Windows. This is a different compiler, in a
+  different process, from the one used in the generation stage.
+
+The stages must agree on what the headers declare. When they do not, the
+bindings describe one view of the header and the object code implements another;
+see [Non-portability][manual:non-portability].
+
+## Root directives
+
+`hs-bindgen` does not parse the headers you specify one at a time. It
+synthesises a *root header* and parses that:
+
+```c
+#define SUPPORTS_UNICODE 1
+#include <generated_names.h>
+```
+
+The lines of that header are the *root directives*. At the moment, we support
+`#include` directives for the headers you name, and `#define` directives. They
+are a single ordered list.
+
+The same rendering is prepended to the C wrapper source of every generated
+module. A `#define` stated as a root directive therefore holds in *both* C
+stages, from one declaration site.
+
+| Root directive     | Command line               | Template Haskell          |
+|--------------------|----------------------------|---------------------------|
+| `#include <a.h>`   | `a.h` (positional)         | `hashInclude "a.h"`       |
+| `#define FOO 1`    | `--hash-define FOO 1`      | `hashDefine "FOO" "1"`    |
+| `#define FOO`      | `--hash-define FOO ''`     | `hashDefine "FOO" ""`     |
+| `#define FOO(x) x` | `--hash-define 'FOO(x)' x` | `hashDefine "FOO(x)" "x"` |
+
+### Order matters
+
+A `#define` only affects the headers that follow it. The command line
+
+```console
+hs-bindgen-cli preprocess --hash-define A 1 a.h --hash-define B 1 b.h ...
+```
+
+produces the root header
+
+```c
+#define A 1
+#include <a.h>
+#define B 1
+#include <b.h>
+```
+
+so `a.h` is parsed with `A` defined and `B` undefined. This is why
+`--hash-define` is position-sensitive (unlike the C compiler command line option
+`-D`), and why `hashDefine` must precede the `hashInclude` calls it applies to.
+
+### `#define` syntax, not `-D` syntax
+
+Users arriving with `-D` arguments in hand should note that the translation is
+not the identity: `-DFOO` defines `FOO` as `1`, and the `=` of `-DFOO=BAR` is
+not part of `#define` syntax.
+
+| C compiler `-D` argument | Command line               | Template Haskell          | Emitted directive  |
+|--------------------------|----------------------------|---------------------------|--------------------|
+| `-D FOO`                 | `--hash-define FOO 1`      | `hashDefine "FOO" "1"`    | `#define FOO 1`    |
+| `-D FOO=BAR`             | `--hash-define FOO BAR`    | `hashDefine "FOO" "BAR"`  | `#define FOO BAR`  |
+| `-D FOO=`                | `--hash-define FOO ''`     | `hashDefine "FOO" ""`     | `#define FOO`      |
+| `-D 'FOO(x)=x'`          | `--hash-define 'FOO(x)' x` | `hashDefine "FOO(x)" "x"` | `#define FOO(x) x` |
+
+`-DFOO` and `-DFOO=` define *different* macros: the replacement list is `1` for
+the former and empty for the latter. Both are `#ifdef`-true, which is why the
+difference is easy to miss, but `#if FOO` is true for the first and an error for
+the second.
+
+`hs-bindgen` validates neither the name nor the replacement list. A malformed
+definition is reported by Clang as a diagnostic in the root header. Unresolvable
+`#include`s have the same behavior.
+
+The command-line option takes *two* arguments, which has two consequences:
+
+* Omitting the value silently consumes the next header argument:
+  `--hash-define FOO a.h` defines `FOO` as `a.h` and leaves no header to
+  translate.
+* A value starting with `-` is rejected as an unknown option.  Write
+  `--hash-define MIN '(-1)'`, which is better C anyway since the replacement
+  list is substituted literally, or place `--` before it.  Everything after `--`
+  is positional, so no further `--hash-define` may follow.
+
+### Root-header `#define`s do not become bindings
+
+The root header of `hs-bindgen` is synthetic (i.e., in-memory), and declarations
+located in it are skipped. A `#define` stated as a root directive never produces
+a binding, under any selection predicate, `--select-all` included. It only
+changes how the headers are preprocessed. Define the macro in a header if you
+want a binding for it.
+
+### What cannot be a root directive
+
+Include directories. There is no C syntax for "add a directory to the include
+search path", so `-I` cannot be a root directive: it configures the generation
+stage only. The compilation stage takes its include directories from the
+`.cabal` file (`include-dirs`) and the `cabal.project` files
+(`extra-include-dirs`), and you must keep those in agreement. See
+[Includes][manual:includes].
+
+The same holds for Clang options generally. `--clang-option`,
+`--clang-option-before`, `--clang-option-after` and `BINDGEN_EXTRA_CLANG_ARGS`
+are passed to `libclang` in the generation stage and are *not* forwarded to the
+compilation stage. A `-D` passed through one of those channels therefore defines
+the macro for the generation stage alone; use a root directive instead. See
+[Clang options][manual:clang-options].
+
+## Header-only libraries
+
+Some libraries ship their implementation in the header, behind a macro:
+
+```c
+int header_only_horns(void);
+
+#ifdef HEADER_ONLY_IMPLEMENTATION
+int header_only_horns(void) { return 1; }
+#endif
+```
+
+Such a macro must *not* be a root directive. It would be emitted into the
+wrapper source of every generated module, and each of those translation units
+would define the function, giving duplicate symbols at link time.
+
+Define it in exactly one C source file of your own package instead:
+
+```c
+/* cbits/header_only.c */
+#define HEADER_ONLY_IMPLEMENTATION
+#include <header_only.h>
+```
+
+```cabal
+library
+  c-sources: cbits/header_only.c
+```
+
+and generate the bindings *without* the define:
+
+```console
+hs-bindgen-cli preprocess \
+  -I c \
+  --module HeaderOnly \
+  --hs-output-dir generated \
+  header_only.h
+```
+
+The generated wrappers see the declarations only, and the symbols come from the
+`cbits` object at link time. This manual does exactly that:
+[`header_only.h`][header:header_only.h],
+[`cbits/header_only.c`][source:header_only.c] and
+[`Manual/HeaderOnly.hs`][source:Manual/HeaderOnly.hs].
+
+Where the header cannot be included without its implementation, the remaining
+option is to make the macro a root directive and generate a *single* module
+(`--single-file`), so that there is only one wrapper translation unit.
+
+<!-- sources and references -->
+
+[header:header_only.h]: ../../c/header_only.h
+[manual:clang-options]: clang-options.md
+[manual:includes]: includes.md
+[manual:non-portability]: non-portability.md
+[source:Manual/HeaderOnly.hs]: ../../hs/manual/app/Manual/HeaderOnly.hs
+[source:header_only.c]: ../../hs/manual/cbits/header_only.c

--- a/manual/low-level/usage/clang-options.md
+++ b/manual/low-level/usage/clang-options.md
@@ -28,6 +28,15 @@ Options are passed to Clang in the following order:
 See `hs-bindgen-cli preprocess --help` for details about which options are
 managed by `hs-bindgen`.
 
+> [!IMPORTANT]
+> Clang options configure the *generation* stage only: they are not forwarded to
+> the C compiler that GHC uses to compile the generated bindings. In particular,
+> a macro defined with `-D` via `--clang-option` or `BINDGEN_EXTRA_CLANG_ARGS`
+> holds while the headers are parsed but not while the generated C wrapper
+> source is compiled. Use a `#define` root directive (`--hash-define NAME
+> VALUE`, or `hashDefine` in Template Haskell) to define a macro for all C
+> stages at once. See [C stages][manual:c-stages].
+
 Example:
 
 ```console
@@ -65,4 +74,5 @@ environment variables.
 [clang]: https://clang.llvm.org/
 [clang:docs:cli]: https://clang.llvm.org/docs/ClangCommandLineReference.html
 [libclang]: https://clang.llvm.org/doxygen/group__CINDEX.html
+[manual:c-stages]: c-stages.md
 [rust-bindgen:env]: https://github.com/rust-lang/rust-bindgen?tab=readme-ov-file#environment-variables

--- a/manual/low-level/usage/includes.md
+++ b/manual/low-level/usage/includes.md
@@ -284,7 +284,9 @@ compiler (such as `C_INCLUDE_PATH`) are also relevant.
 
 Note that `hs-bindgen` configuration is not relevant.  Header resolution at this
 stage is *not* affected by `hs-bindgen-cli` options or the
-`BINDGEN_EXTRA_CLANG_ARGS` environment variable.
+`BINDGEN_EXTRA_CLANG_ARGS` environment variable.  Macro definitions are the
+exception: `#define` root directives are emitted into the generated C source and
+therefore apply here too.  See [C stages][manual:c-stages].
 
 ## Debugging
 
@@ -368,5 +370,6 @@ hs-bindgen-cli info libclang --clang-option=-v
 [clang:docs]: https://clang.llvm.org/docs/index.html
 [clang:docs:cli-include-path]: https://clang.llvm.org/docs/ClangCommandLineReference.html#include-path-management
 [manual:binding-specifications]: binding-specifications.md
+[manual:c-stages]: c-stages.md
 [manual:clang-options]: clang-options.md
 [mermaid]: https://mermaid.js.org/

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -41,6 +41,18 @@ Options controlling module generation:
 - `--unique-id ID` - Unique identifier for C wrapper functions (e.g., `org.example.mylib`)
 - `--create-output-dirs` - Create output directories if they do not exist
 
+#### Input
+
+The headers to translate are given as positional arguments. They are interleaved
+with `#define` root directives:
+
+- `HEADER` - Emit `#include <HEADER>`
+- `--hash-define NAME VALUE` - Emit `#define NAME VALUE` before the following
+  headers
+
+Root directives are ordered, and apply to the compilation of the generated C
+source as well. See [C stages][manual:c-stages].
+
 #### Clang configuration
 
 Options configuring `libclang`:
@@ -342,6 +354,21 @@ let cfg = def
       hashInclude "header2.h"
 ```
 
+### Macro definitions
+
+Use `hashDefine` for macros the headers expect. It is `#define` syntax, not C
+compiler `-D` syntax, and it only affects the `hashInclude`s that follow it:
+
+```haskell
+let cfg = def
+ in withHsBindgen cfg def $ do
+      hashDefine "USE_EXTENDED" "1"
+      hashInclude "header1.h"
+```
+
+The definition also reaches the generated C source that GHC compiles. See [C
+stages][manual:c-stages].
+
 ### Troubleshooting
 
 **"Not in scope" errors:** Verify that `{-# LANGUAGE TemplateHaskell #-}` is
@@ -423,6 +450,7 @@ A complete working example is available in
 
 [example:bundled-c]: ../../../examples/bundled-c
 [example:literate-example]: ../../../examples/literate-example
+[manual:c-stages]: c-stages.md
 [manual:clang-options]: clang-options.md
 [manual:installation]: ../../installation.md
 [manual:installation-clang-vs-gcc]: ../../installation.md#clang-vs-gcc

--- a/manual/low-level/usage/non-portability.md
+++ b/manual/low-level/usage/non-portability.md
@@ -23,10 +23,10 @@ typedef struct {
 } my_record;
 ```
 
-When `hs-bindgen` processes this header with `-DUSE_EXTENDED`, the generated
-struct will have three fields (`type`, `extra`, `value`). Without that flag, it
-will have only two (`type`, `value`). The generated binding specification will
-differ accordingly.
+When `hs-bindgen` processes this header with `USE_EXTENDED` defined, the
+generated struct will have three fields (`type`, `extra`, `value`). Without it,
+the struct will have only two (`type`, `value`). The generated binding
+specification will differ accordingly.
 
 ## Configure-generated headers
 
@@ -51,25 +51,25 @@ hand-written content. The generated bindings will simply reflect whichever
 
 There are several strategies for managing non-portable bindings.
 
-### Pass `-D` flags explicitly
+### Define macros explicitly
 
-When generating bindings, pass `-D` flags to ensure that the CPP resolution
-matches the intended target. There are three mechanisms for doing so (see
-[Clang options][manual:clang-options] for details):
+State the macros the headers expect as `#define` root directives, so that the
+CPP resolution matches the intended target:
 
-* `hs-bindgen-cli preprocess --clang-option="-DUSE_EXTENDED" ...`
-* `BINDGEN_EXTRA_CLANG_ARGS="-DUSE_EXTENDED" hs-bindgen-cli preprocess ...`
-* `--clang-option-before` / `--clang-option-after` for controlling precedence
+* `hs-bindgen-cli preprocess --hash-define USE_EXTENDED 1 ... foo.h`
+* `hashDefine "USE_EXTENDED" "1"` in Template Haskell
 
-### Keep `-D` flags consistent
+A root directive is stated once and reaches every C stage: both the headers
+`libclang` parses and the generated C wrapper source that GHC compiles. This
+matters, because a header parsed under one set of macros and compiled under
+another gives missing symbols or, worse, silently mismatched `struct` layouts.
+Note that a `-D` passed via `--clang-option` or `BINDGEN_EXTRA_CLANG_ARGS` does
+*not* have this property: it affects binding generation alone. See [C
+stages][manual:c-stages].
 
-If a C header requires certain CPP flags to be set (e.g. `-DUSE_IPV6`), those
-same flags must be passed both to `hs-bindgen` when generating bindings *and* as
-C compiler options in the `cabal.project` file (via `ghc-options`), or the
-`.cabal` file (via `cc-options`), when compiling the generated bindings.
-Otherwise, `hs-bindgen` will generate bindings against one view of the header,
-but `cabal` will compile against a different view, leading to missing symbols
-or type mismatches.
+Macros that select an *implementation*, as in a header-only library, are the
+exception: they must be confined to a single translation unit. See [Header-only
+libraries][manual:c-stages-header-only].
 
 ### Treat binding generation as part of the build process
 
@@ -102,5 +102,6 @@ silent runtime data corruption.
 <!-- sources and references -->
 
 [example:bundled-c]: ../../../examples/bundled-c
-[manual:clang-options]: clang-options.md
+[manual:c-stages]: c-stages.md
+[manual:c-stages-header-only]: c-stages.md#header-only-libraries
 [manual:installation]: ../../installation.md


### PR DESCRIPTION
The root header now contains `#define`s and `#include`s in an ordered list. The same rendering is used in all C stages: the root header `libclang` parses and the generated CAPI wrapper source GHC compiles.

Removes `ClangArgsConfig.defineMacros` and CLI `-D`/`--define-macro`; adds `--hash-define NAME VALUE` and TH `hashDefine`. `CWrapper.hashIncludeArg` and `getMainHashIncludeArg` are gone (replaced by root header). The CLI synopsis shows `(HEADER | --hash-define NAME VALUE)...`

A root header without any `#include` now yields a trace message, so Template Haskell and library use are covered too, not just the CLI. It is a warning, not an error.

Having #define in the root header surfaced a latent issues: Trace messages originating from the root header did not have a source file. This lead to a panic when sorting trace message in the `Select` pass. The panic is now fixed by designating a "root header" source location to declarations in the root header. This makes the trace message sort total, avoiding a panic.

A new manual page `low-level/usage/c-stages.md` covers the two C stages and the root directives.

The manual invocation has changed: `SUPPORTS_UNICODE` now uses `--hash-define`, so `generate-and-run.sh` tests the forwarding end to end. Also, add and explicit test `header_only.{h,c}` and `Manual.HeaderOnly` for implementation-selecting macros.

See #2214.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.

- [x] I have updated the manual.

- [x] I have removed all mentions of closed tickets in the code.

- [x] I have associated each new TODO item with a ticket, using the following syntax:

```hs
-- TODO <link to issue>
-- Brief description
```
