### PR TITLE
Warn about unsupported floating-point types

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -291,6 +291,10 @@
 
 ### Bug fixes
 
+* Declarations using `_Float16`, `__fp16`, `__bf16`, or `__ibm128` are now
+  skipped with an unsupported-feature warning, instead of being reported as a
+  bug in `hs-bindgen`. See
+  [#2230](https://github.com/well-typed/hs-bindgen/issues/2230).
 * Skip declarations using SIMD vector types. See [issue #2198][is-2198].
 * The `--path-style` CLI option now shows its intended help text and value hint.
   Previously two `help` modifiers were given, so the descriptive text and the

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Msg.hs
@@ -5,6 +5,7 @@ module HsBindgen.Frontend.Pass.Parse.Msg (
 
     -- * Delayed parse messages
   , DelayedParseMsg(..)
+  , UnsupportedFloatType(..)
   , ParseImplicitFieldsMsg(..)
   ) where
 
@@ -273,13 +274,10 @@ data DelayedParseMsg =
     -- | Clang built-in declaration
   | ParseUnsupportedBuiltin Text
 
-    -- | We do not support @float128@
-  | ParseUnsupportedFloat128
+    -- | We do not support this floating-point type
+  | ParseUnsupportedFloatType UnsupportedFloatType
 
   | ParseUnsupportedLinkage String CXLinkageKind
-
-    -- | We do not support @long double@
-  | ParseUnsupportedLongDouble
 
     -- | Thread local variables
     --
@@ -331,6 +329,43 @@ data DelayedParseMsg =
 
   | ParseNoMainHeadersException String SourcePath
   deriving stock (Show, Generic)
+
+-- | Floating-point types we do not support
+--
+-- @float@ and @double@ are the only floating-point types we support; all others
+-- either have a platform dependent representation or lack a Haskell FFI
+-- counterpart.
+--
+-- <https://github.com/well-typed/hs-bindgen/issues/349>
+-- <https://github.com/well-typed/hs-bindgen/issues/2232>
+data UnsupportedFloatType =
+    -- | @long double@
+    UnsupportedLongDouble
+
+    -- | @__float128@, @_Float128@
+  | UnsupportedFloat128
+
+    -- | @_Float16@
+  | UnsupportedFloat16
+
+    -- | @__fp16@ (half precision, storage only)
+  | UnsupportedHalf
+
+    -- | @__bf16@ (brain floating point)
+  | UnsupportedBFloat16
+
+    -- | @__ibm128@ (PowerPC double-double)
+  | UnsupportedIbm128
+  deriving stock (Show, Eq, Ord, Enum, Bounded, Generic)
+
+instance PrettyForTrace UnsupportedFloatType where
+  prettyForTrace = \case
+      UnsupportedLongDouble -> "long double"
+      UnsupportedFloat128   -> "__float128"
+      UnsupportedFloat16    -> "_Float16"
+      UnsupportedHalf       -> "__fp16"
+      UnsupportedBFloat16   -> "__bf16"
+      UnsupportedIbm128     -> "__ibm128"
 
 instance Exception DelayedParseMsg where
   displayException = PP.renderCtxDoc (PP.mkContext 100) . prettyForTrace
@@ -399,8 +434,8 @@ instance PrettyForTrace DelayedParseMsg where
         "Unexpected unnamed declaration in function signature"
       ParseUnsupportedBuiltin name ->
         "Unsupported built-in " >< PP.show name
-      ParseUnsupportedFloat128 ->
-        "Unsupported float128"
+      ParseUnsupportedFloatType ty ->
+        "Unsupported floating-point type " >< prettyForTrace ty
       ParseUnsupportedLinkage comment linkage -> PP.hcat [
           "Unsupported linkage: "
         , PP.show linkage
@@ -408,8 +443,6 @@ instance PrettyForTrace DelayedParseMsg where
         , PP.string comment
         , ")"
         ]
-      ParseUnsupportedLongDouble ->
-        "Unsupported long double"
       ParseUnsupportedTLS ->
         "Unsupported thread-local variable"
       ParseUnsupportedVariadicFunction ->
@@ -480,9 +513,8 @@ instance IsTrace Level DelayedParseMsg where
       ParseUnsupportedUnnamedInExtern{}    -> Warning
       ParseUnsupportedUnnamedInSignature{} -> Warning
       ParseUnsupportedBuiltin{}            -> Warning
-      ParseUnsupportedFloat128             -> Warning
+      ParseUnsupportedFloatType{}          -> Warning
       ParseUnsupportedLinkage{}            -> Warning
-      ParseUnsupportedLongDouble           -> Warning
       ParseUnsupportedTLS{}                -> Warning
       ParseUnsupportedVariadicFunction     -> Warning
       ParseUnsupportedVector               -> Warning

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Type.hs
@@ -53,12 +53,17 @@ cxtype ty = do
       CXType_LongLong   -> prim $ C.PrimIntegral C.PrimLongLong C.Signed
       CXType_ULongLong  -> prim $ C.PrimIntegral C.PrimLongLong C.Unsigned
       CXType_Float      -> prim $ C.PrimFloating C.PrimFloat
-      CXType_Float128   -> failure ParseUnsupportedFloat128
       CXType_Double     -> prim $ C.PrimFloating C.PrimDouble
-      CXType_LongDouble -> failure ParseUnsupportedLongDouble
       CXType_Bool       -> prim $ C.PrimBool
       CXType_Complex    -> complex
       CXType_Vector     -> failure ParseUnsupportedVector
+
+      CXType_LongDouble -> unsupportedFloatType UnsupportedLongDouble
+      CXType_Float128   -> unsupportedFloatType UnsupportedFloat128
+      CXType_Float16    -> unsupportedFloatType UnsupportedFloat16
+      CXType_Half       -> unsupportedFloatType UnsupportedHalf
+      CXType_BFloat16   -> unsupportedFloatType UnsupportedBFloat16
+      CXType_Ibm128     -> unsupportedFloatType UnsupportedIbm128
 
       CXType_Attributed      -> attributed
       CXType_BlockPointer    -> blockPointer
@@ -81,6 +86,10 @@ cxtype ty = do
   where
     failure :: DelayedParseMsg -> CXType -> ParseType (C.Type Parse)
     failure err _ty = throwError err
+
+    unsupportedFloatType ::
+         UnsupportedFloatType -> CXType -> ParseType (C.Type Parse)
+    unsupportedFloatType = failure . ParseUnsupportedFloatType
 
 qualifiers :: CXType -> ParseType (C.Type Parse -> C.Type Parse)
 qualifiers ty = do

--- a/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
+++ b/hs-bindgen/src-internal/HsBindgen/TraceMsg.hs
@@ -14,6 +14,7 @@ module HsBindgen.TraceMsg (
   , ImmediateFillUnnamedIdsMsg (..)
   , ImmediateParseMsg(..)
   , DelayedParseMsg(..)
+  , UnsupportedFloatType(..)
   , ResolveBindingSpecsMsg(..)
   , ResolveHeaderMsg(..)
   , SelectMsg(..)
@@ -33,7 +34,8 @@ import HsBindgen.Frontend (FrontendMsg (..))
 import HsBindgen.Frontend.Pass.FillUnnamedIds.IsPass (ImmediateFillUnnamedIdsMsg (..))
 import HsBindgen.Frontend.Pass.MangleNames.IsPass (MangleNamesMsg (..))
 import HsBindgen.Frontend.Pass.Parse.Msg (DelayedParseMsg (..),
-                                          ImmediateParseMsg (..))
+                                          ImmediateParseMsg (..),
+                                          UnsupportedFloatType (..))
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass (ResolveBindingSpecsMsg (..))
 import HsBindgen.Frontend.Pass.Select.IsPass (SelectMsg (..))
 import HsBindgen.Imports

--- a/hs-bindgen/test-artefacts/fixtures/types/special/small_floats/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/small_floats/bindingspec.yaml
@@ -1,0 +1,4 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example

--- a/hs-bindgen/test-artefacts/fixtures/types/special/small_floats/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/types/special/small_floats/th.txt
@@ -1,0 +1,1 @@
+-- addDependentFile test-artefacts/headers/golden/types/special/small_floats.h

--- a/hs-bindgen/test-artefacts/headers/golden/types/special/small_floats.h
+++ b/hs-bindgen/test-artefacts/headers/golden/types/special/small_floats.h
@@ -1,0 +1,16 @@
+/*
+ * Small floating-point types are not supported; we warn about them.
+ *
+ * __ibm128 is only available on PowerPC targets, and __bf16 is exposed
+ * differently depending on the target, so neither is tested here.
+ */
+
+typedef _Float16 float16_t;
+typedef __fp16 fp16_t;
+
+struct small_floats {
+  _Float16 f16;
+  __fp16 fp16;
+};
+
+_Float16 fun(int x);

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Comprehensive.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Comprehensive.hs
@@ -56,7 +56,7 @@ test_comprehensive_c2hsc =
 
     trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
     trace = \case
-      MatchDelayed name ParseUnsupportedLongDouble ->
+      MatchDelayed name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
       MatchDoxygen (DoxygenUnsupported _) ->
         Just Tolerated

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros.hs
@@ -117,7 +117,8 @@ test_macros_macro_resolution_log_level_warnings =
 test_macros_macro_type_unresolved_tagged :: TestCase
 test_macros_macro_type_unresolved_tagged =
     testTraceMulti "macros/macro_type_unresolved_tagged" declsWithMsgs $ \case
-      MatchUnusable name@"struct Unparsable" (UnusableParseFailure ParseUnsupportedLongDouble) ->
+      MatchUnusable name@"struct Unparsable"
+        (UnusableParseFailure (ParseUnsupportedFloatType UnsupportedLongDouble)) ->
         Just $ Expected (name, "select-parse-failure")
       MatchSelect name@"macro PTR_UNPARSABLE" (TransitiveDependenciesMissing{}) ->
         Just $ Expected (name, "select-transitive-dependencies-missing")

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
@@ -54,7 +54,8 @@ test_arithmetic_types :: TestCase
 test_arithmetic_types =
     defaultTest "macros/reparse/arithmetic_types"
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
-            MatchDelayed name@"f29" ParseUnsupportedLongDouble ->
+            MatchDelayed name@"f29"
+              (ParseUnsupportedFloatType UnsupportedLongDouble) ->
               Just $ Expected name
             _otherwise ->
               Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/ProgramAnalysis.hs
@@ -74,7 +74,7 @@ test_programAnalysis_delay_traces =
               )
             )
       & #tracePredicate .~ multiTracePredicate declsWithMsgs (\case
