### PR TITLE
Manual: terminology and macros

### DIFF
--- a/manual/installation.md
+++ b/manual/installation.md
@@ -281,7 +281,7 @@ default.
 [t:common-errors-and-solutions]: #common-errors-and-solutions
 
 ### LLVM/Clang version mismatch
-[t:llvm-clang-version-mismatch]: #llvmclang-version-mismatch
+[t:llvmclang-version-mismatch]: #llvmclang-version-mismatch
 
 Three LLVM/Clang versions are relevant:
 
@@ -328,7 +328,7 @@ correctly.  As described in the [Configure `hs-bindgen`][t:configure-hs-bindgen]
 section above, `hs-bindgen` uses the `clang` executable to determine the system
 include directories by default.  Such errors may occur when the `clang`
 executable does not match the `libclang` library.  See
-[LLVM/Clang version mismatch][t:llvm-clang-version-mismatch] above for
+[LLVM/Clang version mismatch][t:llvmclang-version-mismatch] above for
 information about this case.
 
 As a last resort, you may be able to work around such issues using the
@@ -369,7 +369,7 @@ If a different library is missing, see the
 configuring loader library directories.
 
 ### Underlying type mismatches
-[t:underlying type mismatches]: #underlying-type-mismatches
+[t:underlying-type-mismatches]: #underlying-type-mismatches
 
 You might encounter Haskell type errors where, for example, a C `int` is being
 interpreted as a `CUInt` instead of a `CInt`.  This is often due to how

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -1,51 +1,78 @@
 # Macros
 
-A C macro (or simply, a "macro") is a name associated with a replacement text.
+A C [macro][manual:terminology-macro] is a [macro
+name][manual:terminology-macro-name] associated with a [replacement
+list][manual:terminology-replacement-list]. This chapter describes how
+`hs-bindgen` translates macros to Haskell bindings. The terms used throughout
+are defined in the [terminology][manual:terminology] chapter, and the examples
+come from [`macro.h`][header:macro.h].
 
-## Terminology
+## Macros in C
 
-/Macro definitions/ are C preprocessor directives termed "control lines". The C
-standard specifies
+A [macro definition][manual:terminology-macro-definition] is a `#define`
+preprocessing directive. The [C standard][c-standard] gives its syntax as
+follows (6.10.1).
 
