### PR TITLE
Make CLI parse errors use exit code 2

### DIFF
--- a/hs-bindgen/CHANGELOG.md
+++ b/hs-bindgen/CHANGELOG.md
@@ -114,6 +114,8 @@
         wrapper translation unit includes every main header.
       * Declarations in the root header (i.e., the `#define`s) are not parsed: a
         root directive is configuration.
+* CLI exit codes are changed so that exit code 2 is used for CLI usage errors.
+  See the invocation section of the manual for details.
 
 ### New features
 

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -46,7 +46,7 @@ execCliParser = customExecParser prefs' opts
     opts :: ParserInfo Cli
     opts = info (parseCli <**> simpleVersioner vers <**> helper) $
       mconcat [
-          header "hs-bindgen - generate Haskell bindings from C headers"
+          progDesc "Generate Haskell bindings from C headers"
         , failureCode 2
         , footerDoc . Just . Help.vcat $ List.intersperse "" [
               envVarsFooter

--- a/hs-bindgen/app/hs-bindgen-cli.hs
+++ b/hs-bindgen/app/hs-bindgen-cli.hs
@@ -47,6 +47,7 @@ execCliParser = customExecParser prefs' opts
     opts = info (parseCli <**> simpleVersioner vers <**> helper) $
       mconcat [
           header "hs-bindgen - generate Haskell bindings from C headers"
+        , failureCode 2
         , footerDoc . Just . Help.vcat $ List.intersperse "" [
               envVarsFooter
             , clangArgsFooter

--- a/hs-bindgen/src-internal/HsBindgen.hs
+++ b/hs-bindgen/src-internal/HsBindgen.hs
@@ -105,16 +105,16 @@ hsBindgenMacroLang mkMacroLang tu ts b i a = do
       case fromException e of
         Just (LibclangException msg) -> do
           print $ PP.string msg
-          -- We specifically use exit code 2 here; it means that the call to
+          -- We specifically use exit code 3 here; it means that the call to
           -- `libclang` has failed.
-          exitWith (ExitFailure 2)
+          exitWith (ExitFailure 3)
         _ -> throwIO e
     case eRes of
       Left err -> do
         print $ prettyForTrace err
-        -- We specifically use exit code 3 here; it means that `hs-bindgen` ran
+        -- We specifically use exit code 4 here; it means that `hs-bindgen` ran
         -- to completion, but an error has occurred.
-        exitWith (ExitFailure 3)
+        exitWith (ExitFailure 4)
       Right r -> pure r
 
 -- | Like 'hsBindgen' but does not exit with failure when an error has occurred.

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/ExitCode.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/ExitCode.hs
@@ -101,6 +101,6 @@ testUnresolvedIncludeProcess = testCase "unresolved include returns non-zero" $ 
                                                , tempHeader
                                                ]
                                                ""
-    -- We specifically test for exit code 2 here; it means that the `hs-bindgen`
+    -- We specifically test for exit code 3 here; it means that the `hs-bindgen`
     -- invocation of `libclang` has failed.
-    exitCode @?= ExitFailure 2
+    exitCode @?= ExitFailure 3

--- a/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/OverwritePolicy.hs
+++ b/hs-bindgen/test/hs-bindgen/Test/HsBindgen/Integration/OverwritePolicy.hs
@@ -32,9 +32,9 @@ testDirPolicy getTestResources = testCase "do not create output directory by def
                                                , headerPath
                                                ]
                                                ""
-    -- We specifically test for exit code 3 here; it means that `hs-bindgen` ran
+    -- We specifically test for exit code 4 here; it means that `hs-bindgen` ran
     -- to completion, but an error has ocurred.
-    exitCode @?= ExitFailure 3
+    exitCode @?= ExitFailure 4
 
 testFilePolicy :: IO TestResources -> TestTree
 testFilePolicy getTestResources = testCase "do not overwrite existing files by default" $ do
@@ -52,9 +52,9 @@ testFilePolicy getTestResources = testCase "do not overwrite existing files by d
                                                , headerPath
                                                ]
                                                ""
-    -- We specifically test for exit code 3 here; it means that `hs-bindgen` ran
+    -- We specifically test for exit code 4 here; it means that `hs-bindgen` ran
     -- to completion, but an error has ocurred.
-    exitCode @?= ExitFailure 3
+    exitCode @?= ExitFailure 4
 
 testOverwritePolicies :: IO TestResources -> TestTree
 testOverwritePolicies getTestResources = testCase "create directories and overwrite files if told by user" $ do
@@ -115,4 +115,4 @@ testBindingSpecNoDirByDefault getTestResources = testCase "do not create --gen-b
                                                , headerPath
                                                ]
                                                ""
-    exitCode @?= ExitFailure 3
+    exitCode @?= ExitFailure 4

--- a/manual/low-level/usage/invocation.md
+++ b/manual/low-level/usage/invocation.md
@@ -129,10 +129,12 @@ Run `hs-bindgen-cli --help` for details.
 ### Exit codes
 
 `hs-bindgen` uses the following exit codes:
+
 - 0: Success
-- 1: Other errors (panics)
-- 2: Invocation of `libclang` has failed
-- 3: An `hs-bindgen`-specific error has happened
+- 1: Unexpected errors (panics)
+- 2: CLI usage errors
+- 3: Invocation of `libclang` has failed
+- 4: An `hs-bindgen`-specific error has happened
 
 ## Cabal preprocessor integration
 


### PR DESCRIPTION
In my culture, this is a must.  I noticed that we do not do this when I found #2257.  It is a trivial change, so I figure that creating this PR is the best way to propose the change.  If the team explicitly wants to not use meaningful exit codes, feel free to close the PR.