### PR TITLE
Add `TranslateTypes` pass infrastructure

### DIFF
--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -277,6 +277,7 @@ library internal
     HsBindgen.IR.Pass.Macro
     HsBindgen.IR.Pass.Msg
     HsBindgen.IR.Pass.ScopedName
+    HsBindgen.IR.Pass.Types
     HsBindgen.IR.Translation
     HsBindgen.Language.C
     HsBindgen.Language.Haskell

--- a/hs-bindgen/hs-bindgen.cabal
+++ b/hs-bindgen/hs-bindgen.cabal
@@ -244,6 +244,8 @@ library internal
     HsBindgen.Frontend.Pass.Select.IsPass
     HsBindgen.Frontend.Pass.SimplifyAST
     HsBindgen.Frontend.Pass.SimplifyAST.IsPass
+    HsBindgen.Frontend.Pass.TranslateTypes
+    HsBindgen.Frontend.Pass.TranslateTypes.IsPass
     HsBindgen.Frontend.Pass.TypecheckMacros
     HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
     HsBindgen.Frontend.Pass.TypecheckMacros.KnownTypes

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -138,25 +138,25 @@ scanAllFunctionTypes = foldMap $ \decl ->
       C.DeclTypedef typedef
         -- Exclude function type indirections, because they are already handled
         -- by 'typedefFuntypeIndirectionDecs'
-        | Just (args, res, _) <- C.getFirstFunTypeIndirection typedef.typ
+        | Just (args, res, _) <- C.getFirstFunTypeIndirection typedef.typ.c
         -> foldMap C.getAllFunTypes (res : map (.typ) args)
         -- Exclude /direct/ function types, because they are already handled by
         -- 'typedefDecs'
         | otherwise
-        -> C.getAllFunTypeIndirections typedef.typ
-      C.DeclEnum enum -> C.getAllFunTypes enum.typ
+        -> C.getAllFunTypeIndirections typedef.typ.c
+      C.DeclEnum enum -> C.getAllFunTypes enum.typ.c
       C.DeclUntaggedEnumConstant{} -> Set.empty
       C.DeclOpaque{} -> Set.empty
       C.DeclMacro{} -> Set.empty
       C.DeclFunction fn ->
-        foldMap C.getAllFunTypes (fn.res : map (.typ) fn.args)
-      C.DeclGlobal g -> C.getAllFunTypes g.typ
+        foldMap C.getAllFunTypes (fn.res.c : map (.typ.c) fn.args)
+      C.DeclGlobal g -> C.getAllFunTypes g.typ.c
   where
     scanField :: C.Field Final -> Set ([C.TypeFunArg Final], C.Type Final)
     scanField = C.elimField scanRegularField scanImplicitField
-    scanRegularField  field = C.getAllFunTypes field.typ
-    scanImplicitField field = C.getAllFunTypes field.typ <>
-        foldMap (C.getAllFunTypes . (.typ)) field.indirect
+    scanRegularField  field = C.getAllFunTypes field.typ.c
+    scanImplicitField field = C.getAllFunTypes field.typ.c <>
+        foldMap (C.getAllFunTypes . (.typ.c)) field.indirect
 
 -- | Check if a type is defined in the current module
 isDefinedInCurrentModule :: DeclIndex l -> C.Type Final -> Bool
@@ -188,7 +188,7 @@ generateDecs macroLang (C.Decl info kind spec) =
       C.DeclUntaggedEnumConstant enumConst -> withCategoryM CType $ do
         HsM.immediateM $ untaggedEnumConstantDecs info enumConst
       C.DeclTypedef typedef -> withCategoryM CType $
-        case C.getFirstFunTypeIndirection typedef.typ of
+        case C.getFirstFunTypeIndirection typedef.typ.c of
           Just (args, res, reconstruct) ->
             typedefFunTypeIndirectionDecs info (args, res, reconstruct) typedef.names spec
           Nothing ->
@@ -211,7 +211,7 @@ generateDecs macroLang (C.Decl info kind spec) =
         HsM.immediateM $ macroDecs macroLang info macro spec
       C.DeclGlobal g -> do
         withCategoryM (CTerm CGlobal) $
-          HsM.immediateM $ global info g.typ spec
+          HsM.immediateM $ global info g.typ.c spec
   where
     withCategory ::
          Category
@@ -322,7 +322,7 @@ enumDecs info enum spec = do
         newtypeField :: Hs.Field
         newtypeField = Hs.Field {
               name    = enum.names.field
-            , typ     = Type.topLevel enum.typ
+            , typ     = Type.topLevel enum.typ.c
             , origin  = Origin.GeneratedField
             , comment = Nothing
             }
@@ -522,7 +522,7 @@ typedefDecs info mkNewtypeOrigin typedef spec = do
         newtypeField :: Hs.Field
         newtypeField = Hs.Field {
               name    = typedef.names.orig.field
-            , typ     = Type.topLevel typedef.typ
+            , typ     = Type.topLevel typedef.typ.c
             , origin  = Origin.GeneratedField
             , comment = Nothing
             }
@@ -553,7 +553,7 @@ typedefDecs info mkNewtypeOrigin typedef spec = do
 
     -- See comment in 'newtypeWrapper` below
     isFunType :: Maybe ([C.TypeFunArg Final], C.Type Final)
-    isFunType = case typedef.typ of
+    isFunType = case typedef.typ.c of
       C.TypeFun args res | not (any C.hasUnsupportedType (res: fmap (.typ) args)) ->
         Just (args, res)
       _otherwise -> Nothing