-> object-like macro:
->   # define identifier replacement-list new-line
->
-> function-like macro:
->   # define identifier lparen identifier-listopt ) replacement-list new-line
->   # define identifier lparen ... ) replacement-list new-line
->   # define identifier lparen identifier-list , ... ) replacement-list new-line
->
-> identifier: <complex syntax, see C standard>
-> replacement-list: <preprocessing tokens including spaces>
-> new-line: the new-line character
-> lparen: a ( character not immediately preceded by white space
-> identifier-list: identifier | identifier-list , identifier
+```text
+object-like macro:
+    # define identifier replacement-list new-line
 
-A /macro invocation/ references a macro definition by name. Object-like macros
-are invoked by their identifiers alone. Function-like macros are invoked by the
-same syntax as function calls.
+function-like macro:
+    # define identifier lparen identifier-list_opt ) replacement-list new-line
+    # define identifier lparen ... ) replacement-list new-line
+    # define identifier lparen identifier-list , ... ) replacement-list new-line
 
-The C preprocessor parses macro definitions, and replaces macro invocations with
-their `replacement-list`s. This process is termed /macro expansion/. Macro
-expansion is a string query-replace process, and the replacement strings lack
-any specification. This makes macros extremely powerful, but also terribly
-error-prone. What is worse: (a) macros can be chained (e.g., `A` replaced by `B`
-replaced by `C`); (b) macros have scope (macros comes into scope when they are
-defined, and go out of scope when they are `#undefine`d or at the end), and (c)
-C preprocessor directives can be located anywhere in the C code.
-
-`hs-bindgen` uses `libclang` to parse C headers. By default, `libclang` expands
-all macros, and so, we could opt for `hs-bindgen` being completely unaware of
-the existence of macros. However, macros often carry semantic information.
-For example, when translating a C header including
-
-```c
-#define PI 3.14159265
+replacement-list:
+    pp-tokens_opt
+pp-tokens:
+    preprocessing-token
+    pp-tokens preprocessing-token
+lparen:
+    a ( character not immediately preceded by white space
+identifier-list:
+    identifier
+    identifier-list , identifier
+new-line:
+    the new-line character
 ```
 
-it is useful to obtain a binding to `PI`. To this end, `hs-bindgen` tries hard
-to handle macros systematically. Similar to a compiler, it parses, resolves, and
-typechecks macros before translating them to Haskell bindings.
+The preprocessor replaces each macro
+[invocation][manual:terminology-macro-invocation] by the corresponding
+replacement list, a process termed [macro
+expansion][manual:terminology-macro-expansion].
+[Object-like][manual:terminology-object-like-macro] macros are invoked by their
+name alone; [function-like][manual:terminology-function-like-macro] macros are
+invoked by the same syntax as a function call, and only when the macro name is
+followed by a `(`.
+
+A replacement list is a sequence of *preprocessing tokens* that need not form
+any well-formed C construct. That is what makes macros powerful and, for a
+binding generator, awkward. Three further properties compound the problem.
+
+* Macros chain. The result of an expansion is
+  [rescanned][manual:terminology-rescanning] for further macro names, so `A` can
+  expand to `B`, which expands to `C`. Rescanning does not recurse, however: a
+  macro name encountered during its own expansion is never replaced again.
+* Macro definitions have a lifetime rather than a lexical scope. A definition
+  lasts from its `#define` until a matching `#undef`, or until the end of the
+  translation unit, independent of block structure.
+* A `#define` may appear between any two declarations, although the `#` itself
+  must start a line.
+
+## Macros in `hs-bindgen`
+
+`hs-bindgen` uses `libclang` to parse C headers. By default, `libclang` expands
+all macros, and so we could opt for `hs-bindgen` being completely unaware of the
+existence of macros. However, macros often carry semantic information. For
+example, when translating a C header including
+
+```c
+#define EPSILON 0.1
+```
+
+it is useful to obtain a binding to `EPSILON`. To this end, `hs-bindgen` tries
+hard to handle macros systematically. Similar to a compiler, it parses,
+resolves, and typechecks macros before translating them to Haskell bindings.
 
 Since the expansion of macros has no syntactic constraints, generation of
 Haskell bindings to macros is best-effort. `hs-bindgen` supports common schemes
@@ -53,41 +80,54 @@ used in macros, but may fail on a specific macro you need. Let us know!
 
 ## Typical macros and their translations
 
-Typical object-like macros:
+Object-like macros whose replacement list is a C expression are [macro
+values][manual:terminology-macro-value], and are translated to Haskell value
+bindings:
 
 ```c
-// Object-like macros translating to values
-
-#define TRUE  1
-#define FALSE 0
-#define LETTER   'a'
-#define GREETING "hello"
-
-// Object-like macros translating to types
-// TODO.
-#define PtrInt int*
+#define FIELD_OFFSET 4
+#define EPSILON      0.1
+#define LETTER       'a'
+#define GREETING     "hello"
 ```
 
-Typical function-like macros:
+Object-like macros whose replacement list is a C type are [macro
+types][manual:terminology-macro-type], and are translated to Haskell newtypes:
 
 ```c
-// Function-like macros
-#define CMP(X,Y) ( X < Y )
+#define YEAR  int
+#define MONTH int
+#define DAY   int
+```
 
-#define AND    &&
+Function-like macros are translated to Haskell functions:
 
-#define ASSERT(n)           if(!(n)){\
-    printf(__FILE__ "@%d: `" #n "` - Failed | Compilation: " __DATE__ " " __TIME__ "\n", __LINE__);\
+```c
+#define PTR_TO_FIELD(ptr) ptr + 4
+```
+
+Not every macro has a Haskell counterpart. A macro whose replacement list is
+neither an expression nor a type, such as
+
+```c
+#define AND &&
+```
+
+or one that expands to statements rather than to a value, such as
+
+```c
+#define ASSERT(n) if(!(n)){                                                 \
+    printf(__FILE__ "@%d: `" #n "` - Failed\n", __LINE__);                  \
     return(-1);}
 ```
 
-That is, macros can be object-like (e.g., `PI`) and function-like (e.g., `CMP`),
+is not translated. `hs-bindgen` emits a trace message and carries on; see
+[tracing][manual:tracing].
 
 ### Character and string literals
 
 Object-like macros that expand to a single character or string literal are
-translated to Haskell value bindings. The examples in this section come from
-[`macro.h`][header:macro.h].
+translated to Haskell value bindings.
 
 #### Character literals
 
@@ -212,22 +252,80 @@ If you do not require the string to be terminated by `null`, use
 `Data.ByteString.useAsCStringLen`, which copies the bytes, but does not append
 the `null`.
 
+## The path of a macro through `hs-bindgen`
+
+### Macro languages
+
+How a [replacement list][manual:terminology-replacement-list] is parsed,
+typechecked and translated is not fixed: it is decided by the [macro
+language][manual:terminology-macro-language] in use. `hs-bindgen` ships three.
+
+* `CExpr` is the default. It understands C expressions and C type expressions,
+  and is backed by the [`c-expr-dsl`][hackage:c-expr-dsl] package. It is the
+  only macro language that distinguishes [macro
+  types][manual:terminology-macro-type] from [macro
+  values][manual:terminology-macro-value].
+* `Empty` recognises no macro at all. Nothing is [reparsed][t:reparsing], so the
+  bindings use Clang's own [expansions][manual:terminology-macro-expansion]
+  throughout, and no bindings to macros are generated.
+* `Raw` treats every macro as a macro value whose translation is its token list.
+
+Which macros are [parsable][manual:terminology-parsable-macro] therefore depends
+on the macro language: under `Empty` none are, under `Raw` all of them are.
+
+`hs-bindgen-cli` always uses `CExpr`. The other two are reachable from the
+Template Haskell backend, by using `withHsBindgenMacroLang` in place of
+`withHsBindgen`; they exist mainly for testing and for diagnosing macro
+handling.
+
+### Reparsing declarations with macro expansions
+[t:reparsing]: #reparsing-declarations-with-macro-expansions
+
+By default `libclang` expands macros before `hs-bindgen` sees a declaration.
+Given
+
+```c
+#define YEAR int
+
+YEAR getYear(date *d);
+```
+
+`libclang` reports the return type of `getYear` as `int`; that a macro was
+involved at all is lost. `hs-bindgen` therefore
+[reparses][manual:terminology-reparsing] those declarations that contain macro
+expansions, inspecting the original tokens, so that the generated binding can
+refer to the macro type `YEAR` rather than to `int`.
+
+Macros are typechecked before any declaration is reparsed: the [macro
+type][manual:terminology-macro-type] has to exist before a declaration can refer
+to it.
+
+
+
 <!-- sources and references -->
 
+[c-standard]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf
 [creference:character-constant]: https://en.cppreference.com/w/c/language/character_constant.html
 [creference:string-literal]: https://en.cppreference.com/w/c/language/string_literal.html
 [hackage:base:CChar]: https://hackage.haskell.org/package/base/docs/Foreign-C-Types.html#t:CChar
 [hackage:bytestring:ByteString]: https://hackage.haskell.org/package/bytestring/docs/Data-ByteString.html#t:ByteString
 [hackage:bytestring:useAsCString]: https://hackage.haskell.org/package/bytestring/docs/Data-ByteString.html#v:useAsCString
+[hackage:c-expr-dsl]: https://hackage.haskell.org/package/c-expr-dsl
 [header:macro.h]: ../../c/macro.h
+[manual:terminology]: ../../terminology.md
+[manual:terminology-function-like-macro]: ../../terminology.md#function-like-macro
+[manual:terminology-macro]: ../../terminology.md#macro
+[manual:terminology-macro-definition]: ../../terminology.md#macro-definition
+[manual:terminology-macro-expansion]: ../../terminology.md#macro-expansion
+[manual:terminology-macro-invocation]: ../../terminology.md#macro-invocation
+[manual:terminology-macro-language]: ../../terminology.md#macro-language
+[manual:terminology-macro-name]: ../../terminology.md#macro-name
+[manual:terminology-macro-type]: ../../terminology.md#macro-type
+[manual:terminology-macro-value]: ../../terminology.md#macro-value
+[manual:terminology-object-like-macro]: ../../terminology.md#object-like-macro
+[manual:terminology-parsable-macro]: ../../terminology.md#parsable-macro
+[manual:terminology-reparsing]: ../../terminology.md#reparsing
+[manual:terminology-replacement-list]: ../../terminology.md#replacement-list
+[manual:terminology-rescanning]: ../../terminology.md#rescanning
+[manual:tracing]: ../usage/tracing.md
 [manual:translation/globals]: globals.md
-
-
-## The path of a macro through `hs-bindgen`
-
-TODO. Ideas:
-
-- macro languages
-- `c-expr`
-- raw and empty macro languages
-- reparsing of declarations with macro expansions

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -104,7 +104,7 @@ ePSILON = (0.1 :: CDouble)
 
 The Haskell type is not given in the C code; it follows from typechecking the
 replacement list under the C typing rules. Character and string literals are
-macro values, [see below][t:literals].
+macro values, [see below][t:character-and-string-literals].
 
 ### Macro types
 
@@ -125,8 +125,8 @@ newtype YEAR = YEAR
 We use `newtype` instead of a type synonym because the macro carries semantic
 information (see [typedefs][manual:low-level/introduction-typedefs]).
 
-Declarations that use the macro type refer to the newtype, not to its
-underlying type:
+Declarations that use the macro type refer to the newtype, not to its underlying
+type:
 
 ```c
 YEAR getYear(date *d);
@@ -139,7 +139,8 @@ getYear :: Ptr Date -> IO YEAR
 <details>
 The fact that the return type of `getYear` refers to the macro type is lost by
 `libclang` which reports it as `int`. `hs-bindgen` has to recover the reference
-by [reparsing][t:reparsing] the declaration of `getYear`.
+by [reparsing][t:reparsing-declarations-with-macro-expansions] the declaration
+of `getYear`.
 </details>
 
 ### Function-like macros
@@ -182,7 +183,7 @@ is not translated and no binding is generated. `hs-bindgen` emits a trace
 message and carries on; see [tracing][manual:tracing].
 
 ### Character and string literals
-[t:literals]: #character-and-string-literals
+[t:character-and-string-literals]: #character-and-string-literals
 
 Object-like macros that expand to a single character or string literal are
 [macro values][manual:terminology-macro-value], and are translated to Haskell
@@ -337,7 +338,7 @@ Template Haskell backend, by using `withHsBindgenMacroLang` in place of
 handling.
 
 ### Reparsing declarations with macro expansions
-[t:reparsing]: #reparsing-declarations-with-macro-expansions
+[t:reparsing-declarations-with-macro-expansions]: #reparsing-declarations-with-macro-expansions
 
 By default `libclang` expands macros before `hs-bindgen` sees a declaration.
 Given
@@ -383,7 +384,6 @@ declaration can refer to it.
 [manual:terminology-macro-type]: ../../terminology.md#macro-type
 [manual:terminology-macro-value]: ../../terminology.md#macro-value
 [manual:terminology-object-like-macro]: ../../terminology.md#object-like-macro
-[manual:terminology-parsable-macro]: ../../terminology.md#parsable-macro
 [manual:terminology-reparsing]: ../../terminology.md#reparsing
 [manual:terminology-replacement-list]: ../../terminology.md#replacement-list
 [manual:terminology-rescanning]: ../../terminology.md#rescanning

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -11,7 +11,7 @@ come from [`macro.h`][header:macro.h].
 
 A [macro definition][manual:terminology-macro-definition] is a `#define`
 preprocessing directive. The [C standard][c-standard] gives its syntax as
-follows (6.10.1).
+follows
 
 ```text
 object-like macro:
@@ -42,20 +42,20 @@ replacement list, a process termed [macro
 expansion][manual:terminology-macro-expansion].
 [Object-like][manual:terminology-object-like-macro] macros are invoked by their
 name alone; [function-like][manual:terminology-function-like-macro] macros are
-invoked by the same syntax as a function call, and only when the macro name is
-followed by a `(`.
+invoked by the same syntax as a function call (i.e., only when the macro name is
+immediately followed by the argument list enclosed by `(` and `)`).
 
 A replacement list is a sequence of *preprocessing tokens* that need not form
 any well-formed C construct. That is what makes macros powerful and, for a
-binding generator, awkward. Three further properties compound the problem.
+binding generator such as `hs-bindgen`, awkward. Three further properties
+augment the problem:
 
-* Macros chain. The result of an expansion is
+* Macros chains. The result of an expansion is
   [rescanned][manual:terminology-rescanning] for further macro names, so `A` can
-  expand to `B`, which expands to `C`. Rescanning does not recurse, however: a
-  macro name encountered during its own expansion is never replaced again.
-* Macro definitions have a lifetime rather than a lexical scope. A definition
-  lasts from its `#define` until a matching `#undef`, or until the end of the
-  translation unit, independent of block structure.
+  expand to `B`, which expands to `C`.
+* Macro definitions have a lifetime rather than a lexical scope. A macro
+  definition lasts from its `#define` until a matching `#undef`, or until the
+  end of the translation unit.
 * A `#define` may appear between any two declarations, although the `#` itself
   must start a line.
 
@@ -80,6 +80,11 @@ used in macros, but may fail on a specific macro you need. Let us know!
 
 ## Typical macros and their translations
 
+The kind of binding `hs-bindgen` generates depends on what the replacement list
+parses as: an expression, a type, or neither.
+
+### Macro values
+
 Object-like macros whose replacement list is a C expression are [macro
 values][manual:terminology-macro-value], and are translated to Haskell value
 bindings:
@@ -87,24 +92,76 @@ bindings:
 ```c
 #define FIELD_OFFSET 4
 #define EPSILON      0.1
-#define LETTER       'a'
-#define GREETING     "hello"
 ```
+
+```haskell
+fIELD_OFFSET :: CInt
+fIELD_OFFSET = (4 :: CInt)
+
+ePSILON :: CDouble
+ePSILON = (0.1 :: CDouble)
+```
+
+The Haskell type is not given in the C code; it follows from typechecking the
+replacement list under the C typing rules. Character and string literals are
+macro values, [see below][t:literals].
+
+### Macro types
 
 Object-like macros whose replacement list is a C type are [macro
 types][manual:terminology-macro-type], and are translated to Haskell newtypes:
 
 ```c
-#define YEAR  int
-#define MONTH int
-#define DAY   int
+#define YEAR int
 ```
+
+```haskell
+newtype YEAR = YEAR
+  { unwrapYEAR :: CInt
+  }
+  -- Many derived instances here.
+```
+
+We use `newtype` instead of a type synonym because the macro carries semantic
+information (see [typedefs][manual:low-level/introduction-typedefs]).
+
+Declarations that use the macro type refer to the newtype, not to its
+underlying type:
+
+```c
+YEAR getYear(date *d);
+```
+
+```haskell
+getYear :: Ptr Date -> IO YEAR
+```
+
+<details>
+The fact that the return type of `getYear` refers to the macro type is lost by
+`libclang` which reports it as `int`. `hs-bindgen` has to recover the reference
+by [reparsing][t:reparsing] the declaration of `getYear`.
+</details>
+
+### Function-like macros
 
 Function-like macros are translated to Haskell functions:
 
 ```c
 #define PTR_TO_FIELD(ptr) ptr + 4
 ```
+
+```haskell
+pTR_TO_FIELD :: forall a. C.Add a CInt => a -> C.AddRes a CInt
+pTR_TO_FIELD = \ptr -> ptr C.+ (4 :: CInt)
+```
+
+Macro parameters carry no type annotations, so `hs-bindgen` infers the most
+general type. The class `Add` and the type family `AddRes` come from
+[`c-expr-runtime`][hackage:c-expr-runtime], which mirrors the C typing rules at
+the Haskell type level. Instantiating `a` to `Ptr x` yields `Ptr x`;
+instantiating it to `CLong` yields `CLong`.
+
+### Macros that are not translated
 
 Not every macro has a Haskell counterpart. A macro whose replacement list is
 neither an expression nor a type, such as
@@ -121,13 +178,15 @@ or one that expands to statements rather than to a value, such as
     return(-1);}
 ```
 
-is not translated. `hs-bindgen` emits a trace message and carries on; see
-[tracing][manual:tracing].
+is not translated and no binding is generated. `hs-bindgen` emits a trace
+message and carries on; see [tracing][manual:tracing].
 
 ### Character and string literals
+[t:literals]: #character-and-string-literals
 
 Object-like macros that expand to a single character or string literal are
-translated to Haskell value bindings.
+[macro values][manual:terminology-macro-value], and are translated to Haskell
+value bindings.
 
 #### Character literals
 
@@ -200,8 +259,8 @@ The byte-string holds the *execution-encoding bytes* of the literal, assuming a
 UTF-8 execution character set _excluding the terminating `null`_. Apart from the
 terminating `null`, the representation is *bit-for-bit accurate*: the bytes are
 exactly what a C compiler would embed in the object file. This is why we use
-`ByteString` rather than `String` — the generated binding can be passed directly
-to a C function that expects that byte sequence.
+`ByteString` rather than `String`. Then, the generated binding can be passed
+directly to a C function that expects that byte sequence.
 
 Two consequences are worth highlighting:
 
@@ -222,8 +281,8 @@ Two consequences are worth highlighting:
               , 0xE3, 0x81, 0xA1, 0xE3, 0x81, 0xAF ]
     ```
 
-* Because the binding is an ordinary (pure) value rather than an `IO` action —
-  unlike a [global variable][manual:translation/globals] — it can be inspected
+* Because the binding is an ordinary (pure) value rather than an `IO` action
+  (unlike a [global variable][manual:translation/globals]), it can be inspected
   and rendered in pure code:
 
     ```haskell
@@ -256,22 +315,21 @@ the `null`.
 
 ### Macro languages
 
-How a [replacement list][manual:terminology-replacement-list] is parsed,
-typechecked and translated is not fixed: it is decided by the [macro
-language][manual:terminology-macro-language] in use. `hs-bindgen` ships three.
+The way how `hs-bindgen` parses, typechecks and translates [replacement
+lists][manual:terminology-replacement-list] is not fixed. Instead, a pluggable
+[macro language][manual:terminology-macro-language] is used. At the moment,
+`hs-bindgen` comes with the following macro languages:
 
-* `CExpr` is the default. It understands C expressions and C type expressions,
-  and is backed by the [`c-expr-dsl`][hackage:c-expr-dsl] package. It is the
-  only macro language that distinguishes [macro
-  types][manual:terminology-macro-type] from [macro
-  values][manual:terminology-macro-value].
-* `Empty` recognises no macro at all. Nothing is [reparsed][t:reparsing], so the
-  bindings use Clang's own [expansions][manual:terminology-macro-expansion]
-  throughout, and no bindings to macros are generated.
+* `CExpr` is the default. `CExpr` understands C expressions and C type
+  expressions sorting them into [macro values][manual:terminology-macro-value]
+  and [macro types][manual:terminology-macro-type], respectively. The
+  implementation of `CExpr` is available in a separate repository containing the
+  macro language ([`c-expr-dsl`][hackage:c-expr-dsl]), and a corresponding
+  runtime ([`c-expr-runtime`][hackage:c-expr-runtime]).
+* `Empty` recognises no macro at all, so the generated bindings directly use the
+  macro [expansions][manual:terminology-macro-expansion] from `libclang`. No
+  bindings to macros are generated.
 * `Raw` treats every macro as a macro value whose translation is its token list.
-
-Which macros are [parsable][manual:terminology-parsable-macro] therefore depends
-on the macro language: under `Empty` none are, under `Raw` all of them are.
 
 `hs-bindgen-cli` always uses `CExpr`. The other two are reachable from the
 Template Haskell backend, by using `withHsBindgenMacroLang` in place of
@@ -290,15 +348,15 @@ Given
 YEAR getYear(date *d);
 ```
 
-`libclang` reports the return type of `getYear` as `int`; that a macro was
-involved at all is lost. `hs-bindgen` therefore
+`libclang` reports the return type of `getYear` as `int`. The information that a
+macro was involved at all is lost. `hs-bindgen` therefore
 [reparses][manual:terminology-reparsing] those declarations that contain macro
 expansions, inspecting the original tokens, so that the generated binding can
 refer to the macro type `YEAR` rather than to `int`.
 
-Macros are typechecked before any declaration is reparsed: the [macro
-type][manual:terminology-macro-type] has to exist before a declaration can refer
-to it.
+Macros are typechecked before any declaration with macro expansions is reparsed:
+the [macro type][manual:terminology-macro-type] has to exist before a
+declaration can refer to it.
 
 
 
@@ -311,7 +369,9 @@ to it.
 [hackage:bytestring:ByteString]: https://hackage.haskell.org/package/bytestring/docs/Data-ByteString.html#t:ByteString
 [hackage:bytestring:useAsCString]: https://hackage.haskell.org/package/bytestring/docs/Data-ByteString.html#v:useAsCString
 [hackage:c-expr-dsl]: https://hackage.haskell.org/package/c-expr-dsl
+[hackage:c-expr-runtime]: https://hackage.haskell.org/package/c-expr-runtime
 [header:macro.h]: ../../c/macro.h
+[manual:low-level/introduction-typedefs]: ../introduction.md#typedefs
 [manual:terminology]: ../../terminology.md
 [manual:terminology-function-like-macro]: ../../terminology.md#function-like-macro
 [manual:terminology-macro]: ../../terminology.md#macro

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -1,14 +1,95 @@
 # Macros
 
-TODO: General discussion of macro translation.
+A C macro (or simply, a "macro") is a name associated with a replacement text.
 
-## Character and string literals
+## Terminology
+
+/Macro definitions/ are C preprocessor directives termed "control lines". The C
+standard specifies
+
+> object-like macro:
+>   # define identifier replacement-list new-line
+>
+> function-like macro:
+>   # define identifier lparen identifier-listopt ) replacement-list new-line
+>   # define identifier lparen ... ) replacement-list new-line
+>   # define identifier lparen identifier-list , ... ) replacement-list new-line
+>
+> identifier: <complex syntax, see C standard>
+> replacement-list: <preprocessing tokens including spaces>
+> new-line: the new-line character
+> lparen: a ( character not immediately preceded by white space
+> identifier-list: identifier | identifier-list , identifier
+
+A /macro invocation/ references a macro definition by name. Object-like macros
+are invoked by their identifiers alone. Function-like macros are invoked by the
+same syntax as function calls.
+
+The C preprocessor parses macro definitions, and replaces macro invocations with
+their `replacement-list`s. This process is termed /macro expansion/. Macro
+expansion is a string query-replace process, and the replacement strings lack
+any specification. This makes macros extremely powerful, but also terribly
+error-prone. What is worse: (a) macros can be chained (e.g., `A` replaced by `B`
+replaced by `C`); (b) macros have scope (macros comes into scope when they are
+defined, and go out of scope when they are `#undefine`d or at the end), and (c)
+C preprocessor directives can be located anywhere in the C code.
+
+`hs-bindgen` uses `libclang` to parse C headers. By default, `libclang` expands
+all macros, and so, we could opt for `hs-bindgen` being completely unaware of
+the existence of macros. However, macros often carry semantic information.
+For example, when translating a C header including
+
+```c
+#define PI 3.14159265
+```
+
+it is useful to obtain a binding to `PI`. To this end, `hs-bindgen` tries hard
+to handle macros systematically. Similar to a compiler, it parses, resolves, and
+typechecks macros before translating them to Haskell bindings.
+
+Since the expansion of macros has no syntactic constraints, generation of
+Haskell bindings to macros is best-effort. `hs-bindgen` supports common schemes
+used in macros, but may fail on a specific macro you need. Let us know!
+
+## Typical macros and their translations
+
+Typical object-like macros:
+
+```c
+// Object-like macros translating to values
+
+#define TRUE  1
+#define FALSE 0
+#define LETTER   'a'
+#define GREETING "hello"
+
+// Object-like macros translating to types
+// TODO.
+#define PtrInt int*
+```
+
+Typical function-like macros:
+
+```c
+// Function-like macros
+#define CMP(X,Y) ( X < Y )
+
+#define AND    &&
+
+#define ASSERT(n)           if(!(n)){\
+    printf(__FILE__ "@%d: `" #n "` - Failed | Compilation: " __DATE__ " " __TIME__ "\n", __LINE__);\
+    return(-1);}
+```
+
+That is, macros can be object-like (e.g., `PI`) and function-like (e.g., `CMP`),
+
+### Character and string literals
 
 Object-like macros that expand to a single character or string literal are
 translated to Haskell value bindings. The examples in this section come from
 [`macro.h`][header:macro.h].
 
-### Character literals
+#### Character literals
 
 A [character constant][creference:character-constant] such as
 
@@ -60,7 +141,7 @@ Wide character literals (prefixed with `L`, `u`, `U`, or `u8`) and characters
 whose value does not fit in a single byte are rejected. The original C literal
 is preserved in the generated Haddock comment.
 
-### String literals
+#### String literals
 
 A [string literal][creference:string-literal] such as
 
@@ -109,7 +190,7 @@ Two consequences are worth highlighting:
     BS8.unpack gREETING  -- "hello", computed purely, no IO required
     ```
 
-### Passing a string literal to C
+#### Passing a string literal to C
 
 Since the byte-string carries no terminating `null`, handing it to a C function
 that expects a `null`-terminated string requires
@@ -140,3 +221,13 @@ the `null`.
 [hackage:bytestring:useAsCString]: https://hackage.haskell.org/package/bytestring/docs/Data-ByteString.html#v:useAsCString
 [header:macro.h]: ../../c/macro.h
 [manual:translation/globals]: globals.md
+
+
+## The path of a macro through `hs-bindgen`
+
+TODO. Ideas:
+
+- macro languages
+- `c-expr`
+- raw and empty macro languages
+- reparsing of declarations with macro expansions

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -36,23 +36,39 @@ new-line:
     the new-line character
 ```
 
+For example,
+
+```c
+#define EPSILON 0.1
+#define PTR_TO_FIELD(ptr) ptr + 4
+```
+
+defines an [object-like][manual:terminology-object-like-macro] macro `EPSILON`
+with the replacement list `0.1`, and a
+[function-like][manual:terminology-function-like-macro] macro `PTR_TO_FIELD`
+with the single [parameter][manual:terminology-macro-parameter] `ptr` and the
+replacement list `ptr + 4`.
+
 The preprocessor replaces each macro
 [invocation][manual:terminology-macro-invocation] by the corresponding
 replacement list, a process termed [macro
-expansion][manual:terminology-macro-expansion].
-[Object-like][manual:terminology-object-like-macro] macros are invoked by their
-name alone; [function-like][manual:terminology-function-like-macro] macros are
-invoked by the same syntax as a function call (i.e., only when the macro name is
-immediately followed by the argument list enclosed by `(` and `)`).
+expansion][manual:terminology-macro-expansion]. Object-like macros are invoked
+by their name alone, so every occurrence of `EPSILON` is replaced. Function-like
+macros are invoked by the same syntax as a function call, that is, *only* when
+the macro name is immediately followed by an argument list enclosed by `(` and
+`)`: `PTR_TO_FIELD(p)` is replaced, but a bare `PTR_TO_FIELD` is left alone. The
+[arguments][manual:terminology-macro-argument] of an invocation are substituted
+for the corresponding parameters in the replacement list, the `#` and `##`
+operators are applied, and the result is
+[rescanned][manual:terminology-rescanning] for further macro names.
 
 A replacement list is a sequence of *preprocessing tokens* that need not form
 any well-formed C construct. That is what makes macros powerful and, for a
 binding generator such as `hs-bindgen`, awkward. Three further properties
 augment the problem:
 
-* Macros chains. The result of an expansion is
-  [rescanned][manual:terminology-rescanning] for further macro names, so `A` can
-  expand to `B`, which expands to `C`.
+* Macros chain. Because the result of an expansion is rescanned, `A` can expand
+  to `B`, which expands to `C`.
 * Macro definitions have a lifetime rather than a lexical scope. A macro
   definition lasts from its `#define` until a matching `#undef`, or until the
   end of the translation unit.
@@ -106,10 +122,10 @@ ePSILON = (0.1 :: CDouble)
 The Haskell type is not given in the C code; it follows from typechecking the
 replacement list under the C typing rules. [Character and string
 literals][t:character-and-string-literals] are macro values. `hs-bindgen` also
-supports [function-like macro values][t:function-like-macros].
+supports [function-like macro values][t:function-like-macro-values].
 
 ### Function-like macro values
-[t:function-like-macros]: #function-like-macros
+[t:function-like-macro-values]: #function-like-macro-values
 
 [Function-like][manual:terminology-function-like-macro] macros whose replacement
 list is a C expression are [macro values][manual:terminology-macro-value] too;
@@ -383,11 +399,13 @@ declaration can refer to it.
 [manual:terminology]: ../../terminology.md
 [manual:terminology-function-like-macro]: ../../terminology.md#function-like-macro
 [manual:terminology-macro]: ../../terminology.md#macro
+[manual:terminology-macro-argument]: ../../terminology.md#macro-argument
 [manual:terminology-macro-definition]: ../../terminology.md#macro-definition
 [manual:terminology-macro-expansion]: ../../terminology.md#macro-expansion
 [manual:terminology-macro-invocation]: ../../terminology.md#macro-invocation
 [manual:terminology-macro-language]: ../../terminology.md#macro-language
 [manual:terminology-macro-name]: ../../terminology.md#macro-name
+[manual:terminology-macro-parameter]: ../../terminology.md#macro-parameter
 [manual:terminology-macro-type]: ../../terminology.md#macro-type
 [manual:terminology-macro-value]: ../../terminology.md#macro-value
 [manual:terminology-object-like-macro]: ../../terminology.md#object-like-macro

--- a/manual/low-level/translation/macros.md
+++ b/manual/low-level/translation/macros.md
@@ -85,9 +85,10 @@ parses as: an expression, a type, or neither.
 
 ### Macro values
 
-Object-like macros whose replacement list is a C expression are [macro
-values][manual:terminology-macro-value], and are translated to Haskell value
-bindings:
+A macro whose replacement list is a C expression is a [macro
+value][manual:terminology-macro-value]. Macro values are translated to Haskell
+value bindings. [Object-like][manual:terminology-object-like-macro] macros yield
+plain values:
 
 ```c
 #define FIELD_OFFSET 4
@@ -103,8 +104,31 @@ ePSILON = (0.1 :: CDouble)
 ```
 
 The Haskell type is not given in the C code; it follows from typechecking the
-replacement list under the C typing rules. Character and string literals are
-macro values, [see below][t:character-and-string-literals].
+replacement list under the C typing rules. [Character and string
+literals][t:character-and-string-literals] are macro values. `hs-bindgen` also
+supports [function-like macro values][t:function-like-macros].
+
+### Function-like macro values
+[t:function-like-macros]: #function-like-macros
+
+[Function-like][manual:terminology-function-like-macro] macros whose replacement
+list is a C expression are [macro values][manual:terminology-macro-value] too;
+they are translated to Haskell functions:
+
+```c
+#define PTR_TO_FIELD(ptr) ptr + 4
+```
+
+```haskell
+pTR_TO_FIELD :: forall a. C.Add a CInt => a -> C.AddRes a CInt
+pTR_TO_FIELD = \ptr -> ptr C.+ (4 :: CInt)
+```
+
+Macro parameters carry no type annotations, so `hs-bindgen` infers the most
+general type. The class `Add` and the type family `AddRes` come from
+[`c-expr-runtime`][hackage:c-expr-runtime], which mirrors the C typing rules at
+the Haskell type level. Instantiating `a` to `Ptr x` yields `Ptr x`;
+instantiating it to `CLong` yields `CLong`.
 
 ### Macro types
 
@@ -125,6 +149,8 @@ newtype YEAR = YEAR
 We use `newtype` instead of a type synonym because the macro carries semantic
 information (see [typedefs][manual:low-level/introduction-typedefs]).
 
+At the moment, we do not support function-like macro types.
+
 Declarations that use the macro type refer to the newtype, not to its underlying
 type:
 
@@ -142,25 +168,6 @@ The fact that the return type of `getYear` refers to the macro type is lost by
 by [reparsing][t:reparsing-declarations-with-macro-expansions] the declaration
 of `getYear`.
 </details>
-
-### Function-like macros
-
-Function-like macros are translated to Haskell functions:
-
-```c
-#define PTR_TO_FIELD(ptr) ptr + 4
-```
-
-```haskell
-pTR_TO_FIELD :: forall a. C.Add a CInt => a -> C.AddRes a CInt
-pTR_TO_FIELD = \ptr -> ptr C.+ (4 :: CInt)
-```
-
-Macro parameters carry no type annotations, so `hs-bindgen` infers the most
-general type. The class `Add` and the type family `AddRes` come from
-[`c-expr-runtime`][hackage:c-expr-runtime], which mirrors the C typing rules at
-the Haskell type level. Instantiating `a` to `Ptr x` yields `Ptr x`;
-instantiating it to `CLong` yields `CLong`.
 
 ### Macros that are not translated
 
@@ -316,10 +323,10 @@ the `null`.
 
 ### Macro languages
 
-The way how `hs-bindgen` parses, typechecks and translates [replacement
-lists][manual:terminology-replacement-list] is not fixed. Instead, a pluggable
-[macro language][manual:terminology-macro-language] is used. At the moment,
-`hs-bindgen` comes with the following macro languages:
+The way how `hs-bindgen` parses, typechecks and translates [macro
+definitions][manual:terminology-macro-definition] is not fixed. Instead, a
+pluggable [macro language][manual:terminology-macro-language] is used. At the
+moment, `hs-bindgen` comes with the following macro languages:
 
 * `CExpr` is the default. `CExpr` understands C expressions and C type
   expressions sorting them into [macro values][manual:terminology-macro-value]

--- a/manual/low-level/translation/structs/nesting.md
+++ b/manual/low-level/translation/structs/nesting.md
@@ -14,6 +14,14 @@ struct-in-struct case looks like, but note that it works the same for any
 nesting of structs and unions, in any order, and even recursively. See also the
 [Unions/Nesting][manual:unions/nesting] manual section.
 
+Nesting does not introduce a [scope][creference:scope] of its own. If the nested
+struct has a [tag][manual:terminology-tag], that tag is visible from its
+declaration onwards with the same scope the enclosing struct is declared in; for
+declarations at [file scope][manual:terminology-file-scope], this is the rest of
+the [translation unit][manual:terminology-translation-unit]. An
+[untagged][manual:terminology-untagged-structunionenum] nested struct cannot be
+referred to elsewhere.
+
 ## Example A
 
 The most straightforward way to declare nested structs is by declaring `door`
@@ -239,10 +247,15 @@ supported. A warning-level trace message will be emitted in this case.
 
 <!-- sources and references -->
 
+[creference:scope]: https://en.cppreference.com/w/c/language/scope.html
 [creference:struct]: https://en.cppreference.com/w/c/language/struct.html
 [is-2178]: https://github.com/well-typed/hs-bindgen/issues/2178
 [manual:binding-specifications]: ../../usage/binding-specifications.md
 [manual:pointer-manipulation-api]: ../pointer-manipulation.md
 [manual:record-dot-syntax]: ../record-dot-syntax.md
+[manual:terminology-file-scope]: ../../../terminology.md#file-scope
+[manual:terminology-tag]: ../../../terminology.md#tag
+[manual:terminology-translation-unit]: ../../../terminology.md#translation-unit
+[manual:terminology-untagged-structunionenum]: ../../../terminology.md#untagged-structunionenum
 [manual:unions/nesting]: ../unions/nesting.md
 [manual:usage/binding-specs]: ../../usage/binding-specifications.md

--- a/manual/low-level/translation/unions/nesting.md
+++ b/manual/low-level/translation/unions/nesting.md
@@ -14,6 +14,14 @@ what the union-in-struct case looks like, but note that it works the same for
 any nesting of structs and unions, in any order, and even recursively. See also
 the [Structs/Nesting][manual:structs/nesting] manual section.
 
+Nesting does not introduce a [scope][creference:scope] of its own. If the nested
+union has a [tag][manual:terminology-tag], that tag is visible from its
+declaration onwards with the same scope the enclosing union is declared in; for
+declarations at [file scope][manual:terminology-file-scope], this is the rest of
+the [translation unit][manual:terminology-translation-unit]. An
+[untagged][manual:terminology-untagged-structunionenum] nested union cannot be
+referred to elsewhere.
+
 ## Preliminaries
 
 C unions do not carry any information about which alternative of the union is

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -1,13 +1,155 @@
 # Terminology
 
-## Public
+* [C](#c) — terms describing the C input
+* [Haskell](#haskell) — terms describing the generated Haskell bindings
+* [`hs-bindgen`](#hs-bindgen) — terms describing how `hs-bindgen` translates the
+  C input into Haskell bindings
 
-### Anonymous struct/union
+References of the form (6.10.5) point at the corresponding clause of the [C
+standard][c-standard].
+
+## C
+
+### Preprocessor
+
+#### Function-like macro
+[t:function_like]: #function-like-macro
+
+A [macro definition][t:macro_def] of the form
+
+```c
+#define NAME(a, b) replacement-list
+```
+
+defines a *function-like* macro with [parameters][t:macro_param] `a` and `b`
+(6.10.5). An occurrence of `NAME` immediately followed by its arguments
+enclosed in `(` and `)` (similar to C function calls) is an
+[invocation][t:macro_inv] and is therefore replaced; a bare `NAME` is left
+alone. The [arguments][t:macro_arg] of the invocation are substituted for the
+corresponding parameters in the [replacement list][t:replacement_list]
+(6.10.5.1).
+
+#### Macro
+[t:macro]: #macro
+
+A *macro* is a [macro name][t:macro_name] associated with a [replacement
+list][t:replacement_list]. Macros are either [object-like][t:object_like] or
+[function-like][t:function_like].
+
+#### Macro argument
+[t:macro_arg]: #macro-argument
+
+The preprocessing tokens supplied at a [function-like macro][t:function_like]
+[invocation][t:macro_inv], enclosed in parentheses and separated by commas
+(6.10.5). Arguments are substituted for [parameters][t:macro_param].
+
+#### Macro definition
+[t:macro_def]: #macro-definition
+
+A macro *definition* is a `#define` preprocessing directive. It binds a [macro
+name][t:macro_name] to a [replacement list][t:replacement_list].
+
+Macro definitions are one kind of *control line* (6.10.1), the group of
+directives that also contains `#include`, `#undef` and `#pragma`.
+
+#### Macro expansion
+[t:macro_expansion]: #macro-expansion
+
+The process by which a C preprocessor replaces [invocations][t:macro_inv] with
+the corresponding [replacement lists][t:replacement_list], substituting
+[arguments][t:macro_arg] for [parameters][t:macro_param], applying the `#` and
+`##` operators, and [rescanning][t:rescanning] the result.
+
+Macro expansion operates on *preprocessing tokens*, not on text. The C standard
+specifically refers to the substitution of invocations with their replacement
+lists as "macro replacement" (6.10.5), and the overall process as "macro
+expansion" (6.10.5.1); we use *macro expansion* throughout.
+
+#### Macro invocation
+[t:macro_inv]: #macro-invocation
+
+A macro *invocation* references a [macro definition][t:macro_def] by
+[name][t:macro_name], so that it can be replaced by the [replacement
+list][t:replacement_list]. An [object-like][t:object_like] macro is invoked by
+its name alone; a [function-like][t:function_like] macro is invoked by its name
+followed by a parenthesised argument list.
+
+#### Macro name
+[t:macro_name]: #macro-name
+
+The identifier immediately following `define` in a [macro
+definition][t:macro_def] (6.10.5).
+
+Macro names have their own name space (6.10.5), separate from the name spaces
+of label names, [tags][t:tag], struct/union [fields][t:field], attributes and
+ordinary identifiers (6.2.3). A macro and a tag can therefore share a
+spelling.
+
+#### Macro parameter
+[t:macro_param]: #macro-parameter
+
+One of the identifiers in the identifier list of a [function-like
+macro][t:function_like] definition (6.10.5). Its scope ends at the new-line
+terminating the `#define`. Contrast [macro argument][t:macro_arg].
+
+#### Object-like macro
+[t:object_like]: #object-like-macro
+
+A [macro definition][t:macro_def] of the form
+
+```c
+#define NAME replacement-list
+```
+
+defines an *object-like* macro. Every subsequent occurrence of `NAME` is
+replaced by the [replacement list][t:replacement_list] (6.10.5).
+
+#### Replacement list
+[t:replacement_list]: #replacement-list
+
+The sequence of preprocessing tokens making up the remainder of a [macro
+definition][t:macro_def]. White space preceding or following the list is not
+part of it (6.10.1, 6.10.5).
+
+A replacement list is a token sequence rather than text, and it need not form a
+well-formed C construct. This is what makes generating bindings for macros hard;
+see [macros][manual:translation/macros].
+
+#### Rescanning
+[t:rescanning]: #rescanning
+
+After argument substitution and `#`/`##` processing, the resulting token
+sequence is scanned again for further macro names to replace (6.10.5.4). This
+is how macros chain: `A` expanding to `B` expanding to `C`.
+
+Rescanning does not recurse. If the name of the macro currently being replaced
+turns up during its own expansion it is *not* replaced, and it is never eligible
+for replacement again.
+
+#### Scope of a macro definition
+[t:macro_scope]: #scope-of-a-macro-definition
+
+A [macro definition][t:macro_def] lasts from its `#define` until a matching
+`#undef`, or until the end of the preprocessing translation unit (6.10.5.5).
+This is independent of block structure, and unrelated to the four kinds of scope
+(1) function, (2) [file][t:file_scope], (3) block and (4) function prototype
+scope (6.2.1).
+
+### Structs, unions and enums
+
+#### Anonymous struct/union
 [t:anon]: #anonymous-structunion
 
-A [field][t:field] that declares a nested [untagged][t:untagged] struct or union
-can optionally omit the [field name][t:named_field]. In this case, the [nested
-struct/union][t:nested] is called an *anonymous struct/union*.
+An [unnamed][t:unnamed_field] [field][t:field] whose type is an
+[untagged][t:untagged] struct or union is called an *anonymous struct* or
+*anonymous union* (6.7.3.2). Its [named fields][t:named_field] become
+[indirect fields][t:indirect_field] of the [enclosing
+struct/union][t:enclosing].
+
+The C standard applies the adjective to the *field*; we also apply it to the
+[nested][t:nested] struct or union type that the field declares. The two name
+the same construct. Our name for the field itself is [implicit
+field][t:implicit_field].
 
 <details>
 <summary>Notice</summary>
@@ -29,7 +171,6 @@ struct S {
   };
 };
 ```
-
 </details>
 
 <details>
@@ -37,150 +178,103 @@ struct S {
 
 * [Binding generation for anonymous structs][manual:structs/nesting-example-e]
 * [Binding generation for anonymous unions][manual:unions/nesting-example-e]
-
 </details>
 
-### Bit-field
+#### Bit-field
 [t:bit_field]: #bit-field
 
-A *bit-field* is a special kind of [field][t:field] that has a bit-width, used
-for packing and [padding][t:padding].
+A *bit-field* is a [field][t:field] which is a specified number of bits wide
+(6.7.3.2). Bit-fields are used for packing. An [unnamed][t:unnamed_field]
+bit-field declares [padding][t:padding] instead.
 
-### Direct field
+#### Direct field
 [t:direct_field]: #direct-field
 
-A *direct* field is a member of a struct or union itself as opposed to a member of its children.
+A *direct* field is a [field][t:field] of a struct or union itself, as opposed
+to a field of one of its [nested][t:nested] structs or unions. Contrast
+[indirect field][t:indirect_field].
 
-### Enclosing struct/union
+#### Enclosing struct/union
 [t:enclosing]: #enclosing-structunion
 
 A [field][t:field] is declared inside a struct/union definition. This parent
 definition is called the *enclosing struct/union*.
 
-### Regular field
-[t:regular_field]: #regular-field
-
-A *regular field* is a [direct][t:direct_field], [named][t:named_field] field.
-
-### Field
+#### Field
 [t:field]: #field
 
-A *field* is described in the C reference as a "member" of a struct/union.
-Fields are declared using variable declarations or [bit-field][t:bit_field]
-declarations.
+A *field* is what the C standard calls a *member* of a struct or union
+(6.7.3.2). Fields are declared using variable declarations or
+[bit-field][t:bit_field] declarations.
 
-### File scope
-[t:file_scope]: #file-scope
+We say "field" rather than "member" because the Haskell side generates [record
+fields][t:record_field], and because the C standard itself already uses field in
+*bit-field*.
 
-<https://en.cppreference.com/w/c/language/scope.html#File_scope>
+#### Implicit field
+[t:implicit_field]: #implicit-field
 
-### Function-like macro
-[t:function_like]: #function-like-macro
-
-A *function-like* macro replaces each occurrence of that macro's name with its
-definition, additionally taking a list of named arguments, which replace
-corresponding occurrences of the argument name in the definition.
-
-### Implicit field
-
-An *implicit* field* is a [direct][t:direct_field], [unnamed][t:unnamed_field]
-field that references an [anonymous struct/union][t:anon].
+An *implicit* field is a [direct][t:direct_field], [unnamed][t:unnamed_field]
+field whose type is an [anonymous struct/union][t:anon]. The C standard has no
+separate name for it, since it calls the field itself the anonymous struct or
+union.
 
 <details>
 <summary>Binding generation</summary>
 
 * [Binding generation for anonymous structs][manual:structs/nesting-example-e]
 * [Binding generation for anonymous unions][manual:unions/nesting-example-e]
-
 </details>
 
-
-### Indirect field
+#### Indirect field
 [t:indirect_field]: #indirect-field
 
-[Named fields][t:named_field] of an [anonymous struct/union][t:anon] can be
-accessed as if they were fields of the [enclosing struct/union][t:enclosing].
-Such a field is called an *indirect field* with respect to the enclosing
-struct/union. Such fields are still fields of the anonymous struct/union as
-well.
+The [named fields][t:named_field] of an [anonymous struct/union][t:anon] are
+fields of the [enclosing struct/union][t:enclosing] as well (6.7.3.2), and
+can be accessed as such. With respect to the enclosing struct/union, such a
+field is called an *indirect field*. It remains a field of the anonymous
+struct/union too.
 
-This also works recursively: if an anonymous struct/union has indirect fields,
-then the enclosing struct/union has its own indirect fields for those fields as
-well.
+This applies recursively: if an anonymous struct/union has indirect fields, then
+the enclosing struct/union has its own indirect fields for those fields as well.
+
+*Indirect field* is a term coined by Clang (`IndirectFieldDecl`), not by the C
+standard.
 
 <details>
 <summary>Binding generation</summary>
 
 * [Binding generation for indirect fields for structs][manual:structs/nesting-indirect-fields]
 * [Binding generation for indirect fields for unions][manual:unions/nesting-indirect-fields]
-
 </details>
 
-### Macro
-[t:macro]: #macro
-
-A (text) macro is a name associated with a replacement text.
-
-### Macro definition
-[t:macro_def]: #macro-definition
-
-A macro *definition* declares a name in the macro namespace with a replacement
-text. A macro can be [object-like][t:object_like] or
-[function-like][t:function_like]. Macro definitions might be
-[parsable][t:parsable_macro].
-
-### Macro expansion
-[t:macro_expansion]: #macro-expansion
-
-A C preprocessor *expands* macro [invocations][t:macro_inv], replacing
-invocations by their definition, which may be processed additionally depending
-on the type of the macro [definition][t:macro_def].
-
-### Macro invocation
-[t:macro_inv]: #macro-invocation
-
-A macro *invocation* references a macro definition by name so that it can be
-replaced by its definition. Macro invocations are [expanded][t:macro_expansion]
-by a C preprocessor. An [object-like][t:object_like] macro is invoked by
-referencing the macro's name. A [function-like][t:function_like] macro is
-invoked as if it is a function call.
-
-### Macro type
-[t:macro_type]: #macro-type
-
-A [macro][t:macro] that is parsed by `hs-bindgen` as a Haskell type.
-
-### Macro value
-[t:macro_value]: #macro-value
-
-A [macro][t:macro] that is parsed by `hs-bindgen` as a Haskell value.
-
-### Named field
+#### Named field
 [t:named_field]: #named-field
 
-A [field][t:field] with a name is called a *named field*. All fields should be
-named, with some exceptions: see [unnamed field][t:unnamed_field].
+A [field][t:field] with a name is called a *named field*; see also [unnamed
+field][t:unnamed_field].
 
-### Nested struct/union
+#### Nested struct/union
 [t:nested]: #nested-structunion
 
 A [field][t:field] can declare a new struct or union type, in which case it is
-called a *nested struct/union*. The nested struct/union can be
-[untagged][t:untagged] as usual. The nested struct/union typically has [file
-scope][t:file_scope] as long as its [enclosing struct/union][t:enclosing] has
-file scope, which is usually if not always the case.
+called a *nested struct/union*. A nested struct/union can be
+[untagged][t:untagged].
 
-### Object-like macro
-[t:object_like]: #object-like-macro
+Nesting does not introduce a scope of its own. If the nested struct/union has a
+[tag][t:tag], that tag is visible from its declaration onwards in whichever
+scope the [enclosing struct/union][t:enclosing] is declared in (6.2.1). For
+declarations at [file scope][t:file_scope], this is the rest of the [translation
+unit][t:translation_unit]. An untagged nested struct/union declares no tag at
+all and so cannot be referred to elsewhere.
 
-An *object-like* macro replaces each occurrence of that macro's name with its
-definition.
-
-### Padding
+#### Padding
 [t:padding]: #padding
 
-Unnamed padding may be inserted by the compiler in between [fields][t:field].
-Unnamed padding can be inserted by the using an [unnamed][t:unnamed_field]
+A compiler may insert unnamed *padding* between [fields][t:field] and at the end
+of a struct or union, but not at the beginning (6.7.3.2).
+
+Padding can also be declared explicitly, using an [unnamed][t:unnamed_field]
 [bit-field][t:bit_field].
 
 <details>
@@ -190,53 +284,237 @@ Unnamed bit-fields are not translated to fields in the corresponding Haskell
 record in the generated Haskell bindings.
 </details>
 
-### Parsable macro
-[t:parsable_macro]: #parsable-macro
+#### Regular field
+[t:regular_field]: #regular-field
 
-A *parsable* macro is a macro definition that can be parsed as a [macro
-type][t:macro_type] or as a [macro value][t:macro_value].
+A *regular field* is a [direct][t:direct_field], [named][t:named_field] field.
 
-### Reparsing
-[t:reparsing]: #reparsing
-
-`hs-bindgen` parses headers once, and a subset of the headers is parsed a second
-time (those declarations that contain macro expansions). The second *reparse*
-inspects the source C code to augment the Haskell bindings with [macro
-types][t:macro_type].
-
-### Tag
+#### Tag
 [t:tag]: #tag
 
-A struct/union/enum (optionally) declares a name in the tag namespace. We refer
+A struct/union/enum (optionally) declares a name in the tag name space. We refer
 to this name as a *tag*.
 
-### Tagged struct/union/enum
+There is a single tag name space shared by all three tags (6.2.3),
+and it is separate from the name space of ordinary identifiers, so `struct date`
+and a `typedef` named `date` can coexist.
 
-A struct or union or enum with a [tag][t:tag] is called *tagged*.
+#### Tagged struct/union/enum
+[t:tagged]: #tagged-structunionenum
 
-### Type macro
+A struct or union or enum with a [tag][t:tag] is called *tagged*. The C
+standard says "with a tag"; we use *tagged*.
 
-See [macro type][t:macro_type].
-
-### Unnamed field
+#### Unnamed field
 [t:unnamed_field]: #unnamed-field
 
 A [field][t:field] without a name is called an *unnamed field*.
-[bit-fields][t:bit_field] are allowed to be unnamed. Fields that declare an
-[anonymous struct/union][t:anon] are unnamed by definition.
+[Bit-fields][t:bit_field] are allowed to be unnamed, and fields that declare an
+[anonymous struct/union][t:anon] are unnamed by definition (6.7.3.2).
 
-### Untagged struct/union/enum
+#### Untagged struct/union/enum
 [t:untagged]: #untagged-structunionenum
 
-A struct or union or enum without a [tag][t:tag] is called *untagged*.
+A struct or union or enum without a [tag][t:tag] is called *untagged*. The C
+standard says "without a tag"; we use *untagged*.
 
-### Value macro
+### Declarations and scope
 
-See [macro value][t:macro_value].
+#### File scope
+[t:file_scope]: #file-scope
+
+An identifier whose declarator or type specifier appears outside any block or
+parameter list has *file scope*: it is visible from the point of declaration
+until the end of the [translation unit][t:translation_unit]. File scope is one
+of four kinds of scope, the others being function, block and function prototype
+scope (6.2.1).
+
+See also ["scope" on cppreference.com][creference:scope].
+
+#### Translation unit
+[t:translation_unit]: #translation-unit
+
+A source file together with all the headers and source files it includes is a
+*preprocessing translation unit*; after preprocessing, it is called a
+*translation unit* (5.1.1.1). `hs-bindgen` translates one translation unit per
+invocation; see [includes][manual:includes].
+
+## Haskell
+
+### Bindings
+
+#### Binding
+[t:binding]: #binding
+
+A *binding* is a Haskell declaration providing access to a C declaration: a
+foreign import for a function, a record type for a struct, a value for a [macro
+value][t:macro_value], and so on.
+
+#### High-level bindings
+[t:high_level]: #high-level-bindings
+
+Bindings written in idiomatic Haskell, hiding the C representation behind
+Haskell types and conventions. `hs-bindgen` does not generate high-level
+bindings; they are hand-written on top of the [low-level bindings][t:low_level].
+
+See the [roadmap][manual:roadmap].
+
+#### Low-level bindings
+[t:low_level]: #low-level-bindings
+
+Bindings mirroring the C declarations one for one and using C types (`CInt`,
+`Ptr`, …). See the [introduction to the low-level
+API][manual:low-level/introduction].
+
+### Generated declarations
+
+#### Newtype wrapper
+[t:newtype]: #newtype-wrapper
+
+Many bindings are generated as a `newtype` around the underlying C
+representation rather than as a bare type synonym, so that the C type and its
+uses stay distinct in Haskell. [Macro types][t:macro_type] are generated this
+way, and so are enums; but beware, enums are not Haskell sum types, see
+[enums][manual:enums].
+
+#### Opaque data type
+[t:opaque]: #opaque-data-type
+
+For a C type whose definition is not available (e.g., an incomplete struct),
+`hs-bindgen` generates a Haskell data type with no constructors, used only
+behind a `Ptr`. See [opaque structs][manual:structs-opaque].
+
+#### Record field
+[t:record_field]: #record-field
+
+A field of a generated Haskell record. `hs-bindgen` generates one record field
+per [regular field][t:regular_field] of a struct; [unnamed][t:unnamed_field]
+[bit-fields][t:bit_field] are not translated.
+
+## `hs-bindgen`
+
+### Macros
+
+#### Macro language
+[t:macro_lang]: #macro-language
+
+The pluggable `hs-bindgen` component that parses, typechecks and translates the
+[replacement lists][t:replacement_list] of [macro definitions][t:macro_def].
+
+#### Macro type
+[t:macro_type]: #macro-type
+
+A [macro][t:macro] whose [replacement list][t:replacement_list] parses as a C
+*type* expression, and which is therefore translated to a Haskell type using a
+[newtype wrapper][t:newtype] around the translation of that C type. For example,
+`#define YEAR int`.
+
+#### Macro value
+[t:macro_value]: #macro-value
+
+A [macro][t:macro] whose [replacement list][t:replacement_list] parses as a C
+*expression*, and which is therefore translated to a Haskell value binding. For
+example, `#define EPSILON 0.1`.
+
+#### Parsable macro
+[t:parsable_macro]: #parsable-macro
+
+A [macro definition][t:macro_def] whose [replacement list][t:replacement_list]
+the active [macro language][t:macro_lang] can parse, either as a [macro
+type][t:macro_type] or as a [macro value][t:macro_value].
+
+#### Reparsing
+[t:reparsing]: #reparsing
+
+The second parse of those declarations that contain macro
+[expansions][t:macro_expansion], recovering the [macro types][t:macro_type] that
+`libclang` had already expanded away; see [macros][manual:translation/macros].
+
+### Selection
+
+#### Extern declaration
+[t:extern]: #extern-declaration
+
+A declaration listed in an external [binding specification][t:binding_spec].
+`hs-bindgen` does not generate bindings for it, and instead imports the
+declaration from the specified module instead.
+
+#### Omitted declaration
+[t:omitted]: #omitted-declaration
+
+A declaration that is not translated due to a prescriptive [binding
+specification][t:binding_spec]. We use *omit* exclusively for this. We avoid
+*omit* in the context of [deselection][t:selected] or translation failures.
+
+#### Program slicing
+[t:slicing]: #program-slicing
+
+Translating a declaration is only useful if its transitive dependencies are
+translated too. *Program slicing* determines those dependencies and selects
+them, even if a [selection predicate][t:selection_predicate] deselected them.
+See [selecting and program slicing][manual:selecting-and-program-slicing].
+
+#### Selected declaration
+[t:selected]: #selected-declaration
+
+A declaration that `hs-bindgen` will translate. Declarations are *selected* or
+*deselected*, by a [selection predicate][t:selection_predicate] and by [program
+slicing][t:slicing]. We avoid the terms *exclude*, *skip* and [omit][t:omitted]
+in the context of selection.
+
+#### Selection predicate
+[t:selection_predicate]: #selection-predicate
+
+A predicate matched against declarations, determining which ones are
+[selected][t:selected] for translation. See [selecting and program
+slicing][manual:selecting-and-program-slicing].
+
+### Naming and configuration
+
+#### Binding specification
+[t:binding_spec]: #binding-specification
+
+A YAML or JSON file specifying details about the bindings of a single Haskell
+module. A *prescriptive* binding specification guides generation (custom names,
+type representations, instances, [omission][t:omitted]); an *external* binding
+specification declares that the listed types come from another module, so that
+separately generated bindings compose. See [binding
+specifications][manual:binding-specifications].
+
+#### Name mangling
+[t:name_mangling]: #name-mangling
+
+C names are not valid Haskell names, and the two languages have different
+conventions. The *name mangler* derives all Haskell names from the corresponding
+C names, staying as close to the C spelling as possible. See [generated
+names][manual:generated-names].
+
+#### Root directive
+[t:root_directive]: #root-directive
+
+A preprocessing directive that `hs-bindgen` emits ahead of the headers being
+translated, such as `--hash-define NAME VALUE`. Root directives are ordered and
+also apply to the compilation of the generated C source. See
+[invocation][manual:invocation] and [C stages][manual:c-stages].
+
+
 
 <!-- sources and references -->
 
+[c-standard]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3220.pdf
+[creference:scope]: https://en.cppreference.com/w/c/language/scope.html
+[manual:binding-specifications]: low-level/usage/binding-specifications.md
+[manual:c-stages]: low-level/usage/c-stages.md
+[manual:enums]: low-level/translation/enums.md
+[manual:generated-names]: low-level/translation/generated-names.md
+[manual:includes]: low-level/usage/includes.md
+[manual:invocation]: low-level/usage/invocation.md
+[manual:low-level/introduction]: low-level/introduction.md
+[manual:roadmap]: roadmap.md
+[manual:selecting-and-program-slicing]: low-level/usage/selecting-and-program-slicing.md
+[manual:structs-opaque]: low-level/translation/structs.md#opaque-structs
 [manual:structs/nesting-example-e]: low-level/translation/structs/nesting.md#example-e
 [manual:structs/nesting-indirect-fields]: low-level/translation/structs/nesting.md#indirect-fields
+[manual:translation/macros]: low-level/translation/macros.md
 [manual:unions/nesting-example-e]: low-level/translation/unions/nesting.md#example-e
 [manual:unions/nesting-indirect-fields]: low-level/translation/unions/nesting.md#indirect-fields

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -51,9 +51,6 @@ parentheses and separated by commas (6.10.5). Arguments are substituted for
 A macro *definition* is a `#define` preprocessing directive. It binds a [macro
 name][t:macro-name] to a [replacement list][t:replacement-list].
 
-Macro definitions are one kind of *control line* (6.10.1), the group of
-directives that also contains `#include`, `#undef` and `#pragma`.
-
 #### Macro expansion
 [t:macro-expansion]: #macro-expansion
 

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -442,7 +442,7 @@ The second parse of those declarations that contain macro
 
 A declaration listed in an external [binding
 specification][t:binding-specification]. `hs-bindgen` does not generate bindings
-for it, and instead imports the declaration from the specified module instead.
+for it, and imports the declaration from the specified module instead.
 
 #### Omitted declaration
 [t:omitted-declaration]: #omitted-declaration

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -79,7 +79,7 @@ invoked by its name followed by a parenthesised argument list.
 The identifier immediately following `define` in a [macro
 definition][t:macro-definition] (6.10.5).
 
-Macro names have their own name space (6.10.5), separate from the name spaces of
+Macro names have their own namespace (6.10.5), separate from the namespaces of
 label names, [tags][t:tag], struct/union [fields][t:field], attributes and
 ordinary identifiers (6.2.3). A macro and a tag can therefore share a spelling.
 
@@ -290,11 +290,11 @@ A *regular field* is a [direct][t:direct-field], [named][t:named-field] field.
 #### Tag
 [t:tag]: #tag
 
-A struct/union/enum (optionally) declares a name in the tag name space. We refer
+A struct/union/enum (optionally) declares a name in the tag namespace. We refer
 to this name as a *tag*.
 
-There is a single tag name space shared by all three tags (6.2.3), and it is
-separate from the name space of ordinary identifiers, so `struct date` and a
+There is a single tag namespace shared by all three tags (6.2.3), and it is
+separate from the namespace of ordinary identifiers, so `struct date` and a
 `typedef` named `date` can coexist.
 
 #### Tagged struct/union/enum

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -74,6 +74,13 @@ declarations.
 
 <https://en.cppreference.com/w/c/language/scope.html#File_scope>
 
+### Function-like macro
+[t:function_like]: #function-like-macro
+
+A *function-like* macro replaces each occurrence of that macro's name with its
+definition, additionally taking a list of named arguments, which replace
+corresponding occurrences of the argument name in the definition.
+
 ### Implicit field
 
 An *implicit* field* is a [direct][t:direct_field], [unnamed][t:unnamed_field]
@@ -109,6 +116,45 @@ well.
 
 </details>
 
+### Macro
+[t:macro]: #macro
+
+A (text) macro is a name associated with a replacement text.
+
+### Macro definition
+[t:macro_def]: #macro-definition
+
+A macro *definition* declares a name in the macro namespace with a replacement
+text. A macro can be [object-like][t:object_like] or
+[function-like][t:function_like]. Macro definitions might be
+[parsable][t:parsable_macro].
+
+### Macro expansion
+[t:macro_expansion]: #macro-expansion
+
+A C preprocessor *expands* macro [invocations][t:macro_inv], replacing
+invocations by their definition, which may be processed additionally depending
+on the type of the macro [definition][t:macro_def].
+
+### Macro invocation
+[t:macro_inv]: #macro-invocation
+
+A macro *invocation* references a macro definition by name so that it can be
+replaced by its definition. Macro invocations are [expanded][t:macro_expansion]
+by a C preprocessor. An [object-like][t:object_like] macro is invoked by
+referencing the macro's name. A [function-like][t:function_like] macro is
+invoked as if it is a function call.
+
+### Macro type
+[t:macro_type]: #macro-type
+
+A [macro][t:macro] that is parsed by `hs-bindgen` as a Haskell type.
+
+### Macro value
+[t:macro_value]: #macro-value
+
+A [macro][t:macro] that is parsed by `hs-bindgen` as a Haskell value.
+
 ### Named field
 [t:named_field]: #named-field
 
@@ -124,6 +170,12 @@ called a *nested struct/union*. The nested struct/union can be
 scope][t:file_scope] as long as its [enclosing struct/union][t:enclosing] has
 file scope, which is usually if not always the case.
 
+### Object-like macro
+[t:object_like]: #object-like-macro
+
+An *object-like* macro replaces each occurrence of that macro's name with its
+definition.
+
 ### Padding
 [t:padding]: #padding
 
@@ -138,6 +190,20 @@ Unnamed bit-fields are not translated to fields in the corresponding Haskell
 record in the generated Haskell bindings.
 </details>
 
+### Parsable macro
+[t:parsable_macro]: #parsable-macro
+
+A *parsable* macro is a macro definition that can be parsed as a [macro
+type][t:macro_type] or as a [macro value][t:macro_value].
+
+### Reparsing
+[t:reparsing]: #reparsing
+
+`hs-bindgen` parses headers once, and a subset of the headers is parsed a second
+time (those declarations that contain macro expansions). The second *reparse*
+inspects the source C code to augment the Haskell bindings with [macro
+types][t:macro_type].
+
 ### Tag
 [t:tag]: #tag
 
@@ -147,6 +213,10 @@ to this name as a *tag*.
 ### Tagged struct/union/enum
 
 A struct or union or enum with a [tag][t:tag] is called *tagged*.
+
+### Type macro
+
+See [macro type][t:macro_type].
 
 ### Unnamed field
 [t:unnamed_field]: #unnamed-field
@@ -160,7 +230,9 @@ A [field][t:field] without a name is called an *unnamed field*.
 
 A struct or union or enum without a [tag][t:tag] is called *untagged*.
 
+### Value macro
 
+See [macro value][t:macro_value].
 
 <!-- sources and references -->
 

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -437,8 +437,8 @@ The second parse of those declarations that contain macro
 
 ### Selection
 
-#### Extern declaration
-[t:extern-declaration]: #extern-declaration
+#### External declaration
+[t:external-declaration]: #external-declaration
 
 A declaration listed in an external [binding
 specification][t:binding-specification]. `hs-bindgen` does not generate bindings

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -16,26 +16,21 @@ standard][c-standard].
 #### Function-like macro
 [t:function-like-macro]: #function-like-macro
 
-A [macro definition][t:macro-definition] of the form
-
-```c
-#define NAME(a, b) replacement-list
-```
-
-defines a *function-like* macro with [parameters][t:macro-parameter] `a` and `b`
-(6.10.5). An occurrence of `NAME` immediately followed by its arguments enclosed
-in `(` and `)` (similar to C function calls) is an
-[invocation][t:macro-invocation] and is therefore replaced; a bare `NAME` is
-left alone. The [arguments][t:macro-argument] of the invocation are substituted
-for the corresponding parameters in the [replacement list][t:replacement-list]
-(6.10.5.1).
+A *function-like* macro is a [macro][t:macro] that is
+[defined][t:macro-definition] using a list of named [macro
+parameters][t:macro-parameter] (6.10.5). When a function-like macro is
+[invoked][t:macro-invocation] using [macro arguments][t:macro-argument], those
+arguments are substituted for the corresponding parameters in the [replacement
+list][t:replacement-list] (6.10.5.1). See [macros in
+C][manual:translation/macros-in-c].
 
 #### Macro
 [t:macro]: #macro
 
 A *macro* is a [macro name][t:macro-name] associated with a [replacement
 list][t:replacement-list]. Macros are either [object-like][t:object-like-macro]
-or [function-like][t:function-like-macro].
+or [function-like][t:function-like-macro]. See
+[macros][manual:translation/macros].
 
 #### Macro argument
 [t:macro-argument]: #macro-argument
@@ -55,14 +50,18 @@ name][t:macro-name] to a [replacement list][t:replacement-list].
 [t:macro-expansion]: #macro-expansion
 
 The process by which a C preprocessor replaces [invocations][t:macro-invocation]
-with the corresponding [replacement lists][t:replacement-list], substituting
-[arguments][t:macro-argument] for [parameters][t:macro-parameter], applying the
-`#` and `##` operators, and [rescanning][t:rescanning] the result.
+with the corresponding [replacement lists][t:replacement-list]. Macro expansion
+operates on *preprocessing tokens*, not on text. See [macros in
+C][manual:translation/macros-in-c].
 
-Macro expansion operates on *preprocessing tokens*, not on text. The C standard
-specifically refers to the substitution of invocations with their replacement
-lists as "macro replacement" (6.10.5), and the overall process as "macro
-expansion" (6.10.5.1); we use *macro expansion* throughout.
+<details>
+<summary>Notice</summary>
+
+> The C standard specifically refers to the substitution of invocations with
+> their replacement lists as "macro replacement" (6.10.5), and the overall
+> process as "macro expansion" (6.10.5.1); we use *macro expansion* throughout.
+
+</details>
 
 #### Macro invocation
 [t:macro-invocation]: #macro-invocation
@@ -93,14 +92,12 @@ argument][t:macro-argument].
 #### Object-like macro
 [t:object-like-macro]: #object-like-macro
 
