### PR TITLE
`UniqueExpansions`: support variadic macros

### DIFF
--- a/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Parse.hs
@@ -10,8 +10,8 @@ module HsBindgen.Clang.Macros.UniqueExpansion.Parse (
 
 import Control.Monad (guard, unless)
 import Data.Maybe (catMaybes)
-import Text.Parsec (anyToken, choice, lookAhead, many, manyTill, parserFail,
-                    sepBy, try)
+import Text.Parsec (anyToken, choice, lookAhead, many, manyTill, option, sepBy,
+                    try, unexpected)
 
 import Clang.Enum.Simple (fromSimpleEnum)
 import Clang.HighLevel.Types (MultiLoc (multiLocExpansion),
@@ -35,20 +35,30 @@ import HsBindgen.Clang.Macros.UniqueExpansion.Types (Definition (..),
 parseDefinition :: Parser Definition
 parseDefinition = do
     (macroLocRange, macroName) <- parseLocName
-    let
-        functionLike :: Parser Definition
-        functionLike = do
-          noWhitespace macroLocRange
-          paramNames <- parseParams
-          macroBody <- parseBody paramNames
-          pure $ Definition { name = macroName, params = paramNames, body = macroBody }
+    isFunction <- isFunctionLike macroLocRange
+    params <-
+      if isFunction then parseParams else pure []
+    macroBody <- parseBody params
+    pure Definition {
+        name = macroName
+      , params = params
+      , body = macroBody
+      }
 
-        objectLike :: Parser Definition
-        objectLike = do
-          let paramNames = []
-          macroBody <- parseBody paramNames
-          pure $ Definition { name = macroName, params = paramNames, body = macroBody }
-    choice [try functionLike, objectLike]
+-- | Check if a macro definition is function-like. If not, then the definition
+-- is object-like.
+--
+-- A macro definition is function-like if the macro definition's name is
+-- followed immediately by a ( character without any whitespace in between. See
+-- 'lparen'.
+--
+-- @isFunctionLike@ does not consume input.
+isFunctionLike ::
+     -- | Source location of the macro definition's name
+     Range MultiLoc
+  -> Parser Bool
+isFunctionLike prevRange =
+    lookAhead (option False (True <$ try (lparen prevRange)))
 
 parseBody :: [Name] -> Parser [Var]
 parseBody params = catMaybes <$> many (choice [parseVar, parseNonVar])
@@ -107,30 +117,27 @@ parseArgs = fmap concat $ do
       (try (punctuation ")"))
 
 {-------------------------------------------------------------------------------
-  Whitespace
+  Punctuation
 -------------------------------------------------------------------------------}
 
--- | Check that there is no whitespace between the previous token and the current
--- token
+-- | Parse a ( character not immediately preceded by white space
 --
--- Function-like macros are only function-like if there is /no/ whitespace
--- between the macro name and the opening parenthesis of the parameter list.
+-- @lparen@ consumes input when it fails. Combine with @try@ if this is
+-- undesirable.
+--
+-- NOTE: @lparen@ is defined in the C reference
 --
 -- We used to not check whitespace, which was the source of a bug. See issue
 -- #1903: <https://github.com/well-typed/hs-bindgen/issues/1903>
-noWhitespace ::
-     -- | Source range for the previous token
-     Range MultiLoc
-  -> Parser ()
-noWhitespace prevRange = lookAhead $ do
+lparen :: Range MultiLoc -> Parser ()
+lparen prevRange = do
     tok <- anyToken
     let prev    = prevRange.rangeEnd.multiLocExpansion
         current = tok.tokenExtent.rangeStart.multiLocExpansion
         p       = prev.singleLocPath   == current.singleLocPath &&
                   prev.singleLocLine   == current.singleLocLine &&
                   prev.singleLocColumn == current.singleLocColumn
-    unless p $
-      parserFail "unexpected whitespace"
+    unless p $ unexpected "whitespace before lparen"
 
 {-------------------------------------------------------------------------------
   Identifiers

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Parse.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Parse.hs
@@ -10,8 +10,8 @@ module HsBindgen.Clang.Macros.UniqueExpansion.Parse (
 
 import Control.Monad (guard, unless)
 import Data.Maybe (catMaybes)
-import Text.Parsec (anyToken, choice, lookAhead, many, manyTill, option, sepBy,
-                    try, unexpected)
+import Text.Parsec (anyToken, choice, lookAhead, many, manyTill, option,
+                    sepEndBy, try, unexpected)
 
 import Clang.Enum.Simple (fromSimpleEnum)
 import Clang.HighLevel.Types (MultiLoc (multiLocExpansion),
@@ -36,12 +36,13 @@ parseDefinition :: Parser Definition
 parseDefinition = do
     (macroLocRange, macroName) <- parseLocName
     isFunction <- isFunctionLike macroLocRange
-    params <-
-      if isFunction then parseParams else pure []
-    macroBody <- parseBody params
-    pure Definition {
+    (params, variadic) <-
+      if isFunction then parseParams else pure ([], False)
+    macroBody <- parseBody params variadic
+    pure $ Definition {
         name = macroName
       , params = params
+      , variadic = variadic
       , body = macroBody
       }
 
@@ -60,8 +61,8 @@ isFunctionLike ::
 isFunctionLike prevRange =
     lookAhead (option False (True <$ try (lparen prevRange)))
 
-parseBody :: [Name] -> Parser [Var]
-parseBody params = catMaybes <$> many (choice [parseVar, parseNonVar])
+parseBody :: [Name] -> Bool -> Parser [Var]
+parseBody params variadic = catMaybes <$> many (choice [parseVar, parseNonVar])
   where
     parseVar, parseNonVar :: Parser (Maybe Var)
     parseVar = Just . mkVar <$> parseName
@@ -69,8 +70,21 @@ parseBody params = catMaybes <$> many (choice [parseVar, parseNonVar])
 
     mkVar :: Name -> Var
     mkVar n
-      | n `elem` params = LocalParam n
-      | otherwise = FreeVar n
+      | n `elem` params
+      = LocalParam n
+
+      -- __VA_ARGS__ and __VA_OPT__ are reserved identifiers only in variadic
+      -- macro definitions. We mark them as @LocalParam@ simply to emphasise
+      -- that their expansion relies on parameters.
+      | variadic
+      , n == "__VA_ARGS__"
+      = LocalParam n
+      | variadic
+      , n == "__VA_OPT__"
+      = LocalParam n
+
+      | otherwise
+      = FreeVar n
 
 {-------------------------------------------------------------------------------
   Invocation
@@ -94,8 +108,14 @@ parseInvocation = do
   Parameters
 -------------------------------------------------------------------------------}
 
-parseParams :: Parser [Name]
-parseParams = parens $ parseName `sepBy` comma
+parseParams :: Parser ([Name], Bool)
+parseParams = parens $ do
+    paramNames <- sepEndBy parseName comma
+    variadic <- choice [
+        True <$ try (punctuation "...")
+      , pure False
+      ]
+    pure (paramNames, variadic)
 
 {-------------------------------------------------------------------------------
   Arguments

--- a/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Types.hs
+++ b/hs-bindgen/src-internal/HsBindgen/Clang/Macros/UniqueExpansion/Types.hs
@@ -12,9 +12,19 @@ import Data.String (IsString)
 import Data.Text (Text)
 
 data Definition = Definition {
-      name   :: Name
-    , params :: [Name]
-    , body   :: [Var]
+      name     :: Name
+    , params   :: [Name]
+      -- | A macro definition is variadic if it has @...@ at the end of its
+      -- parameter list
+      --
+      -- Variadic macros are technically a C99 feature, but @libclang@ has
+      -- backported them to C89 as well. We follow @libclang@ behaviour here,
+      -- and support variadic macros regardless of the C standard that is
+      -- configured (because C89 is the first standard).
+      --
+      -- <https://clang.llvm.org/docs/LanguageExtensions.html#language-extensions-back-ported-to-previous-standards>
+    , variadic :: Bool
+    , body     :: [Var]
     }
   deriving stock (Show, Eq)
 

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/Example.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.T(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T = T
+  { unwrapT :: BG.CInt
+  }
+  deriving stock (Eq, BG.Generic, Ord, Read, Show)
+  deriving newtype
+    ( BG.Bitfield
+    , BG.Bits
+    , Bounded
+    , Enum
+    , BG.FiniteBits
+    , BG.HasFFIType
+    , Integral
+    , BG.Ix
+    , Num
+    , BG.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , BG.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, BG.getField @"unwrapT" x0)
+
+instance (ty ~ BG.CInt) => BG.HasField "unwrapT" (BG.Ptr T) (BG.Ptr ty) where
+
+  getField = HasCField.fromPtr (BG.Proxy @"unwrapT")
+
+instance HasCField.HasCField T "unwrapT" where
+
+  type CFieldType T "unwrapT" = BG.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/bindingspec.yaml
@@ -1,0 +1,40 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/redeclaration/variadic.h
+  cname: T
+  hsname: T
+hstypes:
+- hsname: T
+  representation:
+    newtype:
+      constructor: T
+      fields:
+      - unwrapT
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.1.empty/th.txt
@@ -1,0 +1,33 @@
+-- addDependentFile test-artefacts/headers/golden/macros/redeclaration/variadic.h
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T
+    = T {unwrapT :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
+instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT")
+instance HasCField T "unwrapT"
+    where type CFieldType T "unwrapT" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/Example.hs
@@ -1,0 +1,77 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.iD
+    , Example.T(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+
+{-| __C declaration:__ @macro ID@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 3:9@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+iD :: [String]
+iD = ["(", "A", ",", "...", ")", "A", "__VA_ARGS__"]
+
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T = T
+  { unwrapT :: BG.CInt
+  }
+  deriving stock (Eq, BG.Generic, Ord, Read, Show)
+  deriving newtype
+    ( BG.Bitfield
+    , BG.Bits
+    , Bounded
+    , Enum
+    , BG.FiniteBits
+    , BG.HasFFIType
+    , Integral
+    , BG.Ix
+    , Num
+    , BG.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , BG.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, BG.getField @"unwrapT" x0)
+
+instance (ty ~ BG.CInt) => BG.HasField "unwrapT" (BG.Ptr T) (BG.Ptr ty) where
+
+  getField = HasCField.fromPtr (BG.Proxy @"unwrapT")
+
+instance HasCField.HasCField T "unwrapT" where
+
+  type CFieldType T "unwrapT" = BG.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/bindingspec.yaml
@@ -1,0 +1,40 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/redeclaration/variadic.h
+  cname: T
+  hsname: T
+hstypes:
+- hsname: T
+  representation:
+    newtype:
+      constructor: T
+      fields:
+      - unwrapT
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic.2.raw/th.txt
@@ -1,0 +1,47 @@
+-- addDependentFile test-artefacts/headers/golden/macros/redeclaration/variadic.h
+{-| __C declaration:__ @macro ID@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 3:9@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+iD :: [String]
+{-| __C declaration:__ @macro ID@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 3:9@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+iD = ["(", "A", ",", "...", ")", "A", "__VA_ARGS__"]
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T
+    = T {unwrapT :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
+instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT")
+instance HasCField T "unwrapT"
+    where type CFieldType T "unwrapT" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/Example.hs
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/Example.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Example
+    ( Example.T(..)
+    )
+  where
+
+import qualified HsBindgen.Runtime.HasCField as HasCField
+import qualified HsBindgen.Runtime.Marshal as Marshal
+import qualified HsBindgen.Runtime.Support as BG
+import qualified HsBindgen.Runtime.Support.CompatHasField as BG.CompatHasField
+
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T = T
+  { unwrapT :: BG.CInt
+  }
+  deriving stock (Eq, BG.Generic, Ord, Read, Show)
+  deriving newtype
+    ( BG.Bitfield
+    , BG.Bits
+    , Bounded
+    , Enum
+    , BG.FiniteBits
+    , BG.HasFFIType
+    , Integral
+    , BG.Ix
+    , Num
+    , BG.Prim
+    , Marshal.ReadRaw
+    , Real
+    , Marshal.StaticSize
+    , BG.Storable
+    , Marshal.WriteRaw
+    )
+
+instance (ty ~ BG.CInt) => BG.CompatHasField.HasField "unwrapT" T ty where
+
+  hasField =
+    \x0 ->
+      (\y1 -> T {unwrapT = y1}, BG.getField @"unwrapT" x0)
+
+instance (ty ~ BG.CInt) => BG.HasField "unwrapT" (BG.Ptr T) (BG.Ptr ty) where
+
+  getField = HasCField.fromPtr (BG.Proxy @"unwrapT")
+
+instance HasCField.HasCField T "unwrapT" where
+
+  type CFieldType T "unwrapT" = BG.CInt
+
+  offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/bindingspec.yaml
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/bindingspec.yaml
@@ -1,0 +1,40 @@
+version:
+  hs_bindgen: 0.1.0
+  binding_specification: '1.0'
+hsmodule: Example
+ctypes:
+- headers: macros/redeclaration/variadic.h
+  cname: T
+  hsname: T
+hstypes:
+- hsname: T
+  representation:
+    newtype:
+      constructor: T
+      fields:
+      - unwrapT
+  instances:
+  - Bitfield
+  - Bits
+  - Bounded
+  - Enum
+  - Eq
+  - FiniteBits
+  - Generic
+  - HasCField
+  - HasFFIType
+  - HasField
+  - HasFieldCompat
+  - HasFieldPtr
+  - Integral
+  - Ix
+  - Num
+  - Ord
+  - Prim
+  - Read
+  - ReadRaw
+  - Real
+  - Show
+  - StaticSize
+  - Storable
+  - WriteRaw

--- a/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/th.txt
+++ b/hs-bindgen/test-artefacts/fixtures/macros/redeclaration/variadic/th.txt
@@ -1,0 +1,33 @@
+-- addDependentFile test-artefacts/headers/golden/macros/redeclaration/variadic.h
+{-| __C declaration:__ @T@
+
+    __defined at:__ @macros\/redeclaration\/variadic.h 4:24@
+
+    __exported by:__ @macros\/redeclaration\/variadic.h@
+-}
+newtype T
+    = T {unwrapT :: CInt}
+    deriving stock (Eq, Generic, Ord, Read, Show)
+    deriving newtype (Bitfield,
+                      Bits,
+                      Bounded,
+                      Enum,
+                      FiniteBits,
+                      HasFFIType,
+                      Integral,
+                      Ix,
+                      Num,
+                      Prim,
+                      ReadRaw,
+                      Real,
+                      StaticSize,
+                      Storable,
+                      WriteRaw)
+instance (~) ty CInt => HasField "unwrapT" T ty
+    where hasField = \x_0 -> (\y_1 -> T{unwrapT = y_1},
+                              getField @"unwrapT" x_0)
+instance (~) ty CInt => HasField "unwrapT" (Ptr T) (Ptr ty)
+    where getField = fromPtr (Proxy @"unwrapT")
+instance HasCField T "unwrapT"
+    where type CFieldType T "unwrapT" = CInt
+          offset# = \_ -> \_ -> 0

--- a/hs-bindgen/test-artefacts/headers/golden/macros/redeclaration/variadic.h
+++ b/hs-bindgen/test-artefacts/headers/golden/macros/redeclaration/variadic.h
@@ -1,0 +1,4 @@
+#define A int
+#define A int
+#define ID(A, ...) A __VA_ARGS__
+typedef ID(const, int) T;

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Clang/Macros/UniqueExpansion.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Clang/Macros/UniqueExpansion.hs
@@ -32,6 +32,9 @@ tests = testGroup "Test.HsBindgen.Clang.Macros.UniqueExpansion" [
         , testProperty "example11" example11
         , testProperty "example12" example12
         , testProperty "example13" example13
+          -- Variadic macros
+        , testProperty "example14" example14
+        , testProperty "example15" example15
         ]
     ]
 
@@ -53,7 +56,7 @@ example1 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "A" []
     defs = [
-        Definition "A" [] []
+        Definition "A" [] False []
       ]
 
 -- | Invoked object-like macro has dependencies. Expansion is unique.
@@ -62,8 +65,8 @@ example2 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "B" []
     defs = [
-        Definition "A" [] []
-      , Definition "B" [] [FreeVar "A"]
+        Definition "A" [] False []
+      , Definition "B" [] False [FreeVar "A"]
       ]
 
 -- | Invoked object-like macro has no dependencies. Invoked macro has two definitions.
@@ -73,8 +76,8 @@ example3 = once $ propIsExpansionUnique False defs inv
   where
     inv = Invocation "A" []
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
+        Definition "A" [] False []
+      , Definition "A" [] False []
       ]
 
 -- | Invoked macro has dependencies. Dependencies do not have unique expansions.
@@ -84,9 +87,9 @@ example4 = once $ propIsExpansionUnique False defs inv
   where
     inv = Invocation "B" []
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
-      , Definition "B" [] [FreeVar "A"]
+        Definition "A" [] False []
+      , Definition "A" [] False []
+      , Definition "B" [] False [FreeVar "A"]
       ]
 
 -- | Invoked function-like macro has no dependencies. Invoked with a argument
@@ -96,10 +99,10 @@ example5 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "F" ["B"]
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
-      , Definition "B" [] []
-      , Definition "F" ["C"] [LocalParam "C"]
+        Definition "A" []    False []
+      , Definition "A" []    False []
+      , Definition "B" []    False []
+      , Definition "F" ["C"] False [LocalParam "C"]
       ]
 
 -- | Invoked function-like macro has no dependencies. Invoked with an argument
@@ -109,10 +112,10 @@ example6 = once $ propIsExpansionUnique False defs inv
   where
     inv = Invocation "F" ["A"]
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
-      , Definition "B" [] []
-      , Definition "F" ["C"] [LocalParam "C"]
+        Definition "A" []    False []
+      , Definition "A" []    False []
+      , Definition "B" []    False []
+      , Definition "F" ["C"] False [LocalParam "C"]
       ]
 
 --
@@ -127,10 +130,10 @@ example7 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "F" ["B"]
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
-      , Definition "B" [] []
-      , Definition "F" ["A"] [LocalParam "A"]
+        Definition "A" []    False []
+      , Definition "A" []    False []
+      , Definition "B" []    False []
+      , Definition "F" ["A"] False [LocalParam "A"]
       ]
 
 -- | Invoked function-like macro has no dependencies. The parameter name matches
@@ -141,10 +144,10 @@ example8 = once $ propIsExpansionUnique False defs inv
   where
     inv = Invocation "F" ["A"]
     defs = [
-        Definition "A" [] []
-      , Definition "A" [] []
-      , Definition "B" [] []
-      , Definition "F" ["A"] [LocalParam "A"]
+        Definition "A" []    False []
+      , Definition "A" []    False []
+      , Definition "B" []    False []
+      , Definition "F" ["A"] False [LocalParam "A"]
       ]
 
 --
@@ -165,7 +168,7 @@ example10 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "B" []
     defs = [
-        Definition "B" [] [FreeVar "A"]
+        Definition "B" [] False [FreeVar "A"]
       ]
 
 -- | Invoked function-like macro is undefined. Expansion is unique.
@@ -174,7 +177,7 @@ example11 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "F" ["A"]
     defs = [
-        Definition "A" [] []
+        Definition "A" [] False []
       ]
 
 -- | Invoked function-like macro has undefined dependencies. Expansion is
@@ -184,8 +187,8 @@ example12 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "F" ["C"]
     defs = [
-        Definition "C" [] []
-      , Definition "F" ["A"] [FreeVar "B"]
+        Definition "C" []    False []
+      , Definition "F" ["A"] False [FreeVar "B"]
       ]
 
 -- | Invoked function-like macro with an undefined argument. Expansion is unique.
@@ -194,5 +197,28 @@ example13 = once $ propIsExpansionUnique True defs inv
   where
     inv = Invocation "F" ["B"]
     defs = [
-        Definition "F" ["A"] [LocalParam "A"]
+        Definition "F" ["A"] False [LocalParam "A"]
+      ]
+
+--
+-- Variadic macros
+--
+
+-- | Invoked function-like macro is variadic. Expansion is unique.
+example14 :: Property
+example14 = once $ propIsExpansionUnique True defs inv
+  where
+    inv = Invocation "F" ["A", "B"]
+    defs = [
+        Definition "F" [] True []
+      ]
+
+-- | Invoked function-like macro is variadic. The variadic function uses
+-- reserved @__VA_ARGS__@ in its body. Expansion is unique.
+example15 :: Property
+example15 = once $ propIsExpansionUnique True defs inv
+  where
+    inv = Invocation "F" ["A", "B"]
+    defs = [
+        Definition "F" [] True  [LocalParam "__VA_ARGS__"]
       ]

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
@@ -3,7 +3,8 @@ module Test.HsBindgen.Golden.Macros.Redeclaration (testCases) where
 
 import Control.Applicative
 
-import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg (PrepareReparseExpansionNotUnique))
+import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg (PrepareReparseExpansionNotUnique),
+                                                          PrepareReparseMsg (PrepareReparseMacroDefinitionParseFailures))
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass.Msg
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
@@ -193,7 +194,7 @@ test_variadic =
       & #tracePredicate .~ multiTracePredicate_custom expected trace
   where
     expected :: [C.DeclName]
-    expected = ["macro A", "macro ID", "T", "T", "T"]
+    expected = ["macro A", "macro ID", "ID", "T", "T", "T"]
 
     trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
     trace = \case
@@ -201,6 +202,8 @@ test_variadic =
         Just $ Expected name
       MatchDelayed name@"macro ID" ParseMacroErrorParse{}  ->
         Just $ Expected name
+      MatchImmediatePrepareReparse (PrepareReparseMacroDefinitionParseFailures ("ID" :| [])) ->
+        Just $ Expected "ID"
       MatchDelayedPrepareReparse name@"T" PrepareReparseExpansionNotUnique{} ->
         Just $ Expected name
       MatchDelayedReparseMacroExpansions name@"T" (ReparseMacroExpansionUnknownType "ID") ->

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
@@ -27,6 +27,7 @@ testCases = [
     , TestCaseLeaf test_identical_semantics
     , TestCaseLeaf test_identical_syntax
     , TestCaseLeaf test_same_line_tag_field
+    , TestCaseLeaf test_variadic
     ]
 
 {-------------------------------------------------------------------------------
@@ -177,6 +178,34 @@ test_same_line_tag_field =
     trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
     trace = \case
       MatchSelect name@"macro A" SelectConflict{} ->
+        Just $ Expected name
+      _otherwise ->
+        Nothing
+
+-- | Regression test for issue #2245, where variadic macros were parsed as
+-- object-like macros instead of function-like macros in the context of the
+-- @isExpansionUnique@ query
+--
+-- <https://github.com/well-typed/hs-bindgen/issues/2245>
+test_variadic :: TestCase
+test_variadic =
+    defaultTest_custom "macros/redeclaration/variadic"
+      & #tracePredicate .~ multiTracePredicate_custom expected trace
+  where
+    expected :: [C.DeclName]
+    expected = ["macro A", "macro ID", "T", "T", "T"]
+
+    trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
+    trace = \case
+      MatchSelect name@"macro A" SelectConflict{} ->
+        Just $ Expected name
+      MatchDelayed name@"macro ID" ParseMacroErrorParse{}  ->
+        Just $ Expected name
+      MatchDelayedPrepareReparse name@"T" PrepareReparseExpansionNotUnique{} ->
+        Just $ Expected name
+      MatchDelayedReparseMacroExpansions name@"T" (ReparseMacroExpansionUnknownType "ID") ->
+        Just $ Expected name
+      MatchDelayedReparseMacroExpansions name@"T" ReparseMacroExpansionsLanC{} ->
         Just $ Expected name
       _otherwise ->
         Nothing

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Golden/Macros/Redeclaration.hs
@@ -3,8 +3,7 @@ module Test.HsBindgen.Golden.Macros.Redeclaration (testCases) where
 
 import Control.Applicative
 
-import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg (PrepareReparseExpansionNotUnique),
-                                                          PrepareReparseMsg (PrepareReparseMacroDefinitionParseFailures))
+import HsBindgen.Frontend.Pass.PrepareReparse.IsPass.Msg (DelayedPrepareReparseMsg (PrepareReparseExpansionNotUnique))
 import HsBindgen.Frontend.Pass.ReparseMacroExpansions.IsPass.Msg
 import HsBindgen.Frontend.Pass.Select.IsPass
 import HsBindgen.Imports
@@ -194,21 +193,15 @@ test_variadic =
       & #tracePredicate .~ multiTracePredicate_custom expected trace
   where
     expected :: [C.DeclName]
-    expected = ["macro A", "macro ID", "ID", "T", "T", "T"]
+    expected = ["macro A", "macro ID", "T"]
 
     trace :: TraceMsg -> Maybe (TraceExpectation C.DeclName)
     trace = \case
       MatchSelect name@"macro A" SelectConflict{} ->
         Just $ Expected name
-      MatchDelayed name@"macro ID" ParseMacroErrorParse{}  ->
-        Just $ Expected name
-      MatchImmediatePrepareReparse (PrepareReparseMacroDefinitionParseFailures ("ID" :| [])) ->
-        Just $ Expected "ID"
-      MatchDelayedPrepareReparse name@"T" PrepareReparseExpansionNotUnique{} ->
+      (MatchDelayed name@"macro ID" ParseMacroErrorParse{})  ->
         Just $ Expected name
       MatchDelayedReparseMacroExpansions name@"T" (ReparseMacroExpansionUnknownType "ID") ->
-        Just $ Expected name
-      MatchDelayedReparseMacroExpansions name@"T" ReparseMacroExpansionsLanC{} ->
         Just $ Expected name
       _otherwise ->
         Nothing


### PR DESCRIPTION
Resolves #2245

The fix is twofold: 
* first, I make sure that macros are parsed as either object-like or function-like (not both)
* then, I make sure that function-like macro parsing supports variadic macros

---

- [x] I have updated the changelog. I have included a migration hint if this is a breaking change.
- [x] I have updated the manual.
- [x] I have removed all mentions of closed tickets in the code.
- [x] I have associated each new TODO item with a ticket.