@@ -668,7 +668,9 @@ typedefFunTypeIndirectionDecs origInfo (args, res, reconstruct) names origSpec =
 
     auxTypedef :: C.Typedef Final
     auxTypedef = C.Typedef{
-          typ = C.TypeFun args res
+          typ = TranslatedTypes{
+              c = C.TypeFun args res
+            }
         , ann = MangleNames.TypedefNames{
               orig = auxNames
             , aux  = Nothing
@@ -686,9 +688,11 @@ typedefFunTypeIndirectionDecs origInfo (args, res, reconstruct) names origSpec =
     mainTypedef :: C.Typedef Final
     mainTypedef = C.Typedef{
           ann = names
-        , typ = reconstruct $ C.TypeTypedef $ C.Ref {
-              name       = auxInfo.id
-            , underlying = C.TypeFun args res
+        , typ = TranslatedTypes{
+              c = reconstruct $ C.TypeTypedef $ C.Ref {
+                  name       = auxInfo.id
+                , underlying = C.TypeFun args res
+                }
             }
         }
 

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -744,8 +744,7 @@ macroDecsTypedef macroLang info macroType spec = do
           MacroTypeExtBinding ext ->
             Hs.ExtBinding ext.hsName ext.cSpec ext.hsSpec $
               Hs.TypRef
-                (Hs.assertNs (Proxy @Hs.NsTypeConstr)
-                (BindingSpec.extDeclIdPair ext).hsName)
+                (Hs.assertNs (Proxy @Hs.NsTypeConstr) (extDeclIdPair ext).hsName)
                 Nothing
           MacroTypeBodyVar pair ->
             Hs.TypRef (Hs.assertNs (Proxy @Hs.NsTypeConstr) pair.hsName) Nothing

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation.hs
@@ -149,7 +149,7 @@ scanAllFunctionTypes = foldMap $ \decl ->
       C.DeclOpaque{} -> Set.empty
       C.DeclMacro{} -> Set.empty
       C.DeclFunction fn ->
-        foldMap C.getAllFunTypes (fn.res : map (.argTyp.typ) fn.args)
+        foldMap C.getAllFunTypes (fn.res : map (.typ) fn.args)
       C.DeclGlobal g -> C.getAllFunTypes g.typ
   where
     scanField :: C.Field Final -> Set ([C.TypeFunArg Final], C.Type Final)
@@ -198,7 +198,7 @@ generateDecs macroLang (C.Decl info kind spec) =
       C.DeclFunction function -> do
         let funDeclsWith safety =
               functionDecs safety info function spec
-            funType = C.TypeFun (map (.argTyp) function.args) function.res
+            funType = C.typeOfFunction function
             -- Declare a function pointer. We can pass this 'FunPtr' to C
             -- functions that take a function pointer of the appropriate type.
             funPtrDecls = fst <$>

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Field.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Field.hs
@@ -11,6 +11,7 @@ module HsBindgen.Backend.Hs.Translation.Field (
 
 import HsBindgen.Frontend.Pass.Final
 import HsBindgen.IR.C qualified as C
+import HsBindgen.IR.Pass.Types (PassTypes (Types))
 
 flattenFields :: [C.Field Final] -> [Field]
 flattenFields = concatMap flattenField
@@ -31,7 +32,7 @@ getFieldInfo = \case
     ImplicitField field -> field.info
     IndirectField _impField indField -> indField.info
 
-getFieldTyp :: Field -> C.Type Final
+getFieldTyp :: Field -> Types Final
 getFieldTyp = \case
     RegularField  field -> field.typ
     ImplicitField field -> field.typ

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -113,7 +113,7 @@ functionDecs safety info origCFun _spec = do
         primResult = classifyResPassingMethod origCFun.res
 
         primParams :: [PassArgBy]
-        primParams = map (\arg -> classifyArgPassingMethod (arg.argTyp)) origCFun.args
+        primParams = map classifyArgPassingMethod origCFun.args
 
         foreignImport :: [Hs.Decl l]
         foreignImport =
@@ -203,7 +203,7 @@ functionDecs safety info origCFun _spec = do
           let params :: [(Maybe Text, Hs.FunctionParameter)]
               params = [ ( fmap (.cName.text) arg.name
                         , Hs.FunctionParameter{
-                            typ     = toOrigType Type.FunArg (classifyArgPassingMethod arg.argTyp)
+                            typ     = toOrigType Type.FunArg (classifyArgPassingMethod arg)
                           , comment = Nothing
                           })
                         | arg <- origCFun.args
@@ -292,7 +292,7 @@ ioComment purity =
 
 -- | Classification of the type of a function argument: it is either passed by
 -- value or by address.
-type PassArgBy = PassBy (C.TypeFunArg Final) (C.Type Final)
+type PassArgBy = PassBy (C.FunctionArg Final) (C.Type Final)
 
 -- | Classification of the type of a function result: it is either passed by
 -- value or by address.
@@ -338,11 +338,11 @@ classifyResPassingMethod res
   = PassByValue res
 
 -- | Classify how a function argument is passed from Haskell to C
-classifyArgPassingMethod :: HasCallStack => C.TypeFunArg Final -> PassArgBy
+classifyArgPassingMethod :: HasCallStack => C.FunctionArg Final -> PassArgBy
 classifyArgPassingMethod arg
   -- Heap types
-  | C.isCanonicalTypeStruct arg.typ ||
-    C.isCanonicalTypeUnion arg.typ ||
+  | C.isCanonicalTypeStruct  arg.typ ||
+    C.isCanonicalTypeUnion   arg.typ ||
     C.isCanonicalTypeComplex arg.typ
   = if arg.ann == NotAdjusted
     then PassByAddress arg.typ

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Function.hs
@@ -110,7 +110,7 @@ functionDecs safety info origCFun _spec = do
                 ]
 
         primResult :: PassResBy
-        primResult = classifyResPassingMethod origCFun.res
+        primResult = classifyResPassingMethod origCFun.res.c
 
         primParams :: [PassArgBy]
         primParams = map classifyArgPassingMethod origCFun.args
@@ -341,23 +341,23 @@ classifyResPassingMethod res
 classifyArgPassingMethod :: HasCallStack => C.FunctionArg Final -> PassArgBy
 classifyArgPassingMethod arg
   -- Heap types
-  | C.isCanonicalTypeStruct  arg.typ ||
-    C.isCanonicalTypeUnion   arg.typ ||
-    C.isCanonicalTypeComplex arg.typ
+  | C.isCanonicalTypeStruct  arg.typ.c ||
+    C.isCanonicalTypeUnion   arg.typ.c ||
+    C.isCanonicalTypeComplex arg.typ.c
   = if arg.ann == NotAdjusted
-    then PassByAddress arg.typ
+    then PassByAddress arg.typ.c
     else panicPure
           "classifyArgPassingMethod: found a function argument/result type that is \
           \a struct/union/complex with an unexpected annotation. \
           \Is there a bug in the AdjustTypes frontend pass?"
 
-  | C.isCanonicalTypeArray arg.typ
+  | C.isCanonicalTypeArray arg.typ.c
   = panicPure
       "classifyArgPassingMethod: found a function argument/result type that is an array, \
       \which is unexpected because it should have been adjusted to a pointer. \
       \Is there a bug in the AdjustTypes frontend pass?"
 
-  | C.isCanonicalTypeFunction arg.typ
+  | C.isCanonicalTypeFunction arg.typ.c
   = panicPure
       "classifyArgPassingMethod: found a function argument/result type that is a function, \
       \which is unexpected because it should have been adjusted to a pointer. \
@@ -373,7 +373,7 @@ class ToWrapperType a where
 
 instance ToWrapperType PassArgBy where
   toWrapperType = \case
-      PassByValue argTy -> argTy.typ
+      PassByValue argTy -> argTy.typ.c
       PassByAddress ty -> C.TypePointers 1 ty
 
 instance ToWrapperType PassResBy where

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Structure.hs
@@ -96,7 +96,7 @@ getDeclsFlam flam auxName spec info struct = do
           , instanceDecl =
               Hs.InstanceHasFlam hsStruct $
                 Hs.HasFlamInstance
-                  (Type.topLevel flam.typ)
+                  (Type.topLevel flam.typ.c)
                   (flam.offset `div` 8)
           }
 
@@ -109,7 +109,7 @@ getDeclsFlam flam auxName spec info struct = do
             name
           , typ     =
               Hs.WithFlam
-                (Type.topLevel flam.typ)
+                (Type.topLevel flam.typ.c)
                 (Hs.TypRef auxName Nothing)
           , origin  = Origin.Decl{
               info = info
@@ -129,7 +129,7 @@ getInstances supInsts structName fields instanceMap =
     Hs.getInstances instanceMap (Just structName) candidateInsts fieldTypes
   where
     fieldTypes :: [Hs.Type]
-    fieldTypes = Type.topLevel . (.typ) <$> fields
+    fieldTypes = Type.topLevel . (.typ.c) <$> fields
 
     candidateInsts :: Set Inst.TypeClass
     candidateInsts = Hs.getCandidateInsts supInsts
@@ -155,7 +155,7 @@ getDecls supInsts env spec structName info struct insts =
     getHsField field =
         Hs.Field {
             name    = fieldName field
-          , typ     = Type.topLevel field.typ
+          , typ     = Type.topLevel field.typ.c
           , origin  = Origin.StructField field
           , comment = mkHaddocksFieldInfo env.haddockConfig info field.info
           }
@@ -334,7 +334,7 @@ hasFieldDecs env info struct field = case field of
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     auxIndirectField :: C.ImplicitField Final -> C.IndirectField Final -> [Hs.Decl l]
     auxIndirectField impField indField = [
@@ -386,7 +386,7 @@ hasFieldCompatDecs env info struct field = [
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasFieldCompatInstance
     decl = Hs.HasFieldCompatInstance {
@@ -437,7 +437,7 @@ hasFieldPtrDecs struct field =
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     hasFieldPtrDecl :: Hs.HasFieldPtrInstance
     hasFieldPtrDecl = Hs.HasFieldPtrInstance {
@@ -470,7 +470,7 @@ hasCFieldDecs struct field = case getFieldWidth field of
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasCFieldInstance
     decl = Hs.HasCFieldInstance {
@@ -500,7 +500,7 @@ hasCBitfieldDecs struct field = case getFieldWidth field of
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Int -> Hs.HasCBitfieldInstance
     decl w = Hs.HasCBitfieldInstance {

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Type.hs
@@ -103,6 +103,9 @@ instance InContext (C.TypeFunArg Final) where
       AdjustedFromFunction _origTy -> inContext ctx arg.typ
       NotAdjusted -> inContext ctx arg.typ
 
+instance InContext (C.FunctionArg Final) where
+  inContext ctx arg = inContext ctx (C.typeOfFunctionArg arg)
+
 {-------------------------------------------------------------------------------
   Internal auxiliary
 -------------------------------------------------------------------------------}

--- a/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Backend/Hs/Translation/Union.hs
@@ -200,7 +200,7 @@ hasFieldDecs st env info union field =
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasFieldInstance
     decl = Hs.HasFieldInstance {
@@ -273,7 +273,7 @@ hasFieldCompatDecs st env info union field =
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasFieldCompatInstance
     decl = Hs.HasFieldCompatInstance {
@@ -329,7 +329,7 @@ hasFieldPtrDecs union field =
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasFieldPtrInstance
     decl = Hs.HasFieldPtrInstance {
@@ -362,7 +362,7 @@ hasCFieldDecs union field = case getFieldWidth field of
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Hs.HasCFieldInstance
     decl = Hs.HasCFieldInstance {
@@ -392,7 +392,7 @@ hasCBitfieldDecs union field = case getFieldWidth field of
     fieldName = Hs.assertNs (Proxy @Hs.NsVar) (getFieldInfo field).name.hsName
 
     fieldType :: Hs.Type
-    fieldType = Type.topLevel (getFieldTyp field)
+    fieldType = Type.topLevel (getFieldTyp field).c
 
     decl :: Int -> Hs.HasCBitfieldInstance
     decl w = Hs.HasCBitfieldInstance {

--- a/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
+++ b/hs-bindgen/src-internal/HsBindgen/BindingSpec.hs
@@ -46,7 +46,6 @@ module HsBindgen.BindingSpec (
   , getCTypes
   , lookupCTypeSpec
   , lookupHsTypeSpec
-  , extDeclIdPair
     -- ** Merging
   , BindingSpec.MergedBindingSpecs
   , BindingSpec.lookupMergedBindingSpecs
@@ -64,7 +63,6 @@ import HsBindgen.BindingSpec.Private.V1 qualified as BindingSpec
 import HsBindgen.BindingSpec.Private.Version qualified as Version
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
-import HsBindgen.IR.Translation
 import HsBindgen.Language.Haskell qualified as Hs
 import HsBindgen.Util.Monad
 import HsBindgen.Util.Tracer
@@ -322,10 +320,3 @@ lookupHsTypeSpec ::
   -> Maybe BindingSpec.HsTypeSpec
 lookupHsTypeSpec hsIdentifier spec =
     BindingSpec.lookupHsTypeSpec hsIdentifier spec.resolved
-
--- | Get the 'DeclIdPair' for a 'ResolvedExtBinding'
-extDeclIdPair :: ResolvedExtBinding -> DeclIdPair
-extDeclIdPair ext = DeclIdPair{
-      cName  = ext.cName
-    , hsName = Hs.demoteNs ext.hsName.name
-    }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend.hs
@@ -50,6 +50,8 @@ import HsBindgen.Frontend.Pass.Select
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Frontend.Pass.SimplifyAST
 import HsBindgen.Frontend.Pass.SimplifyAST.IsPass
+import HsBindgen.Frontend.Pass.TranslateTypes
+import HsBindgen.Frontend.Pass.TranslateTypes.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Frontend.Predicate
@@ -219,7 +221,12 @@ import Doxygen.Parser (Doxygen, DoxygenException (..), Result (..),
 -- example, if a function argument is a function type, then it is adjusted to a
 -- function /pointer/ type.
 --
--- == 12. "HsBindgen.Frontend.Pass.Select"
+-- == 12. "HsBindgen.Frontend.Pass.TranslateTypes"
+--
+-- "HsBindgen.Frontend.Pass.TranslateTypes" translates types (use sites) to
+-- Haskell types.
+--
+-- == 13. "HsBindgen.Frontend.Pass.Select"
 --
 -- "HsBindgen.Frontend.Pass.Select" filters the declarations using predicates
 -- and program slicing. It also emits delayed trace messages for declarations
@@ -377,15 +384,19 @@ runFrontend tracer config boot = do
       afterMangleNamesPass <- mangleNamesPass
       pure $ adjustTypes afterMangleNamesPass
 
+    translateTypesPass <- cache "TranslateTypes" $ do
+      afterAdjustTypesPass <- adjustTypesPass
+      pure $ translateTypes afterAdjustTypesPass
+
     selectPass <- cache "select" $ do
       afterParse <- parsePass
-      afterAdjustTypesPass <- adjustTypesPass
+      afterTranslateTypesPass <- translateTypesPass
       let (afterSelect, msgsSelect) =
             selectDecls
               afterParse.isMainHeader
               afterParse.isInMainHeaderDir
               selectConfig
-              afterAdjustTypesPass
+              afterTranslateTypesPass
       forM_ msgsSelect $  traceWith (contramap FrontendSelect tracer)
       pure afterSelect
 
@@ -404,6 +415,7 @@ runFrontend tracer config boot = do
       , resolveBindingSpecs      = resolveBindingSpecsPass
       , mangleNames              = mangleNamesPass
       , adjustTypes              = adjustTypesPass
+      , translateTypes           = translateTypesPass
       , select                   = selectPass
       , final                    = finalPass
       }
@@ -453,6 +465,7 @@ data FrontendArtefact l = FrontendArtefact {
     , resolveBindingSpecs      :: Cached (C.TranslationUnit l ResolveBindingSpecs)
     , mangleNames              :: Cached (C.TranslationUnit l MangleNames)
     , adjustTypes              :: Cached (C.TranslationUnit l AdjustTypes)
+    , translateTypes           :: Cached (C.TranslationUnit l TranslateTypes)
     , select                   :: Cached (C.TranslationUnit l Select)
     , final                    :: Cached (C.TranslationUnit l Final)
     }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -9,6 +9,8 @@ module HsBindgen.Frontend.Analysis.Deps (
   , depsOfDeclParsedMacro
   ) where
 
+import Data.Proxy (Proxy (..))
+
 import HsBindgen.Frontend.Analysis
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
@@ -35,9 +37,9 @@ depsOfDeclWith depsOfMacro = \case
     C.DeclOpaque{}                 -> []
     (C.DeclMacro m)                -> depsOfMacro m
     (C.DeclFunction function)      ->
-      C.depsOfType function.res ++
-      concatMap (\arg -> C.depsOfType arg.typ) function.args
-    (C.DeclGlobal global)          -> C.depsOfType global.typ
+      C.depsOfType (cType (Proxy @p) function.res) ++
+      concatMap (\arg -> C.depsOfType (cType (Proxy @p) arg.typ)) function.args
+    (C.DeclGlobal global)          -> C.depsOfType (cType (Proxy @p) global.typ)
 
 {-------------------------------------------------------------------------------
   Dependencies of declarations with parsed macros only
@@ -109,23 +111,23 @@ depsOfRegularField ::
      forall p. IsPass p
   => C.RegularField p
   -> [(Id p, Dependency)]
-depsOfRegularField field = C.depsOfType field.typ
+depsOfRegularField field = C.depsOfType (cType (Proxy @p) field.typ)
 
 depsOfImplicitField ::
      forall p. IsPass p
   => C.ImplicitField p
   -> [(Id p, Dependency)]
-depsOfImplicitField field = C.depsOfType field.typ ++ concatMap depsOfIndirectField field.indirect
+depsOfImplicitField field = C.depsOfType (cType (Proxy @p) field.typ) ++ concatMap depsOfIndirectField field.indirect
 
 depsOfIndirectField ::
      forall p. IsPass p
   => C.IndirectField p
   -> [(Id p, Dependency)]
-depsOfIndirectField field = C.depsOfType field.typ
+depsOfIndirectField field = C.depsOfType (cType (Proxy @p) field.typ)
 
 {-------------------------------------------------------------------------------
   Typedefs
 -------------------------------------------------------------------------------}
 
-depsOfTypedef :: IsPass p => C.Typedef p -> [(Id p, Dependency)]
-depsOfTypedef typedef = C.depsOfType typedef.typ
+depsOfTypedef :: forall p. IsPass p => C.Typedef p -> [(Id p, Dependency)]
+depsOfTypedef typedef = C.depsOfType (cType (Proxy @p) typedef.typ)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -36,9 +36,7 @@ depsOfDeclWith depsOfMacro = \case
     (C.DeclTypedef ty)             -> depsOfTypedef ty
     C.DeclOpaque{}                 -> []
     (C.DeclMacro m)                -> depsOfMacro m
-    (C.DeclFunction function)      ->
-      C.depsOfType (cType (Proxy @p) function.res) ++
-      concatMap (\arg -> C.depsOfType (cType (Proxy @p) arg.typ)) function.args
+    (C.DeclFunction function)      -> C.depsOfType (C.typeOfFunction function)
     (C.DeclGlobal global)          -> C.depsOfType (cType (Proxy @p) global.typ)
 
 {-------------------------------------------------------------------------------
@@ -117,7 +115,8 @@ depsOfImplicitField ::
      forall p. IsPass p
   => C.ImplicitField p
   -> [(Id p, Dependency)]
-depsOfImplicitField field = C.depsOfType (cType (Proxy @p) field.typ) ++ concatMap depsOfIndirectField field.indirect
+depsOfImplicitField field = C.depsOfType (cType (Proxy @p) field.typ)
+    ++ concatMap depsOfIndirectField field.indirect
 
 depsOfIndirectField ::
      forall p. IsPass p

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Analysis/Deps.hs
@@ -36,7 +36,7 @@ depsOfDeclWith depsOfMacro = \case
     (C.DeclMacro m)                -> depsOfMacro m
     (C.DeclFunction function)      ->
       C.depsOfType function.res ++
-      concatMap (\arg -> C.depsOfTypeFunArg arg.argTyp) function.args
+      concatMap (\arg -> C.depsOfType arg.typ) function.args
     (C.DeclGlobal global)          -> C.depsOfType global.typ
 
 {-------------------------------------------------------------------------------

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes.hs
@@ -182,7 +182,7 @@ processMacroExpr macroExpr = coercePass macroExpr
 
 processFunction :: C.Function MangleNames -> C.Function AdjustTypes
 processFunction function =
-    C.Function {
+    C.Function{
         args  = map processFunctionArg function.args
       , res   = processType function.res
       , attrs = function.attrs
@@ -191,10 +191,13 @@ processFunction function =
 
 processFunctionArg :: C.FunctionArg MangleNames -> C.FunctionArg AdjustTypes
 processFunctionArg functionArg =
-    C.FunctionArg {
+    C.FunctionArg{
         name = functionArg.name
-      , argTyp = processTypeFunArg functionArg.argTyp
+      , typ  = typ'
+      , ann  = ann'
       }
+  where
+    (typ', ann') = adjustFunArg $ processType functionArg.typ
 
 processGlobal :: C.Global MangleNames -> C.Global AdjustTypes
 processGlobal global = C.Global{

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
@@ -52,7 +52,7 @@ instance PassMacro AdjustTypes where
 instance PassExtBinding AdjustTypes where
   type ExtBinding AdjustTypes = BindingSpec.ResolvedExtBinding
 
-  extBindingId _ extBinding = BindingSpec.extDeclIdPair extBinding
+  extBindingId _ extBinding = extDeclIdPair extBinding
 
 instance PassCommentDecl AdjustTypes where
   type CommentDecl AdjustTypes = Maybe (C.Comment AdjustTypes)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/AdjustTypes/IsPass.hs
@@ -42,6 +42,8 @@ instance PassId AdjustTypes where
 instance PassScopedName AdjustTypes where
   type ScopedName AdjustTypes = ScopedNamePair
 
+instance PassTypes AdjustTypes
+
 instance PassMacro AdjustTypes where
   type MacroId         AdjustTypes = Id AdjustTypes
   type MacroBody       AdjustTypes = TypecheckedMacro AdjustTypes

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ConstructTranslationUnit/IsPass.hs
@@ -7,6 +7,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
 import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
@@ -32,6 +33,8 @@ instance PassId ConstructTranslationUnit
 
 instance PassScopedName ConstructTranslationUnit
 
+instance PassTypes ConstructTranslationUnit
+
 instance PassMacro ConstructTranslationUnit where
   type MacroBody ConstructTranslationUnit = Macro.Resolved
 
@@ -49,7 +52,9 @@ instance PassMsg ConstructTranslationUnit
   CoercePass
 -------------------------------------------------------------------------------}
 
+instance CoercePassAnonRef            EnrichComments ConstructTranslationUnit
 instance CoercePassId                 EnrichComments ConstructTranslationUnit
+instance CoercePassTypes              EnrichComments ConstructTranslationUnit
 instance CoercePassMacroId            EnrichComments ConstructTranslationUnit
 instance CoercePassMacroUnderlying    EnrichComments ConstructTranslationUnit
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/EnrichComments/IsPass.hs
@@ -6,6 +6,7 @@ import HsBindgen.Frontend.Pass.FillUnnamedIds.IsPass
 import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
 import HsBindgen.Macro.Interface qualified as Macro
 
 {-------------------------------------------------------------------------------
@@ -29,6 +30,8 @@ instance IsPass EnrichComments
 instance PassId EnrichComments
 
 instance PassScopedName EnrichComments
+
+instance PassTypes EnrichComments
 
 instance PassMacro EnrichComments where
   type MacroBody EnrichComments = Macro.Unresolved
@@ -54,10 +57,12 @@ instance PassMsg EnrichComments
   @CommentDecl EnrichComments = Maybe (Comment EnrichComments)@).
 -------------------------------------------------------------------------------}
 
+instance CoercePassAnonRef             FillUnnamedIds EnrichComments
 instance CoercePassId                  FillUnnamedIds EnrichComments
 instance CoercePassMacroBody           FillUnnamedIds EnrichComments
 instance CoercePassMacroId             FillUnnamedIds EnrichComments
 instance CoercePassMacroUnderlying     FillUnnamedIds EnrichComments
+instance CoercePassTypes               FillUnnamedIds EnrichComments
 instance CoercePassAnn "IndirectField" FillUnnamedIds EnrichComments
 instance CoercePassAnn "Global"        FillUnnamedIds EnrichComments
 instance CoercePassAnn "TypeFunArg"    FillUnnamedIds EnrichComments

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/FillUnnamedIds.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/FillUnnamedIds.hs
@@ -347,16 +347,15 @@ instance UpdateUseSites C.Function where
 instance UpdateUseSites C.FunctionArg where
   updateUseSites functionArg =
       reconstruct
-        <$> pure functionArg.name
-        <*> updateUseSites functionArg.argTyp
+        <$> updateUseSites functionArg.typ
     where
       reconstruct ::
-           Maybe (ScopedName FillUnnamedIds)
-        -> C.TypeFunArg FillUnnamedIds
+           C.Type FillUnnamedIds
         -> C.FunctionArg FillUnnamedIds
-      reconstruct name' typ' = C.FunctionArg {
-            name = name'
-          , argTyp = typ'
+      reconstruct typ' = C.FunctionArg {
+            name = functionArg.name
+          , typ  = typ'
+          , ann  = functionArg.ann
           }
 
 instance UpdateUseSites C.Type where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/FillUnnamedIds/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/FillUnnamedIds/IsPass.hs
@@ -34,6 +34,8 @@ instance PassId FillUnnamedIds
 
 instance PassScopedName FillUnnamedIds
 
+instance PassTypes FillUnnamedIds
+
 instance PassMacro FillUnnamedIds where
   type MacroBody FillUnnamedIds = Macro.Unresolved
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
@@ -86,6 +86,8 @@ instance PassId CreateNames where
 instance PassScopedName CreateNames where
   type ScopedName CreateNames = C.ScopedName
 
+instance PassTypes CreateNames
+
 instance PassMacro CreateNames where
   type MacroId         CreateNames = C.DeclId
   type MacroBody       CreateNames = TypecheckedMacro CreateNames
@@ -736,7 +738,8 @@ createFunction function = do
         }
 
 createGlobal ::
-     C.Global ResolveBindingSpecs -> CreateE (C.Global CreateNames)
+     C.Global ResolveBindingSpecs
+  -> CreateE (C.Global CreateNames)
 createGlobal global = pure C.Global{
       typ = coercePass global.typ
     , ann = global.ann

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/CreateNames.hs
@@ -730,8 +730,9 @@ createFunction function = do
     createFunctionArg arg = do
       name' <- traverse createArgumentName arg.name
       pure C.FunctionArg{
-          name   = fmap (.cName) name'
-        , argTyp = coercePass arg.argTyp
+          name = fmap (.cName) name'
+        , typ  = coercePass arg.typ
+        , ann  = arg.ann
         }
 
 createGlobal ::

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -64,7 +64,7 @@ instance PassMacro MangleNames where
 instance PassExtBinding MangleNames where
   type ExtBinding MangleNames = BindingSpec.ResolvedExtBinding
 
-  extBindingId _ extBinding = BindingSpec.extDeclIdPair extBinding
+  extBindingId _ extBinding = extDeclIdPair extBinding
 
 instance PassCommentDecl MangleNames where
   type CommentDecl MangleNames = Maybe (C.Comment MangleNames)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/IsPass.hs
@@ -54,6 +54,8 @@ instance PassId MangleNames where
 instance PassScopedName MangleNames where
   type ScopedName MangleNames = ScopedNamePair
 
+instance PassTypes MangleNames
+
 instance PassMacro MangleNames where
   type MacroId         MangleNames = Id MangleNames
   type MacroBody       MangleNames = TypecheckedMacro MangleNames

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/MangleNames/ResolveNames.hs
@@ -336,13 +336,15 @@ instance Resolve C.Function where
       }
     where
       resolveArg ::
-           C.FunctionArg CreateNames -> ResolveE (C.FunctionArg MangleNames)
+           C.FunctionArg CreateNames
+        -> ResolveE (C.FunctionArg MangleNames)
       resolveArg arg = do
         name' <- mapM (lookupScopedNamePairR info.id) arg.name
-        argTyp' <- (resolve info) arg.argTyp
+        typ' <- resolve info arg.typ
         pure C.FunctionArg{
-            name   = name'
-          , argTyp = argTyp'
+            name = name'
+          , typ  = typ'
+          , ann  = arg.ann
           }
 
 instance Resolve C.Global where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/Decl.hs
@@ -680,9 +680,10 @@ functionDecl macroLang enclosing ctx info =
                        then Nothing
                        else Just (C.ScopedName argName)
 
-              return C.FunctionArg {
+              return C.FunctionArg{
                   name = mbArgName
-                , argTyp = argCType
+                , typ  = argCType.typ
+                , ann  = argCType.ann
                 }
             pure $ Right (args', res)
           C.TypeTypedef{} ->

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Parse/IsPass.hs
@@ -50,6 +50,8 @@ instance PassId Parse where
 
 instance PassScopedName Parse
 
+instance PassTypes Parse
+
 instance PassMacro Parse where
   type MacroBody Parse = Macro.Unresolved
 

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
@@ -78,7 +78,7 @@ instance CoercePassId                  TypecheckMacros PrepareReparse
 instance CoercePassMacroId             TypecheckMacros PrepareReparse
 instance CoercePassAnn "TypeFunArg"    TypecheckMacros PrepareReparse
 
-instance CoercePassCommentDecl      TypecheckMacros PrepareReparse where
+instance CoercePassCommentDecl TypecheckMacros PrepareReparse where
   coercePassCommentDecl _ = fmap coercePass
 
 instance CoercePassMacroUnderlying TypecheckMacros PrepareReparse

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/PrepareReparse/IsPass.hs
@@ -40,6 +40,8 @@ instance PassId PrepareReparse
 
 instance PassScopedName PrepareReparse
 
+instance PassTypes PrepareReparse
+
 instance PassMacro PrepareReparse where
   type MacroId   PrepareReparse = Id PrepareReparse
   type MacroBody PrepareReparse = TypecheckedMacro PrepareReparse
@@ -76,6 +78,7 @@ data FlatTokens = FlatTokens {
 
 instance CoercePassId                  TypecheckMacros PrepareReparse
 instance CoercePassMacroId             TypecheckMacros PrepareReparse
+instance CoercePassTypes               TypecheckMacros PrepareReparse
 instance CoercePassAnn "TypeFunArg"    TypecheckMacros PrepareReparse
 
 instance CoercePassCommentDecl TypecheckMacros PrepareReparse where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions.hs
@@ -384,8 +384,9 @@ processFunction info function = do
 
     mkFunctionArg :: Maybe Text -> C.Type LanC -> C.FunctionArg LanC
     mkFunctionArg mname typ = C.FunctionArg{
-          name   = C.ScopedName <$> mname
-        , argTyp = C.TypeFunArgF typ NoAnn
+          name = C.ScopedName <$> mname
+        , typ  = typ
+        , ann  = NoAnn
         }
 
 -- | Globals (externs or constants)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/IsPass.hs
@@ -24,6 +24,8 @@ instance IsPass ReparseMacroExpansions
 
 instance PassId ReparseMacroExpansions
 
+instance PassTypes ReparseMacroExpansions
+
 instance PassScopedName ReparseMacroExpansions
 
 instance PassMacro ReparseMacroExpansions where
@@ -49,6 +51,7 @@ instance PassMsg ReparseMacroExpansions
 
 instance CoercePassId                  PrepareReparse ReparseMacroExpansions
 instance CoercePassMacroId             PrepareReparse ReparseMacroExpansions
+instance CoercePassTypes               PrepareReparse ReparseMacroExpansions
 instance CoercePassAnn "TypeFunArg"    PrepareReparse ReparseMacroExpansions
 
 instance CoercePassCommentDecl PrepareReparse ReparseMacroExpansions where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/LanC.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/LanC.hs
@@ -21,6 +21,8 @@ instance IsPass LanC
 
 instance PassId LanC
 
+instance PassTypes LanC
+
 instance PassScopedName LanC
 
 instance PassMacro LanC where
@@ -45,6 +47,7 @@ instance PassMsg LanC
 -------------------------------------------------------------------------------}
 
 instance CoercePassId               PrepareReparse LanC
+instance CoercePassTypes            PrepareReparse LanC
 instance CoercePassMacroId          PrepareReparse LanC
 instance CoercePassAnn "TypeFunArg" PrepareReparse LanC
 instance CoercePassCommentDecl      PrepareReparse LanC where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ReparseMacroExpansions/Zip.hs
@@ -209,11 +209,13 @@ instance ZipReparsed C.Function where
         -> C.FunctionArg Out
         -> ZipResult (C.FunctionArg ReparseMacroExpansions)
       zipFunctionArg arg1 arg2 = do
-            name'   <- checkEq       arg1.name   arg2.name
-            argTyp' <- zipTypeFunArg arg1.argTyp arg2.argTyp
+            name' <- checkEq arg1.name arg2.name
+            typ'  <- zipType arg1.typ  arg2.typ
+            ann'  <- checkEq arg1.ann  arg2.ann
             success C.FunctionArg {
-                name   = name'
-              , argTyp = argTyp'
+                name = name'
+              , typ  = typ'
+              , ann  = ann'
               }
 
 instance ZipReparsed C.Global where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs.hs
@@ -605,16 +605,15 @@ instance Resolve C.Global l where
 instance Resolve C.FunctionArg l where
   resolve ctx functionArg =
     reconstruct
-      <$> pure functionArg.name
-      <*> resolve ctx functionArg.argTyp
+      <$> resolve ctx functionArg.typ
     where
       reconstruct ::
-           Maybe (ScopedName ResolveBindingSpecs)
-        -> C.TypeFunArg ResolveBindingSpecs
+           C.Type ResolveBindingSpecs
         -> C.FunctionArg ResolveBindingSpecs
-      reconstruct name' argTyp' = C.FunctionArg {
-            name = name'
-          , argTyp = argTyp'
+      reconstruct typ' = C.FunctionArg{
+            name = functionArg.name
+          , typ  = typ'
+          , ann  = functionArg.ann
           }
 
 instance Resolve (Flip TypecheckedMacro l) l where

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/ResolveBindingSpecs/IsPass.hs
@@ -42,6 +42,8 @@ instance PassId ResolveBindingSpecs
 
 instance PassScopedName ResolveBindingSpecs
 
+instance PassTypes ResolveBindingSpecs
+
 instance PassMacro ResolveBindingSpecs where
   type MacroId         ResolveBindingSpecs = Id ResolveBindingSpecs
   type MacroBody       ResolveBindingSpecs = TypecheckedMacro ResolveBindingSpecs

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select.hs
@@ -26,10 +26,10 @@ import HsBindgen.Frontend.Analysis.IncludeGraph qualified as IncludeGraph
 import HsBindgen.Frontend.Analysis.UseDeclGraph (UseDeclGraph)
 import HsBindgen.Frontend.Analysis.UseDeclGraph qualified as UseDeclGraph
 import HsBindgen.Frontend.DeclMeta
-import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
 import HsBindgen.Frontend.Pass.ConstructTranslationUnit.IsPass
 import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.Select.IsPass
+import HsBindgen.Frontend.Pass.TranslateTypes.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.Frontend.TranslationUnit qualified as C
 import HsBindgen.Imports
@@ -92,7 +92,7 @@ selectDecls ::
   => IsMainHeader
   -> IsInMainHeaderDir
   -> SelectConfig
-  -> C.TranslationUnit l AdjustTypes
+  -> C.TranslationUnit l TranslateTypes
   -> (C.TranslationUnit l Select, [AnnMsg Select])
 selectDecls isMainHeader isInMainHeaderDir config unit =
     let -- Directly match the selection predicate on the 'DeclIndex', obtaining

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -31,6 +31,7 @@ import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
 import HsBindgen.IR.Translation
 import HsBindgen.Util.Tracer
 
@@ -64,6 +65,8 @@ instance PassId Select where
 
 instance PassScopedName Select where
   type ScopedName Select = ScopedNamePair
+
+instance PassTypes Select
 
 instance PassMacro Select where
   type MacroId Select = Id Select
@@ -297,7 +300,9 @@ instance IsTrace Level SelectMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
+instance CoercePassAnonRef   AdjustTypes Select
 instance CoercePassId        AdjustTypes Select
+instance CoercePassTypes     AdjustTypes Select
 instance CoercePassMacroId   AdjustTypes Select
 instance CoercePassMacroUnderlying AdjustTypes Select where
   coercePassMacroUnderlying _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -75,7 +75,7 @@ instance PassMacro Select where
 instance PassExtBinding Select where
   type ExtBinding Select = BindingSpec.ResolvedExtBinding
 
-  extBindingId _ extBinding = BindingSpec.extDeclIdPair extBinding
+  extBindingId _ extBinding = extDeclIdPair extBinding
 
 instance PassCommentDecl Select where
   type CommentDecl Select = Maybe (C.Comment Select)

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/Select/IsPass.hs
@@ -27,11 +27,12 @@ import HsBindgen.Frontend.Pass.Parse.Msg
 import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg)
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass.Msg (DelayedReparseMacroExpansionsMsg)
 import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
+import HsBindgen.Frontend.Pass.TranslateTypes.IsPass
 import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
 import HsBindgen.Frontend.Predicate
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
-import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef (coercePassAnonRef))
 import HsBindgen.IR.Translation
 import HsBindgen.Util.Tracer
 
@@ -66,7 +67,12 @@ instance PassId Select where
 instance PassScopedName Select where
   type ScopedName Select = ScopedNamePair
 
-instance PassTypes Select
+instance PassTypes Select where
+  type Types Select   = TranslatedTypes Select
+  type AnonRef Select = TranslatedAnonRef Select
+
+  cType _ translatedTypes = translatedTypes.c
+  anonRefTypes _ = translatedAnonRefType
 
 instance PassMacro Select where
   type MacroId Select = Id Select
@@ -300,25 +306,31 @@ instance IsTrace Level SelectMsg where
   CoercePass
 -------------------------------------------------------------------------------}
 
-instance CoercePassAnonRef   AdjustTypes Select
-instance CoercePassId        AdjustTypes Select
-instance CoercePassTypes     AdjustTypes Select
-instance CoercePassMacroId   AdjustTypes Select
-instance CoercePassMacroUnderlying AdjustTypes Select where
+instance CoercePassAnonRef TranslateTypes Select where
+  coercePassAnonRef _ = coercePass
+
+instance CoercePassId      TranslateTypes Select
+
+instance CoercePassTypes TranslateTypes Select where
+  coercePassTypes _ = coercePass
+
+instance CoercePassMacroId TranslateTypes Select
+
+instance CoercePassMacroUnderlying TranslateTypes Select where
   coercePassMacroUnderlying _ = coercePass
 
-instance CoercePassMacroBody AdjustTypes Select where
+instance CoercePassMacroBody TranslateTypes Select where
   coercePassMacroBody _ = coercePassParam
 
-instance CoercePassAnn "IndirectField" AdjustTypes Select where
+instance CoercePassAnn "IndirectField" TranslateTypes Select where
   coercePassAnn _ = \case
       IndirectFieldNames name -> IndirectFieldNames name
 
-instance CoercePassAnn "TypeFunArg" AdjustTypes Select where
+instance CoercePassAnn "TypeFunArg" TranslateTypes Select where
   coercePassAnn _ = \case
       AdjustedFromArray ty    -> AdjustedFromArray (coercePass ty)
       AdjustedFromFunction ty -> AdjustedFromFunction (coercePass ty)
       NotAdjusted             -> NotAdjusted
 
-instance CoercePassCommentDecl AdjustTypes Select where
+instance CoercePassCommentDecl TranslateTypes Select where
   coercePassCommentDecl _ = fmap coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -56,11 +56,10 @@ instance PassAnn SimplifyAST where
 instance PassMsg SimplifyAST where
   type Msg SimplifyAST = SimplifyASTMsg
 
-instance CoercePassId                Parse SimplifyAST
-instance CoercePassMacroBody         Parse SimplifyAST
-instance CoercePassMacroId           Parse SimplifyAST
-instance CoercePassMacroUnderlying   Parse SimplifyAST
-
+instance CoercePassId                  Parse SimplifyAST
+instance CoercePassMacroBody           Parse SimplifyAST
+instance CoercePassMacroId             Parse SimplifyAST
+instance CoercePassMacroUnderlying     Parse SimplifyAST
 instance CoercePassAnn "Global"        Parse SimplifyAST
 instance CoercePassAnn "IndirectField" Parse SimplifyAST
 instance CoercePassAnn "TypeFunArg"    Parse SimplifyAST

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/SimplifyAST/IsPass.hs
@@ -10,6 +10,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
 import HsBindgen.Macro.Interface qualified as Macro
 import HsBindgen.Util.Tracer
 
@@ -43,6 +44,8 @@ instance PassId SimplifyAST where
 
 instance PassScopedName SimplifyAST
 
+instance PassTypes SimplifyAST
+
 instance PassMacro SimplifyAST where
   type MacroBody SimplifyAST = Macro.Unresolved
 
@@ -56,10 +59,16 @@ instance PassAnn SimplifyAST where
 instance PassMsg SimplifyAST where
   type Msg SimplifyAST = SimplifyASTMsg
 
+{-------------------------------------------------------------------------------
+  CoercePass: Parse
+-------------------------------------------------------------------------------}
+
+instance CoercePassAnonRef             Parse SimplifyAST
 instance CoercePassId                  Parse SimplifyAST
 instance CoercePassMacroBody           Parse SimplifyAST
 instance CoercePassMacroId             Parse SimplifyAST
 instance CoercePassMacroUnderlying     Parse SimplifyAST
+instance CoercePassTypes               Parse SimplifyAST
 instance CoercePassAnn "Global"        Parse SimplifyAST
 instance CoercePassAnn "IndirectField" Parse SimplifyAST
 instance CoercePassAnn "TypeFunArg"    Parse SimplifyAST

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes.hs
@@ -1,0 +1,163 @@
+module HsBindgen.Frontend.Pass.TranslateTypes (
+    translateTypes
+  ) where
+
+import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
+import HsBindgen.Frontend.Pass.TranslateTypes.IsPass
+import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
+import HsBindgen.Frontend.TranslationUnit qualified as C
+import HsBindgen.Imports
+import HsBindgen.IR.C qualified as C
+import HsBindgen.IR.Pass
+import HsBindgen.IR.Translation
+
+{-------------------------------------------------------------------------------
+  Top-level
+-------------------------------------------------------------------------------}
+
+translateTypes ::
+     C.TranslationUnit l AdjustTypes
+  -> C.TranslationUnit l TranslateTypes
+translateTypes unit = C.TranslationUnit{
+      decls        = map processDecl unit.decls
+    , includeGraph = unit.includeGraph
+    , meta         = unit.meta
+    }
+
+{-------------------------------------------------------------------------------
+  Decls
+-------------------------------------------------------------------------------}
+
+processDecl :: C.Decl l AdjustTypes -> C.Decl l TranslateTypes
+processDecl decl = C.Decl{
+      info = coercePass decl.info
+    , kind = processDeclKind decl.kind
+    , ann  = decl.ann
+    }
+
+processDeclKind :: C.DeclKind l AdjustTypes -> C.DeclKind l TranslateTypes
+processDeclKind = \case
+    C.DeclStruct               struct   -> C.DeclStruct               $ processStruct           struct
+    C.DeclUnion                union    -> C.DeclUnion                $ processUnion            union
+    C.DeclTypedef              typedef  -> C.DeclTypedef              $ processTypedef          typedef
+    C.DeclEnum                 enum     -> C.DeclEnum                 $ processEnum             enum
+    C.DeclUntaggedEnumConstant cnst     -> C.DeclUntaggedEnumConstant $ processUntaggedEnumConstant cnst
+    C.DeclOpaque               mSize    -> C.DeclOpaque mSize
+    C.DeclMacro                macro    -> C.DeclMacro                $ processMacro            macro
+    C.DeclFunction             function -> C.DeclFunction             $ processFunction         function
+    C.DeclGlobal               global   -> C.DeclGlobal               $ processGlobal           global
+
+processStruct :: C.Struct AdjustTypes -> C.Struct TranslateTypes
+processStruct struct = C.Struct{
+      sizeof    = struct.sizeof
+    , alignment = struct.alignment
+    , fields    = map processField struct.fields
+    , flam      = C.mapFlamField processRegularField struct.flam
+    , ann       = struct.ann
+    }
+
+processUnion :: C.Union AdjustTypes -> C.Union TranslateTypes
+processUnion union = C.Union{
+      sizeof    = union.sizeof
+    , alignment = union.alignment
+    , fields    = map processField union.fields
+    , ann       = union.ann
+    }
+
+processField :: C.Field AdjustTypes -> C.Field TranslateTypes
+processField = \case
+    C.FieldRegular  field -> C.FieldRegular  $ processRegularField field
+    C.FieldImplicit field -> C.FieldImplicit $ processImplicitField field
+
+processRegularField :: C.RegularField AdjustTypes -> C.RegularField TranslateTypes
+processRegularField field = C.RegularField{
+      info   = coercePass field.info
+    , typ    = processType field.typ
+    , offset = field.offset
+    , width  = field.width
+    , ann    = field.ann
+    }
+
+processImplicitField :: C.ImplicitField AdjustTypes -> C.ImplicitField TranslateTypes
+processImplicitField field = C.ImplicitField{
+      info     = coercePass field.info
+    , typRef   = processAnonRef field.typRef
+    , offset   = field.offset
+    , indirect = map processIndirectField field.indirect
+    , ann      = field.ann
+    }
+
+processIndirectField :: C.IndirectField AdjustTypes -> C.IndirectField TranslateTypes
+processIndirectField field = C.IndirectField{
+      info   = coercePass field.info
+    , typ    = processType field.typ
+    , offset = field.offset
+    , width  = field.width
+    , path   = map processAnonRef field.path
+    , ann    = coercePassAnn (Proxy @'("IndirectField", AdjustTypes, TranslateTypes)) field.ann
+    }
+
+processTypedef :: C.Typedef AdjustTypes -> C.Typedef TranslateTypes
+processTypedef typedef = C.Typedef{
+      typ = processType typedef.typ
+    , ann = typedef.ann
+    }
+
+processEnum :: C.Enum AdjustTypes -> C.Enum TranslateTypes
+processEnum enum = C.Enum{
+      typ       = processType enum.typ
+    , sizeof    = enum.sizeof
+    , alignment = enum.alignment
+    , constants = map coercePass enum.constants
+    , ann       = enum.ann
+    }
+
+processUntaggedEnumConstant ::
+     C.UntaggedEnumConstant AdjustTypes
+  -> C.UntaggedEnumConstant TranslateTypes
+processUntaggedEnumConstant = coercePass
+
+processMacro :: MacroBody AdjustTypes l -> MacroBody TranslateTypes l
+processMacro = \case
+    MacroType  typ -> MacroType  $ coercePass typ
+    MacroValue val -> MacroValue $ coercePass val
+
+processFunction :: C.Function AdjustTypes -> C.Function TranslateTypes
+processFunction fun = C.Function{
+      args  = map processFunctionArg fun.args
+    , res   = processType fun.res
+    , attrs = fun.attrs
+    , ann   = fun.ann
+    }
+
+processFunctionArg :: C.FunctionArg AdjustTypes -> C.FunctionArg TranslateTypes
+processFunctionArg arg = C.FunctionArg{
+      name = arg.name
+    , typ  = processType arg.typ
+    , ann  =
+        coercePassAnn
+          (Proxy @'("TypeFunArg", AdjustTypes, TranslateTypes))
+          arg.ann
+    }
+
+processGlobal :: C.Global AdjustTypes -> C.Global TranslateTypes
+processGlobal global = C.Global{
+      typ = processType global.typ
+    , ann = global.ann
+    }
+
+{-------------------------------------------------------------------------------
+  Types
+-------------------------------------------------------------------------------}
+
+processType :: C.Type AdjustTypes -> TranslatedTypes TranslateTypes
+processType typ = TranslatedTypes{
+      c = coercePass typ
+      -- TODO
+    }
+
+processAnonRef :: C.AnonRef AdjustTypes -> TranslatedAnonRef TranslateTypes
+processAnonRef typ = TranslatedAnonRef{
+      c = coercePass typ
+      -- TODO
+    }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes.hs
@@ -153,11 +153,11 @@ processGlobal global = C.Global{
 processType :: C.Type AdjustTypes -> TranslatedTypes TranslateTypes
 processType typ = TranslatedTypes{
       c = coercePass typ
-      -- TODO
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1599>
     }
 
 processAnonRef :: C.AnonRef AdjustTypes -> TranslatedAnonRef TranslateTypes
 processAnonRef typ = TranslatedAnonRef{
       c = coercePass typ
-      -- TODO
+      -- TODO <https://github.com/well-typed/hs-bindgen/issues/1599>
     }

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TranslateTypes/IsPass.hs
@@ -1,0 +1,99 @@
+module HsBindgen.Frontend.Pass.TranslateTypes.IsPass (
+    -- * Definition
+    TranslateTypes
+  ) where
+
+import HsBindgen.BindingSpec qualified as BindingSpec
+import HsBindgen.Frontend.Pass.AdjustTypes.IsPass
+import HsBindgen.Frontend.Pass.MangleNames.IsPass
+import HsBindgen.Frontend.Pass.ResolveBindingSpecs.IsPass
+import HsBindgen.Frontend.Pass.TypecheckMacros.IsPass
+import HsBindgen.IR.C qualified as C
+import HsBindgen.IR.Pass
+import HsBindgen.IR.Translation
+
+{-------------------------------------------------------------------------------
+  Definition
+-------------------------------------------------------------------------------}
+
+type TranslateTypes :: Pass
+data TranslateTypes a
+
+type family AnnTranslateTypes ix where
+  AnnTranslateTypes "Decl"                 = PrescriptiveDeclSpec
+  AnnTranslateTypes "Enum"                 = NewtypeNames
+  AnnTranslateTypes "IndirectField"        = IndirectFieldNames TranslateTypes
+  AnnTranslateTypes "Flam"                 = FlamNames
+  AnnTranslateTypes "Struct"               = StructNames
+  AnnTranslateTypes "Typedef"              = TypedefNames
+  AnnTranslateTypes "TypecheckedMacroType" = NewtypeNames
+  AnnTranslateTypes "TypeFunArg"           = AdjustedFrom TranslateTypes
+  AnnTranslateTypes "Union"                = NewtypeNames
+  AnnTranslateTypes _                      = NoAnn
+
+instance IsPass TranslateTypes
+
+instance PassId TranslateTypes where
+  type Id TranslateTypes = DeclIdPair
+
+  idNameKind     _ namePair = namePair.cName.name.kind
+  idSourceName   _ namePair = C.declIdSourceName namePair.cName
+  idLocationInfo _ namePair = C.declIdLocationInfo namePair.cName
+
+instance PassScopedName TranslateTypes where
+  type ScopedName TranslateTypes = ScopedNamePair
+
+instance PassTypes TranslateTypes where
+  type Types TranslateTypes = TranslatedTypes TranslateTypes
+  type AnonRef TranslateTypes = TranslatedAnonRef TranslateTypes
+
+  cType _ translatedTypes = translatedTypes.c
+  anonRefTypes _ translatedAnonRef = TranslatedTypes {
+        c = C.anonRefType translatedAnonRef.c
+      }
+
+instance PassMacro TranslateTypes where
+  type MacroId         TranslateTypes = Id TranslateTypes
+  type MacroBody       TranslateTypes = TypecheckedMacro TranslateTypes
+  type MacroUnderlying TranslateTypes = C.Type TranslateTypes
+
+  macroIdId _ = id
+
+instance PassExtBinding TranslateTypes where
+  type ExtBinding TranslateTypes = BindingSpec.ResolvedExtBinding
+
+  extBindingId _ extBinding = extDeclIdPair extBinding
+
+instance PassCommentDecl TranslateTypes where
+  type CommentDecl TranslateTypes = Maybe (C.Comment TranslateTypes)
+
+instance PassAnn TranslateTypes where
+  type Ann ix TranslateTypes = AnnTranslateTypes ix
+
+instance PassMsg TranslateTypes
+
+{-------------------------------------------------------------------------------
+  CoercePass
+-------------------------------------------------------------------------------}
+
+instance CoercePassId      AdjustTypes TranslateTypes
+instance CoercePassMacroId AdjustTypes TranslateTypes
+
+instance CoercePassMacroUnderlying AdjustTypes TranslateTypes where
+  coercePassMacroUnderlying _ = coercePass
+
+instance CoercePassMacroBody AdjustTypes TranslateTypes where
+  coercePassMacroBody _ = coercePassParam
+
+instance CoercePassAnn "IndirectField" AdjustTypes TranslateTypes where
+  coercePassAnn _ = \case
+      IndirectFieldNames name -> IndirectFieldNames name
+
+instance CoercePassAnn "TypeFunArg" AdjustTypes TranslateTypes where
+  coercePassAnn _ = \case
+    AdjustedFromArray    ty -> AdjustedFromArray    (coercePass ty)
+    AdjustedFromFunction ty -> AdjustedFromFunction (coercePass ty)
+    NotAdjusted             -> NotAdjusted
+
+instance CoercePassCommentDecl AdjustTypes TranslateTypes where
+  coercePassCommentDecl _ = fmap coercePass

--- a/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Frontend/Pass/TypecheckMacros/IsPass.hs
@@ -13,6 +13,7 @@ import HsBindgen.Frontend.Pass.Parse.IsPass (ReparseInfo, Tokens)
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef)
 import HsBindgen.Macro.Type qualified as Macro
 
 {-------------------------------------------------------------------------------
@@ -39,6 +40,8 @@ instance IsPass TypecheckMacros
 instance PassId TypecheckMacros
 
 instance PassScopedName TypecheckMacros
+
+instance PassTypes TypecheckMacros
 
 instance PassMacro TypecheckMacros where
   type MacroId   TypecheckMacros = Id TypecheckMacros
@@ -139,7 +142,9 @@ instance CoercePassId p p' => CoercePass (TypecheckedMacroValue l) p p' where
   CoercePass: ConstructTranslationUnit → TypecheckMacros
 -------------------------------------------------------------------------------}
 
+instance CoercePassAnonRef          ConstructTranslationUnit TypecheckMacros
 instance CoercePassId               ConstructTranslationUnit TypecheckMacros
+instance CoercePassTypes            ConstructTranslationUnit TypecheckMacros
 instance CoercePassMacroId          ConstructTranslationUnit TypecheckMacros where
     coercePassMacroId _ = absurd
 instance CoercePassMacroUnderlying  ConstructTranslationUnit TypecheckMacros

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
@@ -43,7 +43,6 @@ module HsBindgen.IR.C.Decl (
   , elimField
   , RegularField(..)
   , ImplicitField(..)
-  , AnonRef(..)
   , IndirectField(..)
     -- ** Comments
   , Comment(..)
@@ -60,9 +59,9 @@ import Clang.HighLevel.Types
 import HsBindgen.Imports
 import HsBindgen.IR.C.HashIncludeArg qualified as C
 import HsBindgen.IR.C.Naming qualified as C
-import HsBindgen.IR.C.Type (CoercePassExtBindingRef (coercePassExtBindingRef))
 import HsBindgen.IR.C.Type qualified as C
 import HsBindgen.IR.Pass
+import HsBindgen.IR.Pass.Types (CoercePassAnonRef (coercePassAnonRef))
 import HsBindgen.Language.C (PrimType)
 import HsBindgen.Macro.Type qualified as Macro
 
@@ -257,15 +256,14 @@ data Union (p :: Pass) = Union {
     }
   deriving stock (Generic)
 
-
 data Typedef (p :: Pass) = Typedef {
-      typ :: C.Type p
+      typ :: Types p
     , ann :: Ann "Typedef" p
     }
   deriving stock (Generic)
 
 data Enum (p :: Pass) = Enum {
-      typ       :: C.Type p
+      typ       :: Types p
     , sizeof    :: Int
     , alignment :: Int
     , constants :: [EnumConstant p]
@@ -291,7 +289,7 @@ data UntaggedEnumConstant (p :: Pass) = UntaggedEnumConstant {
 
 data Function (p :: Pass) = Function {
       args  :: [FunctionArg p]
-    , res   :: C.Type p
+    , res   :: Types p
     , attrs :: FunctionAttributes
     , ann   :: Ann "Function" p
     }
@@ -310,20 +308,21 @@ data Function (p :: Pass) = Function {
 -- Both of these types use the @TypeFunArg@ annotation, however.
 data FunctionArg (p :: Pass) = FunctionArg {
       name :: Maybe (ScopedName p)
-    , typ  :: C.Type p
+    , typ  :: Types p
     , ann  :: Ann "TypeFunArg" p
     }
     deriving stock (Generic)
 
 -- | Get the type of a function declaration
-typeOfFunction :: Function p -> C.Type p
-typeOfFunction fun = C.TypeFun (map typeOfFunctionArg fun.args) fun.res
+typeOfFunction :: forall p. PassTypes p => Function p -> C.Type p
+typeOfFunction fun =
+    C.TypeFun (map typeOfFunctionArg fun.args) (cType (Proxy @p) fun.res)
 
 -- | Get the type of a function argument
-typeOfFunctionArg :: FunctionArg p -> C.TypeFunArg p
+typeOfFunctionArg :: forall p. PassTypes p => FunctionArg p -> C.TypeFunArg p
 typeOfFunctionArg functionArg =
     C.TypeFunArgF{
-        typ = functionArg.typ
+        typ = cType (Proxy @p) functionArg.typ
       , ann = functionArg.ann
       }
 
@@ -423,7 +422,7 @@ decideFunctionPurity = foldr prefer ImpureFunction
       CPureFunction -> ()
 
 data Global (p :: Pass) = Global {
-      typ :: C.Type p
+      typ :: Types p
     , ann :: Ann "Global" p
     }
   deriving stock (Generic)
@@ -440,7 +439,7 @@ data Field p =
 instance HasField "info" (Field p) (FieldInfo p) where
   getField = elimField (.info) (.info)
 
-instance HasField "typ" (Field p) (C.Type p) where
+instance (ty ~ Types p, PassTypes p) => HasField "typ" (Field p) ty where
   getField = elimField (.typ) (.typ)
 
 instance HasField "offset" (Field p) Int where
@@ -475,7 +474,7 @@ elimField f g = \case
 
 data RegularField p = RegularField {
       info   :: FieldInfo p
-    , typ    :: C.Type p
+    , typ    :: Types p
       -- | Offset in bits
     , offset :: Int
     , width  :: Maybe Int
@@ -498,19 +497,10 @@ data ImplicitField p = ImplicitField {
     }
     deriving stock (Generic)
 
--- | A reference to an anonymous struct or union
-data AnonRef p =
-    AnonRef (Id p)
-    -- NOTE: strictness annotations help GHC infer redundant pattern matches
-  | AnonExtBinding !(C.ExtBindingRef p)
-
--- | Implicit fields can only refer to anonymous structs or unions, so the type
--- of the field is always @TypeRef typRef@. Use the @typRef@ field to access the
--- reference directly.
-instance HasField "typ" (ImplicitField p) (C.Type p) where
-  getField x = case x.typRef of
-      AnonRef ref -> C.TypeRef ref
-      AnonExtBinding ext -> C.TypeExtBinding ext
+-- | Implicit fields can only refer to anonymous structs or unions. Use the
+-- @typRef@ field to access the reference directly.
+instance (ty ~ Types p, PassTypes p) => HasField "typ" (ImplicitField p) ty where
+  getField x = anonRefTypes (Proxy @p) x.typRef
 
 -- | Implicit fields can only refer to anonymous structs or unions, so they have
 -- no bit width.
@@ -521,7 +511,7 @@ instance HasField "width" (ImplicitField p) (Maybe Int) where
 -- be accessed /as if/ it were a member of the enclosing struct\/union
 data IndirectField p = IndirectField {
       info   :: FieldInfo p
-    , typ    :: C.Type p
+    , typ    :: Types p
       -- | Offset in bits
     , offset :: Int
     , width  :: Maybe Int
@@ -560,7 +550,6 @@ data CommentRef p = CommentRef Text (Maybe (Id p)) (Maybe Doxy.RefKind)
   Eq and Show instances
 -------------------------------------------------------------------------------}
 
-deriving stock instance IsPass p => Eq (AnonRef              p)
 deriving stock instance IsPass p => Eq (Comment              p)
 deriving stock instance IsPass p => Eq (CommentRef           p)
 deriving stock instance IsPass p => Eq (DeclInfo             p)
@@ -580,7 +569,6 @@ deriving stock instance IsPass p => Eq (Typedef              p)
 deriving stock instance IsPass p => Eq (Union                p)
 deriving stock instance IsPass p => Eq (UntaggedEnumConstant p)
 
-deriving stock instance IsPass p => Show (AnonRef              p)
 deriving stock instance IsPass p => Show (Comment              p)
 deriving stock instance IsPass p => Show (CommentRef           p)
 deriving stock instance IsPass p => Show (DeclInfo             p)
@@ -714,12 +702,12 @@ instance (
 
 instance (
       CoercePass FieldInfo p p'
-    , CoercePass C.Type p p'
+    , CoercePassTypes p p'
     , Ann "RegularField" p ~ Ann "RegularField" p'
     ) => CoercePass RegularField p p' where
   coercePass field = RegularField {
         info = coercePass field.info
-      , typ = coercePass field.typ
+      , typ = coercePassTypes (Proxy @'(p, p')) field.typ
       , offset = field.offset
       , width = field.width
       , ann = field.ann
@@ -727,57 +715,49 @@ instance (
 
 instance (
       CoercePass FieldInfo p p'
-    , CoercePass AnonRef p p'
+    , CoercePassAnonRef p p'
     , CoercePass IndirectField p p'
     , Ann "ImplicitField" p ~ Ann "ImplicitField" p'
     ) => CoercePass ImplicitField p p' where
   coercePass field = ImplicitField {
         info = coercePass field.info
-      , typRef = coercePass field.typRef
+      , typRef = coercePassAnonRef (Proxy @'(p, p')) field.typRef
       , offset = field.offset
       , indirect = fmap coercePass field.indirect
       , ann = field.ann
       }
 
 instance (
-      CoercePassId p p'
-    , CoercePassExtBindingRef p p'
-    ) => CoercePass AnonRef p p' where
-  coercePass = \case
-      AnonRef ref -> AnonRef $ coercePassId (Proxy @'(p, p')) ref
-      AnonExtBinding ext -> AnonExtBinding $ coercePassExtBindingRef ext
-
-instance (
       CoercePass FieldInfo p p'
-    , CoercePass C.Type p p'
-    , CoercePass AnonRef p p'
+    , CoercePassTypes p p'
+    , CoercePassAnonRef p p'
     , CoercePassAnn "IndirectField" p p'
     ) => CoercePass IndirectField p p' where
   coercePass field = IndirectField {
         info = coercePass field.info
-      , typ = coercePass field.typ
+      , typ = coercePassTypes (Proxy @'(p, p')) field.typ
       , offset = field.offset
       , width = field.width
-      , path = fmap coercePass field.path
+      , path = fmap (coercePassAnonRef (Proxy @'(p, p'))) field.path
       , ann = coercePassAnn (Proxy @'("IndirectField", p, p')) field.ann
       }
 
 instance (
-      CoercePass C.Type p p'
+      CoercePassTypes p p'
     , Ann "Typedef" p ~ Ann "Typedef" p'
     ) => CoercePass Typedef p p' where
   coercePass typedef = Typedef{
-        typ = coercePass typedef.typ
+        typ = coercePassTypes (Proxy @'(p, p')) typedef.typ
       , ann = typedef.ann
       }
 
 instance (
-       CoercePass C.Type p p'
+       CoercePassTypes p p'
      , CoercePass EnumConstant p p'
      , Ann "Enum" p ~ Ann "Enum" p'
      ) => CoercePass Enum p p' where
   coercePass enum = Enum{
-        typ       = coercePass enum.typ
+        typ       = coercePassTypes (Proxy @'(p, p')) enum.typ
       , constants = coercePass <$> enum.constants
       , sizeof    = enum.sizeof
       , alignment = enum.alignment
@@ -803,46 +783,35 @@ instance (
       }
 
 instance (
-      CoercePassId p p'
-    , CoercePassMacroId p p'
-    , CoercePassMacroUnderlying p p'
+      CoercePassTypes p p'
     , CoercePassAnn "TypeFunArg" p p'
     , ScopedName p ~ ScopedName p'
-    , ExtBinding p ~ ExtBinding p'
     , Ann "Function" p ~ Ann "Function" p'
     ) => CoercePass Function p p' where
   coercePass function = Function{
         args  = map coercePass function.args
-      , res   = coercePass function.res
+      , res   = coercePassTypes (Proxy @'(p, p')) function.res
       , attrs = function.attrs
       , ann   = function.ann
       }
 
 instance (
-      CoercePassId p p'
-    , CoercePassMacroId p p'
-    , CoercePassMacroUnderlying p p'
+      CoercePassTypes p p'
     , CoercePassAnn "TypeFunArg" p p'
     , ScopedName p ~ ScopedName p'
-    , ExtBinding p ~ ExtBinding p'
     ) => CoercePass FunctionArg p p' where
   coercePass functionArg = FunctionArg{
         name = functionArg.name
-      , typ  = coercePass functionArg.typ
+      , typ  = coercePassTypes (Proxy @'(p, p')) functionArg.typ
       , ann  = coercePassAnn (Proxy @'("TypeFunArg", p, p')) functionArg.ann
       }
 
 instance (
-      CoercePassId p p'
-    , CoercePassMacroId p p'
-    , CoercePassMacroUnderlying p p'
-    , CoercePassAnn "TypeFunArg" p p'
-    , ScopedName p ~ ScopedName p'
-    , ExtBinding p ~ ExtBinding p'
+      CoercePassTypes p p'
     , Ann "Global" p ~ Ann "Global" p'
     ) => CoercePass Global p p' where
   coercePass global = Global{
-        typ = coercePass global.typ
+        typ = coercePassTypes (Proxy @'(p, p')) global.typ
       , ann = global.ann
       }
 

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Decl.hs
@@ -30,6 +30,8 @@ module HsBindgen.IR.C.Decl (
   , UntaggedEnumConstant(..)
   , Function(..)
   , FunctionArg(..)
+  , typeOfFunction
+  , typeOfFunctionArg
   , FunctionAttributes(..)
   , FunctionPurity(..)
   , decideFunctionPurity
@@ -295,11 +297,35 @@ data Function (p :: Pass) = Function {
     }
   deriving stock (Generic)
 
+-- | Function argument
+--
+-- Separate types are used to represent function arguments in declarations and
+-- function arguments in types ('HsBindgen.IR.C.Type.TypeFunArg').
+--
+-- * An argument in a declaration may have a name, while type arguments do not
+--   have names.
+-- * We translate declaration arguments to Haskell, while recursively
+--   translating type arguments is not necessary.
+--
+-- Both of these types use the @TypeFunArg@ annotation, however.
 data FunctionArg (p :: Pass) = FunctionArg {
-      name   :: Maybe (ScopedName p)
-    , argTyp :: C.TypeFunArg p
+      name :: Maybe (ScopedName p)
+    , typ  :: C.Type p
+    , ann  :: Ann "TypeFunArg" p
     }
     deriving stock (Generic)
+
+-- | Get the type of a function declaration
+typeOfFunction :: Function p -> C.Type p
+typeOfFunction fun = C.TypeFun (map typeOfFunctionArg fun.args) fun.res
+
+-- | Get the type of a function argument
+typeOfFunctionArg :: FunctionArg p -> C.TypeFunArg p
+typeOfFunctionArg functionArg =
+    C.TypeFunArgF{
+        typ = functionArg.typ
+      , ann = functionArg.ann
+      }
 
 -- | Function attributes specify properties for C functions
 --
@@ -801,8 +827,9 @@ instance (
     , ExtBinding p ~ ExtBinding p'
     ) => CoercePass FunctionArg p p' where
   coercePass functionArg = FunctionArg{
-        name   = functionArg.name
-      , argTyp = coercePass functionArg.argTyp
+        name = functionArg.name
+      , typ  = coercePass functionArg.typ
+      , ann  = coercePassAnn (Proxy @'("TypeFunArg", p, p')) functionArg.ann
       }
 
 instance (

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
@@ -38,6 +38,7 @@ module HsBindgen.IR.C.Type (
   , MacroRef(..)
   , TypedefRef
   , ExtBindingRef
+  , AnonRef (..)
 
     -- * Normal forms
   , Normalize(..)
@@ -329,6 +330,15 @@ type TypedefRef p = Ref (Id p) p
 --
 -- > Ref { name = ResolvedBinding "S", underlying = TypeRef ("S", StructKind) }
 type ExtBindingRef p = Ref (ExtBinding p) p
+
+-- | A reference to an anonymous struct or union
+data AnonRef p =
+    AnonRef (Id p)
+    -- NOTE: strictness annotations help GHC infer redundant pattern matches
+  | AnonExtBinding !(ExtBindingRef p)
+
+deriving instance (Eq (Id p), Eq (ExtBindingRef p)) => Eq (AnonRef p)
+deriving instance (Show (Id p), Show (ExtBindingRef p)) => Show (AnonRef p)
 
 {-------------------------------------------------------------------------------
   Normal forms
@@ -866,6 +876,14 @@ instance (
 
       goMacroUnderlying :: MacroUnderlying p -> MacroUnderlying p'
       goMacroUnderlying = coercePassMacroUnderlying (Proxy @'(p, p'))
+
+instance (
+      CoercePassId p p'
+    , CoercePassExtBindingRef p p'
+    ) => CoercePass AnonRef p p' where
+  coercePass = \case
+      AnonRef ref -> AnonRef $ coercePassId (Proxy @'(p, p')) ref
+      AnonExtBinding ext -> AnonExtBinding $ coercePassExtBindingRef ext
 
 class CoercePassExtBindingRef p p' where
   coercePassExtBindingRef :: ExtBindingRef p -> ExtBindingRef p'

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
@@ -167,6 +167,16 @@ deriving stock instance ValidTypeTag tag p => Show (TypeF tag p)
 type TypeFunArg = TypeFunArgF Full
 
 -- | C types in function argument positions
+--
+-- Separate types are used to represent function arguments in declarations
+-- ('HsBindgen.IR.C.Decl.FunctionArg') and function arguments in types.
+--
+-- * An argument in a declaration may have a name, while type arguments do not
+--   have names.
+-- * We translate declaration arguments to Haskell, while recursively
+--   translating type arguments is not necessary.
+--
+-- Both of these types use the @TypeFunArg@ annotation, however.
 data TypeFunArgF (tag :: TypeTag) (p :: Pass) = TypeFunArgF {
     typ :: TypeF tag p
   , ann :: Ann "TypeFunArg" p

--- a/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/C/Type.hs
@@ -39,6 +39,7 @@ module HsBindgen.IR.C.Type (
   , TypedefRef
   , ExtBindingRef
   , AnonRef (..)
+  , anonRefType
 
     -- * Normal forms
   , Normalize(..)
@@ -336,6 +337,11 @@ data AnonRef p =
     AnonRef (Id p)
     -- NOTE: strictness annotations help GHC infer redundant pattern matches
   | AnonExtBinding !(ExtBindingRef p)
+
+anonRefType :: AnonRef p -> Type p
+anonRefType = \case
+    AnonRef ref -> TypeRef ref
+    AnonExtBinding ext -> TypeExtBinding ext
 
 deriving instance (Eq (Id p), Eq (ExtBindingRef p)) => Eq (AnonRef p)
 deriving instance (Show (Id p), Show (ExtBindingRef p)) => Show (AnonRef p)

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass.hs
@@ -16,6 +16,7 @@ module HsBindgen.IR.Pass (
   , IsPass
   , PassId(..)
   , PassScopedName(..)
+  , PassTypes(..)
   , PassMacro(..)
   , PassExtBinding(..)
   , PassCommentDecl(..)
@@ -26,6 +27,7 @@ module HsBindgen.IR.Pass (
   , CoercePass(..)
   , CoercePassParam(..)
   , CoercePassId(..)
+  , CoercePassTypes(..)
   , CoercePassMacroId(..)
   , CoercePassMacroBody(..)
   , CoercePassMacroUnderlying(..)
@@ -44,6 +46,7 @@ import HsBindgen.IR.Pass.Id
 import HsBindgen.IR.Pass.Macro
 import HsBindgen.IR.Pass.Msg
 import HsBindgen.IR.Pass.ScopedName
+import HsBindgen.IR.Pass.Types
 
 {-------------------------------------------------------------------------------
   Associated type families
@@ -62,4 +65,5 @@ class (
     , PassMacro       p
     , PassMsg         p
     , PassScopedName  p
+    , PassTypes       p
     ) => IsPass (p :: Pass)

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass/Ann.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass/Ann.hs
@@ -32,12 +32,12 @@ class (
     , Eq   (Ann "IndirectField"        p)
     , Eq   (Ann "RegularField"         p)
     , Eq   (Ann "Struct"               p)
-    , Eq   (Ann "TypeFunArg"           p)
     , Eq   (Ann "TypecheckedMacroType" p)
     , Eq   (Ann "Typedef"              p)
     , Eq   (Ann "Union"                p)
 
       -- For de-duplicating types
+    , Eq   (Ann "TypeFunArg"           p)
     , Ord  (Ann "TypeFunArg"           p)
 
       -- For debugging

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass/Types.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass/Types.hs
@@ -53,9 +53,7 @@ class (
     => Proxy p
     -> AnonRef p
     -> Types p
-  anonRefTypes _ = \case
-      C.AnonRef ref -> C.TypeRef ref
-      C.AnonExtBinding ext -> C.TypeExtBinding ext
+  anonRefTypes _ = C.anonRefType
 
 {-------------------------------------------------------------------------------
   Coercion

--- a/hs-bindgen/src-internal/HsBindgen/IR/Pass/Types.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Pass/Types.hs
@@ -1,0 +1,78 @@
+-- | Types (use sites)
+--
+-- This module should only be used within the @HsBindgen.IR@ hierarchy.  From
+-- outside the @HsBindgen.IR@ hierarchy, "HsBindgen.IR.Pass" should be used.
+--
+-- Intended for unqualified import.
+--
+-- > import HsBindgen.IR.Pass.Types
+module HsBindgen.IR.Pass.Types (
+    -- * Associated type families
+    PassTypes(..)
+    -- * Coercion
+  , CoercePassTypes(..)
+  , CoercePassAnonRef(..)
+  ) where
+
+import HsBindgen.Imports
+import HsBindgen.IR.C.Type qualified as C
+import HsBindgen.IR.Pass.Definition
+
+{-------------------------------------------------------------------------------
+  Associated type families
+-------------------------------------------------------------------------------}
+
+-- | Types (use sites) vary across passes
+class (
+      Eq   (AnonRef p)
+    , Eq   (Types p)
+
+    -- For debugging
+    , Show (AnonRef p)
+    , Show (Types p)
+    ) => PassTypes (p :: Pass) where
+
+  -- | Types (use sites)
+  --
+  -- 1. After 'HsBindgen.Frontend.Pass.Parse.IsPass.Parse', this is
+  --    @'C.Type' p@.
+  type Types p :: Star
+  type Types p = C.Type p
+
+  type AnonRef p :: Star
+  type AnonRef p = C.AnonRef p
+
+  -- | C type
+  cType :: Proxy p -> Types p -> C.Type p
+  default cType :: Types p ~ C.Type p => Proxy p -> Types p -> C.Type p
+  cType _ = id
+
+  anonRefTypes :: Proxy p -> AnonRef p -> Types p
+  default anonRefTypes ::
+       (AnonRef p ~ C.AnonRef p, Types p ~ C.Type p)
+    => Proxy p
+    -> AnonRef p
+    -> Types p
+  anonRefTypes _ = \case
+      C.AnonRef ref -> C.TypeRef ref
+      C.AnonExtBinding ext -> C.TypeExtBinding ext
+
+{-------------------------------------------------------------------------------
+  Coercion
+-------------------------------------------------------------------------------}
+
+class CoercePassTypes (p :: Pass) (p' :: Pass) where
+  coercePassTypes :: Proxy '(p, p') -> Types p -> Types p'
+
+  default coercePassTypes ::
+       (CoercePass C.Type p p', Types p ~ C.Type p, Types p' ~ C.Type p')
+    => Proxy '(p, p') -> Types p -> Types p'
+  coercePassTypes _ = coercePass
+
+class CoercePassAnonRef (p :: Pass) (p' :: Pass) where
+  coercePassAnonRef :: Proxy '(p, p') -> AnonRef p -> AnonRef p'
+
+  default coercePassAnonRef ::
+       (CoercePass C.AnonRef p p', AnonRef p ~ C.AnonRef p, AnonRef p' ~ C.AnonRef p')
+    => Proxy '(p, p') -> AnonRef p -> AnonRef p'
+  coercePassAnonRef _ = coercePass

--- a/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
@@ -4,17 +4,20 @@
 --
 -- > import HsBindgen.IR.Translation
 module HsBindgen.IR.Translation (
-    -- * Types
+    -- * DeclIdPair
     DeclIdPair(..)
+  , extDeclIdPair
+    -- * ScopedNamePair
   , ScopedNamePair(..)
   ) where
 
+import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
 import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
-  Types
+  DeclIdPair
 -------------------------------------------------------------------------------}
 
 -- | A t'C.DeclId' paired with a Haskell name
@@ -24,7 +27,16 @@ data DeclIdPair = DeclIdPair {
     }
   deriving stock (Eq, Ord, Show)
 
---------------------------------------------------------------------------------
+-- | Get the 'DeclIdPair' for a 'ResolvedExtBinding'
+extDeclIdPair :: BindingSpec.ResolvedExtBinding -> DeclIdPair
+extDeclIdPair ext = DeclIdPair{
+      cName  = ext.cName
+    , hsName = Hs.demoteNs ext.hsName.name
+    }
+
+{-------------------------------------------------------------------------------
+  ScopedNamePair
+-------------------------------------------------------------------------------}
 
 -- | A t'C.ScopedName' paired with a Haskell name
 data ScopedNamePair = ScopedNamePair {

--- a/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
@@ -9,6 +9,7 @@ module HsBindgen.IR.Translation (
   , extDeclIdPair
     -- * ScopedNamePair
   , ScopedNamePair(..)
+    -- * TranslatedTypes
   , TranslatedTypes(..)
   , TranslatedAnonRef(..)
   , translatedAnonRefType
@@ -59,7 +60,7 @@ data ScopedNamePair = ScopedNamePair {
 -- | A t'C.Type' associated with possible Haskell type translations
 data TranslatedTypes (p :: Pass) = TranslatedTypes {
       c :: C.Type p
---    , hs :: Hs.Type    -- TODO
+--    , hs :: Hs.Type    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1599>
     }
   deriving stock (Eq, Generic, Show)
 
@@ -73,7 +74,7 @@ instance (
 -- | A t'C.AnonRef' associated with possible Haskell type translations
 data TranslatedAnonRef (p :: Pass) = TranslatedAnonRef {
       c :: C.AnonRef p
---    , hs :: Hs.Type    -- TODO
+--    , hs :: Hs.Type    -- TODO <https://github.com/well-typed/hs-bindgen/issues/1599>
     }
   deriving stock (Eq, Generic, Show)
 

--- a/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
+++ b/hs-bindgen/src-internal/HsBindgen/IR/Translation.hs
@@ -9,11 +9,15 @@ module HsBindgen.IR.Translation (
   , extDeclIdPair
     -- * ScopedNamePair
   , ScopedNamePair(..)
+  , TranslatedTypes(..)
+  , TranslatedAnonRef(..)
+  , translatedAnonRefType
   ) where
 
 import HsBindgen.BindingSpec qualified as BindingSpec
 import HsBindgen.Imports
 import HsBindgen.IR.C qualified as C
+import HsBindgen.IR.Pass
 import HsBindgen.Language.Haskell qualified as Hs
 
 {-------------------------------------------------------------------------------
@@ -47,3 +51,40 @@ data ScopedNamePair = ScopedNamePair {
     , hsName :: Hs.SomeName
     }
   deriving stock (Eq, Generic, Ord, Show)
+
+{-------------------------------------------------------------------------------
+  TranslatedTypes
+-------------------------------------------------------------------------------}
+
+-- | A t'C.Type' associated with possible Haskell type translations
+data TranslatedTypes (p :: Pass) = TranslatedTypes {
+      c :: C.Type p
+--    , hs :: Hs.Type    -- TODO
+    }
+  deriving stock (Eq, Generic, Show)
+
+instance (
+      CoercePass C.Type p p'
+    ) => CoercePass TranslatedTypes p p' where
+  coercePass translatedTypes = TranslatedTypes{
+      c = coercePass translatedTypes.c
+    }
+
+-- | A t'C.AnonRef' associated with possible Haskell type translations
+data TranslatedAnonRef (p :: Pass) = TranslatedAnonRef {
+      c :: C.AnonRef p
+--    , hs :: Hs.Type    -- TODO
+    }
+  deriving stock (Eq, Generic, Show)
+
+instance (
+      CoercePass C.AnonRef p p'
+    ) => CoercePass TranslatedAnonRef p p' where
+  coercePass translatedAnonRef = TranslatedAnonRef {
+      c = coercePass translatedAnonRef.c
+    }
+
+translatedAnonRefType :: TranslatedAnonRef p -> TranslatedTypes p
+translatedAnonRefType translatedAnonRef = TranslatedTypes {
+      c = C.anonRefType translatedAnonRef.c
+    }


### PR DESCRIPTION
Part of #1599

The pass infrastructure is in place, but we do not yet translate C types to Haskell types in the frontend.

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.