-A [macro definition][t:macro-definition] of the form
-
-```c
-#define NAME replacement-list
-```
-
-defines an *object-like* macro. Every subsequent occurrence of `NAME` is
-replaced by the [replacement list][t:replacement-list] (6.10.5).
+An *object-like* macro is a [macro][t:macro] that is
+[defined][t:macro-definition] without [macro parameters][t:macro-parameter].
+Every subsequent occurrence of its [name][t:macro-name] is an
+[invocation][t:macro-invocation], and is replaced by the [replacement
+list][t:replacement-list] (6.10.5). See [macros in
+C][manual:translation/macros-in-c].
 
 #### Replacement list
 [t:replacement-list]: #replacement-list
@@ -257,14 +254,8 @@ field][t:unnamed-field].
 
 A [field][t:field] can declare a new struct or union type, in which case it is
 called a *nested struct/union*. A nested struct/union can be
-[untagged][t:untagged-structunionenum].
-
-Nesting does not introduce a scope of its own. If the nested struct/union has a
-[tag][t:tag], that tag is visible from its declaration onwards in whichever
-scope the [enclosing struct/union][t:enclosing-structunion] is declared in
-(6.2.1). For declarations at [file scope][t:file-scope], this is the rest of the
-[translation unit][t:translation-unit]. An untagged nested struct/union declares
-no tag at all and so cannot be referred to elsewhere.
+[untagged][t:untagged-structunionenum], and nesting does not introduce a scope
+of its own. See [nesting][manual:structs/nesting].
 
 #### Padding
 [t:padding]: #padding
