### PR TITLE
Rename `IncludeDir` constructors to `AbsDir` and `PkgDir`

### DIFF
--- a/examples/cross-compilation/hs-project-th/app/MainTH.hs
+++ b/examples/cross-compilation/hs-project-th/app/MainTH.hs
@@ -11,7 +11,7 @@ import PrintStructs
 -- cross-compilation, the splice runs inside iserv under QEMU.
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg "../c-src"]
+      & #clang % #extraIncludeDirs .~ [PkgDir "../c-src"]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* The `IncludeDir` data constructors have been renamed: `Dir` → `AbsDir` and
+  `Pkg` → `PkgDir`. See
+  [#2217](https://github.com/well-typed/hs-bindgen/issues/2217).
 * The `SelectPredicate` type has been renamed to `SelectionPredicate`, and the
   `selectPredicate` field of `FrontendConfig` has been renamed to
   `selectionPredicate`. Update any code that references these names.

--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -5,7 +5,10 @@
 ### Breaking changes
 
 * The `IncludeDir` data constructors have been renamed: `Dir` → `AbsDir` and
-  `Pkg` → `PkgDir`. See
+  `Pkg` → `PkgDir`. Their paths are now checked in TH mode: a relative `AbsDir`
+  path warns (it is resolved against the working directory of the compiler
+  invocation), and an absolute `PkgDir` path is an error (the package root would
+  be discarded). See
   [#2217](https://github.com/well-typed/hs-bindgen/issues/2217).
 * The `SelectPredicate` type has been renamed to `SelectionPredicate`, and the
   `selectPredicate` field of `FrontendConfig` has been renamed to

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -15,9 +15,10 @@ module HsBindgen.TH.Internal (
 import Control.Monad.State (State, execState)
 import Control.Monad.State.Class (MonadState, modify)
 import Data.Foldable qualified as Foldable
+import Data.List qualified as List
 import Data.Set qualified as Set
 import Language.Haskell.TH qualified as TH
-import System.FilePath ((</>))
+import System.FilePath (isAbsolute, (</>))
 
 import Clang.CStandard
 import Clang.Paths
@@ -54,14 +55,72 @@ type Config = Config_ IncludeDir
 -- | C include directory added to the C include search path
 data IncludeDir =
     -- | Include directory at absolute path
+    --
+    -- A relative path is warned about: it is resolved against the working
+    -- directory of the compiler invocation, not the package root.
     AbsDir FilePath
+
     -- | Include directory relative to package root
+    --
+    -- An absolute path is an error: it would discard the package root.
   | PkgDir FilePath
   deriving stock (Eq, Show, Generic)
 
 toFilePath :: FilePath -> IncludeDir -> FilePath
 toFilePath root (PkgDir x) = root </> x
 toFilePath _    (AbsDir x) = x
+
+-- | Misuse of an 'IncludeDir' constructor
+data IncludeDirMisuse =
+    -- | 'AbsDir' with a relative path
+    RelativeAbsDir FilePath
+
+    -- | 'PkgDir' with an absolute path
+  | AbsolutePkgDir FilePath
+  deriving stock (Eq, Show)
+
+checkIncludeDir :: IncludeDir -> Maybe IncludeDirMisuse
+checkIncludeDir = \case
+    AbsDir path | not (isAbsolute path) -> Just $ RelativeAbsDir path
+    PkgDir path | isAbsolute path       -> Just $ AbsolutePkgDir path
+    _otherwise                          -> Nothing
+
+-- | An absolute 'PkgDir' path discards the package root, so it is never what
+-- the user meant; a relative 'AbsDir' path does work, but only by accident.
+isFatal :: IncludeDirMisuse -> Bool
+isFatal RelativeAbsDir{}  = False
+isFatal AbsolutePkgDir{}  = True
+
+prettyIncludeDirMisuse :: IncludeDirMisuse -> String
+prettyIncludeDirMisuse = \case
+    RelativeAbsDir path -> unwords [
+        "Relative path in 'AbsDir " ++ show path ++ "':"
+      , "it is resolved relative to the working directory of the compiler"
+      , "invocation, which is not necessarily the package root."
+      , "Use an absolute path, or 'PkgDir' for a path relative to the"
+      , "package root."
+      ]
+    AbsolutePkgDir path -> unwords [
+        "Absolute path in 'PkgDir " ++ show path ++ "':"
+      , "the package root is discarded, so the path is not relative to it."
+      , "Use 'AbsDir' for an absolute path."
+      ]
+
+-- | Warn about, or reject, misuses of 'IncludeDir' constructors
+--
+-- NOTE: We report through Template Haskell instead of the tracer: the tracers
+-- are only created in 'hsBindgenMacroLang', which needs the configuration we
+-- are checking here. Consequently, the warning cannot be silenced via
+-- 'ConfigTH'. The same applies to 'checkLanguageExtensions'.
+checkIncludeDirs :: [IncludeDir] -> TH.Q ()
+checkIncludeDirs includeDirs = do
+    mapM_ (TH.reportWarning . prettyIncludeDirMisuse) warnings
+    unless (null errors) $
+      failQ $ List.intercalate "\n" $ map prettyIncludeDirMisuse errors
+  where
+    errors, warnings :: [IncludeDirMisuse]
+    (errors, warnings) =
+      List.partition isFatal $ mapMaybe checkIncludeDir includeDirs
 
 -- | Generate bindings for given C headers at compile-time using a custom
 -- macro language.
@@ -252,6 +311,9 @@ data BindgenState = BindgenState {
 
 -- NOTE: We could also check which enabled extension may interfere with the
 -- generated code (e.g. Strict/Data).
+--
+-- NOTE: We report through Template Haskell instead of the tracer; see
+-- 'checkIncludeDirs'.
 checkLanguageExtensions :: Set TH.Extension -> TH.Q ()
 checkLanguageExtensions requiredExts = do
     enabledExts <- Set.fromList <$> extsEnabled
@@ -264,6 +326,7 @@ checkLanguageExtensions requiredExts = do
 
 toBindgenConfigTH :: Config -> FilePath -> ByCategory Choice -> TH.Q BindgenConfig
 toBindgenConfigTH config packageRoot choice = do
+    checkIncludeDirs $ Foldable.toList config
     uniqueId <- getUniqueId
     hsModuleName <- fromString . TH.loc_module <$> TH.location
     let bindgenConfig :: BindgenConfig

--- a/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TH/Internal.hs
@@ -48,19 +48,20 @@ import HsBindgen.Util.Tracer
 -- | Configuration with C include directories
 --
 -- C include directories can be provided relative to the package root (see the
--- 'IncludeDir' data constructor 'Pkg').
+-- 'IncludeDir' data constructor 'PkgDir').
 type Config = Config_ IncludeDir
 
 -- | C include directory added to the C include search path
 data IncludeDir =
-    Dir FilePath
+    -- | Include directory at absolute path
+    AbsDir FilePath
     -- | Include directory relative to package root
-  | Pkg FilePath
+  | PkgDir FilePath
   deriving stock (Eq, Show, Generic)
 
 toFilePath :: FilePath -> IncludeDir -> FilePath
-toFilePath root (Pkg x) = root </> x
-toFilePath _    (Dir x) = x
+toFilePath root (PkgDir x) = root </> x
+toFilePath _    (AbsDir x) = x
 
 -- | Generate bindings for given C headers at compile-time using a custom
 -- macro language.

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Generate.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/THFixtures/Generate.hs
@@ -117,7 +117,7 @@ letBlock bootConfig directives = [
     -- All type 'String':
     builtinIncDir' = show bootConfig.clangArgs.builtinIncDir
     extraIncludeDirs' = ("[" ++) . (++ "]") $ List.intercalate ", " [
-        "Dir " ++ show includeDir
+        "AbsDir " ++ show includeDir
       | includeDir <- bootConfig.clangArgs.extraIncludeDirs
       ]
     enableBlocks' = show bootConfig.clangArgs.enableBlocks

--- a/hs-bindgen/test/th/Test/TH/RecordDot.hs
+++ b/hs-bindgen/test/th/Test/TH/RecordDot.hs
@@ -37,7 +37,7 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg ("test-artefacts" </> "headers")]
+      & #clang % #extraIncludeDirs .~ [PkgDir ("test-artefacts" </> "headers")]
       & #fieldNamingStrategy       .~ OmitFieldPrefixes
     cfgTh :: ConfigTH
     cfgTh = def

--- a/hs-bindgen/test/th/Test/TH/StaticCounterA.hs
+++ b/hs-bindgen/test/th/Test/TH/StaticCounterA.hs
@@ -18,7 +18,7 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg ("test-artefacts" </> "headers")]
+      & #clang % #extraIncludeDirs .~ [PkgDir ("test-artefacts" </> "headers")]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $

--- a/hs-bindgen/test/th/Test/TH/StaticCounterB.hs
+++ b/hs-bindgen/test/th/Test/TH/StaticCounterB.hs
@@ -18,7 +18,7 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg ("test-artefacts" </> "headers")]
+      & #clang % #extraIncludeDirs .~ [PkgDir ("test-artefacts" </> "headers")]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $

--- a/hs-bindgen/test/th/Test/TH/Test01.hs
+++ b/hs-bindgen/test/th/Test/TH/Test01.hs
@@ -21,7 +21,7 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg ("test-artefacts" </> "headers")]
+      & #clang % #extraIncludeDirs .~ [PkgDir ("test-artefacts" </> "headers")]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $

--- a/hs-bindgen/test/th/Test/TH/Test02.hs
+++ b/hs-bindgen/test/th/Test/TH/Test02.hs
@@ -20,7 +20,7 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg ("test-artefacts" </> "headers")]
+      & #clang % #extraIncludeDirs .~ [PkgDir ("test-artefacts" </> "headers")]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $

--- a/manual/low-level/usage/cross-compilation.md
+++ b/manual/low-level/usage/cross-compilation.md
@@ -528,7 +528,8 @@ let cfg :: Config
 ```
 
 `PkgDir` paths are resolved relative to the package root (the directory
-containing the `.cabal` file). `AbsDir` accepts an absolute path. Cross- and
+containing the `.cabal` file); passing an absolute path is an error. `AbsDir`
+accepts an absolute path; a relative path is warned about. Cross- and
 host-target flags (e.g. `--target=aarch64-linux-gnu`) can be passed via
 `Config`'s clang fields.
 

--- a/manual/low-level/usage/cross-compilation.md
+++ b/manual/low-level/usage/cross-compilation.md
@@ -520,15 +520,15 @@ import HsBindgen.TH
 
 let cfg :: Config
     cfg = def
-      & #clang % #extraIncludeDirs .~ [Pkg "../c-src"]
+      & #clang % #extraIncludeDirs .~ [PkgDir "../c-src"]
     cfgTh :: ConfigTH
     cfgTh = def
  in withHsBindgen cfg cfgTh $
       hashInclude "arch_types.h"
 ```
 
