### PR TITLE
Update `Digraph` API

### DIFF
--- a/hs-bindgen/src-internal/Data/Digraph.hs
+++ b/hs-bindgen/src-internal/Data/Digraph.hs
@@ -28,7 +28,6 @@ module Data.Digraph (
   , neighbors
   , reaches
   , sort
-  , sortBy
   , dfs
   , dff
   , dfFindMember
@@ -549,11 +548,6 @@ sort graph = vs
         graph.idxMap IntMap.! idx
       | idx <- sccFromMap IntMap.! idx'
       ]
-
--- | Sort the vertices of a graph using a topological sort of groups of strongly
--- connected components, ordering with the specified ordering function
-sortBy :: Ord v => (v -> v -> Ordering) -> Digraph e v -> [v]
-sortBy cmp = sort . reIndex cmp
 
 -- | Depth-first traversal of the graph from the specified vertices
 --

--- a/hs-bindgen/src-internal/Data/Digraph.hs
+++ b/hs-bindgen/src-internal/Data/Digraph.hs
@@ -27,6 +27,7 @@ module Data.Digraph (
   , vertices
   , neighbors
   , reaches
+  , sortSccs
   , sort
   , dfs
   , dff
@@ -438,8 +439,10 @@ reaches fromVs graph =
 
 -- | Sort the vertices of a graph using a topological sort of groups of strongly
 -- connected components
-sort :: forall e v. Digraph e v -> [v]
-sort graph = vs
+--
+-- This function returns sorted groups of strongly connected componenets.
+sortSccs :: forall e v. Digraph e v -> [[v]]
+sortSccs graph = vss
   where
     -- Get the strongly connected components for the graph.
     sccs :: [Tree Idx]
@@ -540,14 +543,18 @@ sort graph = vs
           [] -> (startIdxs, rEdgeMap)
 
     -- Transform the topological sort of the internal graph to a list of
-    -- vertices in the actual graph.  Each representative index is expanded to
-    -- the (already sorted) list of graph indices, and the actual vertices are
-    -- queried.
-    vs :: [v]
-    vs = flip Foldable.concatMap idxs' $ \idx' -> [
-        graph.idxMap IntMap.! idx
-      | idx <- sccFromMap IntMap.! idx'
-      ]
+    -- strongly connected components (already sorted), querying the actual
+    -- vertices.
+    vss :: [[v]]
+    vss = map (graph.idxMap IntMap.!) . (sccFromMap IntMap.!) <$> idxs'
+
+-- | Sort the vertices of a graph using a topological sort of groups of strongly
+-- connected components
+--
+-- This function concatenates the sorted groups of strongly connected
+-- componenets.
+sort :: Digraph e v -> [v]
+sort = concat . sortSccs
 
 -- | Depth-first traversal of the graph from the specified vertices
 --

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Digraph.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Digraph.hs
@@ -37,6 +37,7 @@ tests = testGroup "Test.HsBindgen.Unit.Digraph" [
     , testVertices
     , testNeighbors
     , testReaches
+    , testSortSccs
     , testSort
     , testDfs
     , testDff
@@ -429,6 +430,24 @@ testReaches = testGroup "reaches" [
     , testCase "multi" $
         vSet [3, 4, 7, 9, 12, 14]
           @=? Digraph.reaches (vSet [4, 7, 9, 14]) graph1E
+    ]
+
+testSortSccs :: TestTree
+testSortSccs = testGroup "sortSccs" [
+      testCase "empty" $
+        [] @=? Digraph.sortSccs graph0
+    , testCase "no edges" $
+        map List.singleton graph1Vs @=? Digraph.sortSccs graph1V
+    , testCase "with edges" $ do
+        let expected = map (mkVs . List.singleton) $
+              [16, 15, 2, 6, 10, 14, 12, 3, 8, 5, 4, 1, 11, 7, 13, 9]
+        expected @=? Digraph.sortSccs graph1E
+    , testCase "with cycle" $ do
+        let expected = map mkVs [[3, 2], [1]]
+        expected @=? Digraph.sortSccs graph2E
+    , testCase "with cycles" $ do
+        let expected = map mkVs [[1], [2, 6], [8, 11, 3, 7], [4, 10], [5], [9]]
+        expected @=? Digraph.sortSccs graph3E
     ]
 
 testSort :: TestTree

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Digraph.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Unit/Digraph.hs
@@ -38,7 +38,6 @@ tests = testGroup "Test.HsBindgen.Unit.Digraph" [
     , testNeighbors
     , testReaches
     , testSort
-    , testSortBy
     , testDfs
     , testDff
     , testDfFindMember
@@ -449,29 +448,6 @@ testSort = testGroup "sort" [
         let expected = mkVs [1, 2, 6, 8, 11, 3, 7, 4, 10, 5, 9]
         expected @=? Digraph.sort graph3E
     ]
-
-testSortBy :: TestTree
-testSortBy = testGroup "sortBy" [
-      testCase "empty" $
-        [] @=? Digraph.sortBy cmp graph0
-    , testCase "no edges" $ do
-        let expected = List.sortBy cmp graph1Vs
-        expected @=? Digraph.sortBy cmp graph1V
-    , testCase "with edges" $ do
-        let expected =
-              mkVs [1, 4, 6, 7, 8, 5, 9, 10, 11, 13, 16, 2, 14, 3, 12, 15]
-        expected @=? Digraph.sortBy cmp graph1E
-    , testCase "with cycle" $ do
-        let expected = mkVs [2, 3, 1]
-        expected @=? Digraph.sortBy cmp graph2E
-    , testCase "with cycles" $ do
-        let expected = mkVs [1, 2, 6, 3, 7, 8, 11, 4, 10, 5, 9]
-        expected @=? Digraph.sortBy cmp graph3E
-    ]
-  where
-    cmp :: String -> String -> Ordering
-    cmp (_ : l) (_ : r) = compare (read @Int l) (read @Int r)
-    cmp l       r       = compare l r
 
 testDfs :: TestTree
 testDfs = testGroup "dfs" [


### PR DESCRIPTION
This API is internal, not user-facing.

This PR includes two changes:

* The `sortBy` convenience function is removed.  See https://github.com/well-typed/hs-bindgen/issues/2219#issuecomment-5446897664
* A new `sortSccs` function is exposed, for use in #742.  This is a trivial change, just a matter of factoring `concat` out of `sort`.