@@ -403,6 +394,7 @@ per [regular field][t:regular-field] of a struct; [unnamed][t:unnamed-field]
 The pluggable `hs-bindgen` component that parses, typechecks and translates
 [macro definitions][t:macro-definition]: the [macro name][t:macro-name], the
 [parameters][t:macro-parameter], and the [replacement list][t:replacement-list].
+See [macro languages][manual:translation/macros-macro-languages].
 
 #### Macro type
 [t:macro-type]: #macro-type
@@ -410,14 +402,14 @@ The pluggable `hs-bindgen` component that parses, typechecks and translates
 A [macro][t:macro] whose [replacement list][t:replacement-list] parses as a C
 *type* expression, and which is therefore translated to a Haskell type using a
 [newtype wrapper][t:newtype-wrapper] around the translation of that C type. For
-example, `#define YEAR int`.
+example, `#define YEAR int`. See [macro types][manual:translation/macros-macro-types].
 
 #### Macro value
 [t:macro-value]: #macro-value
 
 A [macro][t:macro] whose [replacement list][t:replacement-list] parses as a C
 *expression*, and which is therefore translated to a Haskell value binding. For
-example, `#define EPSILON 0.1`.
+example, `#define EPSILON 0.1`. See [macro values][manual:translation/macros-macro-values].
 
 #### Parsable macro
 [t:parsable-macro]: #parsable-macro