-`Pkg` paths are resolved relative to the package root (the directory
-containing the `.cabal` file). `Dir` accepts an absolute path. Cross- and
+`PkgDir` paths are resolved relative to the package root (the directory
+containing the `.cabal` file). `AbsDir` accepts an absolute path. Cross- and
 host-target flags (e.g. `--target=aarch64-linux-gnu`) can be passed via
 `Config`'s clang fields.
 

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -264,7 +264,7 @@ import HsBindgen.TH
 import Optics ((&), (%), (.~))
 
 let cfg :: Config
-    cfg = def & #clang % #extraIncludeDirs .~ [Pkg "my-c-lib"]
+    cfg = def & #clang % #extraIncludeDirs .~ [PkgDir "my-c-lib"]
 
     cfgTH :: ConfigTH
     cfgTH = def & #verbosity .~ Verbosity Warning
@@ -285,9 +285,8 @@ The `withHsBindgen` function takes three arguments:
 The `Config` type configures binding generation.  Common fields:
 
 - `#clang % #extraIncludeDirs` - Include directories
-  - `Pkg "package"` - Package directory
-  - `Abs "/path"` - Absolute path
-  - `Rel "path"` - Relative path (relative to module directory)
+  - `PkgDir "path"` - Path relative to the package root
+  - `AbsDir "/path"` - Absolute path
 - `#clang % #gnu` - GNU extensions (`GnuEnabled` or `GnuDisabled`)
 - `#clang % #cStandard` - C standard (e.g., `C99`, `C11`)
 - `#selectionPredicate` - Select a subset of declarations
@@ -319,8 +318,8 @@ import Optics ((&), (%), (.~))
 let cfg :: Config
     cfg = def
             & #clang % #extraIncludeDirs .~ [
-                  Pkg "my-c-library"
-                , Abs "/usr/local/include"
+                  PkgDir "my-c-library"
+                , AbsDir "/usr/local/include"
                 ]
             & #clang % #gnu .~ GnuEnabled
             & #clang % #cStandard .~ C11

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -285,8 +285,10 @@ The `withHsBindgen` function takes three arguments:
 The `Config` type configures binding generation.  Common fields:
 
 - `#clang % #extraIncludeDirs` - Include directories
-  - `PkgDir "path"` - Path relative to the package root
-  - `AbsDir "/path"` - Absolute path
+  - `PkgDir "path"` - Path relative to the package root; an absolute path is an
+    error, because the package root would be discarded
+  - `AbsDir "/path"` - Absolute path; a relative path is resolved against the
+    working directory of the compiler invocation and therefore warned about
 - `#clang % #gnu` - GNU extensions (`GnuEnabled` or `GnuDisabled`)
 - `#clang % #cStandard` - C standard (e.g., `C99`, `C11`)
 - `#selectionPredicate` - Select a subset of declarations


### PR DESCRIPTION
- Rename `IncludeDir` constructors to `AbsDir` and `PkgDir`

- Check `IncludeDir` paths in TH mode

  A relative `AbsDir` path is resolved against the working directory of the
  compiler invocation, not the package root: warn.

  An absolute `PkgDir` path discards the package root, so it cannot mean what it
  says: fail.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
 
- [x] I have updated the manual.

- [x] I have removed all mentions of closed tickets in the code.

- [x] I have associated each new TODO item with a ticket, using the following syntax:

```hs
-- TODO <link to issue>
-- Brief description
```