-            MatchDelayed name ParseUnsupportedLongDouble ->
+            MatchDelayed name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
               Just $ Expected name
             MatchDelayed name ParseUnsupportedVariadicFunction ->
               Just $ Expected name

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Types.hs
@@ -84,6 +84,7 @@ testCases = [
     , test_types_scoping_deep_nesting
     , test_types_scoping_nesting
     , test_types_scoping_wide_nesting
+    , test_types_small_floats
     , test_types_special_parse_failure_long_double
     , test_types_structs_bitfields
     , test_types_structs_omit_field_prefixes
@@ -211,7 +212,7 @@ test_types_anonymous_edge_cases_reparse =
 test_types_long_double :: TestCase
 test_types_long_double =
     testTraceSimple "types/special/long_double" $ \case
-      MatchDelayed _name ParseUnsupportedLongDouble ->
+      MatchDelayed _name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected ()
       _otherwise ->
         Nothing
@@ -246,7 +247,8 @@ test_types_scoping_deep_nesting =
     testTraceMulti "types/scoping/deep_nesting" declsWithMsgs $ \case
       MatchDelayed name@"struct foo" ParseNestedDeclsFailed ->
         Just $ Expected name
-      MatchDelayed name@"struct bar" ParseUnsupportedLongDouble ->
+      MatchDelayed name@"struct bar"
+        (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
       _otherwise ->
         Nothing
@@ -257,7 +259,8 @@ test_types_scoping_deep_nesting =
 test_types_scoping_nesting :: TestCase
 test_types_scoping_nesting =
     testTraceMulti "types/scoping/nesting" declsWithMsgs $ \case
-      MatchDelayed name@"struct foo" ParseUnsupportedLongDouble ->
+      MatchDelayed name@"struct foo"
+        (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
       _otherwise ->
         Nothing
@@ -270,7 +273,8 @@ test_types_scoping_wide_nesting =
     testTraceMulti "types/scoping/wide_nesting" declsWithMsgs $ \case
       MatchDelayed name@"struct foo" ParseNestedDeclsFailed ->
         Just $ Expected name
-      MatchDelayed name@"struct bar" ParseUnsupportedLongDouble ->
+      MatchDelayed name@"struct bar"
+        (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
       _otherwise ->
         Nothing
@@ -278,10 +282,27 @@ test_types_scoping_wide_nesting =
     declsWithMsgs :: [C.DeclName]
     declsWithMsgs = ["struct foo", "struct bar"]
 
+-- | Test that small floating-point types are unsupported, but do not crash us
+--
+-- Clang only supports @_Float16@ on x86 since version 15.
+test_types_small_floats :: TestCase
+test_types_small_floats =
+    testTraceMulti "types/special/small_floats" declsWithMsgs (\case
+      MatchDelayed name (ParseUnsupportedFloatType UnsupportedFloat16) ->
+        Just $ Expected name
+      MatchDelayed name (ParseUnsupportedFloatType UnsupportedHalf) ->
+        Just $ Expected name
+      _otherwise ->
+        Nothing)
+      & #clangVersion .~ Just (>= (15, 0, 0))
+  where
+    declsWithMsgs :: [C.DeclName]
+    declsWithMsgs = ["float16_t", "fp16_t", "struct small_floats", "fun"]
+
 test_types_special_parse_failure_long_double :: TestCase
 test_types_special_parse_failure_long_double =
     testTraceMulti "types/special/parse_failure_long_double" declsWithMsgs $ \case
-      MatchDelayed name ParseUnsupportedLongDouble ->
+      MatchDelayed name (ParseUnsupportedFloatType UnsupportedLongDouble) ->
         Just $ Expected name
       _otherwise ->
         Nothing


### PR DESCRIPTION
`_Float16`, `__fp16`, `__bf16` and `__ibm128` were reported as a bug (unexpected type kind); they are now deselected with a warning, like `long double` and `__float128`.

Collect all six in a new `UnsupportedFloatType`, carried by the single delayed parse message `ParseUnsupportedFloatType`.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.

- [x] I have updated the manual.

- [x] I have removed all mentions of closed tickets in the code.

- [x] I have associated each new TODO item with a ticket, using the following syntax:

```hs
-- TODO <link to issue>
-- Brief description
```