@@ -433,7 +425,8 @@ list][t:replacement-list].
 
 The second parse of those declarations that contain macro
 [expansions][t:macro-expansion], recovering the [macro types][t:macro-type] that
-`libclang` had already expanded away; see [macros][manual:translation/macros].
+`libclang` had already expanded away. See [reparsing declarations with macro
+expansions][manual:translation/macros-reparsing].
 
 ### Selection
 
@@ -519,8 +512,14 @@ also apply to the compilation of the generated C source. See
 [manual:roadmap]: roadmap.md
 [manual:selecting-and-program-slicing]: low-level/usage/selecting-and-program-slicing.md
 [manual:structs-opaque]: low-level/translation/structs.md#opaque-structs
+[manual:structs/nesting]: low-level/translation/structs/nesting.md
 [manual:structs/nesting-example-e]: low-level/translation/structs/nesting.md#example-e
 [manual:structs/nesting-indirect-fields]: low-level/translation/structs/nesting.md#indirect-fields
 [manual:translation/macros]: low-level/translation/macros.md
+[manual:translation/macros-in-c]: low-level/translation/macros.md#macros-in-c
+[manual:translation/macros-macro-languages]: low-level/translation/macros.md#macro-languages
+[manual:translation/macros-macro-types]: low-level/translation/macros.md#macro-types
+[manual:translation/macros-macro-values]: low-level/translation/macros.md#macro-values
+[manual:translation/macros-reparsing]: low-level/translation/macros.md#reparsing-declarations-with-macro-expansions
 [manual:unions/nesting-example-e]: low-level/translation/unions/nesting.md#example-e
 [manual:unions/nesting-indirect-fields]: low-level/translation/unions/nesting.md#indirect-fields

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -76,7 +76,7 @@ invoked by its name followed by a parenthesised argument list.
 #### Macro name
 [t:macro-name]: #macro-name
 
