### PR TITLE
Do not label Template Haskell traces as errors

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -372,6 +372,10 @@
 * Make `UnnamedId`s unique by including a hash of the unnamed declaration's AST.
   This prevents accidental `UnnamedId` collisions on all supported `llvm`
   versions, even on `llvm < 19.1.0`. See [issue #2210][is-2210].
+* In Template Haskell mode, traces are no longer prefixed with "Template
+  Haskell error: ", which made warnings look like errors. All traces now go to
+  `stderr` (previously, only warnings and errors did). See [issue
+  #2216][is-2216].
 
 [is-1225]: https://github.com/well-typed/hs-bindgen/issues/1225
 [is-1253]: https://github.com/well-typed/hs-bindgen/issues/1253
@@ -400,6 +404,7 @@
 [is-2198]: https://github.com/well-typed/hs-bindgen/issues/2198
 [is-2210]: https://github.com/well-typed/hs-bindgen/issues/2210
 [is-2214]: https://github.com/well-typed/hs-bindgen/issues/2214
+[is-2216]: https://github.com/well-typed/hs-bindgen/issues/2216
 [pr-1862]: https://github.com/well-typed/hs-bindgen/pull/1862
 [pr-1892]: https://github.com/well-typed/hs-bindgen/pull/1892
 [pr-1917]: https://github.com/well-typed/hs-bindgen/pull/1917

--- a/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Util/Tracer.hs
@@ -51,7 +51,6 @@ import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
 import Data.Kind (Type)
 import GHC.Generics as GHC
 import GHC.Stack (CallStack, prettyCallStack)
-import Language.Haskell.TH (reportError, reportWarning, runQ)
 import System.Console.ANSI (Color (..), ColorIntensity (Vivid),
                             ConsoleIntensity (BoldIntensity),
                             ConsoleLayer (Foreground),
@@ -377,22 +376,17 @@ instance Default OutputHandle where
 -- | Output configuration suitable for compile-time code generation with
 -- Template Haskell.
 --
--- Propagate warnings and errors to GHC.
+-- Report all traces to @stderr@, without ANSI colours (GHC output is usually
+-- captured by the build tool).
 --
--- Report traces with other log levels to @stdout@.
+-- NOTE: We cannot use GHC's own diagnostics (@reportWarning@/@reportError@),
+-- because the pipeline runs in @IO@, not in @Q@; @runQ@ would then pick
+-- @instance Quasi IO@, which labels /every/ message a Template Haskell error.
 outputConfigTH :: OutputConfig e
-outputConfigTH = OutputConfigCustom OutputCustom{
-      report    = report
-    , ansiColor = DisableAnsiColor
+outputConfigTH = OutputConfigHandle OutputHandle{
+      handle    = stderr
+    , ansiColor = Just DisableAnsiColor
     }
-  where
-    report :: Report e
-    report level _ = case level of
-      -- NOTE: In general, 'runQ' is a bad idea, but it supports 'reportWarning'
-      -- and 'reportError'.
-      Warning -> runQ . reportWarning
-      Error   -> runQ . reportError
-      _level  -> putStr
 
 -- | Sometimes, we want to change log levels. For example, we want to suppress
 -- specific traces in tests.


### PR DESCRIPTION
`outputConfigTH` routed warnings and errors through `runQ . reportWarning` and `runQ . reportError`, but the pipeline runs in `IO`, so `runQ` picked `instance Quasi IO`, whose `qReport` prefixes "Template Haskell error: " for both severities.

Template Haskell mode now uses the plain handle output configuration: all traces go to `stderr` (previously the other log levels went to `stdout`), without ANSI colours. The `[Warning]`/`[Error]` label the formatter prepends is now the only label.

See #2216.
