### PR TITLE
`Golden`: set trace verbosity to `Debug`

### DIFF
--- a/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Predicate.hs
+++ b/hs-bindgen/test/common/Test/Common/HsBindgen/Trace/Predicate.hs
@@ -201,7 +201,9 @@ withTraceConfigPredicate report (TracePredicate customLogLevel predicate) action
         tracerConfig :: TracerConfig l a
         tracerConfig = def {
             customLogLevel = customLogLevel
-          , verbosity      = Verbosity Info
+            -- The verbosity is @Debug@ so that trace predicates can match on
+            -- trace messages of /every/ log level.
+          , verbosity      = Verbosity Debug
           , outputConfig   = OutputConfigCustom OutputCustom{
                 report    = writer
               , ansiColor = DisableAnsiColor

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
@@ -206,18 +206,22 @@ multiTracePredicate_custom expected predicate = multiTracePredicate expected pre
     -- below, this predicate marks all reparse-related trace messages as
     -- unexpected so that we can precisely test every message
     defaultPredicate :: TraceMsg -> Maybe (TraceExpectation b)
-    defaultPredicate = \case
-        -- Parse (macro)
-        MatchDelayed _info ParseMacroErrorParse{} ->
-          Just Unexpected
-        -- PrepareReparse
-        MatchImmediatePrepareReparse _ ->
-          Just Unexpected
-        MatchDelayedPrepareReparse _info _ ->
-          Just Unexpected
-        -- ReparseMacroExpansions
-        MatchImmediateReparseMacroExpansions _ ->
-          Just Unexpected
-        MatchDelayedReparseMacroExpansions _info _ ->
-          Just Unexpected
-        _ -> Nothing
+    defaultPredicate x
+      | getDefaultLogLevel x == Debug
+      = Just Tolerated
+      | otherwise
+      = case x of
+          -- Parse (macro)
+          MatchDelayed _info ParseMacroErrorParse{} ->
+            Just Unexpected
+          -- PrepareReparse
+          MatchImmediatePrepareReparse _ ->
+            Just Unexpected
+          MatchDelayedPrepareReparse _info _ ->
+            Just Unexpected
+          -- ReparseMacroExpansions
+          MatchImmediateReparseMacroExpansions _ ->
+            Just Unexpected
+          MatchDelayedReparseMacroExpansions _info _ ->
+            Just Unexpected
+          _ -> Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Reparse.hs
@@ -108,18 +108,22 @@ multiTracePredicate_nesting expected predicate = multiTracePredicate expected pr
     -- below, this predicate marks all reparse-related trace messages as
     -- unexpected so that we can precisely test every message
     defaultPredicate :: TraceMsg -> Maybe (TraceExpectation b)
-    defaultPredicate = \case
-        -- Parse (macro)
-        MatchDelayed _info ParseMacroErrorParse{} ->
-          Just Unexpected
-        -- PrepareReparse
-        MatchImmediatePrepareReparse _ ->
-          Just Unexpected
-        MatchDelayedPrepareReparse _info _ ->
-          Just Unexpected
-        -- ReparseMacroExpansions
-        MatchImmediateReparseMacroExpansions _ ->
-          Just Unexpected
-        MatchDelayedReparseMacroExpansions _info _ ->
-          Just Unexpected
-        _ -> Nothing
+    defaultPredicate x
+      | getDefaultLogLevel x == Debug
+      = Just Tolerated
+      | otherwise
+      = case x of
+          -- Parse (macro)
+          MatchDelayed _info ParseMacroErrorParse{} ->
+            Just Unexpected
+          -- PrepareReparse
+          MatchImmediatePrepareReparse _ ->
+            Just Unexpected
+          MatchDelayedPrepareReparse _info _ ->
+            Just Unexpected
+          -- ReparseMacroExpansions
+          MatchImmediateReparseMacroExpansions _ ->
+            Just Unexpected
+          MatchDelayedReparseMacroExpansions _info _ ->
+            Just Unexpected
+          _ -> Nothing


### PR DESCRIPTION
So that we can write trace predicates on debug-level trace messages.

This doesn't affect existing tests because default trace predicates mark debug-level messages as `Tolerated`. There are two exceptions where a custom trace predicate would mark debug-level messages as `Unexpected`, but these were easily fixed.

I was racking my brain for quite a while over why I couldn't write trace predicates over debug-level trace message in golden tests, and the verbosity setting was why. Hopefully by changing the verbosity to `Debug` now, others won't run into the same issue in the future.


---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.