-The identifier immediately following `define` in a [macro
+The identifier immediately following `#define` in a [macro
 definition][t:macro-definition] (6.10.5).
 
 Macro names have their own namespace (6.10.5), separate from the namespaces of

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -87,8 +87,8 @@ ordinary identifiers (6.2.3). A macro and a tag can therefore share a spelling.
 [t:macro-parameter]: #macro-parameter
 
 One of the identifiers in the identifier list of a [function-like
-macro][t:function-like-macro] definition (6.10.5). Its scope ends at the
-new-line terminating the `#define`. Contrast [macro argument][t:macro-argument].
+macro][t:function-like-macro] definition (6.10.5). Contrast [macro
+argument][t:macro-argument].
 
 #### Object-like macro
 [t:object-like-macro]: #object-like-macro

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -400,9 +400,9 @@ per [regular field][t:regular-field] of a struct; [unnamed][t:unnamed-field]
 #### Macro language
 [t:macro-language]: #macro-language
 
-The pluggable `hs-bindgen` component that parses, typechecks and translates the
-[replacement lists][t:replacement-list] of [macro
-definitions][t:macro-definition].
+The pluggable `hs-bindgen` component that parses, typechecks and translates
+[macro definitions][t:macro-definition]: the [macro name][t:macro-name], the
+[parameters][t:macro-parameter], and the [replacement list][t:replacement-list].
 
 #### Macro type
 [t:macro-type]: #macro-type
@@ -422,10 +422,11 @@ example, `#define EPSILON 0.1`.
 #### Parsable macro
 [t:parsable-macro]: #parsable-macro
 
-A [macro definition][t:macro-definition] whose [replacement
-list][t:replacement-list] the active [macro language][t:macro-language] can
-parse, either as a [macro type][t:macro-type] or as a [macro
-value][t:macro-value].
+A [macro definition][t:macro-definition] that the active [macro
+language][t:macro-language] can parse: the [macro name][t:macro-name], the
+[parameters][t:macro-parameter] if the macro is
+[function-like][t:function-like-macro], and the [replacement
+list][t:replacement-list].
 
 #### Reparsing
 [t:reparsing]: #reparsing

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -1,64 +1,66 @@
 # Terminology
 
-* [C](#c) — terms describing the C input
-* [Haskell](#haskell) — terms describing the generated Haskell bindings
-* [`hs-bindgen`](#hs-bindgen) — terms describing how `hs-bindgen` translates the
-  C input into Haskell bindings
+* [C][t:c] — terms describing the C input
+* [Haskell][t:haskell] — terms describing the generated Haskell bindings
+* [`hs-bindgen`][t:hs-bindgen] — terms describing how `hs-bindgen` translates
+  the C input into Haskell bindings
 
 References of the form (6.10.5) point at the corresponding clause of the [C
 standard][c-standard].
 
 ## C
+[t:c]: #c
 
 ### Preprocessor
 
 #### Function-like macro
-[t:function_like]: #function-like-macro
+[t:function-like-macro]: #function-like-macro
 
-A [macro definition][t:macro_def] of the form
+A [macro definition][t:macro-definition] of the form
 
 ```c
 #define NAME(a, b) replacement-list
 ```
 
-defines a *function-like* macro with [parameters][t:macro_param] `a` and `b`
-(6.10.5). An occurrence of `NAME` immediately followed by its arguments
-enclosed in `(` and `)` (similar to C function calls) is an
-[invocation][t:macro_inv] and is therefore replaced; a bare `NAME` is left
-alone. The [arguments][t:macro_arg] of the invocation are substituted for the
-corresponding parameters in the [replacement list][t:replacement_list]
+defines a *function-like* macro with [parameters][t:macro-parameter] `a` and `b`
+(6.10.5). An occurrence of `NAME` immediately followed by its arguments enclosed
+in `(` and `)` (similar to C function calls) is an
+[invocation][t:macro-invocation] and is therefore replaced; a bare `NAME` is
+left alone. The [arguments][t:macro-argument] of the invocation are substituted
+for the corresponding parameters in the [replacement list][t:replacement-list]
 (6.10.5.1).
 
 #### Macro
 [t:macro]: #macro
 
-A *macro* is a [macro name][t:macro_name] associated with a [replacement
-list][t:replacement_list]. Macros are either [object-like][t:object_like] or
-[function-like][t:function_like].
+A *macro* is a [macro name][t:macro-name] associated with a [replacement
+list][t:replacement-list]. Macros are either [object-like][t:object-like-macro]
+or [function-like][t:function-like-macro].
 
 #### Macro argument
-[t:macro_arg]: #macro-argument
+[t:macro-argument]: #macro-argument
 
-The preprocessing tokens supplied at a [function-like macro][t:function_like]
-[invocation][t:macro_inv], enclosed in parentheses and separated by commas
-(6.10.5). Arguments are substituted for [parameters][t:macro_param].
+The preprocessing tokens supplied at a [function-like
+macro][t:function-like-macro] [invocation][t:macro-invocation], enclosed in
+parentheses and separated by commas (6.10.5). Arguments are substituted for
+[parameters][t:macro-parameter].
 
 #### Macro definition
-[t:macro_def]: #macro-definition
+[t:macro-definition]: #macro-definition
 
 A macro *definition* is a `#define` preprocessing directive. It binds a [macro
-name][t:macro_name] to a [replacement list][t:replacement_list].
+name][t:macro-name] to a [replacement list][t:replacement-list].
 
 Macro definitions are one kind of *control line* (6.10.1), the group of
 directives that also contains `#include`, `#undef` and `#pragma`.
 
 #### Macro expansion
-[t:macro_expansion]: #macro-expansion
+[t:macro-expansion]: #macro-expansion
 
-The process by which a C preprocessor replaces [invocations][t:macro_inv] with
-the corresponding [replacement lists][t:replacement_list], substituting
-[arguments][t:macro_arg] for [parameters][t:macro_param], applying the `#` and
-`##` operators, and [rescanning][t:rescanning] the result.
+The process by which a C preprocessor replaces [invocations][t:macro-invocation]
+with the corresponding [replacement lists][t:replacement-list], substituting
+[arguments][t:macro-argument] for [parameters][t:macro-parameter], applying the
+`#` and `##` operators, and [rescanning][t:rescanning] the result.
 
 Macro expansion operates on *preprocessing tokens*, not on text. The C standard
 specifically refers to the substitution of invocations with their replacement
@@ -66,50 +68,49 @@ lists as "macro replacement" (6.10.5), and the overall process as "macro
 expansion" (6.10.5.1); we use *macro expansion* throughout.
 
 #### Macro invocation
-[t:macro_inv]: #macro-invocation
+[t:macro-invocation]: #macro-invocation
 
-A macro *invocation* references a [macro definition][t:macro_def] by
-[name][t:macro_name], so that it can be replaced by the [replacement
-list][t:replacement_list]. An [object-like][t:object_like] macro is invoked by
-its name alone; a [function-like][t:function_like] macro is invoked by its name
-followed by a parenthesised argument list.
+A macro *invocation* references a [macro definition][t:macro-definition] by
+[name][t:macro-name], so that it can be replaced by the [replacement
+list][t:replacement-list]. An [object-like][t:object-like-macro] macro is
+invoked by its name alone; a [function-like][t:function-like-macro] macro is
+invoked by its name followed by a parenthesised argument list.
 
 #### Macro name
-[t:macro_name]: #macro-name
+[t:macro-name]: #macro-name
 
 The identifier immediately following `define` in a [macro
-definition][t:macro_def] (6.10.5).
+definition][t:macro-definition] (6.10.5).
 
-Macro names have their own name space (6.10.5), separate from the name spaces
-of label names, [tags][t:tag], struct/union [fields][t:field], attributes and
-ordinary identifiers (6.2.3). A macro and a tag can therefore share a
-spelling.
+Macro names have their own name space (6.10.5), separate from the name spaces of
+label names, [tags][t:tag], struct/union [fields][t:field], attributes and
+ordinary identifiers (6.2.3). A macro and a tag can therefore share a spelling.
 
 #### Macro parameter
-[t:macro_param]: #macro-parameter
+[t:macro-parameter]: #macro-parameter
 
 One of the identifiers in the identifier list of a [function-like
-macro][t:function_like] definition (6.10.5). Its scope ends at the new-line
-terminating the `#define`. Contrast [macro argument][t:macro_arg].
+macro][t:function-like-macro] definition (6.10.5). Its scope ends at the
+new-line terminating the `#define`. Contrast [macro argument][t:macro-argument].
 
 #### Object-like macro
-[t:object_like]: #object-like-macro
+[t:object-like-macro]: #object-like-macro
 
-A [macro definition][t:macro_def] of the form
+A [macro definition][t:macro-definition] of the form
 
 ```c
 #define NAME replacement-list
 ```
 
 defines an *object-like* macro. Every subsequent occurrence of `NAME` is
-replaced by the [replacement list][t:replacement_list] (6.10.5).
+replaced by the [replacement list][t:replacement-list] (6.10.5).
 
 #### Replacement list
-[t:replacement_list]: #replacement-list
+[t:replacement-list]: #replacement-list
 
 The sequence of preprocessing tokens making up the remainder of a [macro
-definition][t:macro_def]. White space preceding or following the list is not
-part of it (6.10.1, 6.10.5).
+definition][t:macro-definition]. White space preceding or following the list is
+not part of it (6.10.1, 6.10.5).
 
 A replacement list is a token sequence rather than text, and it need not form a
 well-formed C construct. This is what makes generating bindings for macros hard;
@@ -119,37 +120,37 @@ see [macros][manual:translation/macros].
 [t:rescanning]: #rescanning
 
 After argument substitution and `#`/`##` processing, the resulting token
-sequence is scanned again for further macro names to replace (6.10.5.4). This
-is how macros chain: `A` expanding to `B` expanding to `C`.
+sequence is scanned again for further macro names to replace (6.10.5.4). This is
+how macros chain: `A` expanding to `B` expanding to `C`.
 
 Rescanning does not recurse. If the name of the macro currently being replaced
 turns up during its own expansion it is *not* replaced, and it is never eligible
 for replacement again.
 
 #### Scope of a macro definition
-[t:macro_scope]: #scope-of-a-macro-definition
+[t:scope-of-a-macro-definition]: #scope-of-a-macro-definition
 
-A [macro definition][t:macro_def] lasts from its `#define` until a matching
-`#undef`, or until the end of the preprocessing translation unit (6.10.5.5).
-This is independent of block structure, and unrelated to the four kinds of scope
-(1) function, (2) [file][t:file_scope], (3) block and (4) function prototype
-scope (6.2.1).
+A [macro definition][t:macro-definition] lasts from its `#define` until a
+matching `#undef`, or until the end of the preprocessing translation unit
+(6.10.5.5). This is independent of block structure, and unrelated to the four
+kinds of scope (1) function, (2) [file][t:file-scope], (3) block and (4)
+function prototype scope (6.2.1).
 
 ### Structs, unions and enums
 
 #### Anonymous struct/union
-[t:anon]: #anonymous-structunion
+[t:anonymous-structunion]: #anonymous-structunion
 
-An [unnamed][t:unnamed_field] [field][t:field] whose type is an
-[untagged][t:untagged] struct or union is called an *anonymous struct* or
-*anonymous union* (6.7.3.2). Its [named fields][t:named_field] become
-[indirect fields][t:indirect_field] of the [enclosing
-struct/union][t:enclosing].
+An [unnamed][t:unnamed-field] [field][t:field] whose type is an
+[untagged][t:untagged-structunionenum] struct or union is called an *anonymous
+struct* or *anonymous union* (6.7.3.2). Its [named fields][t:named-field] become
+[indirect fields][t:indirect-field] of the [enclosing
+struct/union][t:enclosing-structunion].
 
 The C standard applies the adjective to the *field*; we also apply it to the
-[nested][t:nested] struct or union type that the field declares. The two name
-the same construct. Our name for the field itself is [implicit
-field][t:implicit_field].
+[nested][t:nested-structunion] struct or union type that the field declares. The
+two name the same construct. Our name for the field itself is [implicit
+field][t:implicit-field].
 
 <details>
 <summary>Notice</summary>
@@ -181,21 +182,21 @@ struct S {
 </details>
 
 #### Bit-field
-[t:bit_field]: #bit-field
+[t:bit-field]: #bit-field
 
 A *bit-field* is a [field][t:field] which is a specified number of bits wide
-(6.7.3.2). Bit-fields are used for packing. An [unnamed][t:unnamed_field]
+(6.7.3.2). Bit-fields are used for packing. An [unnamed][t:unnamed-field]
 bit-field declares [padding][t:padding] instead.
 
 #### Direct field
-[t:direct_field]: #direct-field
+[t:direct-field]: #direct-field
 
 A *direct* field is a [field][t:field] of a struct or union itself, as opposed
-to a field of one of its [nested][t:nested] structs or unions. Contrast
-[indirect field][t:indirect_field].
+to a field of one of its [nested][t:nested-structunion] structs or unions.
+Contrast [indirect field][t:indirect-field].
 
 #### Enclosing struct/union
-[t:enclosing]: #enclosing-structunion
+[t:enclosing-structunion]: #enclosing-structunion
 
 A [field][t:field] is declared inside a struct/union definition. This parent
 definition is called the *enclosing struct/union*.
@@ -205,19 +206,19 @@ definition is called the *enclosing struct/union*.
 
 A *field* is what the C standard calls a *member* of a struct or union
 (6.7.3.2). Fields are declared using variable declarations or
-[bit-field][t:bit_field] declarations.
+[bit-field][t:bit-field] declarations.
 
 We say "field" rather than "member" because the Haskell side generates [record
-fields][t:record_field], and because the C standard itself already uses field in
+fields][t:record-field], and because the C standard itself already uses field in
 *bit-field*.
 
 #### Implicit field
-[t:implicit_field]: #implicit-field
+[t:implicit-field]: #implicit-field
 
-An *implicit* field is a [direct][t:direct_field], [unnamed][t:unnamed_field]
-field whose type is an [anonymous struct/union][t:anon]. The C standard has no
-separate name for it, since it calls the field itself the anonymous struct or
-union.
+An *implicit* field is a [direct][t:direct-field], [unnamed][t:unnamed-field]
+field whose type is an [anonymous struct/union][t:anonymous-structunion]. The C
+standard has no separate name for it, since it calls the field itself the
+anonymous struct or union.
 
 <details>
 <summary>Binding generation</summary>
@@ -227,13 +228,13 @@ union.
 </details>
 
 #### Indirect field
-[t:indirect_field]: #indirect-field
+[t:indirect-field]: #indirect-field
 
-The [named fields][t:named_field] of an [anonymous struct/union][t:anon] are
-fields of the [enclosing struct/union][t:enclosing] as well (6.7.3.2), and
-can be accessed as such. With respect to the enclosing struct/union, such a
-field is called an *indirect field*. It remains a field of the anonymous
-struct/union too.
+The [named fields][t:named-field] of an [anonymous
+struct/union][t:anonymous-structunion] are fields of the [enclosing
+struct/union][t:enclosing-structunion] as well (6.7.3.2), and can be accessed as
+such. With respect to the enclosing struct/union, such a field is called an
+*indirect field*. It remains a field of the anonymous struct/union too.
 
 This applies recursively: if an anonymous struct/union has indirect fields, then
 the enclosing struct/union has its own indirect fields for those fields as well.
@@ -249,24 +250,24 @@ standard.
 </details>
 
 #### Named field
-[t:named_field]: #named-field
+[t:named-field]: #named-field
 
 A [field][t:field] with a name is called a *named field*; see also [unnamed
-field][t:unnamed_field].
+field][t:unnamed-field].
 
 #### Nested struct/union
-[t:nested]: #nested-structunion
+[t:nested-structunion]: #nested-structunion
 
 A [field][t:field] can declare a new struct or union type, in which case it is
 called a *nested struct/union*. A nested struct/union can be
-[untagged][t:untagged].
+[untagged][t:untagged-structunionenum].
 
 Nesting does not introduce a scope of its own. If the nested struct/union has a
 [tag][t:tag], that tag is visible from its declaration onwards in whichever
-scope the [enclosing struct/union][t:enclosing] is declared in (6.2.1). For
-declarations at [file scope][t:file_scope], this is the rest of the [translation
-unit][t:translation_unit]. An untagged nested struct/union declares no tag at
-all and so cannot be referred to elsewhere.
+scope the [enclosing struct/union][t:enclosing-structunion] is declared in
+(6.2.1). For declarations at [file scope][t:file-scope], this is the rest of the
+[translation unit][t:translation-unit]. An untagged nested struct/union declares
+no tag at all and so cannot be referred to elsewhere.
 
 #### Padding
 [t:padding]: #padding
@@ -274,8 +275,8 @@ all and so cannot be referred to elsewhere.
 A compiler may insert unnamed *padding* between [fields][t:field] and at the end
 of a struct or union, but not at the beginning (6.7.3.2).
 
-Padding can also be declared explicitly, using an [unnamed][t:unnamed_field]
-[bit-field][t:bit_field].
+Padding can also be declared explicitly, using an [unnamed][t:unnamed-field]
+[bit-field][t:bit-field].
 
 <details>
 <summary>Binding generation</summary>
@@ -285,9 +286,9 @@ record in the generated Haskell bindings.
 </details>
 
 #### Regular field
-[t:regular_field]: #regular-field
+[t:regular-field]: #regular-field
 
-A *regular field* is a [direct][t:direct_field], [named][t:named_field] field.
+A *regular field* is a [direct][t:direct-field], [named][t:named-field] field.
 
 #### Tag
 [t:tag]: #tag
@@ -295,25 +296,26 @@ A *regular field* is a [direct][t:direct_field], [named][t:named_field] field.
 A struct/union/enum (optionally) declares a name in the tag name space. We refer
 to this name as a *tag*.
 
-There is a single tag name space shared by all three tags (6.2.3),
-and it is separate from the name space of ordinary identifiers, so `struct date`
-and a `typedef` named `date` can coexist.
+There is a single tag name space shared by all three tags (6.2.3), and it is
+separate from the name space of ordinary identifiers, so `struct date` and a
+`typedef` named `date` can coexist.
 
 #### Tagged struct/union/enum
-[t:tagged]: #tagged-structunionenum
+[t:tagged-structunionenum]: #tagged-structunionenum
 
-A struct or union or enum with a [tag][t:tag] is called *tagged*. The C
-standard says "with a tag"; we use *tagged*.
+A struct or union or enum with a [tag][t:tag] is called *tagged*. The C standard
+says "with a tag"; we use *tagged*.
 
 #### Unnamed field
-[t:unnamed_field]: #unnamed-field
+[t:unnamed-field]: #unnamed-field
 
 A [field][t:field] without a name is called an *unnamed field*.
-[Bit-fields][t:bit_field] are allowed to be unnamed, and fields that declare an
-[anonymous struct/union][t:anon] are unnamed by definition (6.7.3.2).
+[Bit-fields][t:bit-field] are allowed to be unnamed, and fields that declare an
+[anonymous struct/union][t:anonymous-structunion] are unnamed by definition
+(6.7.3.2).
 
 #### Untagged struct/union/enum
-[t:untagged]: #untagged-structunionenum
+[t:untagged-structunionenum]: #untagged-structunionenum
 
 A struct or union or enum without a [tag][t:tag] is called *untagged*. The C
 standard says "without a tag"; we use *untagged*.
@@ -321,18 +323,18 @@ standard says "without a tag"; we use *untagged*.
 ### Declarations and scope
 
 #### File scope
-[t:file_scope]: #file-scope
+[t:file-scope]: #file-scope
 
 An identifier whose declarator or type specifier appears outside any block or
 parameter list has *file scope*: it is visible from the point of declaration
-until the end of the [translation unit][t:translation_unit]. File scope is one
+until the end of the [translation unit][t:translation-unit]. File scope is one
 of four kinds of scope, the others being function, block and function prototype
 scope (6.2.1).
 
 See also ["scope" on cppreference.com][creference:scope].
 
 #### Translation unit
-[t:translation_unit]: #translation-unit
+[t:translation-unit]: #translation-unit
 
 A source file together with all the headers and source files it includes is a
 *preprocessing translation unit*; after preprocessing, it is called a
@@ -340,6 +342,7 @@ A source file together with all the headers and source files it includes is a
 invocation; see [includes][manual:includes].
 
 ## Haskell
+[t:haskell]: #haskell
 
 ### Bindings
 
@@ -348,19 +351,20 @@ invocation; see [includes][manual:includes].
 
 A *binding* is a Haskell declaration providing access to a C declaration: a
 foreign import for a function, a record type for a struct, a value for a [macro
-value][t:macro_value], and so on.
+value][t:macro-value], and so on.
 
 #### High-level bindings
-[t:high_level]: #high-level-bindings
+[t:high-level-bindings]: #high-level-bindings
 
 Bindings written in idiomatic Haskell, hiding the C representation behind
 Haskell types and conventions. `hs-bindgen` does not generate high-level
-bindings; they are hand-written on top of the [low-level bindings][t:low_level].
+bindings; they are hand-written on top of the [low-level
+bindings][t:low-level-bindings].
 
 See the [roadmap][manual:roadmap].
 
 #### Low-level bindings
-[t:low_level]: #low-level-bindings
+[t:low-level-bindings]: #low-level-bindings
 
 Bindings mirroring the C declarations one for one and using C types (`CInt`,
 `Ptr`, …). See the [introduction to the low-level
@@ -369,120 +373,124 @@ API][manual:low-level/introduction].
 ### Generated declarations
 
 #### Newtype wrapper
-[t:newtype]: #newtype-wrapper
+[t:newtype-wrapper]: #newtype-wrapper
 
 Many bindings are generated as a `newtype` around the underlying C
 representation rather than as a bare type synonym, so that the C type and its
-uses stay distinct in Haskell. [Macro types][t:macro_type] are generated this
+uses stay distinct in Haskell. [Macro types][t:macro-type] are generated this
 way, and so are enums; but beware, enums are not Haskell sum types, see
 [enums][manual:enums].
 
 #### Opaque data type
-[t:opaque]: #opaque-data-type
+[t:opaque-data-type]: #opaque-data-type
 
 For a C type whose definition is not available (e.g., an incomplete struct),
 `hs-bindgen` generates a Haskell data type with no constructors, used only
 behind a `Ptr`. See [opaque structs][manual:structs-opaque].
 
 #### Record field
-[t:record_field]: #record-field
+[t:record-field]: #record-field
 
 A field of a generated Haskell record. `hs-bindgen` generates one record field
-per [regular field][t:regular_field] of a struct; [unnamed][t:unnamed_field]
-[bit-fields][t:bit_field] are not translated.
+per [regular field][t:regular-field] of a struct; [unnamed][t:unnamed-field]
+[bit-fields][t:bit-field] are not translated.
 
 ## `hs-bindgen`
+[t:hs-bindgen]: #hs-bindgen
 
 ### Macros
 
 #### Macro language
-[t:macro_lang]: #macro-language
+[t:macro-language]: #macro-language
 
 The pluggable `hs-bindgen` component that parses, typechecks and translates the
-[replacement lists][t:replacement_list] of [macro definitions][t:macro_def].
+[replacement lists][t:replacement-list] of [macro
+definitions][t:macro-definition].
 
 #### Macro type
-[t:macro_type]: #macro-type
+[t:macro-type]: #macro-type
 
-A [macro][t:macro] whose [replacement list][t:replacement_list] parses as a C
+A [macro][t:macro] whose [replacement list][t:replacement-list] parses as a C
 *type* expression, and which is therefore translated to a Haskell type using a
-[newtype wrapper][t:newtype] around the translation of that C type. For example,
-`#define YEAR int`.
+[newtype wrapper][t:newtype-wrapper] around the translation of that C type. For
+example, `#define YEAR int`.
 
 #### Macro value
-[t:macro_value]: #macro-value
+[t:macro-value]: #macro-value
 
-A [macro][t:macro] whose [replacement list][t:replacement_list] parses as a C
+A [macro][t:macro] whose [replacement list][t:replacement-list] parses as a C
 *expression*, and which is therefore translated to a Haskell value binding. For
 example, `#define EPSILON 0.1`.
 
 #### Parsable macro
-[t:parsable_macro]: #parsable-macro
+[t:parsable-macro]: #parsable-macro
 
-A [macro definition][t:macro_def] whose [replacement list][t:replacement_list]
-the active [macro language][t:macro_lang] can parse, either as a [macro
-type][t:macro_type] or as a [macro value][t:macro_value].
+A [macro definition][t:macro-definition] whose [replacement
+list][t:replacement-list] the active [macro language][t:macro-language] can
+parse, either as a [macro type][t:macro-type] or as a [macro
+value][t:macro-value].
 
 #### Reparsing
 [t:reparsing]: #reparsing
 
 The second parse of those declarations that contain macro
-[expansions][t:macro_expansion], recovering the [macro types][t:macro_type] that
+[expansions][t:macro-expansion], recovering the [macro types][t:macro-type] that
 `libclang` had already expanded away; see [macros][manual:translation/macros].
 
 ### Selection
 
 #### Extern declaration
-[t:extern]: #extern-declaration
+[t:extern-declaration]: #extern-declaration
 
-A declaration listed in an external [binding specification][t:binding_spec].
-`hs-bindgen` does not generate bindings for it, and instead imports the
-declaration from the specified module instead.
+A declaration listed in an external [binding
+specification][t:binding-specification]. `hs-bindgen` does not generate bindings
+for it, and instead imports the declaration from the specified module instead.
 
 #### Omitted declaration
-[t:omitted]: #omitted-declaration
+[t:omitted-declaration]: #omitted-declaration
 
 A declaration that is not translated due to a prescriptive [binding
-specification][t:binding_spec]. We use *omit* exclusively for this. We avoid
-*omit* in the context of [deselection][t:selected] or translation failures.
+specification][t:binding-specification]. We use *omit* exclusively for this. We
+avoid *omit* in the context of [deselection][t:selected-declaration] or
+translation failures.
 
 #### Program slicing
-[t:slicing]: #program-slicing
+[t:program-slicing]: #program-slicing
 
 Translating a declaration is only useful if its transitive dependencies are
 translated too. *Program slicing* determines those dependencies and selects
-them, even if a [selection predicate][t:selection_predicate] deselected them.
+them, even if a [selection predicate][t:selection-predicate] deselected them.
 See [selecting and program slicing][manual:selecting-and-program-slicing].
 
 #### Selected declaration
-[t:selected]: #selected-declaration
+[t:selected-declaration]: #selected-declaration
 
 A declaration that `hs-bindgen` will translate. Declarations are *selected* or
-*deselected*, by a [selection predicate][t:selection_predicate] and by [program
-slicing][t:slicing]. We avoid the terms *exclude*, *skip* and [omit][t:omitted]
-in the context of selection.
+*deselected*, by a [selection predicate][t:selection-predicate] and by [program
+slicing][t:program-slicing]. We avoid the terms *exclude*, *skip* and
+[omit][t:omitted-declaration] in the context of selection.
 
 #### Selection predicate
-[t:selection_predicate]: #selection-predicate
+[t:selection-predicate]: #selection-predicate
 
 A predicate matched against declarations, determining which ones are
-[selected][t:selected] for translation. See [selecting and program
+[selected][t:selected-declaration] for translation. See [selecting and program
 slicing][manual:selecting-and-program-slicing].
 
 ### Naming and configuration
 
 #### Binding specification
-[t:binding_spec]: #binding-specification
+[t:binding-specification]: #binding-specification
 
 A YAML or JSON file specifying details about the bindings of a single Haskell
 module. A *prescriptive* binding specification guides generation (custom names,
-type representations, instances, [omission][t:omitted]); an *external* binding
-specification declares that the listed types come from another module, so that
-separately generated bindings compose. See [binding
+type representations, instances, [omission][t:omitted-declaration]); an
+*external* binding specification declares that the listed types come from
+another module, so that separately generated bindings compose. See [binding
 specifications][manual:binding-specifications].
 
 #### Name mangling
-[t:name_mangling]: #name-mangling
+[t:name-mangling]: #name-mangling
 
 C names are not valid Haskell names, and the two languages have different
 conventions. The *name mangler* derives all Haskell names from the corresponding
@@ -490,7 +498,7 @@ C names, staying as close to the C spelling as possible. See [generated
 names][manual:generated-names].
 
 #### Root directive
-[t:root_directive]: #root-directive
+[t:root-directive]: #root-directive
 
 A preprocessing directive that `hs-bindgen` emits ahead of the headers being
 translated, such as `--hash-define NAME VALUE`. Root directives are ordered and

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -200,9 +200,8 @@ A *field* is what the C standard calls a *member* of a struct or union
 (6.7.3.2). Fields are declared using variable declarations or
 [bit-field][t:bit-field] declarations.
 
-We say "field" rather than "member" because the Haskell side generates [record
-fields][t:record-field], and because the C standard itself already uses field in
-*bit-field*.
+We say "field" rather than "member" because Clang calls them fields, and because
+the C standard itself already uses field in *bit-field*.
 
 #### Implicit field
 [t:implicit-field]: #implicit-field

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -208,7 +208,7 @@ the C standard itself already uses field in *bit-field*.
 
 An *implicit* field is a [direct][t:direct-field], [unnamed][t:unnamed-field]
 field whose type is an [anonymous struct/union][t:anonymous-structunion]. The C
-standard has no separate name for it, since it calls the field itself the
+standard has no separate name for the field, since it calls the field itself the
 anonymous struct or union.
 
 <details>
@@ -222,10 +222,11 @@ anonymous struct or union.
 [t:indirect-field]: #indirect-field
 
 The [named fields][t:named-field] of an [anonymous
-struct/union][t:anonymous-structunion] are fields of the [enclosing
-struct/union][t:enclosing-structunion] as well (6.7.3.2), and can be accessed as
-such. With respect to the enclosing struct/union, such a field is called an
-*indirect field*. It remains a field of the anonymous struct/union too.
+struct/union][t:anonymous-structunion] can be [accessed as if they were
+fields][dr-449] of the [enclosing struct/union][t:enclosing-structunion] as well
+(6.7.3.2). With respect to the enclosing struct/union, such a field is called an
+*indirect field*. It is only a true a field of the anonymous struct/union
+[dr-449]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2396.htm#dr_499
 
 This applies recursively: if an anonymous struct/union has indirect fields, then
 the enclosing struct/union has its own indirect fields for those fields as well.
@@ -288,8 +289,9 @@ separate from the namespace of ordinary identifiers, so `struct date` and a
 #### Tagged struct/union/enum
 [t:tagged-structunionenum]: #tagged-structunionenum
 
-A struct or union or enum with a [tag][t:tag] is called *tagged*. The C standard
-says "with a tag"; we use *tagged*.
+A struct or union or enum with a [tag][t:tag] is called *tagged*.
+
+The C standard says "with a tag"; we use *tagged*.
 
 #### Unnamed field
 [t:unnamed-field]: #unnamed-field
@@ -302,8 +304,9 @@ A [field][t:field] without a name is called an *unnamed field*.
 #### Untagged struct/union/enum
 [t:untagged-structunionenum]: #untagged-structunionenum
 
-A struct or union or enum without a [tag][t:tag] is called *untagged*. The C
-standard says "without a tag"; we use *untagged*.
+A struct or union or enum without a [tag][t:tag] is called *untagged*.
+
+The C standard says "without a tag"; we use *untagged*.
 
 ### Declarations and scope
 

--- a/manual/terminology.md
+++ b/manual/terminology.md
@@ -135,16 +135,14 @@ function prototype scope (6.2.1).
 #### Anonymous struct/union
 [t:anonymous-structunion]: #anonymous-structunion
 
-An [unnamed][t:unnamed-field] [field][t:field] whose type is an
-[untagged][t:untagged-structunionenum] struct or union is called an *anonymous
-struct* or *anonymous union* (6.7.3.2). Its [named fields][t:named-field] become
-[indirect fields][t:indirect-field] of the [enclosing
-struct/union][t:enclosing-structunion].
+A [field][t:field] that declares a nested [untagged][t:untagged] struct or union
+can optionally [omit the field name][t:unnamed-field]. In this case, the [nested
+struct/union][t:nested] is called an *anonymous struct/union* (6.7.3.2). See
+also [indirect fields][t:indirect-field].
 
-The C standard applies the adjective to the *field*; we also apply it to the
-[nested][t:nested-structunion] struct or union type that the field declares. The
-two name the same construct. Our name for the field itself is [implicit
-field][t:implicit-field].
+The C standard calls the whole *field* an anonymous struct/union; we only apply
+that terminology to the [nested][t:nested-structunion] struct or union type. The
+terminology for the field itself is [implicit field][t:implicit-field].
 
 <details>
 <summary>Notice</summary>


### PR DESCRIPTION
Group terminology by C input / generated Haskell bindings / `hs-bindgen` translation, and cite C standard clauses.

Fix the preprocessor entries: an invocation is replaced by the replacement list, not by the definition; arguments are substituted for parameters. Add some entries, including those for selection, naming and configuration.

[WIP] macro chapter.

---

- [ ] I have updated the changelog. I have included a migration hint if this is a breaking change.

- [ ] I have updated the manual.

- [ ] I have removed all mentions of closed tickets in the code.

- [ ] I have associated each new TODO item with a ticket, using the following syntax:

```hs
-- TODO <link to issue>
-- Brief description
```
